### PR TITLE
fix(Checkbox): Fix tick rendering issue in IE11

### DIFF
--- a/lib/components/Checkbox/Checkbox.css.js
+++ b/lib/components/Checkbox/Checkbox.css.js
@@ -59,6 +59,9 @@ export default {
     transform: 'scale(0.7)',
     position: 'relative',
     zIndex: 5,
+    // IE11:
+    width: '100%',
+    height: '100%',
   },
   '.realCheckbox:checked ~ .content > * > * > .checkboxIcon': {
     transform: 'none',


### PR DESCRIPTION
Before:

<img width="201" alt="screen shot 2019-03-08 at 11 14 48 am" src="https://user-images.githubusercontent.com/696693/53998384-9823ed00-4193-11e9-9a60-5258c21498ce.png">

After:

<img width="204" alt="screen shot 2019-03-08 at 11 15 39 am" src="https://user-images.githubusercontent.com/696693/53998375-8fcbb200-4193-11e9-8b31-673def9f50e7.png">
