### PR TITLE
feat(TextLinkRenderer): Remove 'inline' prop, fix heading styles

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -1798,7 +1798,6 @@ exports[`TextLink 1`] = `
   htmlFor?: string
   httpEquiv?: string
   id?: string
-  inline?: boolean
   inlist?: any
   inputMode?: string
   integrity?: string
@@ -2063,7 +2062,6 @@ exports[`TextLink 1`] = `
 exports[`TextLinkRenderer 1`] = `
 {
   children: (styleProps: StyleProps) => ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<any, any, any>)>
-  inline?: boolean
 }
 `;
 

--- a/lib/components/FieldLabel/FieldLabel.docs.tsx
+++ b/lib/components/FieldLabel/FieldLabel.docs.tsx
@@ -32,7 +32,7 @@ const docs: ComponentDocs = {
           <FieldLabel
             htmlFor="id"
             label="Password"
-            tertiaryLabel={<TextLink inline>Forgot password?</TextLink>}
+            tertiaryLabel={<TextLink>Forgot password?</TextLink>}
           />
         </div>
       ),
@@ -45,7 +45,7 @@ const docs: ComponentDocs = {
             htmlFor="id"
             label="Title"
             secondaryLabel="Optional"
-            tertiaryLabel={<TextLink inline>Help?</TextLink>}
+            tertiaryLabel={<TextLink>Help?</TextLink>}
           />
         </div>
       ),

--- a/lib/components/Heading/Heading.tsx
+++ b/lib/components/Heading/Heading.tsx
@@ -1,4 +1,5 @@
 import React, { ReactNode } from 'react';
+import HeadingContext from './HeadingContext';
 import { Box, BoxProps } from '../Box/Box';
 import {
   useHeading,
@@ -28,12 +29,14 @@ export const Heading = ({
   children,
   id,
 }: HeadingProps) => (
-  <Box
-    id={id}
-    component={component || resolveDefaultComponent[level]}
-    paddingBottom={level === '1' ? 'small' : 'xsmall'}
-    className={useHeading({ weight, level, baseline: true })}
-  >
-    {children}
-  </Box>
+  <HeadingContext.Provider value={true}>
+    <Box
+      id={id}
+      component={component || resolveDefaultComponent[level]}
+      paddingBottom={level === '1' ? 'small' : 'xsmall'}
+      className={useHeading({ weight, level, baseline: true })}
+    >
+      {children}
+    </Box>
+  </HeadingContext.Provider>
 );

--- a/lib/components/Heading/HeadingContext.ts
+++ b/lib/components/Heading/HeadingContext.ts
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export default createContext(false);

--- a/lib/components/Text/Text.tsx
+++ b/lib/components/Text/Text.tsx
@@ -1,6 +1,7 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useContext } from 'react';
 import { useStyles } from 'sku/react-treat';
 import classnames from 'classnames';
+import TextContext from './TextContext';
 import { Box, BoxProps } from '../Box/Box';
 import { useText, UseTextProps } from '../../hooks/typography';
 import * as styleRefs from './Text.treat';
@@ -25,17 +26,28 @@ export const Text = ({
 }: TextProps) => {
   const styles = useStyles(styleRefs);
   const isListItem = typeof component === 'string' && /^li$/i.test(component);
+  const textStyles = useText({ weight, size, baseline, tone });
+
+  if (process.env.NODE_ENV !== 'production') {
+    const inText = useContext(TextContext);
+
+    if (inText) {
+      throw new Error(
+        'Text components should not be nested within each other.',
+      );
+    }
+  }
 
   return (
-    <Box
-      id={id}
-      display={!isListItem ? 'block' : undefined}
-      component={component}
-      className={classnames(useText({ weight, size, baseline, tone }), {
-        [styles.listItem]: isListItem,
-      })}
-    >
-      {children}
-    </Box>
+    <TextContext.Provider value={true}>
+      <Box
+        id={id}
+        display={!isListItem ? 'block' : undefined}
+        component={component}
+        className={classnames(textStyles, isListItem && styles.listItem)}
+      >
+        {children}
+      </Box>
+    </TextContext.Provider>
   );
 };

--- a/lib/components/Text/TextContext.ts
+++ b/lib/components/Text/TextContext.ts
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export default createContext(false);

--- a/lib/components/TextField/TextField.docs.tsx
+++ b/lib/components/TextField/TextField.docs.tsx
@@ -54,7 +54,7 @@ const docs: ComponentDocs = {
           <TextField
             label="Title"
             secondaryLabel="Optional"
-            tertiaryLabel={<TextLink inline>Help?</TextLink>}
+            tertiaryLabel={<TextLink>Help?</TextLink>}
             id={id}
             value=""
             onChange={handler}

--- a/lib/components/TextLink/TextLink.docs.tsx
+++ b/lib/components/TextLink/TextLink.docs.tsx
@@ -2,23 +2,119 @@ import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { TextLink } from './TextLink';
 import { Text } from '../Text/Text';
+import { Heading } from '../Heading/Heading';
+import { Actions } from '../Actions/Actions';
+import { Button } from '../Button/Button';
 
 const docs: ComponentDocs = {
   migrationGuide: true,
   examples: [
     {
-      label: 'Standard Text Link',
-      render: () => <TextLink href="">Text Link</TextLink>,
-    },
-    {
       label: 'Inline Text Link',
       render: () => (
         <Text>
           The last word of a sentence is a{' '}
-          <TextLink href="" inline>
-            text link.
-          </TextLink>
+          <TextLink href="">text link.</TextLink>
         </Text>
+      ),
+    },
+    {
+      label: 'Block Text Link',
+      render: () => (
+        <TextLink href="">
+          <Text>Text Link</Text>
+        </TextLink>
+      ),
+    },
+    {
+      label: 'Text Link inside Actions',
+      render: () => (
+        <Actions>
+          <Button>Button</Button>
+          <TextLink href="">Text Link</TextLink>
+        </Actions>
+      ),
+    },
+    {
+      label: 'Large Inline Text Link',
+      render: () => (
+        <Text size="large">
+          The last word of a sentence is a{' '}
+          <TextLink href="">text link.</TextLink>
+        </Text>
+      ),
+    },
+    {
+      label: 'Large Block Text Link',
+      render: () => (
+        <TextLink href="">
+          <Text size="large">Text Link</Text>
+        </TextLink>
+      ),
+    },
+    {
+      label: 'Small Inline Text Link',
+      render: () => (
+        <Text size="small">
+          The last word of a sentence is a{' '}
+          <TextLink href="">text link.</TextLink>
+        </Text>
+      ),
+    },
+    {
+      label: 'Small Block Text Link',
+      render: () => (
+        <TextLink href="">
+          <Text size="small">Text Link</Text>
+        </TextLink>
+      ),
+    },
+    {
+      label: 'Heading Level 1 Link',
+      render: () => (
+        <TextLink href="">
+          <Heading level="1">Heading link.</Heading>
+        </TextLink>
+      ),
+    },
+    {
+      label: 'Heading Level 1 Link (Inline)',
+      render: () => (
+        <Heading level="1">
+          The last word of this heading is a <TextLink href="">link.</TextLink>
+        </Heading>
+      ),
+    },
+    {
+      label: 'Heading Level 2 Link',
+      render: () => (
+        <TextLink href="">
+          <Heading level="2">Heading link.</Heading>
+        </TextLink>
+      ),
+    },
+    {
+      label: 'Heading Level 2 Link (Inline)',
+      render: () => (
+        <Heading level="2">
+          The last word of this heading is a <TextLink href="">link.</TextLink>
+        </Heading>
+      ),
+    },
+    {
+      label: 'Heading Level 3 Link',
+      render: () => (
+        <TextLink href="">
+          <Heading level="3">Heading link.</Heading>
+        </TextLink>
+      ),
+    },
+    {
+      label: 'Heading Level 3 Link (Inline)',
+      render: () => (
+        <Heading level="3">
+          The last word of this heading is a <TextLink href="">link.</TextLink>
+        </Heading>
       ),
     },
   ],

--- a/lib/components/TextLink/TextLink.docs.tsx
+++ b/lib/components/TextLink/TextLink.docs.tsx
@@ -70,6 +70,23 @@ const docs: ComponentDocs = {
       ),
     },
     {
+      label: 'Xsmall Text Link',
+      render: () => (
+        <Text size="xsmall">
+          The last word of a sentence is a{' '}
+          <TextLink href="">text link.</TextLink>
+        </Text>
+      ),
+    },
+    {
+      label: 'Xsmall Block Text Link',
+      render: () => (
+        <TextLink href="">
+          <Text size="xsmall">Text Link</Text>
+        </TextLink>
+      ),
+    },
+    {
       label: 'Heading Level 1 Link',
       render: () => (
         <TextLink href="">
@@ -113,6 +130,22 @@ const docs: ComponentDocs = {
       label: 'Heading Level 3 Link (Inline)',
       render: () => (
         <Heading level="3">
+          The last word of this heading is a <TextLink href="">link.</TextLink>
+        </Heading>
+      ),
+    },
+    {
+      label: 'Heading Level 4 Link',
+      render: () => (
+        <TextLink href="">
+          <Heading level="4">Heading link.</Heading>
+        </TextLink>
+      ),
+    },
+    {
+      label: 'Heading Level 4 Link (Inline)',
+      render: () => (
+        <Heading level="4">
           The last word of this heading is a <TextLink href="">link.</TextLink>
         </Heading>
       ),

--- a/lib/components/TextLink/TextLink.docs.tsx
+++ b/lib/components/TextLink/TextLink.docs.tsx
@@ -10,7 +10,7 @@ const docs: ComponentDocs = {
   migrationGuide: true,
   examples: [
     {
-      label: 'Inline Text Link',
+      label: 'Text Link',
       render: () => (
         <Text>
           The last word of a sentence is a{' '}
@@ -36,7 +36,7 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label: 'Large Inline Text Link',
+      label: 'Large Text Link',
       render: () => (
         <Text size="large">
           The last word of a sentence is a{' '}
@@ -53,7 +53,7 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label: 'Small Inline Text Link',
+      label: 'Small Text Link',
       render: () => (
         <Text size="small">
           The last word of a sentence is a{' '}

--- a/lib/components/TextLink/TextLink.tsx
+++ b/lib/components/TextLink/TextLink.tsx
@@ -10,8 +10,8 @@ export interface TextLinkProps
   extends Omit<TextLinkRendererProps, 'children'>,
     Omit<AnchorProps, 'className' | 'style'> {}
 
-export const TextLink = ({ inline, ...restProps }: TextLinkProps) => (
-  <TextLinkRenderer inline={inline}>
-    {props => <a {...restProps} {...props} />}
+export const TextLink = (props: TextLinkProps) => (
+  <TextLinkRenderer>
+    {styleProps => <a {...props} {...styleProps} />}
   </TextLinkRenderer>
 );

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.docs.tsx
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.docs.tsx
@@ -2,33 +2,40 @@ import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { Link } from 'react-router-dom';
 import { TextLinkRenderer } from './TextLinkRenderer';
+import { Text } from '../Text/Text';
 
 const docs: ComponentDocs = {
   examples: [
     {
-      label: 'Standard TextLink with Custom Renderer',
+      label: 'TextLink with Custom Renderer',
       render: () => (
-        <TextLinkRenderer>
-          {textLinkProps => (
-            <Link to="" {...textLinkProps}>
-              Text Link
-            </Link>
-          )}
-        </TextLinkRenderer>
+        <Text>
+          The last word of this sentence is a{' '}
+          <TextLinkRenderer>
+            {textLinkProps => (
+              <Link to="" {...textLinkProps}>
+                link.
+              </Link>
+            )}
+          </TextLinkRenderer>
+        </Text>
       ),
       code: `
         import React from 'react';
         import { Link } from 'react-router-dom';
-        import { TextLinkRenderer } from 'braid-design-system';
+        import { TextLinkRenderer, Text } from 'braid-design-system';
 
         export default () => (
-          <TextLinkRenderer>
-            {textLinkProps => (
-              <Link to="" {...textLinkProps}>
-                Text Link
-              </Link>
-            )}
-          </TextLinkRenderer>
+          <Text>
+            The last word of this sentence is a{' '}
+            <TextLinkRenderer>
+              {textLinkProps => (
+                <Link to="" {...textLinkProps}>
+                  link.
+                </Link>
+              )}
+            </TextLinkRenderer>
+          </Text>
         );
       `,
     },

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.docs.tsx
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.docs.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { Link } from 'react-router-dom';
 import { TextLinkRenderer } from './TextLinkRenderer';
-import { Text } from '../Text/Text';
 
 const docs: ComponentDocs = {
   examples: [
@@ -30,39 +29,6 @@ const docs: ComponentDocs = {
               </Link>
             )}
           </TextLinkRenderer>
-        );
-      `,
-    },
-    {
-      label: 'Inline TextLink with Custom Renderer',
-      render: () => (
-        <Text>
-          The last word of a sentence is a{' '}
-          <TextLinkRenderer inline>
-            {textLinkProps => (
-              <Link to="" {...textLinkProps}>
-                text link.
-              </Link>
-            )}
-          </TextLinkRenderer>
-        </Text>
-      ),
-      code: `
-        import React from 'react';
-        import { Link } from 'react-router-dom';
-        import { TextLinkRenderer } from 'braid-design-system';
-
-        export default () => (
-          <Text>
-            The last word of a sentence is a{' '}
-            <TextLinkRenderer inline>
-              {textLinkProps => (
-                <Link to="/" {...textLinkProps}>
-                  text link.
-                </Link>
-              )}
-            </TextLinkRenderer>
-          </Text>
         );
       `,
     },

--- a/lib/components/TextLinkRenderer/TextLinkRendererContext.ts
+++ b/lib/components/TextLinkRenderer/TextLinkRendererContext.ts
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export default createContext(false);

--- a/lib/components/Textarea/Textarea.docs.tsx
+++ b/lib/components/Textarea/Textarea.docs.tsx
@@ -57,7 +57,7 @@ const docs: ComponentDocs = {
             onChange={handler}
             label="Title"
             secondaryLabel="Optional"
-            tertiaryLabel={<TextLink inline>Help?</TextLink>}
+            tertiaryLabel={<TextLink>Help?</TextLink>}
           />
         </div>
       ),

--- a/lib/hooks/typography/index.ts
+++ b/lib/hooks/typography/index.ts
@@ -66,7 +66,7 @@ export const useWeight = (weight: keyof typeof styleRefs.fontWeight) => {
   const styles = useStyles(styleRefs);
   const inTextLinkRenderer = useContext(TextLinkRendererContext);
 
-  return inTextLinkRenderer ? null : styles.fontWeight[weight];
+  return inTextLinkRenderer ? undefined : styles.fontWeight[weight];
 };
 
 export const useTextTone = (tone?: keyof typeof styleRefs.tone) => {

--- a/lib/hooks/typography/index.ts
+++ b/lib/hooks/typography/index.ts
@@ -1,7 +1,9 @@
+import { useContext } from 'react';
 import { useStyles } from 'sku/react-treat';
 import classnames from 'classnames';
 import { useBackground } from '../../components/Box/BackgroundContext';
 import * as styleRefs from './typography.treat';
+import TextLinkRendererContext from '../../components/TextLinkRenderer/TextLinkRendererContext';
 
 export interface UseTextProps {
   weight?: keyof typeof styleRefs.fontWeight;
@@ -17,15 +19,18 @@ export const useText = ({
   baseline,
 }: UseTextProps) => {
   const styles = useStyles(styleRefs);
+  const inTextLinkRenderer = useContext(TextLinkRendererContext);
 
   return classnames(
     styles.fontFamily,
-    styles.fontWeight[weight],
     styles.text[size].fontSize,
-    useTextTone(tone),
-    {
-      [styles.text[size].transform]: baseline,
-    },
+    inTextLinkRenderer
+      ? useTouchableSpace(size)
+      : [
+          useTextTone(tone),
+          styles.fontWeight[weight],
+          baseline ? styles.text[size].transform : null,
+        ],
   );
 };
 
@@ -44,20 +49,25 @@ export const useHeading = ({
   baseline,
 }: HeadingParams) => {
   const styles = useStyles(styleRefs);
+  const inTextLinkRenderer = useContext(TextLinkRendererContext);
 
   return classnames(
     styles.fontFamily,
     styles.headingWeight[weight],
     styles.heading[level].fontSize,
-    useTextTone(),
+    useTextTone(inTextLinkRenderer ? 'link' : undefined),
     {
       [styles.heading[level].transform]: baseline,
     },
   );
 };
 
-export const useWeight = (weight: keyof typeof styleRefs.fontWeight) =>
-  useStyles(styleRefs).fontWeight[weight];
+export const useWeight = (weight: keyof typeof styleRefs.fontWeight) => {
+  const styles = useStyles(styleRefs);
+  const inTextLinkRenderer = useContext(TextLinkRendererContext);
+
+  return inTextLinkRenderer ? null : styles.fontWeight[weight];
+};
 
 export const useTextTone = (tone?: keyof typeof styleRefs.tone) => {
   const styles = useStyles(styleRefs);

--- a/site/src/App/Components/Link.tsx
+++ b/site/src/App/Components/Link.tsx
@@ -10,9 +10,9 @@ interface LinkProps extends ReactRouterLinkProps {
   inline?: boolean;
 }
 
-export const Link = ({ inline, ...restProps }: LinkProps) => (
-  <TextLinkRenderer inline>
-    {textLinkProps => <ReactRouterLink {...restProps} {...textLinkProps} />}
+export const Link = (props: LinkProps) => (
+  <TextLinkRenderer>
+    {textLinkProps => <ReactRouterLink {...props} {...textLinkProps} />}
   </TextLinkRenderer>
 );
 
@@ -20,6 +20,6 @@ interface ExternalLinkProps
   extends Omit<AllHTMLAttributes<HTMLAnchorElement>, 'style' | 'className'> {
   inline?: boolean;
 }
-export const ExternalLink = ({ inline, ...restProps }: ExternalLinkProps) => (
-  <TextLink inline={inline} {...restProps} />
+export const ExternalLink = (props: ExternalLinkProps) => (
+  <TextLink {...props} />
 );


### PR DESCRIPTION
## Breaking Changes

The `inline` prop has been removed from `TextLinkRenderer`/`TextLink` in favour of contextual inference.

```diff
-<Text>The next word is a <TextLink inline>link.</TextLink></Text>
+<Text>The next word is a <TextLink>link.</TextLink></Text>
```

Block level usage of `TextLinkRenderer`/`TextLink` must now contain a Text node.

```diff
-<TextLink>Link text</TextLink>
+<TextLink><Text>Link text</Text></TextLink>
```