### PR TITLE
build: Seperate out and document release configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,6 @@
       "path": "./node_modules/cz-conventional-changelog"
     }
   },
-  "release": {
-    "success": false
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/seek-oss/braid-design-system.git"

--- a/release.config.js
+++ b/release.config.js
@@ -1,0 +1,6 @@
+// semantic-release configuration
+module.exports = {
+  // Avoid all default success plugins to avoid commenting on PRs
+  // https://github.com/semantic-release/semantic-release/blob/caribou/docs/usage/configuration.md#success
+  success: false
+};


### PR DESCRIPTION
semantic-release [allows the configuration](https://github.com/semantic-release/semantic-release/blob/caribou/docs/usage/configuration.md#configuration) either via `package.json` values or `release.config.js` values.
`package.json` values can not be commented, and without context it can be unintuitive why certain configurations have been chosen.

This change helps document the release process, helping with any further changes that may be made.

Confirmed after this change no success plugins are loaded still:
<img width="485" alt="screen shot 2018-10-03 at 8 25 32 am" src="https://user-images.githubusercontent.com/13903378/46380550-0563bb80-c6e6-11e8-93d8-2f645901c030.png">


