### PR TITLE
fix(build): Use '...restProps' instead of '...props'

### DIFF
--- a/lib/components/Alert/Alert.js
+++ b/lib/components/Alert/Alert.js
@@ -43,7 +43,7 @@ export default class Alert extends React.Component {
   };
 
   render() {
-    const { tone, children, ...props } = this.props;
+    const { tone, children, ...restProps } = this.props;
 
     const icon = iconForTone(tone);
     const color = textColorForTone(tone);
@@ -55,7 +55,7 @@ export default class Alert extends React.Component {
         paddingRight="gutter"
         paddingTop="medium"
         paddingBottom="medium"
-        {...props}
+        {...restProps}
       >
         <div className={styles.root}>
           <div className={styles.icon}>{icon}</div>

--- a/lib/components/Box/Box.js
+++ b/lib/components/Box/Box.js
@@ -48,7 +48,7 @@ export default withTheme(
         backgroundColor,
         borderColor = 'default',
         className,
-        ...props
+        ...restProps
       } = this.props;
 
       return (
@@ -82,7 +82,7 @@ export default withTheme(
             [theme.atoms.paddingLeft[paddingLeft]]:
               paddingLeft && theme.atoms.paddingLeft[paddingLeft]
           })}
-          {...props}
+          {...restProps}
         />
       );
     }

--- a/lib/components/Checkbox/Checkbox.js
+++ b/lib/components/Checkbox/Checkbox.js
@@ -82,7 +82,7 @@ export default withTheme(
         message,
         messageProps,
         children,
-        ...props
+        ...restProps
       } = this.props;
       const { hovered } = this.state;
 
@@ -107,7 +107,7 @@ export default withTheme(
             checked={checked}
             disabled={disabled}
             aria-describedby={fieldMessageId}
-            {...props}
+            {...restProps}
             {...inputProps}
           />
           <div className={styles.content}>

--- a/lib/components/ChecklistCard/ChecklistCard.js
+++ b/lib/components/ChecklistCard/ChecklistCard.js
@@ -26,9 +26,9 @@ export default class ChecklistCard extends React.Component {
   };
 
   render() {
-    const { children, ...props } = this.props;
+    const { children, ...restProps } = this.props;
     return (
-      <Card {...props}>
+      <Card {...restProps}>
         {React.Children.map(children, (child, i) => (
           <React.Fragment>
             {i > 0 && <Divider />}

--- a/lib/components/Divider/Divider.js
+++ b/lib/components/Divider/Divider.js
@@ -27,7 +27,7 @@ export default withTheme(
         borderColor,
         borderWidth,
         className,
-        ...props
+        ...restProps
       } = this.props;
 
       return (
@@ -36,7 +36,7 @@ export default withTheme(
             [styles.root]: true,
             [className]: className
           })}
-          {...props}
+          {...restProps}
         >
           <div
             className={classnames(

--- a/lib/components/FieldMessage/FieldMessage.js
+++ b/lib/components/FieldMessage/FieldMessage.js
@@ -40,9 +40,9 @@ export default withTheme(
     };
 
     render() {
-      const { theme, tone, message, ...props } = this.props;
+      const { theme, tone, message, ...restProps } = this.props;
       return message === false ? null : (
-        <Text paddingBottom="small" color={tone} tabIndex="-1" {...props}>
+        <Text paddingBottom="small" color={tone} tabIndex="-1" {...restProps}>
           <div className={styles.content}>
             {renderIcon(theme, tone)}
             <div

--- a/lib/components/Radio/Radio.js
+++ b/lib/components/Radio/Radio.js
@@ -81,7 +81,7 @@ export default withTheme(
         message,
         messageProps,
         children,
-        ...props
+        ...restProps
       } = this.props;
 
       const { hovered } = this.state;
@@ -106,7 +106,7 @@ export default withTheme(
             checked={checked}
             disabled={disabled}
             aria-describedby={fieldMessageId}
-            {...props}
+            {...restProps}
             {...inputProps}
           />
           <div className={styles.content}>

--- a/lib/components/Reset/Reset.js
+++ b/lib/components/Reset/Reset.js
@@ -19,14 +19,14 @@ export default withTheme(
     };
 
     render() {
-      const { theme, component, className, ...props } = this.props;
+      const { theme, component, className, ...restProps } = this.props;
 
       return React.createElement(component, {
         className: classnames({
           [className]: className,
           [theme.atoms.reset[component]]: theme.atoms.reset[component]
         }),
-        ...props
+        ...restProps
       });
     }
   }

--- a/lib/components/Strong/Strong.js
+++ b/lib/components/Strong/Strong.js
@@ -13,11 +13,11 @@ export default withTheme(
     };
 
     render() {
-      const { theme, className, ...props } = this.props;
+      const { theme, className, ...restProps } = this.props;
 
       return (
         <strong
-          {...props}
+          {...restProps}
           className={classnames(className, theme.atoms.fontWeight.strong)}
         />
       );

--- a/lib/components/Text/Text.js
+++ b/lib/components/Text/Text.js
@@ -41,7 +41,7 @@ export default withTheme(
         baseline,
         className,
         children,
-        ...props
+        ...restProps
       } = this.props;
 
       const Component =
@@ -55,7 +55,7 @@ export default withTheme(
             [styles.block]: true,
             [styles.listItem]: component === 'li'
           })}
-          {...props}
+          {...restProps}
         >
           <span
             className={classnames({

--- a/lib/components/ThemeProvider/ThemeProvider.js
+++ b/lib/components/ThemeProvider/ThemeProvider.js
@@ -10,8 +10,8 @@ export default class ThemeProvider extends React.Component {
   };
 
   render() {
-    const { theme, ...props } = this.props;
+    const { theme, ...restProps } = this.props;
 
-    return <ThemeContext.Provider value={theme} {...props} />;
+    return <ThemeContext.Provider value={theme} {...restProps} />;
   }
 }

--- a/lib/components/icons/ChevronIcon/ChevronIcon.js
+++ b/lib/components/icons/ChevronIcon/ChevronIcon.js
@@ -18,10 +18,10 @@ export default class ChevronIcon extends React.Component {
   };
 
   render() {
-    const { className, direction, ...props } = this.props;
+    const { className, direction, ...restProps } = this.props;
 
     const combinedProps = {
-      ...props,
+      ...restProps,
       className: classnames({
         [styles.root]: true,
         [styles[direction]]: styles[direction],

--- a/lib/components/icons/Icon/Icon.js
+++ b/lib/components/icons/Icon/Icon.js
@@ -30,7 +30,7 @@ export default withTheme(
         size,
         inline,
         fill,
-        ...props
+        ...restProps
       } = this.props;
 
       const type = theme.tokens.type[size];
@@ -45,7 +45,7 @@ export default withTheme(
             [className]: className,
             [theme.atoms.fill[fill]]: theme.atoms.fill[fill]
           })}
-          {...props}
+          {...restProps}
         />
       );
     }

--- a/package.json
+++ b/package.json
@@ -5,11 +5,10 @@
   "main": "lib/components/index.js",
   "sideEffects": false,
   "scripts": {
-    "test": "npm run lint && CI=true sku test",
+    "test": "npm run lint && CI=true npm run unit && npm run build",
     "unit": "sku test",
-    "clean": "rm -rf docs/dist",
-    "build": "npm run clean && sku build",
-    "start": "npm run clean && sku start",
+    "build": "rimraf docs/dist && sku build",
+    "start": "sku start",
     "lint": "sku lint",
     "format": "sku format",
     "commit": "git-cz",
@@ -53,6 +52,7 @@
     "react-dom": "16.5.2",
     "react-testing-library": "^5.1.0",
     "renovate-config-seek": "0.3.0",
+    "rimraf": "^2.6.2",
     "semantic-release": "^15.9.16",
     "sku": "5.7.3",
     "travis-deploy-once": "^5.0.9"


### PR DESCRIPTION
The use of both `...props` and `this.props` seems to be causing issues with Babel somehow, thinking that we have duplicate declarations of "props". This is more of a quick fix, since this isn't technically an issue with our code, but I'm keen to get this fix released ASAP. It doesn't hurt that this is arguably a better notation, anyway.

This only happens during `sku build`, which is why it wasn't picked up in tests, so to catch issues like this in the future, we now run `sku build` on CI as part of `npm test`.