### PR TITLE
feat: Rename color/fill to tone on Text/icons, remove black/white tones

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -2903,24 +2903,6 @@ Object {
         ],
       },
     },
-    "fill": Object {
-      "propName": "fill",
-      "required": false,
-      "type": Object {
-        "type": "union",
-        "types": Array [
-          "\\"info\\"",
-          "\\"critical\\"",
-          "\\"positive\\"",
-          "\\"formAccent\\"",
-          "\\"black\\"",
-          "\\"white\\"",
-          "\\"link\\"",
-          "\\"neutral\\"",
-          "\\"secondary\\"",
-        ],
-      },
-    },
     "inline": Object {
       "propName": "inline",
       "required": false,
@@ -2936,6 +2918,22 @@ Object {
           "\\"small\\"",
           "\\"large\\"",
           "\\"standard\\"",
+        ],
+      },
+    },
+    "tone": Object {
+      "propName": "tone",
+      "required": false,
+      "type": Object {
+        "type": "union",
+        "types": Array [
+          "\\"info\\"",
+          "\\"critical\\"",
+          "\\"positive\\"",
+          "\\"formAccent\\"",
+          "\\"link\\"",
+          "\\"neutral\\"",
+          "\\"secondary\\"",
         ],
       },
     },
@@ -3187,24 +3185,6 @@ Object {
 exports[`Public API Contract ErrorIcon 1`] = `
 Object {
   "props": Object {
-    "fill": Object {
-      "propName": "fill",
-      "required": false,
-      "type": Object {
-        "type": "union",
-        "types": Array [
-          "\\"info\\"",
-          "\\"critical\\"",
-          "\\"positive\\"",
-          "\\"formAccent\\"",
-          "\\"black\\"",
-          "\\"white\\"",
-          "\\"link\\"",
-          "\\"neutral\\"",
-          "\\"secondary\\"",
-        ],
-      },
-    },
     "inline": Object {
       "propName": "inline",
       "required": false,
@@ -3220,6 +3200,22 @@ Object {
           "\\"small\\"",
           "\\"large\\"",
           "\\"standard\\"",
+        ],
+      },
+    },
+    "tone": Object {
+      "propName": "tone",
+      "required": false,
+      "type": Object {
+        "type": "union",
+        "types": Array [
+          "\\"info\\"",
+          "\\"critical\\"",
+          "\\"positive\\"",
+          "\\"formAccent\\"",
+          "\\"link\\"",
+          "\\"neutral\\"",
+          "\\"secondary\\"",
         ],
       },
     },
@@ -3669,24 +3665,6 @@ Object {
 exports[`Public API Contract InfoIcon 1`] = `
 Object {
   "props": Object {
-    "fill": Object {
-      "propName": "fill",
-      "required": false,
-      "type": Object {
-        "type": "union",
-        "types": Array [
-          "\\"info\\"",
-          "\\"critical\\"",
-          "\\"positive\\"",
-          "\\"formAccent\\"",
-          "\\"black\\"",
-          "\\"white\\"",
-          "\\"link\\"",
-          "\\"neutral\\"",
-          "\\"secondary\\"",
-        ],
-      },
-    },
     "inline": Object {
       "propName": "inline",
       "required": false,
@@ -3702,6 +3680,22 @@ Object {
           "\\"small\\"",
           "\\"large\\"",
           "\\"standard\\"",
+        ],
+      },
+    },
+    "tone": Object {
+      "propName": "tone",
+      "required": false,
+      "type": Object {
+        "type": "union",
+        "types": Array [
+          "\\"info\\"",
+          "\\"critical\\"",
+          "\\"positive\\"",
+          "\\"formAccent\\"",
+          "\\"link\\"",
+          "\\"neutral\\"",
+          "\\"secondary\\"",
         ],
       },
     },
@@ -4075,24 +4069,6 @@ Object {
         ],
       },
     },
-    "color": Object {
-      "propName": "color",
-      "required": false,
-      "type": Object {
-        "type": "union",
-        "types": Array [
-          "\\"info\\"",
-          "\\"critical\\"",
-          "\\"positive\\"",
-          "\\"formAccent\\"",
-          "\\"black\\"",
-          "\\"white\\"",
-          "\\"link\\"",
-          "\\"neutral\\"",
-          "\\"secondary\\"",
-        ],
-      },
-    },
     "component": Object {
       "propName": "component",
       "required": false,
@@ -4291,6 +4267,22 @@ Object {
           "\\"small\\"",
           "\\"large\\"",
           "\\"standard\\"",
+        ],
+      },
+    },
+    "tone": Object {
+      "propName": "tone",
+      "required": false,
+      "type": Object {
+        "type": "union",
+        "types": Array [
+          "\\"info\\"",
+          "\\"critical\\"",
+          "\\"positive\\"",
+          "\\"formAccent\\"",
+          "\\"link\\"",
+          "\\"neutral\\"",
+          "\\"secondary\\"",
         ],
       },
     },
@@ -6847,24 +6839,6 @@ Object {
 exports[`Public API Contract TickCircleIcon 1`] = `
 Object {
   "props": Object {
-    "fill": Object {
-      "propName": "fill",
-      "required": false,
-      "type": Object {
-        "type": "union",
-        "types": Array [
-          "\\"info\\"",
-          "\\"critical\\"",
-          "\\"positive\\"",
-          "\\"formAccent\\"",
-          "\\"black\\"",
-          "\\"white\\"",
-          "\\"link\\"",
-          "\\"neutral\\"",
-          "\\"secondary\\"",
-        ],
-      },
-    },
     "inline": Object {
       "propName": "inline",
       "required": false,
@@ -6880,6 +6854,22 @@ Object {
           "\\"small\\"",
           "\\"large\\"",
           "\\"standard\\"",
+        ],
+      },
+    },
+    "tone": Object {
+      "propName": "tone",
+      "required": false,
+      "type": Object {
+        "type": "union",
+        "types": Array [
+          "\\"info\\"",
+          "\\"critical\\"",
+          "\\"positive\\"",
+          "\\"formAccent\\"",
+          "\\"link\\"",
+          "\\"neutral\\"",
+          "\\"secondary\\"",
         ],
       },
     },
@@ -6890,24 +6880,6 @@ Object {
 exports[`Public API Contract TickIcon 1`] = `
 Object {
   "props": Object {
-    "fill": Object {
-      "propName": "fill",
-      "required": false,
-      "type": Object {
-        "type": "union",
-        "types": Array [
-          "\\"info\\"",
-          "\\"critical\\"",
-          "\\"positive\\"",
-          "\\"formAccent\\"",
-          "\\"black\\"",
-          "\\"white\\"",
-          "\\"link\\"",
-          "\\"neutral\\"",
-          "\\"secondary\\"",
-        ],
-      },
-    },
     "inline": Object {
       "propName": "inline",
       "required": false,
@@ -6923,6 +6895,22 @@ Object {
           "\\"small\\"",
           "\\"large\\"",
           "\\"standard\\"",
+        ],
+      },
+    },
+    "tone": Object {
+      "propName": "tone",
+      "required": false,
+      "type": Object {
+        "type": "union",
+        "types": Array [
+          "\\"info\\"",
+          "\\"critical\\"",
+          "\\"positive\\"",
+          "\\"formAccent\\"",
+          "\\"link\\"",
+          "\\"neutral\\"",
+          "\\"secondary\\"",
         ],
       },
     },

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -90,7 +90,7 @@ export const Button = ({
         <Text
           baseline={false}
           weight="medium"
-          color={weight === 'weak' ? 'formAccent' : undefined}
+          tone={weight === 'weak' ? 'formAccent' : undefined}
         >
           {children}
         </Text>

--- a/lib/components/Dropdown/Dropdown.tsx
+++ b/lib/components/Dropdown/Dropdown.tsx
@@ -11,7 +11,7 @@ import { Omit } from 'utility-types';
 import { Box } from '../Box/Box';
 import { Field, FieldProps } from '../private/Field/Field';
 import { ChevronIcon } from '../icons/ChevronIcon/ChevronIcon';
-import { useTextColor } from '../../hooks/typography';
+import { useTextTone } from '../../hooks/typography';
 import * as styleRefs from './Dropdown.treat';
 
 type ValidDropdownChildren = AllHTMLAttributes<
@@ -27,7 +27,7 @@ interface DropdownProps extends Omit<FieldProps, 'secondaryMessage'> {
   placeholder?: string;
 }
 
-const getColor = (
+const getTone = (
   placeholder: DropdownProps['placeholder'],
   value: DropdownProps['value'],
 ) => {
@@ -79,7 +79,7 @@ export const Dropdown = forwardRef<HTMLSelectElement, DropdownProps>(
               className={classnames(
                 styles.field,
                 className,
-                useTextColor(getColor(placeholder, value)),
+                useTextTone(getTone(placeholder, value)),
               )}
               {...fieldProps}
               ref={fieldRef}

--- a/lib/components/FieldLabel/FieldLabel.tsx
+++ b/lib/components/FieldLabel/FieldLabel.tsx
@@ -42,7 +42,7 @@ export const FieldLabel = ({
       </Box>
       {description ? (
         <Box paddingTop="xxsmall" paddingBottom="xxsmall">
-          <Text color="secondary">{description}</Text>
+          <Text tone="secondary">{description}</Text>
         </Box>
       ) : null}
     </Box>

--- a/lib/components/FieldMessage/FieldMessage.tsx
+++ b/lib/components/FieldMessage/FieldMessage.tsx
@@ -21,8 +21,8 @@ export interface FieldMessageProps {
 }
 
 const Icon: Record<'critical' | 'positive', ReactNode> = {
-  critical: <ErrorIcon fill="critical" size="small" inline />,
-  positive: <TickCircleIcon fill="positive" size="small" inline />,
+  critical: <ErrorIcon tone="critical" size="small" inline />,
+  positive: <TickCircleIcon tone="positive" size="small" inline />,
 };
 export const FieldMessage = ({
   id,
@@ -58,7 +58,7 @@ export const FieldMessage = ({
     >
       <Box className={classnames(styles.grow, styles.minHeight)}>
         {showMessage ? (
-          <Text size="small" color={tone === 'neutral' ? 'secondary' : tone}>
+          <Text size="small" tone={tone === 'neutral' ? 'secondary' : tone}>
             <Box display="flex">
               {tone !== 'neutral' ? (
                 <Box paddingRight="xxsmall" className={styles.fixedSize}>

--- a/lib/components/Heading/Heading.migration.md
+++ b/lib/components/Heading/Heading.migration.md
@@ -11,7 +11,7 @@
 
 ## TBD
 
-- `color={string}`
+- `tone={string}`
 
 ## Diff
 

--- a/lib/components/Secondary/Secondary.tsx
+++ b/lib/components/Secondary/Secondary.tsx
@@ -1,5 +1,5 @@
 import React, { ReactNode } from 'react';
-import { useTextColor } from '../../hooks/typography';
+import { useTextTone } from '../../hooks/typography';
 
 export interface SecondaryProps {
   children: ReactNode;
@@ -7,7 +7,7 @@ export interface SecondaryProps {
 }
 
 export const Secondary = ({ children, id }: SecondaryProps) => (
-  <span className={useTextColor('secondary')} id={id}>
+  <span className={useTextTone('secondary')} id={id}>
     {children}
   </span>
 );

--- a/lib/components/Text/Text.migration.md
+++ b/lib/components/Text/Text.migration.md
@@ -5,9 +5,8 @@
 - No longer handles heading text. Use [`Heading`](https://seek-oss.github.io/braid-design-system/components/Heading) instead.
 - Deprecated `conversational`/`loud`/`intimate`/`whispering` in favour of `size={'large' | 'standard' | 'small'}` and `weight={'strong' | 'regular'}`. Please note that this is a breaking change to our design language. When migrating, try to match existing styling as much as possible in consultation with your local designer.
 - No longer renders white space below it, also removing the need for a `raw` prop. Consider using a [`Paragraph`](https://seek-oss.github.io/braid-design-system/components/Paragraph) component instead, where semantically appropriate.
-- Renamed `tone` prop to `color`.
 - Removed `weak` weight.
-- Removed boolean size props in favour of `size` and `color` props.
+- Removed boolean size props in favour of `size` and `tone` props.
 - Removed `bullet` prop. Use [`Bullet`](https://seek-oss.github.io/braid-design-system/components/Bullet) insted.
 - No longer accepts arbitrary DOM properties, e.g. `className`. Please check that everything you need is exposed via the [public API.](https://seek-oss.github.io/braid-design-system/components/Text)
 
@@ -28,7 +27,7 @@
 -<Text large>...</Text>
 -<Text positive>...</Text>
 +<Text size="large">...</Text>
-+<Text color="positive">...</Text>
++<Text tone="positive">...</Text>
 ```
 
 ### SEEK Asia Style Guide

--- a/lib/components/Text/Text.tsx
+++ b/lib/components/Text/Text.tsx
@@ -9,7 +9,7 @@ export interface TextProps extends Pick<BoxProps, 'component'> {
   id?: string;
   children?: ReactNode;
   size?: UseTextProps['size'];
-  color?: UseTextProps['color'];
+  tone?: UseTextProps['tone'];
   weight?: UseTextProps['weight'];
   baseline?: UseTextProps['baseline'];
 }
@@ -18,7 +18,7 @@ export const Text = ({
   id,
   component = 'span',
   size,
-  color,
+  tone,
   weight,
   baseline = true,
   children,
@@ -31,7 +31,7 @@ export const Text = ({
       id={id}
       display={!isListItem ? 'block' : undefined}
       component={component}
-      className={classnames(useText({ weight, size, baseline, color }), {
+      className={classnames(useText({ weight, size, baseline, tone }), {
         [styles.listItem]: isListItem,
       })}
     >

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
@@ -6,7 +6,7 @@ import { Text } from '../Text/Text';
 import { FieldOverlay } from '../private/FieldOverlay/FieldOverlay';
 import useBox from '../../hooks/useBox';
 import {
-  useTextColor,
+  useTextTone,
   useTouchableSpace,
   useWeight,
 } from '../../hooks/typography';
@@ -28,11 +28,7 @@ export const TextLinkRenderer = ({
 }: TextLinkRendererProps) => {
   const styles = useStyles(styleRefs);
   const inActions = useContext(ActionsContext);
-  const defaultStyles = [
-    styles.root,
-    useTextColor('link'),
-    useWeight('medium'),
-  ];
+  const defaultStyles = [styles.root, useTextTone('link'), useWeight('medium')];
 
   if (inline) {
     return children({

--- a/lib/components/Textarea/Textarea.tsx
+++ b/lib/components/Textarea/Textarea.tsx
@@ -43,7 +43,7 @@ const renderCount = ({
   const valid = diff >= 0;
 
   return (
-    <Text size="small" color={valid ? 'secondary' : 'critical'}>
+    <Text size="small" tone={valid ? 'secondary' : 'critical'}>
       {diff}
     </Text>
   );

--- a/lib/components/icons/Icon/Icon.tsx
+++ b/lib/components/icons/Icon/Icon.tsx
@@ -2,7 +2,7 @@ import React, { ComponentType } from 'react';
 import { useStyles } from 'sku/react-treat';
 import classnames from 'classnames';
 import { Box } from '../../Box/Box';
-import { useTextColor, UseTextProps } from '../../../hooks/typography';
+import { useTextTone, UseTextProps } from '../../../hooks/typography';
 import * as styleRefs from './Icon.treat';
 
 type IconSize = NonNullable<UseTextProps['size']> | 'fill';
@@ -10,7 +10,7 @@ type IconSize = NonNullable<UseTextProps['size']> | 'fill';
 export interface IconProps {
   size?: IconSize;
   inline?: boolean;
-  fill?: UseTextProps['color'];
+  tone?: UseTextProps['tone'];
   svgComponent: ComponentType;
 }
 
@@ -30,7 +30,7 @@ export const Icon = ({
   size = 'standard',
   svgComponent,
   inline = false,
-  fill,
+  tone,
 }: IconProps) => {
   const styles = useStyles(styleRefs);
 
@@ -42,7 +42,7 @@ export const Icon = ({
       className={classnames(
         resolveSizeClasses(size, inline),
         styles.currentColor,
-        useTextColor(fill),
+        useTextTone(tone),
       )}
     />
   );

--- a/lib/components/private/InlineField/InlineField.tsx
+++ b/lib/components/private/InlineField/InlineField.tsx
@@ -13,6 +13,7 @@ import { TickIcon } from '../../icons/TickIcon/TickIcon';
 import { useTouchableSpace } from '../../../hooks/typography';
 import buildDataAttributes, { DataAttributeMap } from '../buildDataAttributes';
 import * as styleRefs from './InlineField.treat';
+import { BackgroundProvider } from 'lib/components/Box/BackgroundContext';
 
 const tones = ['neutral', 'critical'] as const;
 type InlineFieldTone = typeof tones[number];
@@ -68,6 +69,8 @@ export const InlineField = forwardRef<HTMLElement, InternalInlineFieldProps>(
       throw new Error(`Invalid tone: ${tone}`);
     }
 
+    const accentBackground = disabled ? 'formAccentDisabled' : 'formAccent';
+
     return (
       <Box>
         <Box
@@ -102,13 +105,18 @@ export const InlineField = forwardRef<HTMLElement, InternalInlineFieldProps>(
           >
             <FieldOverlay
               variant={tone === 'critical' && isCheckbox ? tone : undefined}
-              backgroundColor={disabled ? 'formAccentDisabled' : 'formAccent'}
+              backgroundColor={accentBackground}
               borderRadius={fieldBorderRadius}
               className={classnames(styles.selected, radioStyles)}
             />
             {isCheckbox ? (
               <Box transition="fast" width="full" className={styles.icon}>
-                <TickIcon size="fill" fill="white" />
+                <BackgroundProvider value={accentBackground}>
+                  <TickIcon
+                    size="fill"
+                    tone={disabled ? 'secondary' : undefined}
+                  />
+                </BackgroundProvider>
               </Box>
             ) : null}
             <FieldOverlay
@@ -130,7 +138,7 @@ export const InlineField = forwardRef<HTMLElement, InternalInlineFieldProps>(
             <Text
               baseline={false}
               weight={checked ? 'strong' : undefined}
-              color={disabled ? 'secondary' : undefined}
+              tone={disabled ? 'secondary' : undefined}
             >
               {label}
             </Text>

--- a/lib/hooks/typography/index.ts
+++ b/lib/hooks/typography/index.ts
@@ -6,14 +6,14 @@ import * as styleRefs from './typography.treat';
 export interface UseTextProps {
   weight?: keyof typeof styleRefs.fontWeight;
   size?: keyof typeof styleRefs.text;
-  color?: keyof typeof styleRefs.color;
+  tone?: keyof typeof styleRefs.tone;
   baseline: boolean;
 }
 
 export const useText = ({
   weight = 'regular',
   size = 'standard',
-  color,
+  tone,
   baseline,
 }: UseTextProps) => {
   const styles = useStyles(styleRefs);
@@ -22,7 +22,7 @@ export const useText = ({
     styles.fontFamily,
     styles.fontWeight[weight],
     styles.text[size].fontSize,
-    useTextColor(color),
+    useTextTone(tone),
     {
       [styles.text[size].transform]: baseline,
     },
@@ -49,7 +49,7 @@ export const useHeading = ({
     styles.fontFamily,
     styles.headingWeight[weight],
     styles.heading[level].fontSize,
-    useTextColor(),
+    useTextTone(),
     {
       [styles.heading[level].transform]: baseline,
     },
@@ -59,20 +59,20 @@ export const useHeading = ({
 export const useWeight = (weight: keyof typeof styleRefs.fontWeight) =>
   useStyles(styleRefs).fontWeight[weight];
 
-export const useTextColor = (color?: keyof typeof styleRefs.color) => {
+export const useTextTone = (tone?: keyof typeof styleRefs.tone) => {
   const styles = useStyles(styleRefs);
   const background = useBackground();
 
   const backgroundContrast = styles.backgroundContrast[background!];
   if (backgroundContrast) {
-    const altColor = backgroundContrast[color || 'default'];
+    const altColor = backgroundContrast[tone || 'default'];
 
     if (altColor) {
       return altColor;
     }
   }
 
-  return styles.color[color || 'neutral'];
+  return styles.tone[tone || 'neutral'];
 };
 
 export const useTouchableSpace = (size: keyof typeof styleRefs.touchable) =>

--- a/lib/hooks/typography/typography.treat.ts
+++ b/lib/hooks/typography/typography.treat.ts
@@ -100,8 +100,13 @@ export const heading = {
   ),
 };
 
-export const color = styleMap(theme => {
-  const { linkHover, link, ...foreground } = theme.color.foreground;
+export const tone = styleMap(theme => {
+  const {
+    linkHover,
+    link,
+    neutralInverted, // Omit from public API
+    ...foreground
+  } = theme.color.foreground;
 
   return {
     ...mapToStyleProperty(foreground, 'color'),
@@ -134,15 +139,15 @@ const textColorForBackground = (
 ) =>
   style(theme => ({
     color: isLight(theme.color.background[background])
-      ? theme.color.foreground.black
-      : theme.color.foreground.white,
+      ? theme.color.foreground.neutral
+      : theme.color.foreground.neutralInverted,
   }));
 
-type ForegroundColor = keyof typeof color;
-type BackgroundColor = NonNullable<UseBoxProps['backgroundColor']>;
+type Foreground = keyof typeof tone;
+type Background = NonNullable<UseBoxProps['backgroundColor']>;
 type BackgroundContrast = {
-  [background in BackgroundColor]?: {
-    [foreground in ForegroundColor | 'default']?: ClassRef
+  [background in Background]?: {
+    [foreground in Foreground | 'default']?: ClassRef
   }
 };
 export const backgroundContrast: BackgroundContrast = {

--- a/lib/themes/makeTreatTheme.ts
+++ b/lib/themes/makeTreatTheme.ts
@@ -88,14 +88,13 @@ export interface TreatTokens {
     foreground: {
       link: string;
       linkHover: string;
-      black: string;
       neutral: string;
+      neutralInverted: string;
       formAccent: string;
       critical: string;
       info: string;
       positive: string;
       secondary: string;
-      white: string;
     };
     background: {
       input: string;

--- a/lib/themes/seekAnz/tokens.ts
+++ b/lib/themes/seekAnz/tokens.ts
@@ -145,14 +145,13 @@ const tokens: TreatTokens = {
     foreground: {
       link,
       linkHover: link,
-      black,
       neutral: black,
+      neutralInverted: 'white',
       formAccent,
       critical,
       info,
       positive,
       secondary: '#1c1c1ca1',
-      white: 'white',
     },
     background: {
       input: '#fff',

--- a/lib/themes/seekAsia/makeTokens.ts
+++ b/lib/themes/seekAsia/makeTokens.ts
@@ -15,7 +15,6 @@ export default ({
   tokenOverrides = {},
 }: SeekAsiaBrandTokens): TreatTokens => {
   const white = '#fff';
-  const black = '#000';
   const blue2 = '#298EB9';
   const blue3 = '#94C9E0';
   const blue5 = '#EEF8FC';
@@ -167,14 +166,13 @@ export default ({
       foreground: {
         link,
         linkHover,
-        black,
         neutral: grey1,
+        neutralInverted: white,
         formAccent,
         critical,
         info,
         positive,
         secondary: grey2,
-        white,
       },
       background: {
         input: white,

--- a/lib/themes/wireframe/tokens.ts
+++ b/lib/themes/wireframe/tokens.ts
@@ -1,6 +1,6 @@
 import { TreatTokens } from '../makeTreatTheme';
 
-const formAccent = 'black';
+const formAccent = '#2b2b2b';
 const critical = 'red';
 const positive = 'green';
 const info = 'navy';
@@ -144,14 +144,13 @@ const tokens: TreatTokens = {
     foreground: {
       link,
       linkHover: link,
-      black,
       neutral: black,
+      neutralInverted: white,
       formAccent,
       critical,
       info,
       positive,
       secondary: '#777',
-      white,
     },
     background: {
       input: white,

--- a/site/src/App/Components/ComponentRoute.tsx
+++ b/site/src/App/Components/ComponentRoute.tsx
@@ -67,7 +67,7 @@ export const ComponentRoute = ({
             ? Object.values(themes).map(theme => (
                 <Box key={theme.name} marginBottom="large">
                   <Box paddingBottom="small">
-                    <Text color="secondary">Theme: {theme.name}</Text>
+                    <Text tone="secondary">Theme: {theme.name}</Text>
                   </Box>
                   <ThemeProvider theme={theme}>
                     {render({
@@ -79,20 +79,20 @@ export const ComponentRoute = ({
               ))
             : null}
           <Box paddingBottom="small">
-            <Text color="secondary">Code:</Text>
+            <Text tone="secondary">Code:</Text>
           </Box>
           <Box
+            backgroundColor="formAccent"
             paddingLeft="small"
             paddingRight="small"
             paddingTop="xxsmall"
             paddingBottom="small"
             borderRadius="standard"
             style={{
-              backgroundColor: '#2b2b2b',
               overflowX: 'auto',
             }}
           >
-            <Text component="pre" color="white">
+            <Text component="pre">
               {render && !code
                 ? cleanCodeSnippet(
                     reactElementToJSXString(render({ id: 'id', handler }), {


### PR DESCRIPTION
## Breaking Changes

- Text `color` prop is now `tone`.
- Icon `fill` prop is now `tone`.
- `black` and `white` tones have been removed.

## Migration Guide

```diff
-<Text color="positive">
+<Text tone="positive">

-<TickCircleIcon fill="positive" />
+<TickCircleIcon tone="positive" />

-<Text color="black">
+<Text tone="neutral">
```