### PR TITLE
fix(FieldMessage): Use inline icons

### DIFF
--- a/lib/components/FieldMessage/FieldMessage.tsx
+++ b/lib/components/FieldMessage/FieldMessage.tsx
@@ -23,12 +23,12 @@ const renderIcon = (tone: FieldTone = 'neutral') => {
 
   const Icon: Record<FieldTone, ReactNode> = {
     neutral: null,
-    critical: <ErrorIcon fill="critical" />,
-    positive: <TickCircleIcon fill="positive" />,
+    critical: <ErrorIcon fill="critical" inline />,
+    positive: <TickCircleIcon fill="positive" inline />,
   };
 
   return (
-    <Box paddingRight="xsmall" className={useClassNames(styles.fixedSize)}>
+    <Box paddingRight="xxsmall" className={useClassNames(styles.fixedSize)}>
       {Icon[tone]}
     </Box>
   );


### PR DESCRIPTION
The icons used for critical and positive `FieldMessage`s were way too large, turns out they were not using the `inline` icon variants — designed for use along side text.

- [Current Playroom](https://braid-design-system--f60166d05d5c062eb1ab0163810c36011a2cbdf2.surge.sh/playroom/#?code=PENhcmQ-CiAgPFRleHRGaWVsZAogICAgaWQ9ImlkIgogICAgdG9uZT0icG9zaXRpdmUiCiAgICB2YWx1ZT0iWWVzIgogICAgbGFiZWw9IkRvIHlvdSBsaWtlIEJyYWlkPyIKICAgIG1lc3NhZ2U9Ik5pY2Ugb25lISIKICAvPgogIDxUZXh0RmllbGQKICAgIGlkPSJpZCIKICAgIHRvbmU9ImNyaXRpY2FsIgogICAgdmFsdWU9Ik5vIgogICAgbGFiZWw9IkRvIHlvdSBsaWtlIEJyYWlkPyIKICAgIG1lc3NhZ2U9Ildyb25nIGFuc3dlciIKICAvPgo8L0NhcmQ-Cg)
- [Proposed change](https://braid-design-system--aa2ee3791c9ee8a1454bad31756ebcf6d57074f8.surge.sh/playroom/#?code=PENhcmQ-CiAgPFRleHRGaWVsZAogICAgaWQ9ImlkIgogICAgdG9uZT0icG9zaXRpdmUiCiAgICB2YWx1ZT0iWWVzIgogICAgbGFiZWw9IkRvIHlvdSBsaWtlIEJyYWlkPyIKICAgIG1lc3NhZ2U9Ik5pY2Ugb25lISIKICAvPgogIDxUZXh0RmllbGQKICAgIGlkPSJpZCIKICAgIHRvbmU9ImNyaXRpY2FsIgogICAgdmFsdWU9Ik5vIgogICAgbGFiZWw9IkRvIHlvdSBsaWtlIEJyYWlkPyIKICAgIG1lc3NhZ2U9Ildyb25nIGFuc3dlciIKICAvPgo8L0NhcmQ-Cg)