### PR TITLE
fix(Reset): Remove default background color on `button`

### DIFF
--- a/lib/hooks/useBox/reset.treat.ts
+++ b/lib/hooks/useBox/reset.treat.ts
@@ -52,6 +52,10 @@ const select = style({
   },
 });
 
+const button = style({
+  background: 'none',
+});
+
 export const element = {
   article: block,
   aside: block,
@@ -73,4 +77,5 @@ export const element = {
   table,
   mark,
   select,
+  button,
 };


### PR DESCRIPTION
The native style sheet for a `<button>` includes a background color of `white`. When using `<Box component="button" />` it would be expected that the component reset takes care of this.