### PR TITLE
test(chromatic): Merge snapshots into a single story per component

### DIFF
--- a/lib/stories/all.stories.tsx
+++ b/lib/stories/all.stories.tsx
@@ -21,23 +21,54 @@ req.keys().forEach(filename => {
   const stories = storiesOf(componentName, module);
   const docs = req(filename).default as ComponentDocs;
 
-  if (docs.storybook === false) {
+  if (
+    docs.storybook === false ||
+    !docs.examples.some(({ render }) => typeof render === 'function')
+  ) {
     return;
   }
 
-  docs.examples.forEach(({ label = componentName, render }) => {
-    if (!render) {
-      return;
-    }
-
-    values(themes).forEach(theme => {
-      stories.add(`${label} (${theme.name})`, () => (
-        <BrowserRouter>
-          <ThemeProvider theme={theme}>
-            {render({ id: 'id', handler })}
-          </ThemeProvider>
-        </BrowserRouter>
-      ));
-    });
+  values(themes).forEach(theme => {
+    stories.add(theme.name, () => (
+      <BrowserRouter>
+        <ThemeProvider theme={theme}>
+          {docs.examples.map(({ label = componentName, render }, i) =>
+            render ? (
+              <div
+                key={i}
+                style={{
+                  minHeight: 300,
+                  paddingBottom: 32,
+                }}
+              >
+                <h4
+                  style={{
+                    margin: 0,
+                    marginBottom: 18,
+                    padding: 0,
+                    fontSize: 14,
+                    fontFamily: 'arial',
+                    color: '#ccc',
+                  }}
+                >
+                  {label}
+                </h4>
+                {render({ id: 'id', handler })}
+                <div style={{ paddingTop: 18 }}>
+                  <hr
+                    style={{
+                      margin: 0,
+                      border: 0,
+                      height: 1,
+                      background: '#eee',
+                    }}
+                  />
+                </div>
+              </div>
+            ) : null,
+          )}
+        </ThemeProvider>
+      </BrowserRouter>
+    ));
   });
 });

--- a/lib/stories/all.stories.tsx
+++ b/lib/stories/all.stories.tsx
@@ -28,47 +28,49 @@ req.keys().forEach(filename => {
     return;
   }
 
-  values(themes).forEach(theme => {
-    stories.add(theme.name, () => (
-      <BrowserRouter>
-        <ThemeProvider theme={theme}>
-          {docs.examples.map(({ label = componentName, render }, i) =>
-            render ? (
-              <div
-                key={i}
-                style={{
-                  minHeight: 300,
-                  paddingBottom: 32,
-                }}
-              >
-                <h4
+  values(themes)
+    .filter(theme => theme.name !== 'wireframe')
+    .forEach(theme => {
+      stories.add(theme.name, () => (
+        <BrowserRouter>
+          <ThemeProvider theme={theme}>
+            {docs.examples.map(({ label = componentName, render }, i) =>
+              render ? (
+                <div
+                  key={i}
                   style={{
-                    margin: 0,
-                    marginBottom: 18,
-                    padding: 0,
-                    fontSize: 14,
-                    fontFamily: 'arial',
-                    color: '#ccc',
+                    minHeight: 300,
+                    paddingBottom: 32,
                   }}
                 >
-                  {label}
-                </h4>
-                {render({ id: 'id', handler })}
-                <div style={{ paddingTop: 18 }}>
-                  <hr
+                  <h4
                     style={{
                       margin: 0,
-                      border: 0,
-                      height: 1,
-                      background: '#eee',
+                      marginBottom: 18,
+                      padding: 0,
+                      fontSize: 14,
+                      fontFamily: 'arial',
+                      color: '#ccc',
                     }}
-                  />
+                  >
+                    {label}
+                  </h4>
+                  {render({ id: 'id', handler })}
+                  <div style={{ paddingTop: 18 }}>
+                    <hr
+                      style={{
+                        margin: 0,
+                        border: 0,
+                        height: 1,
+                        background: '#eee',
+                      }}
+                    />
+                  </div>
                 </div>
-              </div>
-            ) : null,
-          )}
-        </ThemeProvider>
-      </BrowserRouter>
-    ));
-  });
+              ) : null,
+            )}
+          </ThemeProvider>
+        </BrowserRouter>
+      ));
+    });
 });


### PR DESCRIPTION
This should greatly reduce our Chromatic snapshot usage, while also streamlining the review process.

Each component example has a minimum height of `300px`, which should solve the biggest issue with combined screenshots where updates to components higher in the page can cause cascading diffs to the rest of the components.

We're also rendering a divider line below each components so that we can catch differences in surrounding white space, which is otherwise invisible.

I've also removed the `wireframe` theme, since it's not a production theme and any accidental breakages wouldn't really be a big deal.