### PR TITLE
docs(site): Fix generate-component-docs script

### DIFF
--- a/lib/componentDocs/generateComponentDocs.js
+++ b/lib/componentDocs/generateComponentDocs.js
@@ -2,7 +2,20 @@ const fs = require('fs');
 const path = require('path');
 const { promisify } = require('util');
 const writeFile = promisify(fs.writeFile);
+const mapValues = require('lodash/mapValues');
 const globsToReactDocgen = require('./globsToReactDocgen');
+const { normaliseType, normaliseDefaultValue } = require('./normaliseProp');
+
+const normaliseDocs = ({ props = {}, ...rest }) => ({
+  ...rest,
+  props: mapValues(props, prop => ({
+    ...prop,
+    defaultValue: normaliseDefaultValue(prop),
+    type: normaliseType(prop)
+  }))
+});
+
+const omitDocWithNoProps = ({ props = {} }) => Object.keys(props).length > 0;
 
 const byDisplayName = (acc, doc) => ({
   ...acc,
@@ -20,7 +33,10 @@ const byDisplayName = (acc, doc) => ({
     ]
   });
 
-  const keyedDocs = componentDocs.reduce(byDisplayName, {});
+  const keyedDocs = componentDocs
+    .map(normaliseDocs)
+    .filter(omitDocWithNoProps)
+    .reduce(byDisplayName, {});
 
   await writeFile(
     path.join(__dirname, 'componentDocs.json'),

--- a/lib/componentDocs/globsToReactDocgen.js
+++ b/lib/componentDocs/globsToReactDocgen.js
@@ -11,17 +11,6 @@ const { parse: parseTs } = require('react-docgen-typescript').withCustomConfig(
   }
 );
 const partition = require('lodash/partition');
-const mapValues = require('lodash/mapValues');
-const { normaliseType, normaliseDefaultValue } = require('./normaliseProp');
-
-const normaliseData = ({ props = {}, ...rest }) => ({
-  ...rest,
-  props: mapValues(props, prop => ({
-    ...prop,
-    defaultValue: normaliseDefaultValue(prop),
-    type: normaliseType(prop)
-  }))
-});
 
 const parseDocsFromFile = async file => {
   let componentDoc;
@@ -41,23 +30,24 @@ const parseDocsFromFile = async file => {
     throw e;
   }
 
-  return normaliseData(componentDoc);
+  return componentDoc;
 };
 
 module.exports = async ({ include = '', exclude: ignore = [] } = {}) => {
   const files = await fastGlob(include, { ignore });
   const [tsFiles, jsFiles] = partition(files, file => /.*\.tsx?$/.test(file));
-  const docs = [];
+  let tsDocs = [];
+  let jsDocs = [];
 
   if (tsFiles.length > 0) {
-    docs.concat(parseTs(tsFiles).map(normaliseData));
+    tsDocs = parseTs(tsFiles);
   }
 
   if (jsFiles.length > 0) {
     const componentDocs = await Promise.all(jsFiles.map(parseDocsFromFile));
 
-    docs.concat(componentDocs.filter(Boolean));
+    jsDocs = componentDocs.filter(Boolean);
   }
 
-  return docs;
+  return [...tsDocs, ...jsDocs];
 };


### PR DESCRIPTION
I forgot how to javascript and never held on to the array returned from `concat`, which meant the component doc generation script was always returning an empty array.

Also took the opportunity to remove project opinions from from `globsToReactDocgen` which is likely to become it's own external module in the future.