### PR TITLE
docs: Fix icons component routes

### DIFF
--- a/docs/src/App/App.tsx
+++ b/docs/src/App/App.tsx
@@ -12,7 +12,7 @@ import styles from './App.css.js';
 const routes = [
   { path: '/', name: 'Home', exact: true, Component: Home },
   {
-    path: '/components',
+    path: '/(components|icons)',
     name: 'Components',
     exact: false,
     Component: Components,


### PR DESCRIPTION
Since introducing the home route on the docs site the `/icons` route was not catered for — only `/components`. Might merge these urls under `/components` in the future, for now just fixing the routes.