### PR TITLE
fix(fields): Use 'reserveMessageSpace={false}', not 'message={false}'

### DIFF
--- a/lib/components/Checkbox/Checkbox.docs.tsx
+++ b/lib/components/Checkbox/Checkbox.docs.tsx
@@ -19,7 +19,7 @@ const docs: ComponentDocs = {
           checked={false}
           onChange={handler}
           label="Label"
-          message={false}
+          reserveMessageSpace={false}
         />
       ),
     },
@@ -31,7 +31,7 @@ const docs: ComponentDocs = {
           checked={true}
           onChange={handler}
           label="Label"
-          message={false}
+          reserveMessageSpace={false}
         />
       ),
     },
@@ -44,7 +44,7 @@ const docs: ComponentDocs = {
           checked={false}
           onChange={handler}
           label="Label"
-          message={false}
+          reserveMessageSpace={false}
         />
       ),
     },
@@ -82,7 +82,7 @@ const docs: ComponentDocs = {
           checked={true}
           onChange={handler}
           label="Label"
-          message={false}
+          reserveMessageSpace={false}
         >
           <Text>This text is visible when the checkbox is checked.</Text>
         </Checkbox>

--- a/lib/components/Checkbox/Checkbox.docs.tsx
+++ b/lib/components/Checkbox/Checkbox.docs.tsx
@@ -62,19 +62,6 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label: 'Positive Checkbox',
-      render: ({ id, handler }) => (
-        <Checkbox
-          id={id}
-          checked={false}
-          onChange={handler}
-          label="Label"
-          message="This is a positive message"
-          tone="positive"
-        />
-      ),
-    },
-    {
       label: 'Nested Checkbox',
       render: ({ id, handler }) => (
         <Checkbox

--- a/lib/components/Checkbox/Checkbox.tsx
+++ b/lib/components/Checkbox/Checkbox.tsx
@@ -5,5 +5,5 @@ import {
 } from '../private/InlineField/InlineField';
 
 export const Checkbox = (props: InlineFieldProps) => (
-  <InlineField {...props} type="checkbox" />
+  <InlineField reserveMessageSpace={true} {...props} type="checkbox" />
 );

--- a/lib/components/Dropdown/Dropdown.tsx
+++ b/lib/components/Dropdown/Dropdown.tsx
@@ -5,6 +5,7 @@ import React, {
   isValidElement,
 } from 'react';
 import { useClassNames } from 'sku/treat';
+import { Omit } from 'utility-types';
 import { Box } from '../Box/Box';
 import { Field, FieldProps } from '../private/Field/Field';
 import * as styles from './Dropdown.treat';
@@ -15,7 +16,7 @@ type ValidDropdownChildren = AllHTMLAttributes<
   HTMLOptionElement | HTMLOptGroupElement
 >;
 type SelectProps = AllHTMLAttributes<HTMLSelectElement>;
-interface DropdownProps extends FieldProps {
+interface DropdownProps extends Omit<FieldProps, 'secondaryMessage'> {
   children: ValidDropdownChildren[] | ValidDropdownChildren;
   value: NonNullable<SelectProps['value']>;
   onChange: NonNullable<SelectProps['onChange']>;
@@ -36,20 +37,13 @@ const getColor = (
 };
 
 export const Dropdown = ({
-  id,
-  name,
-  disabled,
-  label,
-  secondaryLabel,
-  tertiaryLabel,
-  message,
-  tone = 'neutral',
   children,
   value,
   onChange,
   onBlur,
   onFocus,
   placeholder,
+  ...restProps
 }: DropdownProps) => {
   Children.forEach(children, child => {
     if (!(isValidElement(child) && /^(option|optgroup)$/.test(child.type))) {
@@ -60,16 +54,7 @@ export const Dropdown = ({
   });
 
   return (
-    <Field
-      id={id}
-      name={name}
-      disabled={disabled}
-      label={label}
-      secondaryLabel={secondaryLabel}
-      tertiaryLabel={tertiaryLabel}
-      tone={tone}
-      message={message}
-    >
+    <Field {...restProps} secondaryMessage={null}>
       {({ className, paddingLeft, paddingRight, ...fieldProps }) => (
         <Fragment>
           <Box

--- a/lib/components/Dropdown/Dropdown.tsx
+++ b/lib/components/Dropdown/Dropdown.tsx
@@ -36,15 +36,17 @@ const getColor = (
   return 'neutral';
 };
 
-export const Dropdown = ({
-  children,
-  value,
-  onChange,
-  onBlur,
-  onFocus,
-  placeholder,
-  ...restProps
-}: DropdownProps) => {
+export const Dropdown = (props: DropdownProps) => {
+  const {
+    children,
+    value,
+    onChange,
+    onBlur,
+    onFocus,
+    placeholder,
+    ...restProps
+  } = props;
+
   Children.forEach(children, child => {
     if (!(isValidElement(child) && /^(option|optgroup)$/.test(child.type))) {
       throw new Error(

--- a/lib/components/FieldMessage/FieldMessage.docs.tsx
+++ b/lib/components/FieldMessage/FieldMessage.docs.tsx
@@ -38,7 +38,7 @@ const docs: ComponentDocs = {
     },
     {
       label: "No message, i.e. don't reserve white space",
-      code: `<FieldMessage message={false} />`,
+      code: `<FieldMessage reserveMessageSpace={false} />`,
     },
   ],
 };

--- a/lib/components/FieldMessage/FieldMessage.tsx
+++ b/lib/components/FieldMessage/FieldMessage.tsx
@@ -10,7 +10,8 @@ type FieldTone = 'neutral' | 'critical' | 'positive';
 
 export interface FieldMessageProps extends TextProps {
   id: string;
-  message: ReactNode | false;
+  message: ReactNode;
+  reserveMessageSpace?: boolean;
   tone?: FieldTone;
   secondaryMessage?: ReactNode;
   disabled?: boolean;
@@ -39,9 +40,10 @@ export const FieldMessage = ({
   tone = 'neutral',
   message,
   secondaryMessage,
+  reserveMessageSpace = true,
   disabled = false,
 }: FieldMessageProps) => {
-  if (message === false) {
+  if (!message && !reserveMessageSpace) {
     return null;
   }
 

--- a/lib/components/Radio/Radio.docs.tsx
+++ b/lib/components/Radio/Radio.docs.tsx
@@ -12,27 +12,9 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label: 'Radio Button without Message Placeholder',
-      render: ({ id, handler }) => (
-        <Radio
-          id={id}
-          checked={false}
-          onChange={handler}
-          label="Label"
-          message={false}
-        />
-      ),
-    },
-    {
       label: 'Checked Radio Button',
       render: ({ id, handler }) => (
-        <Radio
-          id={id}
-          checked={true}
-          onChange={handler}
-          label="Label"
-          message={false}
-        />
+        <Radio id={id} checked={true} onChange={handler} label="Label" />
       ),
     },
     {
@@ -44,7 +26,6 @@ const docs: ComponentDocs = {
           checked={false}
           onChange={handler}
           label="Label"
-          message={false}
         />
       ),
     },
@@ -56,7 +37,6 @@ const docs: ComponentDocs = {
           checked={false}
           onChange={handler}
           label="Label"
-          message="This is a critical message"
           tone="critical"
         />
       ),
@@ -69,7 +49,6 @@ const docs: ComponentDocs = {
           checked={false}
           onChange={handler}
           label="Label"
-          message="This is a positive message"
           tone="positive"
         />
       ),
@@ -77,13 +56,7 @@ const docs: ComponentDocs = {
     {
       label: 'Nested Radio Button',
       render: ({ id, handler }) => (
-        <Radio
-          id={id}
-          checked={true}
-          onChange={handler}
-          label="Label"
-          message={false}
-        >
+        <Radio id={id} checked={true} onChange={handler} label="Label">
           <Text>This text is visible when the radio button is checked.</Text>
         </Radio>
       ),

--- a/lib/components/Radio/Radio.docs.tsx
+++ b/lib/components/Radio/Radio.docs.tsx
@@ -42,18 +42,6 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label: 'Positive Radio Button',
-      render: ({ id, handler }) => (
-        <Radio
-          id={id}
-          checked={false}
-          onChange={handler}
-          label="Label"
-          tone="positive"
-        />
-      ),
-    },
-    {
       label: 'Nested Radio Button',
       render: ({ id, handler }) => (
         <Radio id={id} checked={true} onChange={handler} label="Label">

--- a/lib/components/Radio/Radio.tsx
+++ b/lib/components/Radio/Radio.tsx
@@ -5,15 +5,15 @@ import {
   InlineFieldProps,
 } from '../private/InlineField/InlineField';
 
-const validTones = ['neutral', 'critical'] as const;
+const tones = ['neutral', 'critical'] as const;
 
 interface RadioProps
   extends Omit<InlineFieldProps, 'message' | 'reserveMessageSpace'> {
-  tone?: typeof validTones[number];
+  tone?: typeof tones[number];
 }
 
 export const Radio = ({ tone, ...restProps }: RadioProps) => {
-  if (tone && validTones.indexOf(tone) === -1) {
+  if (tone && tones.indexOf(tone) === -1) {
     throw new Error(`Invalid tone: ${tone}`);
   }
 

--- a/lib/components/Radio/Radio.tsx
+++ b/lib/components/Radio/Radio.tsx
@@ -1,9 +1,18 @@
 import React from 'react';
+import { Omit } from 'utility-types';
 import {
   InlineField,
   InlineFieldProps,
 } from '../private/InlineField/InlineField';
 
-export const Radio = (props: InlineFieldProps) => (
-  <InlineField {...props} type="radio" />
+interface RadioProps
+  extends Omit<InlineFieldProps, 'message' | 'reserveMessageSpace'> {}
+
+export const Radio = (props: RadioProps) => (
+  <InlineField
+    {...props}
+    type="radio"
+    message={null}
+    reserveMessageSpace={false}
+  />
 );

--- a/lib/components/Radio/Radio.tsx
+++ b/lib/components/Radio/Radio.tsx
@@ -5,14 +5,25 @@ import {
   InlineFieldProps,
 } from '../private/InlineField/InlineField';
 
-interface RadioProps
-  extends Omit<InlineFieldProps, 'message' | 'reserveMessageSpace'> {}
+const validTones = ['neutral', 'critical'] as const;
 
-export const Radio = (props: RadioProps) => (
-  <InlineField
-    {...props}
-    type="radio"
-    message={null}
-    reserveMessageSpace={false}
-  />
-);
+interface RadioProps
+  extends Omit<InlineFieldProps, 'message' | 'reserveMessageSpace'> {
+  tone?: typeof validTones[number];
+}
+
+export const Radio = ({ tone, ...restProps }: RadioProps) => {
+  if (tone && validTones.indexOf(tone) === -1) {
+    throw new Error(`Invalid tone: ${tone}`);
+  }
+
+  return (
+    <InlineField
+      {...restProps}
+      type="radio"
+      message={null}
+      reserveMessageSpace={false}
+      tone={tone}
+    />
+  );
+};

--- a/lib/components/Radio/Radio.tsx
+++ b/lib/components/Radio/Radio.tsx
@@ -8,12 +8,11 @@ import {
 interface RadioProps
   extends Omit<InlineFieldProps, 'message' | 'reserveMessageSpace'> {}
 
-export const Radio = ({ tone, ...restProps }: RadioProps) => (
+export const Radio = (props: RadioProps) => (
   <InlineField
-    {...restProps}
+    {...props}
     type="radio"
     message={null}
     reserveMessageSpace={false}
-    tone={tone}
   />
 );

--- a/lib/components/Radio/Radio.tsx
+++ b/lib/components/Radio/Radio.tsx
@@ -5,25 +5,15 @@ import {
   InlineFieldProps,
 } from '../private/InlineField/InlineField';
 
-const tones = ['neutral', 'critical'] as const;
-
 interface RadioProps
-  extends Omit<InlineFieldProps, 'message' | 'reserveMessageSpace'> {
-  tone?: typeof tones[number];
-}
+  extends Omit<InlineFieldProps, 'message' | 'reserveMessageSpace'> {}
 
-export const Radio = ({ tone, ...restProps }: RadioProps) => {
-  if (tone && tones.indexOf(tone) === -1) {
-    throw new Error(`Invalid tone: ${tone}`);
-  }
-
-  return (
-    <InlineField
-      {...restProps}
-      type="radio"
-      message={null}
-      reserveMessageSpace={false}
-      tone={tone}
-    />
-  );
-};
+export const Radio = ({ tone, ...restProps }: RadioProps) => (
+  <InlineField
+    {...restProps}
+    type="radio"
+    message={null}
+    reserveMessageSpace={false}
+    tone={tone}
+  />
+);

--- a/lib/components/TextArea/TextArea.tsx
+++ b/lib/components/TextArea/TextArea.tsx
@@ -1,12 +1,13 @@
 import React, { ReactNode, AllHTMLAttributes } from 'react';
 import { useClassNames } from 'sku/treat';
+import { Omit } from 'utility-types';
 import { Box } from '../Box/Box';
 import { Text } from '../Text/Text';
 import * as styles from './TextArea.treat';
 import { Field, FieldProps } from '../private/Field/Field';
 
 type NativeTextAreaProps = AllHTMLAttributes<HTMLTextAreaElement>;
-interface TextAreaProps extends FieldProps {
+interface TextAreaProps extends Omit<FieldProps, 'secondaryMessage'> {
   value: NonNullable<NativeTextAreaProps['value']>;
   onChange: NonNullable<NativeTextAreaProps['onChange']>;
   onBlur?: NativeTextAreaProps['onBlur'];
@@ -34,32 +35,16 @@ const renderCount = ({
 };
 
 export const TextArea = ({
-  id,
-  name,
-  disabled,
-  label,
-  secondaryLabel,
-  tertiaryLabel,
-  description,
-  message,
-  tone = 'neutral',
   value,
   onChange,
   onBlur,
   onFocus,
   placeholder,
   limit,
+  ...restProps
 }: TextAreaProps) => (
   <Field
-    id={id}
-    name={name}
-    disabled={disabled}
-    label={label}
-    secondaryLabel={secondaryLabel}
-    tertiaryLabel={tertiaryLabel}
-    description={description}
-    tone={tone}
-    message={message}
+    {...restProps}
     secondaryMessage={renderCount({
       limit,
       value,

--- a/lib/components/TextField/TextField.tsx
+++ b/lib/components/TextField/TextField.tsx
@@ -1,4 +1,5 @@
 import React, { AllHTMLAttributes } from 'react';
+import { Omit } from 'utility-types';
 import { Box } from '../Box/Box';
 import { Field, FieldProps } from '../private/Field/Field';
 
@@ -13,7 +14,7 @@ const validTypes = {
 };
 
 type InputProps = AllHTMLAttributes<HTMLInputElement>;
-interface TextFieldProps extends FieldProps {
+interface TextFieldProps extends Omit<FieldProps, 'secondaryMessage'> {
   value: NonNullable<InputProps['value']>;
   type?: keyof typeof validTypes;
   onChange: NonNullable<InputProps['onChange']>;
@@ -23,31 +24,15 @@ interface TextFieldProps extends FieldProps {
 }
 
 export const TextField = ({
-  id,
-  name,
-  disabled,
-  label,
-  secondaryLabel,
-  tertiaryLabel,
-  message,
-  tone = 'neutral',
-  type = 'text',
   value,
+  type = 'text',
   onChange,
   onBlur,
   onFocus,
   placeholder,
+  ...restProps
 }: TextFieldProps) => (
-  <Field
-    id={id}
-    name={name}
-    disabled={disabled}
-    label={label}
-    secondaryLabel={secondaryLabel}
-    tertiaryLabel={tertiaryLabel}
-    tone={tone}
-    message={message}
-  >
+  <Field {...restProps} secondaryMessage={null}>
     {fieldProps => (
       <Box
         component="input"

--- a/lib/components/private/Field/Field.tsx
+++ b/lib/components/private/Field/Field.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, AllHTMLAttributes } from 'react';
 import { useClassNames } from 'sku/treat';
 import { Box, BoxProps } from '../../Box/Box';
-import { FieldLabel } from '../../FieldLabel/FieldLabel';
+import { FieldLabel, FieldLabelProps } from '../../FieldLabel/FieldLabel';
 import {
   FieldMessage,
   FieldMessageProps,
@@ -15,12 +15,13 @@ export interface FieldProps {
   id: NonNullable<FormElementProps['id']>;
   name?: FormElementProps['name'];
   disabled?: FormElementProps['disabled'];
-  label?: string;
-  secondaryLabel?: ReactNode;
-  tertiaryLabel?: ReactNode;
-  description?: string;
-  message?: ReactNode | false;
-  secondaryMessage?: ReactNode;
+  label?: FieldLabelProps['label'];
+  secondaryLabel?: FieldLabelProps['secondaryLabel'];
+  tertiaryLabel?: FieldLabelProps['tertiaryLabel'];
+  description?: FieldLabelProps['description'];
+  message?: FieldMessageProps['message'];
+  secondaryMessage?: FieldMessageProps['secondaryMessage'];
+  reserveMessageSpace?: FieldMessageProps['reserveMessageSpace'];
   tone?: FieldMessageProps['tone'];
 }
 
@@ -51,6 +52,7 @@ export const Field = ({
   children,
   message,
   secondaryMessage,
+  reserveMessageSpace = true,
   tone = 'neutral',
 }: InternalFieldProps) => {
   const messageId = `${id}-message`;
@@ -94,6 +96,7 @@ export const Field = ({
         disabled={disabled}
         message={message}
         secondaryMessage={secondaryMessage}
+        reserveMessageSpace={reserveMessageSpace}
       />
     </Box>
   );

--- a/lib/components/private/InlineField/InlineField.tsx
+++ b/lib/components/private/InlineField/InlineField.tsx
@@ -21,6 +21,7 @@ export interface InlineFieldProps {
   name?: FormElementProps['name'];
   disabled?: FormElementProps['disabled'];
   message?: FieldMessageProps['message'];
+  reserveMessageSpace?: FieldMessageProps['reserveMessageSpace'];
   tone?: FieldMessageProps['tone'];
   children?: ReactNode;
 }
@@ -38,6 +39,7 @@ export const InlineField = ({
   type,
   children,
   message,
+  reserveMessageSpace = false,
   tone = 'neutral',
   disabled = false,
 }: InternalInlineFieldProps) => {
@@ -129,6 +131,7 @@ export const InlineField = ({
         tone={tone}
         disabled={disabled}
         message={message}
+        reserveMessageSpace={reserveMessageSpace}
       />
     </Box>
   );

--- a/lib/components/private/InlineField/InlineField.tsx
+++ b/lib/components/private/InlineField/InlineField.tsx
@@ -12,6 +12,8 @@ import { Text } from '../../Text/Text';
 import { TickIcon } from '../../icons/TickIcon/TickIcon';
 import { useTouchableSpace } from '../../../hooks/typography';
 
+const tones = ['neutral', 'critical'] as const;
+
 type FormElementProps = AllHTMLAttributes<HTMLFormElement>;
 export interface InlineFieldProps {
   id: NonNullable<FormElementProps['id']>;
@@ -22,7 +24,7 @@ export interface InlineFieldProps {
   disabled?: FormElementProps['disabled'];
   message?: FieldMessageProps['message'];
   reserveMessageSpace?: FieldMessageProps['reserveMessageSpace'];
-  tone?: FieldMessageProps['tone'];
+  tone?: 'neutral' | 'critical';
   children?: ReactNode;
 }
 
@@ -49,6 +51,10 @@ export const InlineField = ({
     [styles.circle]: type === 'radio',
   };
   const fieldBorderRadius = isCheckbox ? 'standard' : undefined;
+
+  if (tones.indexOf(tone) === -1) {
+    throw new Error(`Invalid tone: ${tone}`);
+  }
 
   return (
     <Box>


### PR DESCRIPTION
This cleans one of the longstanding quirks of our component API. Rather than having a `message` prop that accepts a string, but also accepts `false` to disable the message, we've separated them into two props: `message`, which is only ever a string, and `reserveMessageSpace`, which is a boolean.

So, rather than writing `<TextField message={false} />`, you now write `<TextField reserveMessageSpace={false} />`.

This also cleans up some other form element API issues, which are documented below.

## Breaking Changes

- `message={false}` no longer works on form fields. Use `reserveMessageSpace={false}` instead.
- `Checkbox` and `Radio` components no longer support `positive` tone. They can only be `critical` or `neutral`.
- `Radio` no longer supports `message` prop, since it can't be used in isolation. If you want to reinstate previous behaviour, manually render a `FieldMessage` component below the radio button.
- Fields no longer support `secondaryMessage` prop, since it was only designed for private usage within `TextArea`.