### PR TITLE
fix(ChecklistCard): Show error border on entire row

### DIFF
--- a/lib/components/Checkbox/Checkbox.tsx
+++ b/lib/components/Checkbox/Checkbox.tsx
@@ -90,12 +90,16 @@ export default class Checkbox extends Component<CheckboxProps, State> {
           const checkboxSize = getCheckboxRadioSize(theme);
 
           return (
-            <div
-              className={classnames(className, {
-                [theme.atoms.paddingBottom.xsmall]: inChecklistCard,
-                [theme.atoms.backgroundColor.selection]:
-                  inChecklistCard && (checked || hovered) && !disabled
-              })}
+            <Box
+              {...(inChecklistCard && tone === 'critical'
+                ? { borderWidth: 'standard', borderColor: 'critical' }
+                : {})}
+              backgroundColor={
+                inChecklistCard && (checked || hovered) && !disabled
+                  ? 'selection'
+                  : undefined
+              }
+              paddingBottom={inChecklistCard ? 'xsmall' : undefined}
               style={style}
             >
               <input
@@ -194,19 +198,21 @@ export default class Checkbox extends Component<CheckboxProps, State> {
                         theme.atoms.transition.fast
                       )}
                     />
-                    <Box
-                      borderColor="critical"
-                      borderWidth="standard"
-                      style={{
-                        opacity: tone === 'critical' ? 1 : 0
-                      }}
-                      className={classnames(
-                        styles.checkbox,
-                        styles.checkboxCritical,
-                        theme.atoms.borderRadius.standard,
-                        theme.atoms.transition.fast
-                      )}
-                    />
+                    {!inChecklistCard ? (
+                      <Box
+                        borderColor="critical"
+                        borderWidth="standard"
+                        style={{
+                          opacity: tone === 'critical' ? 1 : 0
+                        }}
+                        className={classnames(
+                          styles.checkbox,
+                          styles.checkboxCritical,
+                          theme.atoms.borderRadius.standard,
+                          theme.atoms.transition.fast
+                        )}
+                      />
+                    ) : null}
                     <TickIcon
                       size="fill"
                       className={classnames(
@@ -253,7 +259,7 @@ export default class Checkbox extends Component<CheckboxProps, State> {
                   />
                 </Box>
               ) : null}
-            </div>
+            </Box>
           );
         }}
       </ThemeConsumer>

--- a/lib/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
+++ b/lib/components/Checkbox/__snapshots__/Checkbox.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Checkbox Theme: jobStreet Checked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -83,7 +83,7 @@ exports[`Checkbox Theme: jobStreet Checked 1`] = `
 
 exports[`Checkbox Theme: jobStreet Children when checked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -174,7 +174,7 @@ exports[`Checkbox Theme: jobStreet Children when checked 1`] = `
 
 exports[`Checkbox Theme: jobStreet Children when unchecked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -264,7 +264,7 @@ exports[`Checkbox Theme: jobStreet Children when unchecked 1`] = `
 
 exports[`Checkbox Theme: jobStreet Unchecked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -344,7 +344,7 @@ exports[`Checkbox Theme: jobStreet Unchecked 1`] = `
 
 exports[`Checkbox Theme: jobStreet With message 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -447,7 +447,7 @@ exports[`Checkbox Theme: jobStreet With message 1`] = `
 
 exports[`Checkbox Theme: seekAnz Checked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -528,7 +528,7 @@ exports[`Checkbox Theme: seekAnz Checked 1`] = `
 
 exports[`Checkbox Theme: seekAnz Children when checked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -619,7 +619,7 @@ exports[`Checkbox Theme: seekAnz Children when checked 1`] = `
 
 exports[`Checkbox Theme: seekAnz Children when unchecked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -709,7 +709,7 @@ exports[`Checkbox Theme: seekAnz Children when unchecked 1`] = `
 
 exports[`Checkbox Theme: seekAnz Unchecked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -789,7 +789,7 @@ exports[`Checkbox Theme: seekAnz Unchecked 1`] = `
 
 exports[`Checkbox Theme: seekAnz With message 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -892,7 +892,7 @@ exports[`Checkbox Theme: seekAnz With message 1`] = `
 
 exports[`Checkbox Theme: seekAsia Checked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -973,7 +973,7 @@ exports[`Checkbox Theme: seekAsia Checked 1`] = `
 
 exports[`Checkbox Theme: seekAsia Children when checked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -1064,7 +1064,7 @@ exports[`Checkbox Theme: seekAsia Children when checked 1`] = `
 
 exports[`Checkbox Theme: seekAsia Children when unchecked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -1154,7 +1154,7 @@ exports[`Checkbox Theme: seekAsia Children when unchecked 1`] = `
 
 exports[`Checkbox Theme: seekAsia Unchecked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -1234,7 +1234,7 @@ exports[`Checkbox Theme: seekAsia Unchecked 1`] = `
 
 exports[`Checkbox Theme: seekAsia With message 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -1337,7 +1337,7 @@ exports[`Checkbox Theme: seekAsia With message 1`] = `
 
 exports[`Checkbox Theme: wireframe Checked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -1418,7 +1418,7 @@ exports[`Checkbox Theme: wireframe Checked 1`] = `
 
 exports[`Checkbox Theme: wireframe Children when checked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -1509,7 +1509,7 @@ exports[`Checkbox Theme: wireframe Children when checked 1`] = `
 
 exports[`Checkbox Theme: wireframe Children when unchecked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -1599,7 +1599,7 @@ exports[`Checkbox Theme: wireframe Children when unchecked 1`] = `
 
 exports[`Checkbox Theme: wireframe Unchecked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -1679,7 +1679,7 @@ exports[`Checkbox Theme: wireframe Unchecked 1`] = `
 
 exports[`Checkbox Theme: wireframe With message 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"

--- a/lib/components/ChecklistCard/ChecklistCard.docs.tsx
+++ b/lib/components/ChecklistCard/ChecklistCard.docs.tsx
@@ -69,6 +69,61 @@ const docs: ComponentDocs = {
           </Checkbox>
         </ChecklistCard>
       )
+    },
+    {
+      label: 'Nested Checklist Card With Critical Messages',
+      render: ({ id }) => (
+        <ChecklistCard>
+          <Checkbox
+            id={`${id}_1`}
+            label="This is a checkbox"
+            checked={false}
+            tone="critical"
+            message="This is a critical message"
+            onChange={handleChange}
+          >
+            <Text>This text is visible when the checkbox is checked.</Text>
+          </Checkbox>
+          <Checkbox
+            id={`${id}_2`}
+            label="This is a checkbox"
+            checked={true}
+            tone="critical"
+            message="This is a critical message"
+            onChange={handleChange}
+          >
+            <Text>This text is visible when the checkbox is checked.</Text>
+          </Checkbox>
+          <Checkbox
+            id={`${id}_3`}
+            label="This is a checkbox"
+            checked={false}
+            tone="critical"
+            message="This is a critical message"
+            onChange={handleChange}
+          >
+            <Text>This text is visible when the checkbox is checked.</Text>
+          </Checkbox>
+          <Checkbox
+            id={`${id}_4`}
+            label="This is a checkbox"
+            checked={true}
+            message={false}
+            onChange={handleChange}
+          >
+            <Text>This text is visible when the checkbox is checked.</Text>
+          </Checkbox>
+          <Checkbox
+            id={`${id}_5`}
+            label="This is a checkbox"
+            checked={false}
+            message={false}
+            onChange={handleChange}
+          >
+            <Text>This text is visible when the checkbox is checked.</Text>
+          </Checkbox>
+        </ChecklistCard>
+      )
     }
   ]
 };

--- a/lib/components/ChecklistCard/__snapshots__/ChecklistCard.test.tsx.snap
+++ b/lib/components/ChecklistCard/__snapshots__/ChecklistCard.test.tsx.snap
@@ -5,7 +5,7 @@ exports[`ChecklistCard Theme: jobStreet Default 1`] = `
   class="Box__root backgroundColor__card borderColor__standard marginBottom__medium"
 >
   <div
-    class="paddingBottom__xsmall"
+    class="Box__root borderColor__standard paddingBottom__xsmall"
   >
     <input
       aria-describedby="1-message"
@@ -39,10 +39,6 @@ exports[`ChecklistCard Theme: jobStreet Default 1`] = `
           />
           <div
             class="Checkbox__checkbox Checkbox__checkboxDisabled borderRadius__standard transition__fast Box__root backgroundColor__inputDisabled borderColor__standard borderWidth__standard"
-          />
-          <div
-            class="Checkbox__checkbox Checkbox__checkboxCritical borderRadius__standard transition__fast Box__root borderColor__critical borderWidth__standard"
-            style="opacity: 0;"
           />
           <svg
             class="Checkbox__checkboxIcon fill__white transition__fast Icon__fillSize Box__root borderColor__standard"
@@ -89,7 +85,7 @@ exports[`ChecklistCard Theme: jobStreet Default 1`] = `
     />
   </div>
   <div
-    class="paddingBottom__xsmall"
+    class="Box__root borderColor__standard paddingBottom__xsmall"
   >
     <input
       aria-describedby="2-message"
@@ -123,10 +119,6 @@ exports[`ChecklistCard Theme: jobStreet Default 1`] = `
           />
           <div
             class="Checkbox__checkbox Checkbox__checkboxDisabled borderRadius__standard transition__fast Box__root backgroundColor__inputDisabled borderColor__standard borderWidth__standard"
-          />
-          <div
-            class="Checkbox__checkbox Checkbox__checkboxCritical borderRadius__standard transition__fast Box__root borderColor__critical borderWidth__standard"
-            style="opacity: 0;"
           />
           <svg
             class="Checkbox__checkboxIcon fill__white transition__fast Icon__fillSize Box__root borderColor__standard"
@@ -173,7 +165,7 @@ exports[`ChecklistCard Theme: jobStreet Default 1`] = `
     />
   </div>
   <div
-    class="paddingBottom__xsmall"
+    class="Box__root borderColor__standard paddingBottom__xsmall"
   >
     <input
       aria-describedby="3-message"
@@ -207,10 +199,6 @@ exports[`ChecklistCard Theme: jobStreet Default 1`] = `
           />
           <div
             class="Checkbox__checkbox Checkbox__checkboxDisabled borderRadius__standard transition__fast Box__root backgroundColor__inputDisabled borderColor__standard borderWidth__standard"
-          />
-          <div
-            class="Checkbox__checkbox Checkbox__checkboxCritical borderRadius__standard transition__fast Box__root borderColor__critical borderWidth__standard"
-            style="opacity: 0;"
           />
           <svg
             class="Checkbox__checkboxIcon fill__white transition__fast Icon__fillSize Box__root borderColor__standard"
@@ -257,7 +245,7 @@ exports[`ChecklistCard Theme: seekAnz Default 1`] = `
   class="Box__root backgroundColor__card borderColor__standard marginBottom__medium"
 >
   <div
-    class="paddingBottom__xsmall"
+    class="Box__root borderColor__standard paddingBottom__xsmall"
   >
     <input
       aria-describedby="1-message"
@@ -291,10 +279,6 @@ exports[`ChecklistCard Theme: seekAnz Default 1`] = `
           />
           <div
             class="Checkbox__checkbox Checkbox__checkboxDisabled borderRadius__standard transition__fast Box__root backgroundColor__inputDisabled borderColor__standard borderWidth__standard"
-          />
-          <div
-            class="Checkbox__checkbox Checkbox__checkboxCritical borderRadius__standard transition__fast Box__root borderColor__critical borderWidth__standard"
-            style="opacity: 0;"
           />
           <svg
             class="Checkbox__checkboxIcon fill__white transition__fast Icon__fillSize Box__root borderColor__standard"
@@ -341,7 +325,7 @@ exports[`ChecklistCard Theme: seekAnz Default 1`] = `
     />
   </div>
   <div
-    class="paddingBottom__xsmall"
+    class="Box__root borderColor__standard paddingBottom__xsmall"
   >
     <input
       aria-describedby="2-message"
@@ -375,10 +359,6 @@ exports[`ChecklistCard Theme: seekAnz Default 1`] = `
           />
           <div
             class="Checkbox__checkbox Checkbox__checkboxDisabled borderRadius__standard transition__fast Box__root backgroundColor__inputDisabled borderColor__standard borderWidth__standard"
-          />
-          <div
-            class="Checkbox__checkbox Checkbox__checkboxCritical borderRadius__standard transition__fast Box__root borderColor__critical borderWidth__standard"
-            style="opacity: 0;"
           />
           <svg
             class="Checkbox__checkboxIcon fill__white transition__fast Icon__fillSize Box__root borderColor__standard"
@@ -425,7 +405,7 @@ exports[`ChecklistCard Theme: seekAnz Default 1`] = `
     />
   </div>
   <div
-    class="paddingBottom__xsmall"
+    class="Box__root borderColor__standard paddingBottom__xsmall"
   >
     <input
       aria-describedby="3-message"
@@ -459,10 +439,6 @@ exports[`ChecklistCard Theme: seekAnz Default 1`] = `
           />
           <div
             class="Checkbox__checkbox Checkbox__checkboxDisabled borderRadius__standard transition__fast Box__root backgroundColor__inputDisabled borderColor__standard borderWidth__standard"
-          />
-          <div
-            class="Checkbox__checkbox Checkbox__checkboxCritical borderRadius__standard transition__fast Box__root borderColor__critical borderWidth__standard"
-            style="opacity: 0;"
           />
           <svg
             class="Checkbox__checkboxIcon fill__white transition__fast Icon__fillSize Box__root borderColor__standard"
@@ -509,7 +485,7 @@ exports[`ChecklistCard Theme: seekAsia Default 1`] = `
   class="Box__root backgroundColor__card borderColor__standard marginBottom__medium"
 >
   <div
-    class="paddingBottom__xsmall"
+    class="Box__root borderColor__standard paddingBottom__xsmall"
   >
     <input
       aria-describedby="1-message"
@@ -543,10 +519,6 @@ exports[`ChecklistCard Theme: seekAsia Default 1`] = `
           />
           <div
             class="Checkbox__checkbox Checkbox__checkboxDisabled borderRadius__standard transition__fast Box__root backgroundColor__inputDisabled borderColor__standard borderWidth__standard"
-          />
-          <div
-            class="Checkbox__checkbox Checkbox__checkboxCritical borderRadius__standard transition__fast Box__root borderColor__critical borderWidth__standard"
-            style="opacity: 0;"
           />
           <svg
             class="Checkbox__checkboxIcon fill__white transition__fast Icon__fillSize Box__root borderColor__standard"
@@ -593,7 +565,7 @@ exports[`ChecklistCard Theme: seekAsia Default 1`] = `
     />
   </div>
   <div
-    class="paddingBottom__xsmall"
+    class="Box__root borderColor__standard paddingBottom__xsmall"
   >
     <input
       aria-describedby="2-message"
@@ -627,10 +599,6 @@ exports[`ChecklistCard Theme: seekAsia Default 1`] = `
           />
           <div
             class="Checkbox__checkbox Checkbox__checkboxDisabled borderRadius__standard transition__fast Box__root backgroundColor__inputDisabled borderColor__standard borderWidth__standard"
-          />
-          <div
-            class="Checkbox__checkbox Checkbox__checkboxCritical borderRadius__standard transition__fast Box__root borderColor__critical borderWidth__standard"
-            style="opacity: 0;"
           />
           <svg
             class="Checkbox__checkboxIcon fill__white transition__fast Icon__fillSize Box__root borderColor__standard"
@@ -677,7 +645,7 @@ exports[`ChecklistCard Theme: seekAsia Default 1`] = `
     />
   </div>
   <div
-    class="paddingBottom__xsmall"
+    class="Box__root borderColor__standard paddingBottom__xsmall"
   >
     <input
       aria-describedby="3-message"
@@ -711,10 +679,6 @@ exports[`ChecklistCard Theme: seekAsia Default 1`] = `
           />
           <div
             class="Checkbox__checkbox Checkbox__checkboxDisabled borderRadius__standard transition__fast Box__root backgroundColor__inputDisabled borderColor__standard borderWidth__standard"
-          />
-          <div
-            class="Checkbox__checkbox Checkbox__checkboxCritical borderRadius__standard transition__fast Box__root borderColor__critical borderWidth__standard"
-            style="opacity: 0;"
           />
           <svg
             class="Checkbox__checkboxIcon fill__white transition__fast Icon__fillSize Box__root borderColor__standard"
@@ -761,7 +725,7 @@ exports[`ChecklistCard Theme: wireframe Default 1`] = `
   class="Box__root backgroundColor__card borderColor__standard marginBottom__medium"
 >
   <div
-    class="paddingBottom__xsmall"
+    class="Box__root borderColor__standard paddingBottom__xsmall"
   >
     <input
       aria-describedby="1-message"
@@ -795,10 +759,6 @@ exports[`ChecklistCard Theme: wireframe Default 1`] = `
           />
           <div
             class="Checkbox__checkbox Checkbox__checkboxDisabled borderRadius__standard transition__fast Box__root backgroundColor__inputDisabled borderColor__standard borderWidth__standard"
-          />
-          <div
-            class="Checkbox__checkbox Checkbox__checkboxCritical borderRadius__standard transition__fast Box__root borderColor__critical borderWidth__standard"
-            style="opacity: 0;"
           />
           <svg
             class="Checkbox__checkboxIcon fill__white transition__fast Icon__fillSize Box__root borderColor__standard"
@@ -845,7 +805,7 @@ exports[`ChecklistCard Theme: wireframe Default 1`] = `
     />
   </div>
   <div
-    class="paddingBottom__xsmall"
+    class="Box__root borderColor__standard paddingBottom__xsmall"
   >
     <input
       aria-describedby="2-message"
@@ -879,10 +839,6 @@ exports[`ChecklistCard Theme: wireframe Default 1`] = `
           />
           <div
             class="Checkbox__checkbox Checkbox__checkboxDisabled borderRadius__standard transition__fast Box__root backgroundColor__inputDisabled borderColor__standard borderWidth__standard"
-          />
-          <div
-            class="Checkbox__checkbox Checkbox__checkboxCritical borderRadius__standard transition__fast Box__root borderColor__critical borderWidth__standard"
-            style="opacity: 0;"
           />
           <svg
             class="Checkbox__checkboxIcon fill__white transition__fast Icon__fillSize Box__root borderColor__standard"
@@ -929,7 +885,7 @@ exports[`ChecklistCard Theme: wireframe Default 1`] = `
     />
   </div>
   <div
-    class="paddingBottom__xsmall"
+    class="Box__root borderColor__standard paddingBottom__xsmall"
   >
     <input
       aria-describedby="3-message"
@@ -963,10 +919,6 @@ exports[`ChecklistCard Theme: wireframe Default 1`] = `
           />
           <div
             class="Checkbox__checkbox Checkbox__checkboxDisabled borderRadius__standard transition__fast Box__root backgroundColor__inputDisabled borderColor__standard borderWidth__standard"
-          />
-          <div
-            class="Checkbox__checkbox Checkbox__checkboxCritical borderRadius__standard transition__fast Box__root borderColor__critical borderWidth__standard"
-            style="opacity: 0;"
           />
           <svg
             class="Checkbox__checkboxIcon fill__white transition__fast Icon__fillSize Box__root borderColor__standard"

--- a/lib/components/Radio/Radio.tsx
+++ b/lib/components/Radio/Radio.tsx
@@ -90,12 +90,16 @@ export default class Radio extends Component<RadioProps, State> {
           const radioSize = getCheckboxRadioSize(theme);
 
           return (
-            <div
-              className={classnames(className, {
-                [theme.atoms.paddingBottom.xsmall]: inChecklistCard,
-                [theme.atoms.backgroundColor.selection]:
-                  inChecklistCard && (checked || hovered) && !disabled
-              })}
+            <Box
+              {...(inChecklistCard && tone === 'critical'
+                ? { borderWidth: 'standard', borderColor: 'critical' }
+                : {})}
+              backgroundColor={
+                inChecklistCard && (checked || hovered) && !disabled
+                  ? 'selection'
+                  : undefined
+              }
+              paddingBottom={inChecklistCard ? 'xsmall' : undefined}
               style={style}
             >
               <input
@@ -175,16 +179,18 @@ export default class Radio extends Component<RadioProps, State> {
                         theme.atoms.transition.fast
                       )}
                     />
-                    <Box
-                      borderColor="critical"
-                      borderWidth="standard"
-                      style={{ opacity: tone === 'critical' ? 1 : 0 }}
-                      className={classnames(
-                        styles.radio,
-                        styles.radioCritical,
-                        theme.atoms.transition.fast
-                      )}
-                    />
+                    {!inChecklistCard ? (
+                      <Box
+                        borderColor="critical"
+                        borderWidth="standard"
+                        style={{ opacity: tone === 'critical' ? 1 : 0 }}
+                        className={classnames(
+                          styles.radio,
+                          styles.radioCritical,
+                          theme.atoms.transition.fast
+                        )}
+                      />
+                    ) : null}
                     <Box
                       backgroundColor={
                         disabled ? 'formAccentDisabled' : 'formAccent'
@@ -231,7 +237,7 @@ export default class Radio extends Component<RadioProps, State> {
                   />
                 </Box>
               ) : null}
-            </div>
+            </Box>
           );
         }}
       </ThemeConsumer>

--- a/lib/components/Radio/__snapshots__/Radio.test.tsx.snap
+++ b/lib/components/Radio/__snapshots__/Radio.test.tsx.snap
@@ -2,7 +2,7 @@
 
 exports[`Radio Theme: jobStreet Checked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -74,7 +74,7 @@ exports[`Radio Theme: jobStreet Checked 1`] = `
 
 exports[`Radio Theme: jobStreet Children when checked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -156,7 +156,7 @@ exports[`Radio Theme: jobStreet Children when checked 1`] = `
 
 exports[`Radio Theme: jobStreet Children when unchecked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -237,7 +237,7 @@ exports[`Radio Theme: jobStreet Children when unchecked 1`] = `
 
 exports[`Radio Theme: jobStreet Unchecked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -308,7 +308,7 @@ exports[`Radio Theme: jobStreet Unchecked 1`] = `
 
 exports[`Radio Theme: jobStreet With message 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -402,7 +402,7 @@ exports[`Radio Theme: jobStreet With message 1`] = `
 
 exports[`Radio Theme: seekAnz Checked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -474,7 +474,7 @@ exports[`Radio Theme: seekAnz Checked 1`] = `
 
 exports[`Radio Theme: seekAnz Children when checked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -556,7 +556,7 @@ exports[`Radio Theme: seekAnz Children when checked 1`] = `
 
 exports[`Radio Theme: seekAnz Children when unchecked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -637,7 +637,7 @@ exports[`Radio Theme: seekAnz Children when unchecked 1`] = `
 
 exports[`Radio Theme: seekAnz Unchecked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -708,7 +708,7 @@ exports[`Radio Theme: seekAnz Unchecked 1`] = `
 
 exports[`Radio Theme: seekAnz With message 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -802,7 +802,7 @@ exports[`Radio Theme: seekAnz With message 1`] = `
 
 exports[`Radio Theme: seekAsia Checked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -874,7 +874,7 @@ exports[`Radio Theme: seekAsia Checked 1`] = `
 
 exports[`Radio Theme: seekAsia Children when checked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -956,7 +956,7 @@ exports[`Radio Theme: seekAsia Children when checked 1`] = `
 
 exports[`Radio Theme: seekAsia Children when unchecked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -1037,7 +1037,7 @@ exports[`Radio Theme: seekAsia Children when unchecked 1`] = `
 
 exports[`Radio Theme: seekAsia Unchecked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -1108,7 +1108,7 @@ exports[`Radio Theme: seekAsia Unchecked 1`] = `
 
 exports[`Radio Theme: seekAsia With message 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -1202,7 +1202,7 @@ exports[`Radio Theme: seekAsia With message 1`] = `
 
 exports[`Radio Theme: wireframe Checked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -1274,7 +1274,7 @@ exports[`Radio Theme: wireframe Checked 1`] = `
 
 exports[`Radio Theme: wireframe Children when checked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -1356,7 +1356,7 @@ exports[`Radio Theme: wireframe Children when checked 1`] = `
 
 exports[`Radio Theme: wireframe Children when unchecked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -1437,7 +1437,7 @@ exports[`Radio Theme: wireframe Children when unchecked 1`] = `
 
 exports[`Radio Theme: wireframe Unchecked 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"
@@ -1508,7 +1508,7 @@ exports[`Radio Theme: wireframe Unchecked 1`] = `
 
 exports[`Radio Theme: wireframe With message 1`] = `
 <div
-  class=""
+  class="Box__root borderColor__standard"
 >
   <input
     aria-describedby="id-message"


### PR DESCRIPTION
This is to fix an issue where the error border wasn't very visible against the background colour when a checkbox is checked:

<img width="132" alt="screen shot 2019-02-08 at 11 39 24 am" src="https://user-images.githubusercontent.com/696693/52452201-38d3bc80-2b96-11e9-9f5b-0d603c8ee11f.png">

Instead, we now show the error border around the entire row:

<img width="591" alt="screen shot 2019-02-08 at 11 40 25 am" src="https://user-images.githubusercontent.com/696693/52452250-691b5b00-2b96-11e9-9694-833f1b17e6c2.png">
