### PR TITLE
refactor: Use YIQ color space to determine if color is light

### DIFF
--- a/lib/hooks/typography/typography.treat.ts
+++ b/lib/hooks/typography/typography.treat.ts
@@ -137,19 +137,29 @@ const accessibleColorVariants = styleMap(({ color: { foreground } }) => ({
   },
 }));
 
-const textColorForBackground = (
-  background: keyof Theme['color']['background'],
-) =>
-  style(theme => ({
-    color: isLight(theme.color.background[background])
-      ? theme.color.foreground.neutral
-      : theme.color.foreground.neutralInverted,
+type ThemeBackgroundColor = keyof Theme['color']['background'];
+const resolveOverride = (theme: Theme, background: ThemeBackgroundColor) => {
+  // Override to ensure we use `neutral` foreground color when on
+  // JobsDB `brandAccent` background.
+  if (theme.name === 'jobsDb' && background === 'brandAccent') {
+    return theme.color.foreground.neutralInverted;
+  }
+};
+
+const textColorForBackground = (background: ThemeBackgroundColor) => {
+  return style(theme => ({
+    color:
+      resolveOverride(theme, background) ||
+      (isLight(theme.color.background[background])
+        ? theme.color.foreground.neutral
+        : theme.color.foreground.neutralInverted),
   }));
+};
 
 type Foreground = keyof typeof tone;
-type Background = NonNullable<UseBoxProps['background']>;
+type BoxBackground = NonNullable<UseBoxProps['background']>;
 type BackgroundContrast = {
-  [background in Background]?: {
+  [background in BoxBackground]?: {
     [foreground in Foreground | 'default']?: ClassRef
   }
 };

--- a/lib/hooks/typography/typography.treat.ts
+++ b/lib/hooks/typography/typography.treat.ts
@@ -122,19 +122,20 @@ const accessibleColorVariants = styleMap(({ color: { foreground } }) => ({
   },
 }));
 
-type ThemeBackgroundColor = keyof Theme['color']['background'];
-const resolveOverride = (theme: Theme, background: ThemeBackgroundColor) => {
-  // Override to ensure we use `neutral` foreground color when on
-  // JobsDB `brandAccent` background.
-  if (theme.name === 'jobsDb' && background === 'brandAccent') {
-    return theme.color.foreground.neutralInverted;
-  }
-};
+const textColorForBackground = (
+  background: keyof Theme['color']['background'],
+) => {
+  const resolveOverride = (theme: Theme) => {
+    // Override to ensure we use `neutral` foreground color when on
+    // JobsDB `brandAccent` background.
+    if (theme.name === 'jobsDb' && background === 'brandAccent') {
+      return theme.color.foreground.neutralInverted;
+    }
+  };
 
-const textColorForBackground = (background: ThemeBackgroundColor) => {
   return style(theme => ({
     color:
-      resolveOverride(theme, background) ||
+      resolveOverride(theme) ||
       (isLight(theme.color.background[background])
         ? theme.color.foreground.neutral
         : theme.color.foreground.neutralInverted),

--- a/lib/utils/isLight/index.ts
+++ b/lib/utils/isLight/index.ts
@@ -1,4 +1,4 @@
-import { getLuminance } from 'polished';
+import { parseToRgb } from 'polished';
 // @ts-ignore
 import { parse as parseGradient } from 'gradient-parser';
 
@@ -28,5 +28,22 @@ export const isLight = (inputColor: string) => {
     ? getLinearGradientColors(inputColor)
     : [inputColor];
 
-  return colors.some(color => getLuminance(color) > 0.6);
+  return colors.some(color => {
+    const { red, green, blue } = parseToRgb(color);
+
+    // Convert RGB to YIQ to better take into account the
+    // luminence of the separate color channels:
+    //
+    // Further reading:
+    //   - YIQ:
+    //     https://en.wikipedia.org/wiki/YIQ
+    //   - Calculating contrast:
+    //     https://24ways.org/2010/calculating-color-contrast/
+
+    const yiq = (red * 299 + green * 587 + blue * 114) / 1000;
+
+    // Colour is considered `light` if greater than the midpoint:
+    // eg. 256 / 2 = 128.
+    return yiq >= 128;
+  });
 };

--- a/lib/utils/isLight/index.ts
+++ b/lib/utils/isLight/index.ts
@@ -32,7 +32,7 @@ export const isLight = (inputColor: string) => {
     const { red, green, blue } = parseToRgb(color);
 
     // Convert RGB to YIQ to better take into account the
-    // luminence of the separate color channels:
+    // luminance of the separate color channels:
     //
     // Further reading:
     //   - YIQ:


### PR DESCRIPTION
Previously we implemented custom logic for determining if a colour was light that was simply a subjective adjustment of a magic number luminance threshold. As it turns out there is an alternative research-based approach that leverages the [YIQ colour space](https://en.wikipedia.org/wiki/YIQ).

For further reading checkout this post on [Calculating Color Contrast](https://24ways.org/2010/calculating-color-contrast/).

Thanks to @patrickliu-sa for pointing us in this direction. 