### PR TITLE
docs: Fix playroom link

### DIFF
--- a/docs/src/App/Home/Home.css.js
+++ b/docs/src/App/Home/Home.css.js
@@ -27,4 +27,11 @@ export default {
       cursor: 'pointer',
     },
   },
+  '.subtitle': {
+    flexWrap: 'wrap',
+    justifyContent: 'center',
+    '> *': {
+      whiteSpace: 'nowrap',
+    },
+  },
 };

--- a/docs/src/App/Home/Home.css.js.d.ts
+++ b/docs/src/App/Home/Home.css.js.d.ts
@@ -5,3 +5,4 @@ export const container: string;
 export const content: string;
 export const linkButton: string;
 export const source: string;
+export const subtitle: string;

--- a/docs/src/App/Home/Home.tsx
+++ b/docs/src/App/Home/Home.tsx
@@ -48,9 +48,17 @@ export const Home = () => {
               width="full"
               className={styles.actionsContainer}
               paddingBottom={['xlarge', 'large']}
-              style={{ textAlign: 'center' }}
             >
-              <Text>Themeable design system for the SEEK Group</Text>
+              <Text>
+                <Box
+                  component="span"
+                  display="flex"
+                  className={styles.subtitle}
+                >
+                  <span>Themeable design system</span>&nbsp;
+                  <span>for the SEEK Group</span>
+                </Box>
+              </Text>
             </Box>
 
             <Box

--- a/docs/src/render.tsx
+++ b/docs/src/render.tsx
@@ -18,8 +18,10 @@ const skuRender: Render<RenderContext> = {
     const githubUrl = 'https://github.com/seek-oss/braid-design-system/tree/';
 
     const sourceUrlPrefix = `${githubUrl}${prSha || 'master'}`;
-    const playroomUrl = !CI ? 'http://localhost:9000' : '/playroom';
     const routerBasename = isGithubPages ? 'braid-design-system' : '';
+    const playroomUrl = !CI
+      ? 'http://localhost:9000'
+      : `${routerBasename ? `/${routerBasename}` : ''}/playroom`;
     const appConfig = {
       playroomUrl,
       sourceUrlPrefix,


### PR DESCRIPTION
Fixes (hopefully) the playroom link is broken when deployed to ghpages site. Unfortunately can't test outside of ghpages deployment at this stage, but logic seems sound.

Also addresses the orphaned text that occurs on certain resolutions on the subtitle of the home page.