### PR TITLE
feat(Box): Rename ‘backgroundColor’ prop to ‘background’

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -597,8 +597,8 @@ Object {
       "required": false,
       "type": "string",
     },
-    "backgroundColor": Object {
-      "propName": "backgroundColor",
+    "background": Object {
+      "propName": "background",
       "required": false,
       "type": Object {
         "type": "union",

--- a/lib/components/Alert/Alert.tsx
+++ b/lib/components/Alert/Alert.tsx
@@ -17,7 +17,7 @@ export interface AlertProps {
   id?: string;
 }
 
-const backgroundColorForTone = (tone: Tone, weight: AlertWeight) => {
+const backgroundForTone = (tone: Tone, weight: AlertWeight) => {
   if (weight === 'strong') {
     return tone;
   }
@@ -48,13 +48,13 @@ export const Alert = ({
   id,
 }: AlertProps) => {
   const styles = useStyles(styleRefs);
-  const backgroundColor = backgroundColorForTone(tone, weight);
+  const background = backgroundForTone(tone, weight);
   const Icon = icons[tone];
 
   return (
     <Box
       id={id}
-      backgroundColor={backgroundColor}
+      background={background}
       paddingLeft="gutter"
       paddingRight="gutter"
       paddingTop="medium"

--- a/lib/components/Box/BackgroundContext.ts
+++ b/lib/components/Box/BackgroundContext.ts
@@ -1,9 +1,7 @@
 import { createContext, useContext } from 'react';
 import { BoxProps } from './Box';
 
-const backgroundContext = createContext<BoxProps['backgroundColor'] | null>(
-  null,
-);
+const backgroundContext = createContext<BoxProps['background'] | null>(null);
 
 export const BackgroundProvider = backgroundContext.Provider;
 

--- a/lib/components/Box/Box.docs.tsx
+++ b/lib/components/Box/Box.docs.tsx
@@ -14,7 +14,7 @@ const docs: ComponentDocs = {
       label: `"${space}" spacing`,
       render: () => (
         <Box
-          backgroundColor="formAccent"
+          background="formAccent"
           style={{ overflow: 'auto', maxWidth: '300px' }}
         >
           <Box
@@ -31,7 +31,7 @@ const docs: ComponentDocs = {
                 })}
           >
             <HideCode>
-              <Box style={{ backgroundColor: 'whitesmoke', height: '20px' }} />
+              <Box style={{ background: 'whitesmoke', height: '20px' }} />
             </HideCode>
           </Box>
         </Box>

--- a/lib/components/Box/Box.tsx
+++ b/lib/components/Box/Box.tsx
@@ -22,7 +22,7 @@ export const Box = forwardRef<HTMLElement, BoxProps>(
       display,
       flexDirection,
       borderRadius,
-      backgroundColor,
+      background,
       boxShadow,
       transition,
       transform,
@@ -45,7 +45,7 @@ export const Box = forwardRef<HTMLElement, BoxProps>(
       display,
       flexDirection,
       borderRadius,
-      backgroundColor,
+      background,
       boxShadow,
       transition,
       transform,
@@ -58,8 +58,8 @@ export const Box = forwardRef<HTMLElement, BoxProps>(
       ref,
     });
 
-    return backgroundColor ? (
-      <BackgroundProvider value={backgroundColor}>{element}</BackgroundProvider>
+    return background ? (
+      <BackgroundProvider value={background}>{element}</BackgroundProvider>
     ) : (
       element
     );

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -20,9 +20,9 @@ export interface ButtonProps {
   'aria-describedby'?: NativeButtonProps['aria-describedby'];
 }
 
-const backgroundColor: Record<
+const background: Record<
   ButtonState,
-  Record<ButtonWeight, BoxProps['backgroundColor'] | undefined>
+  Record<ButtonWeight, BoxProps['background'] | undefined>
 > = {
   base: {
     weak: undefined,
@@ -62,7 +62,7 @@ export const Button = ({
       display="block"
       borderRadius="standard"
       boxShadow={isWeak ? 'borderFormAccentLarge' : undefined}
-      backgroundColor={backgroundColor.base[weight]}
+      background={background.base[weight]}
       transform="touchable"
       transition="touchable"
       className={classnames(styles.root, {
@@ -75,11 +75,11 @@ export const Button = ({
         className={classnames(styles.focusOverlay)}
       />
       <FieldOverlay
-        backgroundColor={backgroundColor.hover[weight]}
+        background={background.hover[weight]}
         className={classnames(styles.hoverOverlay)}
       />
       <FieldOverlay
-        backgroundColor={backgroundColor.active[weight]}
+        background={background.active[weight]}
         className={classnames(styles.activeOverlay)}
       />
       <Box

--- a/lib/components/Card/Card.tsx
+++ b/lib/components/Card/Card.tsx
@@ -8,7 +8,7 @@ export interface CardProps {
 export const Card = ({ children }: CardProps) => (
   <Box paddingBottom="medium">
     <Box
-      backgroundColor="card"
+      background="card"
       paddingTop="small"
       paddingBottom="large"
       paddingLeft="gutter"

--- a/lib/components/Column/Column.docs.tsx
+++ b/lib/components/Column/Column.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
           <Column>
             <HideCode>
               <Box
-                backgroundColor="selection"
+                background="selection"
                 paddingTop="small"
                 paddingBottom="small"
                 paddingLeft="small"
@@ -27,7 +27,7 @@ const docs: ComponentDocs = {
           <Column>
             <HideCode>
               <Box
-                backgroundColor="selection"
+                background="selection"
                 paddingTop="small"
                 paddingBottom="small"
                 paddingLeft="small"
@@ -39,7 +39,7 @@ const docs: ComponentDocs = {
           <Column>
             <HideCode>
               <Box
-                backgroundColor="selection"
+                background="selection"
                 paddingTop="small"
                 paddingBottom="small"
                 paddingLeft="small"

--- a/lib/components/Columns/Columns.docs.tsx
+++ b/lib/components/Columns/Columns.docs.tsx
@@ -16,7 +16,7 @@ const docs: ComponentDocs = {
           <Column>
             <HideCode>
               <Box
-                backgroundColor="selection"
+                background="selection"
                 paddingTop="small"
                 paddingBottom="small"
                 paddingLeft="small"
@@ -28,7 +28,7 @@ const docs: ComponentDocs = {
           <Column>
             <HideCode>
               <Box
-                backgroundColor="selection"
+                background="selection"
                 paddingTop="small"
                 paddingBottom="small"
                 paddingLeft="small"
@@ -40,7 +40,7 @@ const docs: ComponentDocs = {
           <Column>
             <HideCode>
               <Box
-                backgroundColor="selection"
+                background="selection"
                 paddingTop="small"
                 paddingBottom="small"
                 paddingLeft="small"

--- a/lib/components/private/Field/Field.tsx
+++ b/lib/components/private/Field/Field.tsx
@@ -32,7 +32,7 @@ export interface FieldProps {
 
 type PassthroughProps = 'id' | 'name' | 'disabled' | 'autoComplete';
 interface FieldRenderProps extends Pick<FieldProps, PassthroughProps> {
-  backgroundColor: BoxProps['backgroundColor'];
+  background: BoxProps['background'];
   boxShadow: BoxProps['boxShadow'];
   borderRadius: BoxProps['borderRadius'];
   width: BoxProps['width'];
@@ -86,7 +86,7 @@ export const Field = forwardRef<FieldRef, InternalFieldProps>(
             {
               id,
               name,
-              backgroundColor: disabled ? 'inputDisabled' : 'input',
+              background: disabled ? 'inputDisabled' : 'input',
               boxShadow:
                 tone === 'critical' && !disabled
                   ? 'borderCritical'

--- a/lib/components/private/FieldOverlay/FieldOverlay.tsx
+++ b/lib/components/private/FieldOverlay/FieldOverlay.tsx
@@ -3,7 +3,7 @@ import { Overlay, OverlayProps } from '../Overlay/Overlay';
 
 type FieldOverlayVariant = 'focus' | 'hover' | 'critical';
 export interface FieldOverlayProps
-  extends Pick<OverlayProps, 'backgroundColor' | 'borderRadius' | 'className'> {
+  extends Pick<OverlayProps, 'background' | 'borderRadius' | 'className'> {
   variant?: FieldOverlayVariant;
 }
 

--- a/lib/components/private/InlineField/InlineField.tsx
+++ b/lib/components/private/InlineField/InlineField.tsx
@@ -92,7 +92,7 @@ export const InlineField = forwardRef<HTMLElement, InternalInlineFieldProps>(
               radioStyles,
             )}
             marginRight="small"
-            backgroundColor={disabled ? 'inputDisabled' : 'input'}
+            background={disabled ? 'inputDisabled' : 'input'}
             borderRadius={fieldBorderRadius}
             boxShadow={
               tone === 'critical' && !disabled
@@ -102,7 +102,7 @@ export const InlineField = forwardRef<HTMLElement, InternalInlineFieldProps>(
           >
             <FieldOverlay
               variant={tone === 'critical' && isCheckbox ? tone : undefined}
-              backgroundColor={disabled ? 'formAccentDisabled' : 'formAccent'}
+              background={disabled ? 'formAccentDisabled' : 'formAccent'}
               borderRadius={fieldBorderRadius}
               className={classnames(styles.selected, radioStyles)}
             />

--- a/lib/components/private/Overlay/Overlay.tsx
+++ b/lib/components/private/Overlay/Overlay.tsx
@@ -7,16 +7,12 @@ import * as styleRefs from './Overlay.treat';
 export type OverlayProps = Partial<
   Pick<
     BoxProps,
-    | 'backgroundColor'
-    | 'borderRadius'
-    | 'boxShadow'
-    | 'transition'
-    | 'className'
+    'background' | 'borderRadius' | 'boxShadow' | 'transition' | 'className'
   >
 >;
 
 export const Overlay = ({
-  backgroundColor,
+  background,
   borderRadius,
   boxShadow,
   transition,
@@ -26,7 +22,7 @@ export const Overlay = ({
 
   return (
     <Box
-      backgroundColor={backgroundColor}
+      background={background}
       borderRadius={borderRadius}
       boxShadow={boxShadow}
       transition={transition}

--- a/lib/hooks/typography/typography.treat.ts
+++ b/lib/hooks/typography/typography.treat.ts
@@ -138,11 +138,11 @@ const textColorForBackground = (
       : theme.color.foreground.white,
   }));
 
-type ForegroundColor = keyof typeof color;
-type BackgroundColor = NonNullable<UseBoxProps['backgroundColor']>;
+type Foreground = keyof typeof color;
+type Background = NonNullable<UseBoxProps['background']>;
 type BackgroundContrast = {
-  [background in BackgroundColor]?: {
-    [foreground in ForegroundColor | 'default']?: ClassRef
+  [background in Background]?: {
+    [foreground in Foreground | 'default']?: ClassRef
   }
 };
 export const backgroundContrast: BackgroundContrast = {

--- a/lib/hooks/useBox/box.treat.ts
+++ b/lib/hooks/useBox/box.treat.ts
@@ -147,17 +147,17 @@ const getActiveColor = (color: string) =>
 const getHoverColor = (color: string) =>
   isLight(color) ? darken(0.05, color) : lighten(0.05, color);
 
-export const backgroundColor = styleMap(({ color: { background } }) => ({
-  ...mapToStyleProperty(background, 'backgroundColor'),
-  formAccentActive: { backgroundColor: getActiveColor(background.formAccent) },
-  formAccentHover: { backgroundColor: getHoverColor(background.formAccent) },
+export const background = styleMap(({ color }) => ({
+  ...mapToStyleProperty(color.background, 'background'),
+  formAccentActive: { background: getActiveColor(color.background.formAccent) },
+  formAccentHover: { background: getHoverColor(color.background.formAccent) },
   brandAccentActive: {
-    backgroundColor: getActiveColor(background.brandAccent),
+    background: getActiveColor(color.background.brandAccent),
   },
-  brandAccentHover: { backgroundColor: getHoverColor(background.brandAccent) },
-  infoLight: { backgroundColor: getLightVariant(background.info) },
-  criticalLight: { backgroundColor: getLightVariant(background.critical) },
-  positiveLight: { backgroundColor: getLightVariant(background.positive) },
+  brandAccentHover: { background: getHoverColor(color.background.brandAccent) },
+  infoLight: { background: getLightVariant(color.background.info) },
+  criticalLight: { background: getLightVariant(color.background.critical) },
+  positiveLight: { background: getLightVariant(color.background.positive) },
 }));
 
 export const boxShadow = styleMap(

--- a/lib/hooks/useBox/index.ts
+++ b/lib/hooks/useBox/index.ts
@@ -19,7 +19,7 @@ export interface UseBoxProps {
   display?: ResponsiveProp<keyof typeof styleRefs.display>;
   flexDirection?: ResponsiveProp<keyof typeof styleRefs.flexDirection>;
   borderRadius?: keyof typeof styleRefs.borderRadius;
-  backgroundColor?: keyof typeof styleRefs.backgroundColor;
+  background?: keyof typeof styleRefs.background;
   boxShadow?: keyof typeof styleRefs.boxShadow;
   transform?: keyof typeof styleRefs.transform;
   transition?: keyof typeof styleRefs.transition;
@@ -54,7 +54,7 @@ export default ({
   display,
   flexDirection,
   borderRadius,
-  backgroundColor,
+  background,
   boxShadow,
   transition,
   transform,
@@ -66,7 +66,7 @@ export default ({
   return classnames(
     resetStyles.base,
     resetStyles.element[component as keyof typeof resetStyleRefs.element],
-    styles.backgroundColor[backgroundColor!],
+    styles.background[background!],
     styles.borderRadius[borderRadius!],
     styles.boxShadow[boxShadow!],
     styles.transition[transition!],

--- a/site/src/App/Components/ComponentRoute.tsx
+++ b/site/src/App/Components/ComponentRoute.tsx
@@ -82,7 +82,7 @@ export const ComponentRoute = ({
             <Text tone="secondary">Code:</Text>
           </Box>
           <Box
-            backgroundColor="formAccent"
+            background="formAccent"
             paddingLeft="small"
             paddingRight="small"
             paddingTop="xxsmall"


### PR DESCRIPTION
## Breaking Changes

The `backgroundColor` prop on `Box` is now `background`.

## Migration Guide

```diff
-<Box backgroundColor="brandAccent">
+<Box background="brandAccent">
```