### PR TITLE
fix(FieldMessage): Align size and spacing with other style guides

### DIFF
--- a/lib/components/FieldMessage/FieldMessage.treat.ts
+++ b/lib/components/FieldMessage/FieldMessage.treat.ts
@@ -10,7 +10,7 @@ export const grow = style({
 
 export const minHeight = style(theme => {
   const { responsiveStyles, rows } = theme.utils;
-  const { mobile, desktop } = theme.typography.text.standard;
+  const { mobile, desktop } = theme.typography.text.small;
 
   return responsiveStyles(
     { minHeight: rows(mobile.rows) },

--- a/lib/components/FieldMessage/FieldMessage.tsx
+++ b/lib/components/FieldMessage/FieldMessage.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode, Fragment } from 'react';
 import { useClassNames } from 'sku/treat';
 import { Box } from '../Box/Box';
-import { Text, TextProps } from '../Text/Text';
 import { ErrorIcon } from '../icons/ErrorIcon/ErrorIcon';
 import { TickCircleIcon } from '../icons/TickCircleIcon/TickCircleIcon';
 import * as styles from './FieldMessage.treat';
@@ -9,7 +8,7 @@ import { useText } from '../../hooks/typography';
 
 type FieldTone = 'neutral' | 'critical' | 'positive';
 
-export interface FieldMessageProps extends TextProps {
+export interface FieldMessageProps {
   id: string;
   message: ReactNode | false;
   tone?: FieldTone;

--- a/lib/components/FieldMessage/FieldMessage.tsx
+++ b/lib/components/FieldMessage/FieldMessage.tsx
@@ -1,10 +1,10 @@
-import React, { ReactNode, Fragment } from 'react';
+import React, { ReactNode } from 'react';
 import { useClassNames } from 'sku/treat';
 import { Box } from '../Box/Box';
+import { Text } from '../Text/Text';
 import { ErrorIcon } from '../icons/ErrorIcon/ErrorIcon';
 import { TickCircleIcon } from '../icons/TickCircleIcon/TickCircleIcon';
 import * as styles from './FieldMessage.treat';
-import { useText } from '../../hooks/typography';
 
 type FieldTone = 'neutral' | 'critical' | 'positive';
 
@@ -53,18 +53,14 @@ export const FieldMessage = ({
       display="flex"
       className={useClassNames(styles.root, styles.minHeight)}
     >
-      <Box
-        display="flex"
-        className={useClassNames(
-          styles.grow,
-          useText({ size: 'small', color: tone, baseline: true }),
-        )}
-      >
+      <Box className={useClassNames(styles.grow)}>
         {disabled ? null : (
-          <Fragment>
-            {renderIcon(tone)}
-            {message}
-          </Fragment>
+          <Text size="small" color={tone}>
+            <Box display="flex">
+              {renderIcon(tone)}
+              {message}
+            </Box>
+          </Text>
         )}
       </Box>
       {secondaryMessage && !disabled ? (

--- a/lib/components/FieldMessage/FieldMessage.tsx
+++ b/lib/components/FieldMessage/FieldMessage.tsx
@@ -1,10 +1,11 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, Fragment } from 'react';
 import { useClassNames } from 'sku/treat';
 import { Box } from '../Box/Box';
 import { Text, TextProps } from '../Text/Text';
 import { ErrorIcon } from '../icons/ErrorIcon/ErrorIcon';
 import { TickCircleIcon } from '../icons/TickCircleIcon/TickCircleIcon';
 import * as styles from './FieldMessage.treat';
+import { useText } from '../../hooks/typography';
 
 type FieldTone = 'neutral' | 'critical' | 'positive';
 
@@ -23,8 +24,8 @@ const renderIcon = (tone: FieldTone = 'neutral') => {
 
   const Icon: Record<FieldTone, ReactNode> = {
     neutral: null,
-    critical: <ErrorIcon fill="critical" inline />,
-    positive: <TickCircleIcon fill="positive" inline />,
+    critical: <ErrorIcon fill="critical" size="small" inline />,
+    positive: <TickCircleIcon fill="positive" size="small" inline />,
   };
 
   return (
@@ -48,18 +49,21 @@ export const FieldMessage = ({
   return (
     <Box
       id={id}
-      paddingBottom="small"
       display="flex"
-      className={useClassNames(styles.root)}
+      className={useClassNames(styles.root, styles.minHeight)}
     >
-      <Box className={useClassNames(styles.minHeight, styles.grow)}>
+      <Box
+        display="flex"
+        className={useClassNames(
+          styles.grow,
+          useText({ size: 'small', color: tone, baseline: true }),
+        )}
+      >
         {disabled ? null : (
-          <Text color={tone}>
-            <Box display="flex">
-              {renderIcon(tone)}
-              {message}
-            </Box>
-          </Text>
+          <Fragment>
+            {renderIcon(tone)}
+            {message}
+          </Fragment>
         )}
       </Box>
       {secondaryMessage && !disabled ? (

--- a/lib/components/FieldMessage/FieldMessage.tsx
+++ b/lib/components/FieldMessage/FieldMessage.tsx
@@ -5,6 +5,7 @@ import { Text } from '../Text/Text';
 import { ErrorIcon } from '../icons/ErrorIcon/ErrorIcon';
 import { TickCircleIcon } from '../icons/TickCircleIcon/TickCircleIcon';
 import * as styles from './FieldMessage.treat';
+import { useThemeName } from '../ThemeNameConsumer/ThemeNameContext';
 
 type FieldTone = 'neutral' | 'critical' | 'positive';
 
@@ -47,9 +48,16 @@ export const FieldMessage = ({
     return null;
   }
 
+  // Temporary switch to support maintaining a consistent UX
+  // while consumers migrate forms from seek-style-guide.
+  // Can be removed once we have form field parity and have
+  // given consumers the opportunity to migrate.
+  const isSeekAu = useThemeName() === 'seekAnz';
+
   return (
     <Box
       id={id}
+      paddingBottom={isSeekAu ? 'xxsmall' : 'xsmall'}
       display="flex"
       className={useClassNames(styles.root, styles.minHeight)}
     >

--- a/lib/themes/wireframe/tokens.ts
+++ b/lib/themes/wireframe/tokens.ts
@@ -62,11 +62,11 @@ const tokens: TreatTokens = {
       small: {
         mobile: {
           size: 14,
-          rows: 5,
+          rows: 3,
         },
         desktop: {
           size: 14,
-          rows: 5,
+          rows: 3,
         },
       },
       standard: {


### PR DESCRIPTION
BREAKING CHANGE: Reduces the padding below `FieldMessage`. Please validate your app was not depending on this.

This PR brings `FieldMessage` into line with the regional style guides as a better starting point. This will allow for more gradual adoption of form field components while keeping the experience consistent.

Changes include:
- Remove additional white space beyond the default reserved message space
- Make copy and icon `small` rather than `standard`
- `FieldMessage` no longer extends `Text` component api, which was incorrect and did not yield expected result.
- Update wireframe small text definition