### PR TITLE
fix: Fix text styles

### DIFF
--- a/lib/hooks/typography/typography.treat.ts
+++ b/lib/hooks/typography/typography.treat.ts
@@ -1,5 +1,5 @@
 import mapValues from 'lodash/mapValues';
-import { style, styleMap, styleTree, ClassRef } from 'sku/treat';
+import { style, styleMap, ClassRef } from 'sku/treat';
 import { Theme } from 'treat/theme';
 import basekick from 'basekick';
 import { getAccessibleVariant, isLight, mapToStyleProperty } from '../../utils';
@@ -70,11 +70,20 @@ const makeTypographyRules = (
   };
 };
 
-export const text = styleTree((theme, styleNode) =>
-  mapValues(theme.typography.text, size =>
-    mapValues(makeTypographyRules(size, theme), styleNode),
+export const text = {
+  xsmall: styleMap(theme =>
+    makeTypographyRules(theme.typography.text.xsmall, theme),
   ),
-);
+  small: styleMap(theme =>
+    makeTypographyRules(theme.typography.text.small, theme),
+  ),
+  standard: styleMap(theme =>
+    makeTypographyRules(theme.typography.text.standard, theme),
+  ),
+  large: styleMap(theme =>
+    makeTypographyRules(theme.typography.text.large, theme),
+  ),
+};
 
 export const headingWeight = styleMap(({ typography }) =>
   mapValues(typography.heading.weight, weight => ({
@@ -82,11 +91,20 @@ export const headingWeight = styleMap(({ typography }) =>
   })),
 );
 
-export const heading = styleTree((theme, styleNode) =>
-  mapValues(theme.typography.heading.level, level =>
-    mapValues(makeTypographyRules(level, theme), styleNode),
+export const heading = {
+  '1': styleMap(theme =>
+    makeTypographyRules(theme.typography.heading.level['1'], theme),
   ),
-);
+  '2': styleMap(theme =>
+    makeTypographyRules(theme.typography.heading.level['2'], theme),
+  ),
+  '3': styleMap(theme =>
+    makeTypographyRules(theme.typography.heading.level['3'], theme),
+  ),
+  '4': styleMap(theme =>
+    makeTypographyRules(theme.typography.heading.level['4'], theme),
+  ),
+};
 
 export const tone = styleMap(theme => {
   const {


### PR DESCRIPTION
We're currently experiencing issues with text styles in production mode. We're currently investigating, but in the meantime, reverting to `styleMap` instead of `styleTree` fixes the issue.