### PR TITLE
fix(Field): Resolve native types correctly

### DIFF
--- a/lib/components/TextArea/TextArea.tsx
+++ b/lib/components/TextArea/TextArea.tsx
@@ -18,7 +18,7 @@ const renderCount = ({
     return null;
   }
 
-  const diff = limit - value.length;
+  const diff = limit - String(value).length;
   const valid = diff >= 0;
 
   return (

--- a/lib/components/private/Field/Field.tsx
+++ b/lib/components/private/Field/Field.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, AllHTMLAttributes } from 'react';
 import { FieldTone, Color } from '../../../themes/theme';
 import classnames from 'classnames';
 import { useTheme } from '../ThemeContext';
@@ -8,14 +8,15 @@ import { FieldMessage } from '../../FieldMessage/FieldMessage';
 import { FieldOverlay } from '../FieldOverlay/FieldOverlay';
 import styles from './Field.css.js';
 
+type FormElementProps = AllHTMLAttributes<HTMLFormElement>;
 export interface FieldProps {
-  id: NonNullable<HTMLFormElement['id']>;
-  value: NonNullable<HTMLFormElement['value']>;
-  onChange: NonNullable<HTMLFormElement['onChange']>;
-  onBlur?: HTMLFormElement['onBlur'];
-  onFocus?: HTMLFormElement['onFocus'];
-  name?: HTMLFormElement['name'];
-  placeholder?: HTMLFormElement['placeholder'];
+  id: NonNullable<FormElementProps['id']>;
+  value: NonNullable<FormElementProps['value']>;
+  onChange: NonNullable<FormElementProps['onChange']>;
+  onBlur?: FormElementProps['onBlur'];
+  onFocus?: FormElementProps['onFocus'];
+  name?: FormElementProps['name'];
+  placeholder?: FormElementProps['placeholder'];
   label?: string;
   secondaryLabel?: ReactNode;
   tertiaryLabel?: ReactNode;


### PR DESCRIPTION
The usage of the `HTMLFormElement` type in `Field` was incorrect and being exposed incorrectly on the docs site too. This fixes it for all consumers of `Field`.
```diff
Options
  value
-    Type: any (Required)
+    Type: string | number | string[] (Required)
  onChange
-    Type: any (Required)
+    Type: ((event: FormEvent<HTMLFormElement>) => void)
  onBlur
-    Type: any
+    Type: ((event: FocusEvent<HTMLFormElement>) => void)
  onFocus
-    Type: any
+    Type: ((event: FocusEvent<HTMLFormElement>) => void)
```