### PR TITLE
fix: Add ‘themes’ directory to package ‘sideEffects’ list

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "version": "0.0.1",
   "description": "Themeable design system for the SEEK Group",
   "main": "lib/components/index.js",
-  "sideEffects": false,
+  "sideEffects": [
+    "lib/themes/**/*"
+  ],
   "scripts": {
     "check": "yarn check --integrity && echo 'Ignore paths from lint-staged'",
     "pretest": "sku configure",


### PR DESCRIPTION
In production mode, the CSS can end up in the wrong order due to tree shaking. Normally this isn't a problem, but the order of imports is actually important within the theme directories because we need to ensure that the CSS reset is imported first. Without this, the CSS reset can actually be moved below other rules in the resulting CSS file.