### PR TITLE
docs(playroom): Fix Playroom link in production

### DIFF
--- a/docs/src/App/App.js
+++ b/docs/src/App/App.js
@@ -53,13 +53,13 @@ export default class App extends Component {
               </Text>
               <BulletList marginBottom="small">
                 <Bullet>
-                  <a
+                  <Link
                     style={{ color: 'inherit' }}
-                    href="/playroom"
+                    to="/playroom"
                     target="_blank"
                   >
                     Playroom
-                  </a>
+                  </Link>
                 </Bullet>
               </BulletList>
               <Text size="large" weight="strong" marginBottom="small">


### PR DESCRIPTION
The `/playroom` link doesn't work on GitHub pages because it doesn't honour the `braid-design-system` base href, instead taking you to `https://seek-oss.github.io/playroom`. Swapping out the `<a>` tag for a React Router `<Link>` ensures that the same base href logic is applied.