### PR TITLE
fix: Add `toUnit` util

### DIFF
--- a/lib/components/Checkbox/Checkbox.js
+++ b/lib/components/Checkbox/Checkbox.js
@@ -8,6 +8,7 @@ import Text from '../Text/Text';
 import FieldMessage from '../FieldMessage/FieldMessage';
 import TickIcon from '../icons/TickIcon/TickIcon';
 import styles from './Checkbox.css.js';
+import { px } from '../../themes/utils/toUnit';
 
 const textColorForState = ({ disabled, hovered }) => {
   if (disabled) {
@@ -124,8 +125,9 @@ export default withTheme(
                 [styles.label]: true
               })}
               style={{
-                minHeight: `${theme.tokens.rowHeight *
-                  theme.tokens.interactionRows}px`
+                minHeight: px(
+                  theme.tokens.rowHeight * theme.tokens.interactionRows
+                )
               }}
               htmlFor={id}
               {...labelProps}
@@ -136,12 +138,13 @@ export default withTheme(
                 marginRight={inChecklistCard ? 'medium' : 'small'}
                 className={styles.checkboxContainer}
                 style={{
-                  width: `${checkboxSize}px`,
-                  height: `${checkboxSize}px`,
-                  marginTop: `${(theme.tokens.interactionRows *
-                    theme.tokens.rowHeight -
-                    checkboxSize) /
-                    2}px`
+                  width: px(checkboxSize),
+                  height: px(checkboxSize),
+                  marginTop: px(
+                    (theme.tokens.interactionRows * theme.tokens.rowHeight -
+                      checkboxSize) /
+                      2
+                  )
                 }}
               >
                 <Box
@@ -234,7 +237,7 @@ export default withTheme(
                   paddingLeft={inChecklistCard ? 'medium' : 'small'}
                   paddingBottom="small"
                   className={styles.children}
-                  style={{ marginLeft: `${checkboxSize}px` }}
+                  style={{ marginLeft: px(checkboxSize) }}
                 >
                   {children}
                 </Box>

--- a/lib/components/Radio/Radio.js
+++ b/lib/components/Radio/Radio.js
@@ -7,6 +7,7 @@ import Box from '../Box/Box';
 import Text from '../Text/Text';
 import FieldMessage from '../FieldMessage/FieldMessage';
 import styles from './Radio.css.js';
+import { px } from '../../themes/utils/toUnit';
 
 const textColorForState = ({ disabled, hovered }) => {
   if (disabled) {
@@ -124,8 +125,9 @@ export default withTheme(
                 [styles.label]: true
               })}
               style={{
-                minHeight: `${theme.tokens.rowHeight *
-                  theme.tokens.interactionRows}px`
+                minHeight: px(
+                  theme.tokens.rowHeight * theme.tokens.interactionRows
+                )
               }}
               htmlFor={id}
               {...labelProps}
@@ -134,12 +136,13 @@ export default withTheme(
             >
               <Box
                 style={{
-                  width: `${radioSize}px`,
-                  height: `${radioSize}px`,
-                  marginTop: `${(theme.tokens.interactionRows *
-                    theme.tokens.rowHeight -
-                    radioSize) /
-                    2}px`
+                  width: px(radioSize),
+                  height: px(radioSize),
+                  marginTop: px(
+                    (theme.tokens.interactionRows * theme.tokens.rowHeight -
+                      radioSize) /
+                      2
+                  )
                 }}
                 className={styles.radioContainer}
                 marginRight="medium"
@@ -211,7 +214,7 @@ export default withTheme(
                   paddingLeft="medium"
                   paddingBottom="medium"
                   className={styles.children}
-                  style={{ marginLeft: `${radioSize}px` }}
+                  style={{ marginLeft: px(radioSize) }}
                 >
                   {children}
                 </Box>

--- a/lib/themes/jobStreet/atoms/border/borderWidth.css.js
+++ b/lib/themes/jobStreet/atoms/border/borderWidth.css.js
@@ -1,10 +1,11 @@
 import tokens from '../../tokens/tokens';
+import { px } from '../../../utils/toUnit';
 
 const css = {};
 Object.keys(tokens.borderWidth).forEach(borderWidth => {
   css[`.${borderWidth}`] = {
     borderStyle: 'solid',
-    borderWidth: `${tokens.borderWidth[borderWidth]}px`
+    borderWidth: px(tokens.borderWidth[borderWidth])
   };
 });
 

--- a/lib/themes/seekAnz/atoms/border/borderWidth.css.js
+++ b/lib/themes/seekAnz/atoms/border/borderWidth.css.js
@@ -1,10 +1,11 @@
 import tokens from '../../tokens/tokens';
+import { px } from '../../../utils/toUnit';
 
 const css = {};
 Object.keys(tokens.borderWidth).forEach(borderWidth => {
   css[`.${borderWidth}`] = {
     borderStyle: 'solid',
-    borderWidth: `${tokens.borderWidth[borderWidth]}px`
+    borderWidth: px(tokens.borderWidth[borderWidth])
   };
 });
 

--- a/lib/themes/seekAsia/atoms/border/borderWidth.css.js
+++ b/lib/themes/seekAsia/atoms/border/borderWidth.css.js
@@ -1,10 +1,11 @@
 import tokens from '../../tokens/tokens';
+import { px } from '../../../utils/toUnit';
 
 const css = {};
 Object.keys(tokens.borderWidth).forEach(borderWidth => {
   css[`.${borderWidth}`] = {
     borderStyle: 'solid',
-    borderWidth: `${tokens.borderWidth[borderWidth]}px`
+    borderWidth: px(tokens.borderWidth[borderWidth])
   };
 });
 

--- a/lib/themes/utils/columnSpacingForCssRule.js
+++ b/lib/themes/utils/columnSpacingForCssRule.js
@@ -1,3 +1,5 @@
+import { px } from './toUnit';
+
 export default (ruleName, { columnWidth, columnSpacing }) => {
   const css = {
     '.none': {
@@ -7,7 +9,7 @@ export default (ruleName, { columnWidth, columnSpacing }) => {
 
   Object.keys(columnSpacing).forEach(size => {
     css[`.${size}`] = {
-      [ruleName]: `${columnSpacing[size] * columnWidth}px`
+      [ruleName]: px(columnSpacing[size] * columnWidth)
     };
   });
 

--- a/lib/themes/utils/fontSizeRulesForTokens.js
+++ b/lib/themes/utils/fontSizeRulesForTokens.js
@@ -1,6 +1,7 @@
 import basekick from 'basekick';
 import merge from 'lodash/merge';
 import createResponsiveRules from './createResponsiveRules';
+import { px } from './toUnit';
 
 export default ({ tokens }) => {
   const size = (fontSize, rows) =>
@@ -30,12 +31,12 @@ export default ({ tokens }) => {
 
     if (typeName === 'standard') {
       const interactionHeight = tokens.interactionRows * tokens.rowHeight;
-      const mobileInteractionPadding = `${(interactionHeight -
-        type.mobile.rows * tokens.rowHeight) /
-        2}px`;
-      const desktopInteractionPadding = `${(interactionHeight -
-        type.desktop.rows * tokens.rowHeight) /
-        2}px`;
+      const mobileInteractionPadding = px(
+        (interactionHeight - type.mobile.rows * tokens.rowHeight) / 2
+      );
+      const desktopInteractionPadding = px(
+        (interactionHeight - type.desktop.rows * tokens.rowHeight) / 2
+      );
 
       rules.push(
         createResponsiveRules({

--- a/lib/themes/utils/rowSpacingForCssRule.js
+++ b/lib/themes/utils/rowSpacingForCssRule.js
@@ -1,3 +1,5 @@
+import { px } from './toUnit';
+
 export default (ruleName, { rowHeight, rowSpacing }) => {
   const css = {
     '.none': {
@@ -7,7 +9,7 @@ export default (ruleName, { rowHeight, rowSpacing }) => {
 
   Object.keys(rowSpacing).forEach(size => {
     css[`.${size}`] = {
-      [ruleName]: `${rowSpacing[size] * rowHeight}px`
+      [ruleName]: px(rowSpacing[size] * rowHeight)
     };
   });
 

--- a/lib/themes/utils/sizeRulesForTokens.js
+++ b/lib/themes/utils/sizeRulesForTokens.js
@@ -1,5 +1,6 @@
 import merge from 'lodash/merge';
 import createResponsiveRules from './createResponsiveRules';
+import { px } from './toUnit';
 
 export default ({ tokens, property }) => {
   const rules = [];
@@ -12,10 +13,10 @@ export default ({ tokens, property }) => {
         tokens,
         selector: `.${typeName}Text`,
         mobileRules: {
-          [property]: `${type.mobile.rows * tokens.rowHeight}px`
+          [property]: px(type.mobile.rows * tokens.rowHeight)
         },
         desktopRules: {
-          [property]: `${type.desktop.rows * tokens.rowHeight}px`
+          [property]: px(type.desktop.rows * tokens.rowHeight)
         }
       })
     );
@@ -25,10 +26,10 @@ export default ({ tokens, property }) => {
         tokens,
         selector: `.${typeName}TextInline`,
         mobileRules: {
-          [property]: `${type.mobile.size}px`
+          [property]: px(type.mobile.size)
         },
         desktopRules: {
-          [property]: `${type.desktop.size}px`
+          [property]: px(type.desktop.size)
         }
       })
     );

--- a/lib/themes/utils/toUnit.js
+++ b/lib/themes/utils/toUnit.js
@@ -1,0 +1,2 @@
+export const px = str =>
+  str.length === 0 || /^0$|[a-z]+/.test(str) ? str : `${str}px`;

--- a/lib/themes/utils/toUnit.test.js
+++ b/lib/themes/utils/toUnit.test.js
@@ -1,0 +1,61 @@
+import { px } from './toUnit';
+
+const convertCases = [
+  {
+    input: '1',
+    output: '1px'
+  },
+  {
+    input: 1,
+    output: '1px'
+  },
+  {
+    input: '123',
+    output: '123px'
+  },
+  {
+    input: '123.23',
+    output: '123.23px'
+  }
+];
+
+const noConvertCases = [
+  {
+    input: '0',
+    output: '0'
+  },
+  {
+    input: 0,
+    output: 0
+  },
+  {
+    input: '123abc',
+    output: '123abc'
+  },
+  {
+    input: 'abc123',
+    output: 'abc123'
+  },
+  {
+    input: 'abc',
+    output: 'abc'
+  },
+  {
+    input: '',
+    output: ''
+  }
+];
+
+describe('toUnit', () => {
+  convertCases.forEach(({ input, output }) => {
+    it(`should convert \'${input}\' to \'${output}\'`, () => {
+      expect(px(input)).toEqual(output);
+    });
+  });
+
+  noConvertCases.forEach(({ input, output }) => {
+    it(`should not convert \'${input}\'`, () => {
+      expect(px(input)).toEqual(output);
+    });
+  });
+});

--- a/lib/themes/wireframe/atoms/border/borderWidth.css.js
+++ b/lib/themes/wireframe/atoms/border/borderWidth.css.js
@@ -1,10 +1,11 @@
 import tokens from '../../tokens/tokens';
+import { px } from '../../../utils/toUnit';
 
 const css = {};
 Object.keys(tokens.borderWidth).forEach(borderWidth => {
   css[`.${borderWidth}`] = {
     borderStyle: 'solid',
-    borderWidth: `${tokens.borderWidth[borderWidth]}px`
+    borderWidth: px(tokens.borderWidth[borderWidth])
   };
 });
 


### PR DESCRIPTION
Adding a `toUnit` until and implementing `px`. Consolidates all the unit concatenation template strings, allowing the code to focus on the calculation.