### PR TITLE
fix(Bullet): Make children required for Bullet & BulletList

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -2632,12 +2632,41 @@ Object {
 }
 `;
 
+exports[`Public API Contract BraidProvider 1`] = `
+Object {
+  "props": Object {
+    "children": Object {
+      "propName": "children",
+      "required": true,
+      "type": Object {
+        "type": "union",
+        "types": Array [
+          "string",
+          "number",
+          "false",
+          "true",
+          "{}",
+          "ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<any, any, any>)>",
+          "ReactNodeArray",
+          "ReactPortal",
+        ],
+      },
+    },
+    "theme": Object {
+      "propName": "theme",
+      "required": true,
+      "type": "Theme",
+    },
+  },
+}
+`;
+
 exports[`Public API Contract Bullet 1`] = `
 Object {
   "props": Object {
     "children": Object {
       "propName": "children",
-      "required": false,
+      "required": true,
       "type": Object {
         "type": "union",
         "types": Array [
@@ -2661,7 +2690,7 @@ Object {
   "props": Object {
     "children": Object {
       "propName": "children",
-      "required": false,
+      "required": true,
       "type": Object {
         "type": "union",
         "types": Array [
@@ -6802,35 +6831,6 @@ Object {
       "propName": "children",
       "required": true,
       "type": "(name: string) => ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<any, any, any>)>",
-    },
-  },
-}
-`;
-
-exports[`Public API Contract BraidProvider 1`] = `
-Object {
-  "props": Object {
-    "children": Object {
-      "propName": "children",
-      "required": true,
-      "type": Object {
-        "type": "union",
-        "types": Array [
-          "string",
-          "number",
-          "false",
-          "true",
-          "{}",
-          "ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<any, any, any>)>",
-          "ReactNodeArray",
-          "ReactPortal",
-        ],
-      },
-    },
-    "theme": Object {
-      "propName": "theme",
-      "required": true,
-      "type": "Theme",
     },
   },
 }

--- a/lib/components/Bullet/Bullet.tsx
+++ b/lib/components/Bullet/Bullet.tsx
@@ -3,7 +3,7 @@ import { Box } from '../Box/Box';
 import { Text } from '../Text/Text';
 
 export interface BulletProps {
-  children?: ReactNode;
+  children: ReactNode;
 }
 
 export const Bullet = ({ children }: BulletProps) => (

--- a/lib/components/BulletList/BulletList.tsx
+++ b/lib/components/BulletList/BulletList.tsx
@@ -2,7 +2,7 @@ import React, { ReactNode } from 'react';
 import { Box } from '../Box/Box';
 
 export interface BulletListProps {
-  children?: ReactNode;
+  children: ReactNode;
 }
 
 export const BulletList = ({ children }: BulletListProps) => (


### PR DESCRIPTION
`Bullet` and `BulletList` should always have `children` supplied, updating the type def to capture this.