### PR TITLE
refactor(Field): Consumers control their own value & event interface

### DIFF
--- a/lib/atoms/color/makeColors.ts
+++ b/lib/atoms/color/makeColors.ts
@@ -25,6 +25,7 @@ export default ({
   formAccent,
   neutral,
 }: ColorParams): Css => ({
+  '.color_neutral': { color: neutral }, // Should be first to be overrid-able
   '.color_link': {
     color: link,
     '&:hover,&:focus': linkHover
@@ -42,5 +43,4 @@ export default ({
   '.color_brandAccentForeground': {
     color: isLight(brandAccent) ? black : white,
   },
-  '.color_neutral': { color: neutral },
 });

--- a/lib/components/Dropdown/Dropdown.tsx
+++ b/lib/components/Dropdown/Dropdown.tsx
@@ -4,20 +4,38 @@ import React, {
   Children,
   isValidElement,
 } from 'react';
+import classnames from 'classnames';
 import { Box } from '../Box/Box';
 import { Field, FieldProps } from '../private/Field/Field';
 import styles from './Dropdown.css.js';
 import { ChevronIcon } from '../icons/ChevronIcon/ChevronIcon';
 import { useTheme } from '../private/ThemeContext';
 import { px } from '../../atoms/utils/toUnit';
+import { Color } from '../../themes/theme';
 
 type ValidDropdownChildren = AllHTMLAttributes<
   HTMLOptionElement | HTMLOptGroupElement
 >;
+type SelectProps = AllHTMLAttributes<HTMLSelectElement>;
 interface DropdownProps extends FieldProps {
-  placeholder?: string;
   children: ValidDropdownChildren[] | ValidDropdownChildren;
+  value: NonNullable<SelectProps['value']>;
+  onChange: NonNullable<SelectProps['onChange']>;
+  onBlur?: SelectProps['onBlur'];
+  onFocus?: SelectProps['onFocus'];
+  placeholder?: string;
 }
+
+const getColor = (
+  placeholder: DropdownProps['placeholder'],
+  value: DropdownProps['value'],
+): Color => {
+  if (!value && placeholder) {
+    return 'secondary';
+  }
+
+  return 'neutral';
+};
 
 export const Dropdown = ({
   id,
@@ -25,7 +43,6 @@ export const Dropdown = ({
   label,
   secondaryLabel,
   tertiaryLabel,
-  placeholder,
   message,
   tone = 'neutral',
   children,
@@ -33,8 +50,9 @@ export const Dropdown = ({
   onChange,
   onBlur,
   onFocus,
+  placeholder,
 }: DropdownProps) => {
-  const { tokens } = useTheme();
+  const { tokens, atoms } = useTheme();
   const chevronPaddings = tokens.columnSpacing.small * tokens.columnWidth * 2;
   const chevronWidth = tokens.text.standard.mobile.size;
 
@@ -55,13 +73,8 @@ export const Dropdown = ({
       tertiaryLabel={tertiaryLabel}
       tone={tone}
       message={message}
-      value={value}
-      onChange={onChange}
-      onBlur={onBlur}
-      onFocus={onFocus}
-      placeholder={placeholder}
     >
-      {fieldProps => (
+      {({ className, ...fieldProps }) => (
         <Fragment>
           <Box
             component="select"
@@ -73,9 +86,18 @@ export const Dropdown = ({
             paddingTop="standardTouchableText"
             paddingBottom="standardTouchableText"
             borderRadius="standard"
+            value={value}
+            onChange={onChange}
+            onBlur={onBlur}
+            onFocus={onFocus}
+            placeholder={placeholder}
             style={{
               paddingRight: px(chevronPaddings + chevronWidth),
             }}
+            className={classnames(
+              className,
+              atoms.color[getColor(placeholder, value)],
+            )}
             {...fieldProps}
           >
             <option value="" selected={!value} disabled={true}>

--- a/lib/components/TextArea/TextArea.tsx
+++ b/lib/components/TextArea/TextArea.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, AllHTMLAttributes } from 'react';
 import classnames from 'classnames';
 import { Box } from '../Box/Box';
 import { Text } from '../Text/Text';
@@ -6,7 +6,13 @@ import styles from './TextArea.css.js';
 import { useTheme } from '../private/ThemeContext';
 import { Field, FieldProps } from '../private/Field/Field';
 
+type NativeTextAreaProps = AllHTMLAttributes<HTMLTextAreaElement>;
 interface TextAreaProps extends FieldProps {
+  value: NonNullable<NativeTextAreaProps['value']>;
+  onChange: NonNullable<NativeTextAreaProps['onChange']>;
+  onBlur?: NativeTextAreaProps['onBlur'];
+  onFocus?: NativeTextAreaProps['onFocus'];
+  placeholder?: NativeTextAreaProps['placeholder'];
   limit?: number;
 }
 
@@ -30,18 +36,18 @@ const renderCount = ({
 
 export const TextArea = ({
   id,
-  label,
   name,
+  label,
   secondaryLabel,
   tertiaryLabel,
-  placeholder,
+  description,
   message,
   tone = 'neutral',
   value,
   onChange,
   onBlur,
   onFocus,
-  description,
+  placeholder,
   limit,
 }: TextAreaProps) => {
   const { tokens } = useTheme();
@@ -51,20 +57,15 @@ export const TextArea = ({
       id={id}
       name={name}
       label={label}
-      description={description}
       secondaryLabel={secondaryLabel}
       tertiaryLabel={tertiaryLabel}
+      description={description}
       tone={tone}
       message={message}
       secondaryMessage={renderCount({
         limit,
         value,
       })}
-      placeholder={placeholder}
-      value={value}
-      onChange={onChange}
-      onBlur={onBlur}
-      onFocus={onFocus}
     >
       {({ className, ...fieldProps }) => (
         <Box
@@ -79,6 +80,11 @@ export const TextArea = ({
           paddingBottom="standardTouchableText"
           borderRadius="standard"
           rows={3}
+          value={value}
+          onChange={onChange}
+          onBlur={onBlur}
+          onFocus={onFocus}
+          placeholder={placeholder}
           style={{
             minHeight: tokens.rowHeight * 15,
           }}

--- a/lib/components/TextField/TextField.tsx
+++ b/lib/components/TextField/TextField.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { AllHTMLAttributes } from 'react';
 import { Box } from '../Box/Box';
 import { Field, FieldProps } from '../private/Field/Field';
 
@@ -12,8 +12,14 @@ const validTypes = {
   url: 'url',
 };
 
+type InputProps = AllHTMLAttributes<HTMLInputElement>;
 interface TextFieldProps extends FieldProps {
+  value: NonNullable<InputProps['value']>;
   type?: keyof typeof validTypes;
+  onChange: NonNullable<InputProps['onChange']>;
+  onBlur?: InputProps['onBlur'];
+  onFocus?: InputProps['onFocus'];
+  placeholder?: InputProps['placeholder'];
 }
 
 export const TextField = ({
@@ -22,14 +28,14 @@ export const TextField = ({
   label,
   secondaryLabel,
   tertiaryLabel,
-  placeholder,
   message,
   tone = 'neutral',
-  value,
   type = 'text',
+  value,
   onChange,
   onBlur,
   onFocus,
+  placeholder,
 }: TextFieldProps) => (
   <Field
     id={id}
@@ -39,11 +45,6 @@ export const TextField = ({
     tertiaryLabel={tertiaryLabel}
     tone={tone}
     message={message}
-    placeholder={placeholder}
-    value={value}
-    onChange={onChange}
-    onBlur={onBlur}
-    onFocus={onFocus}
   >
     {fieldProps => (
       <Box
@@ -56,6 +57,11 @@ export const TextField = ({
         paddingTop="standardTouchableText"
         paddingBottom="standardTouchableText"
         borderRadius="standard"
+        value={value}
+        onChange={onChange}
+        onFocus={onFocus}
+        onBlur={onBlur}
+        placeholder={placeholder}
         {...fieldProps}
       />
     )}

--- a/lib/components/private/Field/Field.tsx
+++ b/lib/components/private/Field/Field.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode, AllHTMLAttributes } from 'react';
-import { FieldTone, Color } from '../../../themes/theme';
+import { FieldTone } from '../../../themes/theme';
 import classnames from 'classnames';
 import { useTheme } from '../ThemeContext';
 import { Box, BoxProps } from '../../Box/Box';
@@ -11,12 +11,7 @@ import styles from './Field.css.js';
 type FormElementProps = AllHTMLAttributes<HTMLFormElement>;
 export interface FieldProps {
   id: NonNullable<FormElementProps['id']>;
-  value: NonNullable<FormElementProps['value']>;
-  onChange: NonNullable<FormElementProps['onChange']>;
-  onBlur?: FormElementProps['onBlur'];
-  onFocus?: FormElementProps['onFocus'];
   name?: FormElementProps['name'];
-  placeholder?: FormElementProps['placeholder'];
   label?: string;
   secondaryLabel?: ReactNode;
   tertiaryLabel?: ReactNode;
@@ -26,14 +21,7 @@ export interface FieldProps {
   tone?: FieldTone;
 }
 
-type PassthroughProps =
-  | 'id'
-  | 'name'
-  | 'value'
-  | 'onChange'
-  | 'onFocus'
-  | 'onBlur'
-  | 'placeholder';
+type PassthroughProps = 'id' | 'name';
 interface FieldRenderProps extends Pick<FieldProps, PassthroughProps> {
   backgroundColor: BoxProps['backgroundColor'];
   'aria-describedby': string;
@@ -44,25 +32,9 @@ interface InternalFieldProps extends FieldProps {
   children(props: FieldRenderProps): ReactNode;
 }
 
-const getColor = (
-  placeholder: FieldProps['placeholder'],
-  value: FieldProps['value'],
-): Color => {
-  if (!value && placeholder) {
-    return 'secondary';
-  }
-
-  return 'neutral';
-};
-
 export const Field = ({
   id,
   name,
-  value,
-  onChange,
-  onFocus,
-  onBlur,
-  placeholder,
   label,
   secondaryLabel,
   tertiaryLabel,
@@ -88,18 +60,13 @@ export const Field = ({
         {children({
           id,
           name,
-          value,
-          onChange,
-          onFocus,
-          onBlur,
-          placeholder,
           backgroundColor: 'input',
           'aria-describedby': messageId,
           className: classnames(
             styles.field,
             atoms.fontFamily.text,
             atoms.fontSize.standard,
-            atoms.color[getColor(placeholder, value)],
+            atoms.color.neutral,
           ),
         })}
         <FieldOverlay variant="focus" className={styles.focusOverlay} />


### PR DESCRIPTION
Refactored `Field` to allow consuming components to control their own form value and event handlers, as these are not the same for every field, eg. `checked` vs `value` etc.

The `HTMLFormElement` type was too generic, so pulling back to allow the fields to extend their own native props.