### PR TITLE
chore(deps): Pin Playroom to exact versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "husky": "^1.1.3",
     "lint-staged": "^8.0.4",
     "lodash": "^4.17.11",
-    "playroom": "^0.5.0",
+    "playroom": "0.5.1",
     "postcss-js": "^2.0.0",
     "postcss-loader": "^3.0.0",
     "react": "^16.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10794,7 +10794,7 @@ pkginfo@0.x.x:
   resolved "https://registry.yarnpkg.com/pkginfo/-/pkginfo-0.4.1.tgz#b5418ef0439de5425fc4995042dced14fb2a84ff"
   integrity sha1-tUGO8EOd5UJfxJlQQtztFPsqhP8=
 
-playroom@^0.5.0:
+playroom@0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/playroom/-/playroom-0.5.1.tgz#c90eb2f85479c986f09f05a7e015e536b3da295b"
   integrity sha512-YSqayiYX/aoTXEgtmDMU/tqOd3ojgyS9xCS50BbFMi+g13B0hrMWGQ2THCLKtEqrA8+VmuPcd1xV78jiAvtmkw==


### PR DESCRIPTION
This should (hopefully) make sure that Renovate sends us PRs for minor updates too.