### PR TITLE
fix(Button): Make onClick optional to support form submit

### DIFF
--- a/docs/src/App/Home/Home.tsx
+++ b/docs/src/App/Home/Home.tsx
@@ -68,26 +68,12 @@ export const Home = () => {
             >
               <Box {...actionProps}>
                 <Link to="/components" className={styles.linkButton}>
-                  <Button
-                    weight="weak"
-                    onClick={() => {
-                      /* placeholder until ButtonRenderer exists */
-                    }}
-                  >
-                    Components
-                  </Button>
+                  <Button weight="weak">Components</Button>
                 </Link>
               </Box>
               <Box {...actionProps}>
                 <a href={playroomUrl} className={styles.linkButton}>
-                  <Button
-                    weight="weak"
-                    onClick={() => {
-                      /* placeholder until ButtonRenderer exists */
-                    }}
-                  >
-                    Playroom
-                  </Button>
+                  <Button weight="weak">Playroom</Button>
                 </a>
               </Box>
             </Box>

--- a/docs/src/App/Home/Home.tsx
+++ b/docs/src/App/Home/Home.tsx
@@ -63,9 +63,7 @@ export const Home = () => {
                   className={styles.linkButton}
                   tabIndex={-1}
                 >
-                  <Button weight="weak">
-                    Components
-                  </Button>
+                  <Button weight="weak">Components</Button>
                 </Link>
               </Box>
               <Box {...actionProps}>
@@ -74,9 +72,7 @@ export const Home = () => {
                   className={styles.linkButton}
                   tabIndex={-1}
                 >
-                  <Button weight="weak">
-                    Playroom
-                  </Button>
+                  <Button weight="weak">Playroom</Button>
                 </a>
               </Box>
             </Box>

--- a/lib/components/Actions/Actions.docs.tsx
+++ b/lib/components/Actions/Actions.docs.tsx
@@ -8,41 +8,29 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Actions with Strong Button and TextLink',
-      render: ({ handler }) => (
+      render: () => (
         <Actions>
-          <Button onClick={handler} weight="strong">
-            Strong
-          </Button>
+          <Button weight="strong">Strong</Button>
           <TextLink href="#">TextLink</TextLink>
         </Actions>
       ),
     },
     {
       label: 'Actions with Regular Button and Weak Button',
-      render: ({ handler }) => (
+      render: () => (
         <Actions>
-          <Button onClick={handler} weight="regular">
-            Regular
-          </Button>
-          <Button onClick={handler} weight="weak">
-            Weak
-          </Button>
+          <Button weight="regular">Regular</Button>
+          <Button weight="weak">Weak</Button>
         </Actions>
       ),
     },
     {
       label: 'Actions with Weak Buttons and Regular Button',
-      render: ({ handler }) => (
+      render: () => (
         <Actions>
-          <Button onClick={handler} weight="weak">
-            Weak
-          </Button>
-          <Button onClick={handler} weight="weak">
-            Weak
-          </Button>
-          <Button onClick={handler} weight="regular">
-            Regular
-          </Button>
+          <Button weight="weak">Weak</Button>
+          <Button weight="weak">Weak</Button>
+          <Button weight="regular">Regular</Button>
         </Actions>
       ),
     },

--- a/lib/components/Button/Button.docs.tsx
+++ b/lib/components/Button/Button.docs.tsx
@@ -6,29 +6,25 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Default Button',
-      render: ({ handler }) => (
+      render: () => (
         <div style={{ maxWidth: '300px' }}>
-          <Button onClick={handler}>Submit</Button>
+          <Button>Submit</Button>
         </div>
       ),
     },
     {
       label: 'Strong Button',
-      render: ({ handler }) => (
+      render: () => (
         <div style={{ maxWidth: '300px' }}>
-          <Button onClick={handler} weight="strong">
-            Submit
-          </Button>
+          <Button weight="strong">Submit</Button>
         </div>
       ),
     },
     {
       label: 'Weak Button',
-      render: ({ handler }) => (
+      render: () => (
         <div style={{ maxWidth: '300px' }}>
-          <Button onClick={handler} weight="weak">
-            Submit
-          </Button>
+          <Button weight="weak">Submit</Button>
         </div>
       ),
     },

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -11,7 +11,7 @@ type ButtonState = 'base' | 'hover' | 'active';
 
 type NativeButtonProps = AllHTMLAttributes<HTMLButtonElement>;
 export interface ButtonProps {
-  onClick: NonNullable<NativeButtonProps['onClick']>;
+  onClick?: NativeButtonProps['onClick'];
   type?: NativeButtonProps['type'];
   children?: ReactNode;
   weight?: ButtonWeight;


### PR DESCRIPTION
In making `onClick` a required prop (like our form fields) the oversight here was changing the contract of a submit button with it's form — i.e. using the `onSubmit` of a form without providing an `onClick`.

Rolling back the required aspect of the click handler and also rolling it back out of the docs to keep the code examples terse.