### PR TITLE
fix(Text): Align JobStreet large text with other themes

### DIFF
--- a/lib/components/private/examplesForIcon.js
+++ b/lib/components/private/examplesForIcon.js
@@ -28,7 +28,7 @@ export default Icon => {
         <div style={{ display: 'flex', alignItems: 'center' }}>
           <Icon size="large" marginRight="xsmall" />
           <Text size="large" baseline={false}>
-            Standard text
+            Large text
           </Text>
         </div>
       )

--- a/lib/themes/jobStreet/tokens/tokens.ts
+++ b/lib/themes/jobStreet/tokens/tokens.ts
@@ -19,12 +19,12 @@ const tokens: Tokens = {
     },
     large: {
       mobile: {
-        size: 18,
+        size: 16,
         rows: 6
       },
       desktop: {
-        size: 20,
-        rows: 7
+        size: 16,
+        rows: 6
       }
     }
   },

--- a/lib/themes/utils/__snapshots__/fontSizeRulesForTokens.test.js.snap
+++ b/lib/themes/utils/__snapshots__/fontSizeRulesForTokens.test.js.snap
@@ -9,18 +9,12 @@ Object {
     "paddingTop": "12px",
   },
   ".large": Object {
-    "fontSize": "18px",
+    "fontSize": "16px",
     "lineHeight": "24px",
   },
   ".standard": Object {
     "fontSize": "14px",
     "lineHeight": "20px",
-  },
-  "@media screen and (min-width: 768px)": Object {
-    ".large": Object {
-      "fontSize": "20px",
-      "lineHeight": "28px",
-    },
   },
 }
 `;

--- a/lib/themes/utils/__snapshots__/sizeRulesForTokens.test.js.snap
+++ b/lib/themes/utils/__snapshots__/sizeRulesForTokens.test.js.snap
@@ -6,21 +6,13 @@ Object {
     "width": "24px",
   },
   ".largeTextInline": Object {
-    "width": "18px",
+    "width": "16px",
   },
   ".standardText": Object {
     "width": "20px",
   },
   ".standardTextInline": Object {
     "width": "14px",
-  },
-  "@media screen and (min-width: 768px)": Object {
-    ".largeText": Object {
-      "width": "28px",
-    },
-    ".largeTextInline": Object {
-      "width": "20px",
-    },
   },
 }
 `;

--- a/lib/themes/utils/__snapshots__/transformForTokens.test.js.snap
+++ b/lib/themes/utils/__snapshots__/transformForTokens.test.js.snap
@@ -3,15 +3,10 @@
 exports[`transformForTokens Theme: jobStreet Rules 1`] = `
 Object {
   ".largeText": Object {
-    "transform": "translateY(0.29666666666666663em)",
+    "transform": "translateY(0.38em)",
   },
   ".standardText": Object {
     "transform": "translateY(0.3442857142857143em)",
-  },
-  "@media screen and (min-width: 768px)": Object {
-    ".largeText": Object {
-      "transform": "translateY(0.32999999999999996em)",
-    },
   },
 }
 `;


### PR DESCRIPTION
The contrast between `large` and `standard` text is much stronger in the `jobStreet` theme compared to the others. We'll need to investigate a bit more to understand where this discrepancy is coming from, but for now we're reverting back to the previous values.

### Before

<img width="1114" alt="screen shot 2018-12-07 at 11 47 00 am" src="https://user-images.githubusercontent.com/696693/49620653-01ba2100-fa16-11e8-99fc-de0349c4a05d.png">


### After

<img width="1111" alt="screen shot 2018-12-07 at 11 47 12 am" src="https://user-images.githubusercontent.com/696693/49620657-0383e480-fa16-11e8-9b19-54a76ecfee6e.png">

