### PR TITLE
feat: Rename ‘ThemeProvider’ to ‘BraidProvider’

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,15 @@ import React from 'react';
 // ...etc.
 ```
 
-Finally, render the `ThemeProvider` component, providing the imported theme via the `theme` prop:
+Finally, render the `BraidProvider` component, providing the imported theme via the `theme` prop:
 
 ```js
-import { ThemeProvider, Text } from 'braid-design-system';
+import { BraidProvider, Text } from 'braid-design-system';
 
 export default () => (
-  <ThemeProvider theme={jobStreetTheme}>
+  <BraidProvider theme={jobStreetTheme}>
     <Text>Hello World!</Text>
-  </ThemeProvider>
+  </BraidProvider>
 );
 ```
 

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -6815,7 +6815,7 @@ Object {
 }
 `;
 
-exports[`Public API Contract ThemeProvider 1`] = `
+exports[`Public API Contract BraidProvider 1`] = `
 Object {
   "props": Object {
     "children": Object {

--- a/lib/components/BraidProvider/BraidProvider.docs.tsx
+++ b/lib/components/BraidProvider/BraidProvider.docs.tsx
@@ -7,9 +7,9 @@ const docs: ComponentDocs = {
         import { wireframe } from 'braid-design-system/lib/themes';
 
         export default () => (
-          <ThemeProvider theme={wireframe}>
+          <BraidProvider theme={wireframe}>
             ...
-          </ThemeProvider>
+          </BraidProvider>
         );
       `,
     },

--- a/lib/components/BraidProvider/BraidProvider.tsx
+++ b/lib/components/BraidProvider/BraidProvider.tsx
@@ -3,12 +3,12 @@ import { TreatProvider } from 'sku/treat';
 import ThemeNameContext from '../ThemeNameConsumer/ThemeNameContext';
 import { Theme } from '../../themes/theme';
 
-export interface ThemeProviderProps {
+export interface BraidProviderProps {
   theme: Theme;
   children: ReactNode;
 }
 
-export const ThemeProvider = ({ theme, children }: ThemeProviderProps) => (
+export const BraidProvider = ({ theme, children }: BraidProviderProps) => (
   <ThemeNameContext.Provider value={theme.name}>
     <TreatProvider theme={theme.treatTheme}>{children}</TreatProvider>
   </ThemeNameContext.Provider>

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -1,4 +1,4 @@
-export { ThemeProvider } from './ThemeProvider/ThemeProvider';
+export { BraidProvider } from './BraidProvider/BraidProvider';
 export { ThemeNameConsumer } from './ThemeNameConsumer/ThemeNameConsumer';
 export { useThemeName } from './ThemeNameConsumer/ThemeNameContext';
 export { Actions } from './Actions/Actions';

--- a/lib/playroom/FrameComponent.tsx
+++ b/lib/playroom/FrameComponent.tsx
@@ -1,17 +1,17 @@
 import React, { Fragment, ReactNode } from 'react';
-import { ThemeProvider } from '../components';
-import { ThemeProviderProps } from '../components/ThemeProvider/ThemeProvider';
+import { BraidProvider } from '../components';
+import { BraidProviderProps } from '../components/BraidProvider/BraidProvider';
 
 interface Props {
-  theme: ThemeProviderProps['theme'];
+  theme: BraidProviderProps['theme'];
   children: ReactNode;
 }
 
 export default ({ theme, children }: Props) => (
-  <ThemeProvider theme={theme}>
+  <BraidProvider theme={theme}>
     <Fragment>
       <style>{`html,body { margin: 0; }`}</style>
       {children}
     </Fragment>
-  </ThemeProvider>
+  </BraidProvider>
 );

--- a/lib/stories/all.stories.tsx
+++ b/lib/stories/all.stories.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import { BrowserRouter } from 'react-router-dom';
 import values from 'lodash/values';
 import * as themes from '../themes';
-import { ThemeProvider } from '../components';
+import { BraidProvider } from '../components';
 import { ComponentDocs } from '../../site/src/types';
 
 const handler = () => {
@@ -33,7 +33,7 @@ req.keys().forEach(filename => {
     .forEach(theme => {
       stories.add(theme.name, () => (
         <BrowserRouter>
-          <ThemeProvider theme={theme}>
+          <BraidProvider theme={theme}>
             {docs.examples.map(({ label = componentName, render }, i) =>
               render ? (
                 <div
@@ -69,7 +69,7 @@ req.keys().forEach(filename => {
                 </div>
               ) : null,
             )}
-          </ThemeProvider>
+          </BraidProvider>
         </BrowserRouter>
       ));
     });

--- a/site/src/App/App.tsx
+++ b/site/src/App/App.tsx
@@ -4,7 +4,7 @@ import React from 'react';
 import { withRouter, Route } from 'react-router';
 import { CSSTransition } from 'react-transition-group';
 
-import { ThemeProvider } from '../../../lib/components';
+import { BraidProvider } from '../../../lib/components';
 import { Home } from './Home/Home';
 import { Components } from './Components/Components';
 import * as styles from './App.treat';
@@ -20,7 +20,7 @@ const routes = [
 ];
 
 export const App = withRouter(() => (
-  <ThemeProvider theme={themes.wireframe}>
+  <BraidProvider theme={themes.wireframe}>
     <div>
       {routes.map(({ path, exact, Component }) => (
         <Route key={path} exact={exact} path={path}>
@@ -39,5 +39,5 @@ export const App = withRouter(() => (
         </Route>
       ))}
     </div>
-  </ThemeProvider>
+  </BraidProvider>
 ));

--- a/site/src/App/Components/ComponentRoute.tsx
+++ b/site/src/App/Components/ComponentRoute.tsx
@@ -4,7 +4,7 @@ import dedent from 'dedent';
 import { ComponentProps } from './ComponentProps';
 import { ExternalLink } from './Link';
 import {
-  ThemeProvider,
+  BraidProvider,
   Box,
   Heading,
   Paragraph,
@@ -69,12 +69,12 @@ export const ComponentRoute = ({
                   <Box paddingBottom="small">
                     <Text color="secondary">Theme: {theme.name}</Text>
                   </Box>
-                  <ThemeProvider theme={theme}>
+                  <BraidProvider theme={theme}>
                     {render({
                       id: `${index}_${theme.name}`,
                       handler,
                     })}
-                  </ThemeProvider>
+                  </BraidProvider>
                 </Box>
               ))
             : null}


### PR DESCRIPTION
## Breaking Change

`ThemeProvider` has been renamed to `BraidProvider`.

## Migration Guide

```diff
-<ThemeProvider theme={seekAnz}>
+<BraidProvider theme={seekAnz}>
```