### PR TITLE
docs: Fix console error for event handlers

### DIFF
--- a/docs/src/App/ComponentRoute/ComponentRoute.tsx
+++ b/docs/src/App/ComponentRoute/ComponentRoute.tsx
@@ -14,7 +14,7 @@ import { ComponentDocs } from '../../types';
 
 const themes = [wireframe, jobStreet, seekAsia, seekAnz];
 const handler = () => {
-  /* No-op for docs examples  */
+  /* No-op for docs examples */
 };
 
 const cleanCodeSnippet = (code: string) =>
@@ -93,7 +93,7 @@ export default class ComponentRoute extends Component<ComponentRouteProps> {
               <Text component="pre" color="white">
                 {render && !code
                   ? cleanCodeSnippet(
-                      reactElementToJSXString(render({ id: 'id' }), {
+                      reactElementToJSXString(render({ id: 'id', handler }), {
                         useBooleanShorthandSyntax: false,
                         showDefaultProps: false,
                         showFunctions: true,

--- a/docs/src/App/ComponentRoute/ComponentRoute.tsx
+++ b/docs/src/App/ComponentRoute/ComponentRoute.tsx
@@ -13,6 +13,9 @@ import {
 import { ComponentDocs } from '../../types';
 
 const themes = [wireframe, jobStreet, seekAsia, seekAnz];
+const handler = () => {
+  /* No-op for docs examples  */
+};
 
 const cleanCodeSnippet = (code: string) =>
   code.replace(/<HideCode>.*?<\/HideCode>/gs, '...');
@@ -65,7 +68,10 @@ export default class ComponentRoute extends Component<ComponentRouteProps> {
                       <Text color="secondary">Theme: {theme.name}</Text>
                     </Box>
                     <ThemeProvider theme={theme}>
-                      {render({ id: `${index}_${theme.name}` })}
+                      {render({
+                        id: `${index}_${theme.name}`,
+                        handler,
+                      })}
                     </ThemeProvider>
                   </Box>
                 ))

--- a/docs/src/types.d.ts
+++ b/docs/src/types.d.ts
@@ -1,4 +1,4 @@
-import { ComponentType, ReactNode } from 'react';
+import { ComponentType, ReactNode, SyntheticEvent } from 'react';
 
 export interface RenderConfig {
   routerBasename: string;
@@ -12,6 +12,9 @@ export interface ComponentDocs {
 
 export interface ComponentExample {
   label?: string;
-  render?: (args: { id: string; handler?: function }) => ReactNode;
+  render?: (args: {
+    id: string;
+    handler: (event: SyntheticEvent) => void;
+  }) => ReactNode;
   code?: string;
 }

--- a/docs/src/types.d.ts
+++ b/docs/src/types.d.ts
@@ -12,9 +12,11 @@ export interface ComponentDocs {
 
 export interface ComponentExample {
   label?: string;
-  render?: (args: {
-    id: string;
-    handler: (event: SyntheticEvent) => void;
-  }) => ReactNode;
+  render?: (
+    args: {
+      id: string;
+      handler: (event: SyntheticEvent) => void;
+    },
+  ) => ReactNode;
   code?: string;
 }

--- a/docs/src/types.d.ts
+++ b/docs/src/types.d.ts
@@ -12,6 +12,6 @@ export interface ComponentDocs {
 
 export interface ComponentExample {
   label?: string;
-  render?: (args: { id: string }) => ReactNode;
+  render?: (args: { id: string; handler?: function }) => ReactNode;
   code?: string;
 }

--- a/lib/components/Checkbox/Checkbox.docs.tsx
+++ b/lib/components/Checkbox/Checkbox.docs.tsx
@@ -3,28 +3,21 @@ import Checkbox from './Checkbox';
 import Text from '../Text/Text';
 import { ComponentDocs } from '../../../docs/src/types';
 
-const handleChange = () => undefined;
-
 const docs: ComponentDocs = {
   examples: [
     {
       label: 'Standard Checkbox',
-      render: ({ id }) => (
-        <Checkbox
-          id={id}
-          checked={false}
-          onChange={handleChange}
-          label="Label"
-        />
+      render: ({ id, handler }) => (
+        <Checkbox id={id} checked={false} onChange={handler} label="Label" />
       ),
     },
     {
       label: 'Checkbox without Message Placeholder',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <Checkbox
           id={id}
           checked={false}
-          onChange={handleChange}
+          onChange={handler}
           label="Label"
           message={false}
         />
@@ -32,11 +25,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Checked Checkbox',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <Checkbox
           id={id}
           checked={true}
-          onChange={handleChange}
+          onChange={handler}
           label="Label"
           message={false}
         />
@@ -44,12 +37,12 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Disabled Checkbox',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <Checkbox
           id={id}
           disabled={true}
           checked={false}
-          onChange={handleChange}
+          onChange={handler}
           label="Label"
           message={false}
         />
@@ -57,11 +50,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Critical Checkbox',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <Checkbox
           id={id}
           checked={false}
-          onChange={handleChange}
+          onChange={handler}
           label="Label"
           message="This is a critical message"
           tone="critical"
@@ -70,11 +63,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Positive Checkbox',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <Checkbox
           id={id}
           checked={false}
-          onChange={handleChange}
+          onChange={handler}
           label="Label"
           message="This is a positive message"
           tone="positive"
@@ -83,11 +76,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Nested Checkbox',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <Checkbox
           id={id}
           checked={true}
-          onChange={handleChange}
+          onChange={handler}
           label="Label"
           message={false}
         >

--- a/lib/components/Radio/Radio.docs.tsx
+++ b/lib/components/Radio/Radio.docs.tsx
@@ -3,23 +3,21 @@ import Radio from './Radio';
 import Text from '../Text/Text';
 import { ComponentDocs } from '../../../docs/src/types';
 
-const handleChange = () => undefined;
-
 const docs: ComponentDocs = {
   examples: [
     {
       label: 'Standard Radio Button',
-      render: ({ id }) => (
-        <Radio id={id} checked={false} onChange={handleChange} label="Label" />
+      render: ({ id, handler }) => (
+        <Radio id={id} checked={false} onChange={handler} label="Label" />
       ),
     },
     {
       label: 'Radio Button without Message Placeholder',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <Radio
           id={id}
           checked={false}
-          onChange={handleChange}
+          onChange={handler}
           label="Label"
           message={false}
         />
@@ -27,11 +25,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Checked Radio Button',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <Radio
           id={id}
           checked={true}
-          onChange={handleChange}
+          onChange={handler}
           label="Label"
           message={false}
         />
@@ -39,12 +37,12 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Disabled Radio Button',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <Radio
           id={id}
           disabled={true}
           checked={false}
-          onChange={handleChange}
+          onChange={handler}
           label="Label"
           message={false}
         />
@@ -52,11 +50,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Critical Radio Button',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <Radio
           id={id}
           checked={false}
-          onChange={handleChange}
+          onChange={handler}
           label="Label"
           message="This is a critical message"
           tone="critical"
@@ -65,11 +63,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Positive Radio Button',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <Radio
           id={id}
           checked={false}
-          onChange={handleChange}
+          onChange={handler}
           label="Label"
           message="This is a positive message"
           tone="positive"
@@ -78,11 +76,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Nested Radio Button',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <Radio
           id={id}
           checked={true}
-          onChange={handleChange}
+          onChange={handler}
           label="Label"
           message={false}
         >

--- a/lib/components/TextField/TextField.docs.tsx
+++ b/lib/components/TextField/TextField.docs.tsx
@@ -7,14 +7,12 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'TextField',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <div style={{ maxWidth: '300px' }}>
           <TextField
             label="Job Title"
             id={id}
-            onChange={() => {
-              /*...*/
-            }}
+            onChange={handler}
             value="Senior Developer"
           />
         </div>
@@ -22,39 +20,35 @@ const docs: ComponentDocs = {
     },
     {
       label: 'TextField with message',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <div style={{ maxWidth: '300px' }}>
           <TextField
             label="Job Title"
             id={id}
             value=""
             message="e.g. Senior Developer"
-            onChange={() => {
-              /*...*/
-            }}
+            onChange={handler}
           />
         </div>
       ),
     },
     {
       label: 'TextField with secondary label',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <div style={{ maxWidth: '300px' }}>
           <TextField
             label="Title"
             secondaryLabel="Optional"
             id={id}
             value=""
-            onChange={() => {
-              /*...*/
-            }}
+            onChange={handler}
           />
         </div>
       ),
     },
     {
       label: 'TextField with tertiary label',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <div style={{ maxWidth: '300px' }}>
           <TextField
             label="Title"
@@ -62,16 +56,14 @@ const docs: ComponentDocs = {
             tertiaryLabel={<TextLink inline>Help?</TextLink>}
             id={id}
             value=""
-            onChange={() => {
-              /*...*/
-            }}
+            onChange={handler}
           />
         </div>
       ),
     },
     {
       label: 'TextField with error',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <div style={{ maxWidth: '300px' }}>
           <TextField
             label="Do you like Braid?"
@@ -79,16 +71,14 @@ const docs: ComponentDocs = {
             id={id}
             value="No"
             message="Answer is incorrect"
-            onChange={() => {
-              /*...*/
-            }}
+            onChange={handler}
           />
         </div>
       ),
     },
     {
       label: 'TextField with postive message',
-      render: ({ id }) => (
+      render: ({ id, handler }) => (
         <div style={{ maxWidth: '300px' }}>
           <TextField
             label="Do you like Braid?"
@@ -96,9 +86,7 @@ const docs: ComponentDocs = {
             value="Yes"
             message="Nice one!"
             tone="positive"
-            onChange={() => {
-              /*...*/
-            }}
+            onChange={handler}
           />
         </div>
       ),

--- a/lib/stories/all.stories.tsx
+++ b/lib/stories/all.stories.tsx
@@ -6,6 +6,10 @@ import * as themes from '../themes';
 import { ThemeProvider } from '../components';
 import { ComponentDocs } from '../../docs/src/types';
 
+const handler = () => {
+  /* No-op for docs examples */
+};
+
 const req = require.context('../components', true, /\.docs\.tsx?$/);
 req.keys().forEach(filename => {
   const matches = filename.match(/([a-zA-Z]+)\.docs\.tsx?$/);
@@ -29,7 +33,9 @@ req.keys().forEach(filename => {
     values(themes).forEach(theme => {
       stories.add(`${label} (${theme.name})`, () => (
         <BrowserRouter>
-          <ThemeProvider theme={theme}>{render({ id: 'id' })}</ThemeProvider>
+          <ThemeProvider theme={theme}>
+            {render({ id: 'id', handler })}
+          </ThemeProvider>
         </BrowserRouter>
       ));
     });


### PR DESCRIPTION
Fixes the server/client mismatch error caused by the differences in the handler instances between build render and client render. As a bonus it now hands the docs render functions a dummy handler which can be easily consumed in all components