### PR TITLE
fix(ChecklistCard): Ensure divider doesn’t cover error border

### DIFF
--- a/lib/components/ChecklistCard/ChecklistCard.docs.tsx
+++ b/lib/components/ChecklistCard/ChecklistCard.docs.tsx
@@ -78,24 +78,13 @@ const docs: ComponentDocs = {
             id={`${id}_1`}
             label="This is a checkbox"
             checked={false}
-            tone="critical"
-            message="This is a critical message"
+            message={false}
             onChange={handleChange}
           >
             <Text>This text is visible when the checkbox is checked.</Text>
           </Checkbox>
           <Checkbox
             id={`${id}_2`}
-            label="This is a checkbox"
-            checked={true}
-            tone="critical"
-            message="This is a critical message"
-            onChange={handleChange}
-          >
-            <Text>This text is visible when the checkbox is checked.</Text>
-          </Checkbox>
-          <Checkbox
-            id={`${id}_3`}
             label="This is a checkbox"
             checked={false}
             tone="critical"
@@ -105,16 +94,17 @@ const docs: ComponentDocs = {
             <Text>This text is visible when the checkbox is checked.</Text>
           </Checkbox>
           <Checkbox
-            id={`${id}_4`}
+            id={`${id}_3`}
             label="This is a checkbox"
             checked={true}
-            message={false}
+            tone="critical"
+            message="This is a critical message"
             onChange={handleChange}
           >
             <Text>This text is visible when the checkbox is checked.</Text>
           </Checkbox>
           <Checkbox
-            id={`${id}_5`}
+            id={`${id}_4`}
             label="This is a checkbox"
             checked={false}
             message={false}

--- a/lib/components/ChecklistCard/ChecklistCard.tsx
+++ b/lib/components/ChecklistCard/ChecklistCard.tsx
@@ -19,14 +19,24 @@ export default class ChecklistCard extends Component<ChecklistCardProps> {
     const { children, ...restProps } = this.props;
     return (
       <Card {...restProps}>
-        {React.Children.map(children, (child, i) => (
-          <Fragment>
-            {i > 0 && <Divider />}
-            {React.cloneElement(child as ReactElement<CheckboxProps>, {
-              variant: 'inChecklistCard'
-            })}
-          </Fragment>
-        ))}
+        {React.Children.map(children, (child, i) => {
+          if (typeof child !== 'object') {
+            return null;
+          }
+
+          const checkboxChild = child as ReactElement<CheckboxProps>;
+
+          return (
+            <Fragment>
+              {i > 0 && checkboxChild.props.tone !== 'critical' ? (
+                <Divider />
+              ) : null}
+              {React.cloneElement(child, {
+                variant: 'inChecklistCard'
+              })}
+            </Fragment>
+          );
+        })}
       </Card>
     );
   }


### PR DESCRIPTION
## Before:

<img width="252" alt="screen shot 2019-02-13 at 11 50 16 am" src="https://user-images.githubusercontent.com/696693/52678399-a6f8f480-2f85-11e9-9bff-b1113ec01db2.png">

### After:

<img width="245" alt="screen shot 2019-02-13 at 11 50 30 am" src="https://user-images.githubusercontent.com/696693/52678409-aceed580-2f85-11e9-891c-c2d1acbd4a96.png">

Note: This introduces a double border between checkboxes when multiple error states are stacked, but this is being treated as the lesser of two evils for now.