### PR TITLE
fix(Icon): Add 'small' Icon size, tidy up typography

### DIFF
--- a/lib/components/icons/Icon/Icon.treat.ts
+++ b/lib/components/icons/Icon/Icon.treat.ts
@@ -1,4 +1,5 @@
 import { style, css } from 'sku/treat';
+import mapValues from 'lodash/mapValues';
 
 export const inline = style({
   verticalAlign: 'middle',
@@ -12,36 +13,22 @@ export const fullHeight = style({
 
 const makeSizeRules = (size: number) => ({ width: size, height: size });
 
-export const inlineSizes = css(theme => {
-  const { responsiveStyles } = theme.utils;
-  const { standard, large } = theme.typography.text;
+export const inlineSizes = css(({ utils, typography }) =>
+  mapValues(typography.text, ({ mobile, desktop }) =>
+    utils.responsiveStyles(
+      makeSizeRules(mobile.size),
+      makeSizeRules(desktop.size),
+    ),
+  ),
+);
 
-  return {
-    standard: responsiveStyles(
-      makeSizeRules(standard.mobile.size),
-      makeSizeRules(standard.desktop.size),
+export const blockSizes = css(({ utils, typography }) =>
+  mapValues(typography.text, ({ mobile, desktop }) =>
+    utils.responsiveStyles(
+      makeSizeRules(utils.rows(mobile.rows)),
+      makeSizeRules(utils.rows(desktop.rows)),
     ),
-    large: responsiveStyles(
-      makeSizeRules(large.mobile.size),
-      makeSizeRules(large.desktop.size),
-    ),
-  };
-});
-
-export const blockSizes = css(theme => {
-  const { responsiveStyles, rows } = theme.utils;
-  const { standard, large } = theme.typography.text;
-
-  return {
-    standard: responsiveStyles(
-      makeSizeRules(rows(standard.mobile.rows)),
-      makeSizeRules(rows(standard.desktop.rows)),
-    ),
-    large: responsiveStyles(
-      makeSizeRules(rows(large.mobile.rows)),
-      makeSizeRules(rows(large.desktop.rows)),
-    ),
-  };
-});
+  ),
+);
 
 export const currentColor = style({ fill: 'currentColor' });

--- a/lib/components/icons/Icon/Icon.tsx
+++ b/lib/components/icons/Icon/Icon.tsx
@@ -4,7 +4,7 @@ import { Box } from '../../Box/Box';
 import * as styles from './Icon.treat';
 import { useTextColor, UseTextProps } from '../../../hooks/typography';
 
-type IconSize = 'standard' | 'large' | 'fill';
+type IconSize = NonNullable<UseTextProps['size']> | 'fill';
 
 export interface IconProps {
   size?: IconSize;

--- a/lib/hooks/typography/index.ts
+++ b/lib/hooks/typography/index.ts
@@ -56,4 +56,4 @@ export const useTextColor = (color: keyof typeof styles.color) =>
   useClassNames(styles.color[useForeground(color)]);
 
 export const useTouchableSpace = (size: keyof typeof styles.touchable) =>
-  useClassNames(styles.touchable[size], styles.touchableDesktop[size]);
+  useClassNames(styles.touchable[size]);

--- a/lib/hooks/typography/typography.treat.ts
+++ b/lib/hooks/typography/typography.treat.ts
@@ -9,17 +9,9 @@ export const fontFamily = style(({ typography }) => ({
   fontFamily: typography.fontFamily,
 }));
 
-export const fontWeight = css(({ typography }) => ({
-  regular: {
-    fontWeight: typography.fontWeight.regular,
-  },
-  medium: {
-    fontWeight: typography.fontWeight.medium,
-  },
-  strong: {
-    fontWeight: typography.fontWeight.strong,
-  },
-}));
+export const fontWeight = css(({ typography }) =>
+  mapToStyleProperty(typography.fontWeight, 'fontWeight'),
+);
 
 interface TextDefinition {
   rows: number;
@@ -132,22 +124,26 @@ export const color = css(theme => {
   };
 });
 
-const touchableSpace = (theme: Theme, breakpoint: Breakpoint) => {
-  const { spacing, utils } = theme;
+const makeTouchableSpacing = (touchableHeight: number, textHeight: number) => {
+  const space = (touchableHeight - textHeight) / 2;
 
-  return mapValues(theme.typography.text, textDefinition => {
-    const touchableHeight = utils.rows(spacing.touchableRows);
-    const textHeight = utils.rows(textDefinition[breakpoint].rows);
-    const space = (touchableHeight - textHeight) / 2;
-    const spaceStyles = {
-      paddingTop: space,
-      paddingBottom: space,
-    };
-
-    return breakpoint === 'desktop'
-      ? theme.utils.desktopStyles(spaceStyles)
-      : spaceStyles;
-  });
+  return {
+    paddingTop: space,
+    paddingBottom: space,
+  };
 };
-export const touchable = css(theme => touchableSpace(theme, 'mobile'));
-export const touchableDesktop = css(theme => touchableSpace(theme, 'desktop'));
+
+export const touchable = css(({ typography, spacing, utils }) =>
+  mapValues(typography.text, textDefinition =>
+    utils.responsiveStyles(
+      makeTouchableSpacing(
+        utils.rows(spacing.touchableRows),
+        utils.rows(textDefinition.mobile.rows),
+      ),
+      makeTouchableSpacing(
+        utils.rows(spacing.touchableRows),
+        utils.rows(textDefinition.desktop.rows),
+      ),
+    ),
+  ),
+);


### PR DESCRIPTION
Missed adding `small` support to inline icons because the icons were hard coded. This refactors the icons to be generated from the theme definition for text which should prevent this in the future. Also made the font weights generated from the theme and cleaned up the touchableSpace rules.