### PR TITLE
ci(PullApprove): Add `explanation` for invalid PR titles

### DIFF
--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -4,11 +4,3 @@ pullapprove_conditions:
   - condition: "contains_regex(title, '^(build|ci|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\(\\w+\\))?\\:\\s[A-Z].*$')"
     unmet_status: failure
     explanation: "Invalid PR title. For more information please see https://github.com/seek-oss/commitlint-config-seek"
-
-groups:
-  code:
-    reviews:
-      required: 1
-    reviewers:
-      teams:
-        - front-end-contributors

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -4,3 +4,8 @@ pullapprove_conditions:
   - condition: "contains_regex(title, '^(build|ci|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\(\\w+\\))?\\:\\s[A-Z].*$')"
     unmet_status: failure
     explanation: "Invalid PR title. For more information please see https://github.com/seek-oss/commitlint-config-seek"
+
+groups:
+  code:
+    reviews:
+      required: 0

--- a/.pullapprove.yml
+++ b/.pullapprove.yml
@@ -1,5 +1,10 @@
 version: 3
 
+pullapprove_conditions:
+  - condition: "contains_regex(title, '^(build|ci|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\(\\w+\\))?\\:\\s[A-Z].*$')"
+    unmet_status: failure
+    explanation: "Invalid PR title. For more information please see https://github.com/seek-oss/commitlint-config-seek"
+
 groups:
   code:
     reviews:
@@ -7,6 +12,3 @@ groups:
     reviewers:
       teams:
         - front-end-contributors
-    conditions:
-      - "contains_regex(title, '^(build|ci|chore|docs|feat|fix|perf|refactor|revert|style|test)(\\(\\w+\\))?\\:\\s[A-Z].*$')"
-      


### PR DESCRIPTION
We removed the explanation when migrating to v3 PullApprove. The functionality has been restored under the `pullapprove_conditions` section now, so reinstating the behaviour.