### PR TITLE
fix(FieldGroup): Apply `id` to element

### DIFF
--- a/lib/components/private/FieldGroup/FieldGroup.tsx
+++ b/lib/components/private/FieldGroup/FieldGroup.tsx
@@ -43,7 +43,7 @@ export const FieldGroup = ({
   const messageId = `${id}-message`;
 
   return (
-    <Box component="fieldset" disabled={disabled}>
+    <Box component="fieldset" disabled={disabled} id={id}>
       <Box component="legend">
         <FieldLabel
           id={false}


### PR DESCRIPTION
The `id` is used to associate the field message to the field's in the group but expected behaviour should also apply this `id` to the root element returned — in this case the `fieldset`