### PR TITLE
fix: Add display names to components forwarding refs

### DIFF
--- a/lib/components/Box/Box.tsx
+++ b/lib/components/Box/Box.tsx
@@ -7,7 +7,7 @@ export interface BoxProps
   extends Optional<UseBoxProps, 'component'>,
     Omit<AllHTMLAttributes<HTMLElement>, 'width'> {}
 
-export const Box = forwardRef<HTMLElement, BoxProps>(
+const NamedBox = forwardRef<HTMLElement, BoxProps>(
   (
     {
       component = 'div',
@@ -67,3 +67,7 @@ export const Box = forwardRef<HTMLElement, BoxProps>(
     );
   },
 );
+
+NamedBox.displayName = 'Box';
+
+export const Box = NamedBox;

--- a/lib/components/Checkbox/Checkbox.tsx
+++ b/lib/components/Checkbox/Checkbox.tsx
@@ -4,7 +4,7 @@ import {
   InlineFieldProps,
 } from '../private/InlineField/InlineField';
 
-export const Checkbox = forwardRef<HTMLInputElement, InlineFieldProps>(
+const NamedCheckbox = forwardRef<HTMLInputElement, InlineFieldProps>(
   (props, ref) => (
     <InlineField
       reserveMessageSpace={true}
@@ -14,3 +14,7 @@ export const Checkbox = forwardRef<HTMLInputElement, InlineFieldProps>(
     />
   ),
 );
+
+NamedCheckbox.displayName = 'Checkbox';
+
+export const Checkbox = NamedCheckbox;

--- a/lib/components/Dropdown/Dropdown.tsx
+++ b/lib/components/Dropdown/Dropdown.tsx
@@ -38,7 +38,7 @@ const getTone = (
   return 'neutral';
 };
 
-export const Dropdown = forwardRef<HTMLSelectElement, DropdownProps>(
+const NamedDropdown = forwardRef<HTMLSelectElement, DropdownProps>(
   (props: DropdownProps, ref) => {
     const {
       children,
@@ -104,3 +104,7 @@ export const Dropdown = forwardRef<HTMLSelectElement, DropdownProps>(
     );
   },
 );
+
+NamedDropdown.displayName = 'Dropdown';
+
+export const Dropdown = NamedDropdown;

--- a/lib/components/Radio/Radio.tsx
+++ b/lib/components/Radio/Radio.tsx
@@ -8,7 +8,7 @@ import {
 interface RadioProps
   extends Omit<InlineFieldProps, 'message' | 'reserveMessageSpace'> {}
 
-export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => (
+const NamedRadio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => (
   <InlineField
     {...props}
     type="radio"
@@ -17,3 +17,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => (
     ref={ref}
   />
 ));
+
+NamedRadio.displayName = 'Radio';
+
+export const Radio = NamedRadio;

--- a/lib/components/TextField/TextField.tsx
+++ b/lib/components/TextField/TextField.tsx
@@ -23,7 +23,7 @@ interface TextFieldProps extends Omit<FieldProps, 'secondaryMessage'> {
   placeholder?: InputProps['placeholder'];
 }
 
-export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
+const NamedTextField = forwardRef<HTMLInputElement, TextFieldProps>(
   (
     {
       value,
@@ -53,3 +53,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     </Field>
   ),
 );
+
+NamedTextField.displayName = 'TextField';
+
+export const TextField = NamedTextField;

--- a/lib/components/Textarea/Textarea.tsx
+++ b/lib/components/Textarea/Textarea.tsx
@@ -75,7 +75,7 @@ const calculateLines = (
     : currentRows;
 };
 
-export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
+const NamedTextarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
   (
     {
       value,
@@ -128,3 +128,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
     );
   },
 );
+
+NamedTextarea.displayName = 'Textarea';
+
+export const Textarea = NamedTextarea;

--- a/lib/themes/wireframe/tokens.ts
+++ b/lib/themes/wireframe/tokens.ts
@@ -1,10 +1,10 @@
 import { TreatTokens } from '../makeTreatTheme';
 
-const formAccent = '#2b2b2b';
+const formAccent = '#404040';
 const critical = 'red';
 const positive = 'green';
 const info = 'navy';
-const brandAccent = 'DarkOrange';
+const brandAccent = 'black';
 const focus = 'DeepSkyBlue';
 const black = '#2b2b2b';
 const white = '#fff';

--- a/site/src/App/Components/ComponentRoute.tsx
+++ b/site/src/App/Components/ComponentRoute.tsx
@@ -82,7 +82,7 @@ export const ComponentRoute = ({
             <Text tone="secondary">Code:</Text>
           </Box>
           <Box
-            background="formAccent"
+            background="brandAccent"
             paddingLeft="small"
             paddingRight="small"
             paddingTop="xxsmall"


### PR DESCRIPTION
Since implementing `forwardRef` in some components the docs site code snippets and the React Dev Tools experience has been a little broken/hard to use. This mitigates both problems by providing the display name explicitly where we have had to forward refs.