### PR TITLE
fix(FieldMessage): Map minHeight atom correctly to fix wrapping messages

### DIFF
--- a/lib/atoms/normalizeAtoms.ts
+++ b/lib/atoms/normalizeAtoms.ts
@@ -171,10 +171,10 @@ export default (
     xxsmall: atoms.marginRightDesktop_xxsmall,
   },
   minHeight: {
-    largeText: atoms.height_largeText,
-    largeTextInline: atoms.height_largeTextInline,
-    standardText: atoms.height_standardText,
-    standardTextInline: atoms.height_standardTextInline,
+    largeText: atoms.minHeight_largeText,
+    largeTextInline: atoms.minHeight_largeTextInline,
+    standardText: atoms.minHeight_standardText,
+    standardTextInline: atoms.minHeight_standardTextInline,
   },
   paddingBottom: {
     none: atoms.paddingBottom_none,

--- a/lib/components/FieldMessage/FieldMessage.docs.tsx
+++ b/lib/components/FieldMessage/FieldMessage.docs.tsx
@@ -25,6 +25,18 @@ const docs: ComponentDocs = {
       ),
     },
     {
+      label: 'Critical with long (wrapping) message',
+      render: ({ id }) => (
+        <div style={{ maxWidth: '300px' }}>
+          <FieldMessage
+            id={id}
+            tone="critical"
+            message="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque sodales hendrerit nulla."
+          />
+        </div>
+      ),
+    },
+    {
       label: "No message, i.e. don't reserve white space",
       code: `<FieldMessage message={false} />`,
     },


### PR DESCRIPTION
When introducing `min-height` support to `Box` the atom mapping was [incorrectly mapped to `height`](https://github.com/seek-oss/braid-design-system/pull/138/files#diff-1ad626edbafbfdbc7f791bd37d6efa65R173). This resulted in `FieldMessage` (our only usage of `minHeight` atom, to enforce `height` rather than `min-height` — causing text overflow issues for consumers.

Fixed the mapping and added a long message to the docs site to catch this category of problem in a screenshot contract.