### PR TITLE
feat(Box): Add ‘brand’ background

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -196,6 +196,7 @@ exports[`Box 1`] = `
     | "info"
     | "critical"
     | "positive"
+    | "brand"
     | "input"
     | "inputDisabled"
     | "brandAccent"

--- a/lib/components/Dropdown/Dropdown.tsx
+++ b/lib/components/Dropdown/Dropdown.tsx
@@ -95,7 +95,7 @@ export const Dropdown = forwardRef<HTMLSelectElement, DropdownProps>(
               display="flex"
               className={styles.chevron}
             >
-              <ChevronIcon inline />
+              <ChevronIcon tone="neutral" inline />
             </Box>
           </Fragment>
         )}

--- a/lib/hooks/typography/typography.treat.ts
+++ b/lib/hooks/typography/typography.treat.ts
@@ -163,6 +163,9 @@ export const backgroundContrast: BackgroundContrast = {
     default: accessibleColorVariants.info,
     info: accessibleColorVariants.info,
   },
+  brand: {
+    default: textColorForBackground('brand'),
+  },
   brandAccent: {
     default: textColorForBackground('brandAccent'),
   },

--- a/lib/themes/jobStreet/tokens.ts
+++ b/lib/themes/jobStreet/tokens.ts
@@ -1,7 +1,10 @@
 import makeTokens from '../seekAsia/makeTokens';
 
+const brand = '#1c3f94';
+
 export default makeTokens({
   name: 'jobStreet',
-  formAccent: '#1c3f94',
+  brand,
   brandAccent: '#fff200',
+  formAccent: brand,
 });

--- a/lib/themes/jobStreetClassic/tokens.ts
+++ b/lib/themes/jobStreetClassic/tokens.ts
@@ -1,11 +1,13 @@
 import makeTokens from '../seekAsia/makeTokens';
 
+const brand = '#1c3f94';
 const info = '#142d69';
 
 export default makeTokens({
   name: 'jobStreetClassic',
-  formAccent: '#1c3f94',
+  brand,
   brandAccent: '#fff200',
+  formAccent: brand,
   tokenOverrides: {
     typography: {
       fontFamily:

--- a/lib/themes/jobsDb/tokens.ts
+++ b/lib/themes/jobsDb/tokens.ts
@@ -1,7 +1,11 @@
 import makeTokens from '../seekAsia/makeTokens';
 
+const teal = '#0e7e8b';
+const blue = '#0c4b85';
+
 export default makeTokens({
   name: 'jobsDb',
-  formAccent: '#0c4b85',
+  brand: `linear-gradient(90deg, ${teal}, ${blue})`,
+  formAccent: blue,
   brandAccent: '#ff9000',
 });

--- a/lib/themes/makeTreatTheme.ts
+++ b/lib/themes/makeTreatTheme.ts
@@ -97,6 +97,7 @@ export interface TreatTokens {
       secondary: string;
     };
     background: {
+      brand: string;
       input: string;
       inputDisabled: string;
       brandAccent: string;

--- a/lib/themes/seekAnz/tokens.ts
+++ b/lib/themes/seekAnz/tokens.ts
@@ -3,6 +3,7 @@ import { rgba } from 'polished';
 
 const focus = rgba('#1e90ff', 0.7);
 const formAccent = '#2765cf';
+const brand = '#0d3880';
 const brandAccent = '#e60278';
 const positive = '#169400';
 const critical = brandAccent;
@@ -154,6 +155,7 @@ const tokens: TreatTokens = {
       secondary: '#1c1c1ca1',
     },
     background: {
+      brand,
       input: '#fff',
       inputDisabled: '#eee',
       brandAccent,

--- a/lib/themes/seekAsia/makeTokens.ts
+++ b/lib/themes/seekAsia/makeTokens.ts
@@ -4,12 +4,14 @@ import merge from 'lodash/merge';
 
 interface SeekAsiaBrandTokens {
   name: string;
+  brand: string;
   brandAccent: string;
   formAccent: string;
   tokenOverrides?: DeepPartial<TreatTokens>;
 }
 export default ({
   name,
+  brand,
   brandAccent,
   formAccent,
   tokenOverrides = {},
@@ -175,6 +177,7 @@ export default ({
         secondary: grey2,
       },
       background: {
+        brand,
         input: white,
         inputDisabled: grey4,
         brandAccent,

--- a/lib/themes/wireframe/tokens.ts
+++ b/lib/themes/wireframe/tokens.ts
@@ -153,6 +153,7 @@ const tokens: TreatTokens = {
       secondary: '#777',
     },
     background: {
+      brand: black,
       input: white,
       inputDisabled: '#eee',
       brandAccent,

--- a/lib/utils/isLight/index.ts
+++ b/lib/utils/isLight/index.ts
@@ -1,3 +1,32 @@
 import { getLuminance } from 'polished';
+// @ts-ignore
+import { parse as parseGradient } from 'gradient-parser';
 
-export const isLight = (color: string) => getLuminance(color) > 0.6;
+type LinearGradients = Array<{
+  colorStops: Array<{
+    type: string;
+    value: string;
+  }>;
+}>;
+
+const getLinearGradientColors = (color: string) => {
+  const gradients: LinearGradients = parseGradient(color);
+
+  return gradients[0].colorStops.map(({ type, value }) => {
+    if (typeof value !== 'string') {
+      throw new Error(
+        'Gradient parsing in Braid currently only supports hex/literal values',
+      );
+    }
+
+    return `${type === 'hex' ? '#' : ''}${value}`;
+  });
+};
+
+export const isLight = (inputColor: string) => {
+  const colors = /^linear-gradient/.test(inputColor)
+    ? getLinearGradientColors(inputColor)
+    : [inputColor];
+
+  return colors.some(color => getLuminance(color) > 0.6);
+};

--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "basekick": "^3.1.1",
     "classnames": "^2.2.6",
     "csstype": "^2.6.4",
+    "gradient-parser": "^0.1.5",
     "is-mobile": "^2.0.1",
     "lodash": "^4.17.11",
     "polished": "^3.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7286,6 +7286,11 @@ graceful-fs@^4.1.11, graceful-fs@^4.1.15, graceful-fs@^4.1.2, graceful-fs@^4.1.3
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.15.tgz#ffb703e1066e8a0eeaa4c8b80ba9253eeefbfb00"
   integrity sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==
 
+gradient-parser@^0.1.5:
+  version "0.1.5"
+  resolved "https://registry.yarnpkg.com/gradient-parser/-/gradient-parser-0.1.5.tgz#0c7e2179559e5ce7d8d71f4423af937100b2248c"
+  integrity sha1-DH4heVWeXOfY1x9EI6+TcQCyJIw=
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"


### PR DESCRIPTION
Adds a new `brand` option for the `background` prop on `Box`.

Also fixed a bug with the `Dropdown` chevron colour when nested within a dark background context.

[Playroom demo](https://braid-design-system--9345107f63286824add5c4360c6d1168df2f3deb.surge.sh/playroom/#?code=PEJveAogIGJhY2tncm91bmQ9ImJyYW5kIgogIHBhZGRpbmdUb3A9Im1lZGl1bSIKICBwYWRkaW5nQm90dG9tPSJ4bGFyZ2UiCiAgcGFkZGluZ0xlZnQ9Imd1dHRlciIKICBwYWRkaW5nUmlnaHQ9Imd1dHRlciIKPgogIDxUZXh0RmllbGQgbGFiZWw9IldoYXQiIHJlc2VydmVNZXNzYWdlU3BhY2U9e2ZhbHNlfSAvPgogIDxCb3ggcGFkZGluZ1RvcD0ieHhzbWFsbCIgLz4KICA8RHJvcGRvd24gcmVzZXJ2ZU1lc3NhZ2VTcGFjZT17ZmFsc2V9IC8-CiAgPEJveCBwYWRkaW5nVG9wPSJ4c21hbGwiIC8-CiAgPFRleHRGaWVsZCBsYWJlbD0iV2hlcmUiIHJlc2VydmVNZXNzYWdlU3BhY2U9e2ZhbHNlfSAvPgogIDxCb3ggcGFkZGluZ1RvcD0ibGFyZ2UiIC8-CiAgPEJ1dHRvbiB3ZWlnaHQ9InN0cm9uZyI-CiAgICA8VGhlbWVOYW1lQ29uc3VtZXI-CiAgICAgIHtuYW1lID0-IChuYW1lID09PSAic2Vla0FueiIgPyAiU0VFSyIgOiAiU2VhcmNoIil9CiAgICA8L1RoZW1lTmFtZUNvbnN1bWVyPgogIDwvQnV0dG9uPgo8L0JveD4K) (Please excuse my `Box` hackery)

Preview:

<img width="1084" alt="Screen Shot 2019-07-03 at 5 04 39 pm" src="https://user-images.githubusercontent.com/696693/60570328-b05bef80-9db4-11e9-8ecc-af5842f34927.png">
