### PR TITLE
docs(a11y): Fix tab navigation and visual outlines

### DIFF
--- a/docs/src/App/Home/Home.css.js
+++ b/docs/src/App/Home/Home.css.js
@@ -8,6 +8,14 @@ export default {
     minHeight: '80px',
     minWidth: '80px',
   },
+  '.sourceLink': {
+    color: 'white',
+    outline: 'none',
+    '&:focus': {
+      transition: '0.2s ease',
+      color: 'DeepSkyBlue',
+    },
+  },
   '.content': {
     height: '100vh',
     alignItems: 'center',

--- a/docs/src/App/Home/Home.css.js.d.ts
+++ b/docs/src/App/Home/Home.css.js.d.ts
@@ -5,4 +5,5 @@ export const container: string;
 export const content: string;
 export const linkButton: string;
 export const source: string;
+export const sourceLink: string;
 export const subtitle: string;

--- a/docs/src/App/Home/Home.tsx
+++ b/docs/src/App/Home/Home.tsx
@@ -68,7 +68,6 @@ export const Home = () => {
                     onClick={() => {
                       /* placeholder until ButtonRenderer exists */
                     }}
-                    role="link"
                   >
                     Components
                   </Button>
@@ -85,7 +84,6 @@ export const Home = () => {
                     onClick={() => {
                       /* placeholder until ButtonRenderer exists */
                     }}
-                    role="link"
                   >
                     Playroom
                   </Button>

--- a/docs/src/App/Home/Home.tsx
+++ b/docs/src/App/Home/Home.tsx
@@ -20,15 +20,6 @@ export const Home = () => {
     <ConfigConsumer>
       {({ playroomUrl }) => (
         <Fragment>
-          <Box className={styles.source}>
-            <a
-              href="https://github.com/seek-oss/braid-design-system"
-              title="View on Github"
-            >
-              <Github backgroundColor="black" />
-            </a>
-          </Box>
-
           <Box
             display="flex"
             flexDirection="column"
@@ -67,30 +58,50 @@ export const Home = () => {
               display={['block', 'flex']}
             >
               <Box {...actionProps}>
-                <Link to="/components" className={styles.linkButton}>
+                <Link
+                  to="/components"
+                  className={styles.linkButton}
+                  tabIndex={-1}
+                >
                   <Button
                     weight="weak"
                     onClick={() => {
                       /* placeholder until ButtonRenderer exists */
                     }}
+                    role="link"
                   >
                     Components
                   </Button>
                 </Link>
               </Box>
               <Box {...actionProps}>
-                <a href={playroomUrl} className={styles.linkButton}>
+                <a
+                  href={playroomUrl}
+                  className={styles.linkButton}
+                  tabIndex={-1}
+                >
                   <Button
                     weight="weak"
                     onClick={() => {
                       /* placeholder until ButtonRenderer exists */
                     }}
+                    role="link"
                   >
                     Playroom
                   </Button>
                 </a>
               </Box>
             </Box>
+          </Box>
+
+          <Box className={styles.source}>
+            <a
+              href="https://github.com/seek-oss/braid-design-system"
+              title="View on GitHub"
+              className={styles.sourceLink}
+            >
+              <Github color="currentColor" backgroundColor="black" />
+            </a>
           </Box>
         </Fragment>
       )}

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -15,7 +15,6 @@ export interface ButtonProps {
   type?: NativeButtonProps['type'];
   children?: ReactNode;
   weight?: ButtonWeight;
-  role?: NativeButtonProps['role'];
 }
 
 const backgroundColor: Record<
@@ -50,7 +49,6 @@ export const Button = ({
   children,
   weight = 'regular',
   type = 'button',
-  role,
 }: ButtonProps) => {
   const isWeak = weight === 'weak';
 
@@ -69,7 +67,6 @@ export const Button = ({
         [styles.weak]: isWeak,
       })}
       onClick={onClick}
-      role={role}
     >
       <FieldOverlay variant="focus" className={styles.focusOverlay} />
       <FieldOverlay

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -15,6 +15,7 @@ export interface ButtonProps {
   type?: NativeButtonProps['type'];
   children?: ReactNode;
   weight?: ButtonWeight;
+  role?: NativeButtonProps['role'];
 }
 
 const backgroundColor: Record<
@@ -49,6 +50,7 @@ export const Button = ({
   children,
   weight = 'regular',
   type = 'button',
+  role,
 }: ButtonProps) => {
   const isWeak = weight === 'weak';
 
@@ -67,6 +69,7 @@ export const Button = ({
         [styles.weak]: isWeak,
       })}
       onClick={onClick}
+      role={role}
     >
       <FieldOverlay variant="focus" className={styles.focusOverlay} />
       <FieldOverlay


### PR DESCRIPTION
Improve the tab navigation on the homepage, previously there was a double tab for each button and confusion from a screen reader perspective between the link and button elements.

Also change the document order to put the link to github source last with a nicer focus state.