### PR TITLE
refactor(Button): Remove redundant CSS transition

### DIFF
--- a/lib/components/Button/Button.treat.ts
+++ b/lib/components/Button/Button.treat.ts
@@ -10,7 +10,6 @@ export const weak = style({
 });
 
 const overlay = style({
-  transition: 'opacity 0.2s',
   selectors: {
     [`${weak} &`]: {
       zIndex: 2,


### PR DESCRIPTION
This transition is already provided by `FieldOverlay`, which renders an `Overlay` with `transition="fast"`.

This doesn't meaningfully impact consumers, apart from a minuscule drop in CSS size, so decided to mark this as a refactor.