### PR TITLE
fix(FieldMessage): Correct min height & only render icon with message

### DIFF
--- a/lib/components/FieldMessage/FieldMessage.tsx
+++ b/lib/components/FieldMessage/FieldMessage.tsx
@@ -57,6 +57,7 @@ export const FieldMessage = ({
   }
 
   const styles = useStyles(styleRefs);
+  const showMessage = !disabled && message;
 
   // Temporary switch to support maintaining a consistent UX
   // while consumers migrate forms from seek-style-guide.
@@ -69,17 +70,17 @@ export const FieldMessage = ({
       id={id}
       paddingBottom={isSeekAu ? 'xxsmall' : 'xsmall'}
       display="flex"
-      className={classnames(styles.root, styles.minHeight)}
+      className={styles.root}
     >
-      <Box className={styles.grow}>
-        {disabled ? null : (
+      <Box className={classnames(styles.grow, styles.minHeight)}>
+        {showMessage ? (
           <Text size="small" color={tone === 'neutral' ? 'secondary' : tone}>
             <Box display="flex">
               {renderIcon(tone)}
               {message}
             </Box>
           </Text>
-        )}
+        ) : null}
       </Box>
       {secondaryMessage && !disabled ? (
         <Box paddingLeft="xsmall" className={styles.fixedSize}>


### PR DESCRIPTION
We had a slight (single grid row) regression in the min height of a message that was lost amongst [a larger change](https://github.com/seek-oss/braid-design-system/pull/216/files#diff-7921ba9130897fd0697602ce645013eaR62). Result was a slight change in vertical height when a message appears.

Also making the icon conditional to only render when a message is present.