### PR TITLE
fix: Make field text visible within dark background context

### DIFF
--- a/lib/components/Dropdown/Dropdown.docs.tsx
+++ b/lib/components/Dropdown/Dropdown.docs.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { Dropdown } from './Dropdown';
+import { Box } from '../Box/Box';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -69,6 +70,24 @@ const docs: ComponentDocs = {
           <option value="1">Developer</option>
           <option value="2">Designer</option>
         </Dropdown>
+      ),
+    },
+    {
+      label: 'Dropdown on Brand Background',
+      Container,
+      render: ({ id, handler }) => (
+        <Box background="brand" paddingLeft="small" paddingRight="small">
+          <Dropdown
+            label="Job Title"
+            id={id}
+            onChange={handler}
+            value=""
+            placeholder="Please select a role title"
+          >
+            <option value="1">Developer</option>
+            <option value="2">Designer</option>
+          </Dropdown>
+        </Box>
       ),
     },
   ],

--- a/lib/components/Dropdown/Dropdown.tsx
+++ b/lib/components/Dropdown/Dropdown.tsx
@@ -79,7 +79,7 @@ const NamedDropdown = forwardRef<HTMLSelectElement, DropdownProps>(
               className={classnames(
                 styles.field,
                 className,
-                useTextTone(getTone(placeholder, value)),
+                useTextTone({ tone: getTone(placeholder, value) }),
               )}
               {...fieldProps}
               ref={fieldRef}
@@ -96,7 +96,7 @@ const NamedDropdown = forwardRef<HTMLSelectElement, DropdownProps>(
               display="flex"
               className={styles.chevron}
             >
-              <ChevronIcon tone="neutral" inline />
+              <ChevronIcon inline />
             </Box>
           </Fragment>
         )}

--- a/lib/components/Heading/Heading.docs.tsx
+++ b/lib/components/Heading/Heading.docs.tsx
@@ -1,6 +1,12 @@
-import React from 'react';
+import React, { Fragment, ReactNode } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { Heading } from './Heading';
+import { Box } from '../Box/Box';
+import { background as boxBackgrounds } from '../../hooks/useBox/box.treat';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div style={{ maxWidth: '300px' }}>{children}</div>
+);
 
 const docs: ComponentDocs = {
   migrationGuide: true,
@@ -52,6 +58,26 @@ const docs: ComponentDocs = {
           Heading Level 4 Weak
         </Heading>
       ),
+    },
+    {
+      label: 'Heading Contrast',
+      docsSite: false,
+      Container,
+      render: () => {
+        const backgrounds = Object.keys(boxBackgrounds) as Array<
+          keyof typeof boxBackgrounds
+        >;
+
+        return (
+          <Fragment>
+            {backgrounds.sort().map(background => (
+              <Box background={background}>
+                <Heading level="4">{background}</Heading>
+              </Box>
+            ))}
+          </Fragment>
+        );
+      },
     },
   ],
 };

--- a/lib/components/Secondary/Secondary.tsx
+++ b/lib/components/Secondary/Secondary.tsx
@@ -7,7 +7,7 @@ export interface SecondaryProps {
 }
 
 export const Secondary = ({ children, id }: SecondaryProps) => (
-  <span className={useTextTone('secondary')} id={id}>
+  <span className={useTextTone({ tone: 'secondary' })} id={id}>
     {children}
   </span>
 );

--- a/lib/components/Text/Text.docs.tsx
+++ b/lib/components/Text/Text.docs.tsx
@@ -1,6 +1,12 @@
-import React from 'react';
+import React, { Fragment, ReactNode } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { Text } from './Text';
+import { Box } from '../Box/Box';
+import { background as boxBackgrounds } from '../../hooks/useBox/box.treat';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div style={{ maxWidth: '300px' }}>{children}</div>
+);
 
 const docs: ComponentDocs = {
   migrationGuide: true,
@@ -13,6 +19,35 @@ const docs: ComponentDocs = {
     {
       label: 'Large Text',
       render: () => <Text size="large">Large text.</Text>,
+    },
+    {
+      label: 'Text on Brand Background',
+      Container,
+      render: () => (
+        <Box background="brand" paddingBottom="xsmall" paddingLeft="xsmall">
+          <Text>Brand background.</Text>
+        </Box>
+      ),
+    },
+    {
+      label: 'Text Contrast',
+      docsSite: false,
+      Container,
+      render: () => {
+        const backgrounds = Object.keys(boxBackgrounds) as Array<
+          keyof typeof boxBackgrounds
+        >;
+
+        return (
+          <Fragment>
+            {backgrounds.sort().map(background => (
+              <Box background={background}>
+                <Text baseline={false}>{background}</Text>
+              </Box>
+            ))}
+          </Fragment>
+        );
+      },
     },
   ],
 };

--- a/lib/components/TextField/TextField.docs.tsx
+++ b/lib/components/TextField/TextField.docs.tsx
@@ -2,6 +2,7 @@ import React, { ReactNode } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { TextField } from './TextField';
 import { TextLink } from '../TextLink/TextLink';
+import { Box } from '../Box/Box';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -88,6 +89,20 @@ const docs: ComponentDocs = {
           tone="positive"
           onChange={handler}
         />
+      ),
+    },
+    {
+      label: 'TextField on Brand Background',
+      Container,
+      render: ({ id, handler }) => (
+        <Box background="brand" paddingLeft="small" paddingRight="small">
+          <TextField
+            label="Job Title"
+            id={id}
+            onChange={handler}
+            value="Senior Developer"
+          />
+        </Box>
       ),
     },
   ],

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
@@ -46,7 +46,11 @@ function useLinkStyles() {
   const inHeading = useContext(HeadingContext);
   const mediumWeight = useWeight('medium');
 
-  return [styles.root, useTextTone('link'), !inHeading ? mediumWeight : null];
+  return [
+    styles.root,
+    useTextTone({ tone: 'link' }),
+    !inHeading ? mediumWeight : null,
+  ];
 }
 
 function InlineLink({ children }: TextLinkRendererProps) {

--- a/lib/components/icons/Icon/Icon.tsx
+++ b/lib/components/icons/Icon/Icon.tsx
@@ -43,7 +43,7 @@ export const Icon = ({
       className={classnames(
         resolveSizeClasses(size, inline),
         styles.currentColor,
-        useTextTone(tone),
+        useTextTone({ tone }),
       )}
     />
   );

--- a/lib/components/private/Field/Field.tsx
+++ b/lib/components/private/Field/Field.tsx
@@ -11,6 +11,7 @@ import { FieldOverlay } from '../FieldOverlay/FieldOverlay';
 import buildDataAttributes, { DataAttributeMap } from '../buildDataAttributes';
 import { useText, useTouchableSpace } from '../../../hooks/typography';
 import * as styleRefs from './Field.treat';
+import { BackgroundProvider } from 'lib/components/Box/BackgroundContext';
 
 type FormElementProps = AllHTMLAttributes<HTMLFormElement>;
 export interface FieldProps {
@@ -71,6 +72,7 @@ export const Field = forwardRef<FieldRef, InternalFieldProps>(
   ) => {
     const styles = useStyles(styleRefs);
     const messageId = `${id}-message`;
+    const background = disabled ? 'inputDisabled' : 'input';
 
     return (
       <Box>
@@ -82,33 +84,39 @@ export const Field = forwardRef<FieldRef, InternalFieldProps>(
           description={description}
         />
         <Box position="relative">
-          {children(
-            {
-              id,
-              name,
-              background: disabled ? 'inputDisabled' : 'input',
-              boxShadow:
-                tone === 'critical' && !disabled
-                  ? 'borderCritical'
-                  : 'borderStandard',
-              width: 'full',
-              paddingLeft: 'small',
-              paddingRight: 'small',
-              borderRadius: 'standard',
-              ...((message || ariaDescribedBy) && {
-                'aria-describedby': ariaDescribedBy || messageId,
-              }),
-              disabled,
-              autoComplete,
-              ...buildDataAttributes(data),
-              className: classnames(
-                styles.field,
-                useText({ size: 'standard', baseline: false }),
-                useTouchableSpace('standard'),
-              ),
-            },
-            ref,
-          )}
+          <BackgroundProvider value={background}>
+            {children(
+              {
+                id,
+                name,
+                background,
+                boxShadow:
+                  tone === 'critical' && !disabled
+                    ? 'borderCritical'
+                    : 'borderStandard',
+                width: 'full',
+                paddingLeft: 'small',
+                paddingRight: 'small',
+                borderRadius: 'standard',
+                ...((message || ariaDescribedBy) && {
+                  'aria-describedby': ariaDescribedBy || messageId,
+                }),
+                disabled,
+                autoComplete,
+                ...buildDataAttributes(data),
+                className: classnames(
+                  styles.field,
+                  useText({
+                    backgroundContext: background,
+                    size: 'standard',
+                    baseline: false,
+                  }),
+                  useTouchableSpace('standard'),
+                ),
+              },
+              ref,
+            )}
+          </BackgroundProvider>
           <FieldOverlay variant="focus" className={styles.focusOverlay} />
           <FieldOverlay variant="hover" className={styles.hoverOverlay} />
         </Box>

--- a/lib/hooks/typography/index.ts
+++ b/lib/hooks/typography/index.ts
@@ -2,14 +2,16 @@ import { useContext } from 'react';
 import { useStyles } from 'sku/react-treat';
 import classnames from 'classnames';
 import { useBackground } from '../../components/Box/BackgroundContext';
-import * as styleRefs from './typography.treat';
+import { BoxProps } from '../../components/Box/Box';
 import TextLinkRendererContext from '../../components/TextLinkRenderer/TextLinkRendererContext';
+import * as styleRefs from './typography.treat';
 
 export interface UseTextProps {
   weight?: keyof typeof styleRefs.fontWeight;
   size?: keyof typeof styleRefs.text;
   tone?: keyof typeof styleRefs.tone;
   baseline: boolean;
+  backgroundContext?: BoxProps['background'];
 }
 
 export const useText = ({
@@ -17,6 +19,7 @@ export const useText = ({
   size = 'standard',
   tone,
   baseline,
+  backgroundContext,
 }: UseTextProps) => {
   const styles = useStyles(styleRefs);
   const inTextLinkRenderer = useContext(TextLinkRendererContext);
@@ -27,7 +30,7 @@ export const useText = ({
     inTextLinkRenderer
       ? useTouchableSpace(size)
       : [
-          useTextTone(tone),
+          useTextTone({ tone, backgroundContext }),
           styles.fontWeight[weight],
           baseline ? styles.text[size].transform : null,
         ],
@@ -41,12 +44,14 @@ interface HeadingParams {
   weight?: HeadingWeight;
   level: HeadingLevel;
   baseline: boolean;
+  backgroundContext?: BoxProps['background'];
 }
 
 export const useHeading = ({
   weight = 'regular',
   level,
   baseline,
+  backgroundContext,
 }: HeadingParams) => {
   const styles = useStyles(styleRefs);
   const inTextLinkRenderer = useContext(TextLinkRendererContext);
@@ -55,7 +60,10 @@ export const useHeading = ({
     styles.fontFamily,
     styles.headingWeight[weight],
     styles.heading[level].fontSize,
-    useTextTone(inTextLinkRenderer ? 'link' : undefined),
+    useTextTone({
+      tone: inTextLinkRenderer ? 'link' : undefined,
+      backgroundContext,
+    }),
     {
       [styles.heading[level].transform]: baseline,
     },
@@ -69,9 +77,16 @@ export const useWeight = (weight: keyof typeof styleRefs.fontWeight) => {
   return inTextLinkRenderer ? undefined : styles.fontWeight[weight];
 };
 
-export const useTextTone = (tone?: keyof typeof styleRefs.tone) => {
+export const useTextTone = ({
+  tone,
+  backgroundContext: backgroundContextOverride,
+}: {
+  tone?: keyof typeof styleRefs.tone;
+  backgroundContext?: BoxProps['background'];
+} = {}) => {
   const styles = useStyles(styleRefs);
-  const background = useBackground();
+  const backgroundContext = useBackground();
+  const background = backgroundContextOverride || backgroundContext;
 
   const backgroundContrast = styles.backgroundContrast[background!];
   if (backgroundContrast) {

--- a/lib/hooks/typography/typography.treat.ts
+++ b/lib/hooks/typography/typography.treat.ts
@@ -186,7 +186,19 @@ export const backgroundContrast: BackgroundContrast = {
   brandAccent: {
     default: textColorForBackground('brandAccent'),
   },
+  brandAccentHover: {
+    default: textColorForBackground('brandAccent'),
+  },
+  brandAccentActive: {
+    default: textColorForBackground('brandAccent'),
+  },
   formAccent: {
+    default: textColorForBackground('formAccent'),
+  },
+  formAccentHover: {
+    default: textColorForBackground('formAccent'),
+  },
+  formAccentActive: {
     default: textColorForBackground('formAccent'),
   },
   positive: {

--- a/site/src/App/Components/ComponentRoute.tsx
+++ b/site/src/App/Components/ComponentRoute.tsx
@@ -61,65 +61,57 @@ export const ComponentRoute = ({
           </Text>
         </Box>
       ) : null}
-      {examples.map((example, index) => {
-        const {
-          label,
-          docsSite = true,
-          render,
-          code,
-          Container = DefaultContainer,
-        } = example;
+      {examples
+        .filter(example => example.docsSite !== false)
+        .map((example, index) => {
+          const { label, render, code, Container = DefaultContainer } = example;
 
-        if (!docsSite) {
-          return null;
-        }
+          const codeAsString =
+            render && !code
+              ? cleanCodeSnippet(
+                  reactElementToJSXString(render({ id: 'id', handler }), {
+                    useBooleanShorthandSyntax: false,
+                    showDefaultProps: false,
+                    showFunctions: false,
+                    filterProps: ['onChange', 'onBlur', 'onFocus'],
+                  }),
+                )
+              : code
+              ? cleanCodeSnippet(dedent(code))
+              : null;
 
-        const codeAsString =
-          render && !code
-            ? cleanCodeSnippet(
-                reactElementToJSXString(render({ id: 'id', handler }), {
-                  useBooleanShorthandSyntax: false,
-                  showDefaultProps: false,
-                  showFunctions: false,
-                  filterProps: ['onChange', 'onBlur', 'onFocus'],
-                }),
-              )
-            : code
-            ? cleanCodeSnippet(dedent(code))
-            : null;
-
-        return (
-          <Box key={index} marginBottom="xxlarge">
-            {label ? (
-              <Box paddingBottom="small">
-                <Text>{label}</Text>
-              </Box>
-            ) : null}
-            {render
-              ? Object.values(themes).map(theme => (
-                  <Box key={theme.name} marginBottom="large">
-                    <Box paddingBottom="small">
-                      <Text tone="secondary">Theme: {theme.name}</Text>
-                    </Box>
-                    <BraidProvider theme={theme}>
-                      <Container>
-                        {render({ id: `${index}_${theme.name}`, handler })}
-                      </Container>
-                    </BraidProvider>
-                  </Box>
-                ))
-              : null}
-            {codeAsString ? (
-              <Fragment>
+          return (
+            <Box key={index} marginBottom="xxlarge">
+              {label ? (
                 <Box paddingBottom="small">
-                  <Text tone="secondary">Code:</Text>
+                  <Text>{label}</Text>
                 </Box>
-                <Code>{codeAsString}</Code>
-              </Fragment>
-            ) : null}
-          </Box>
-        );
-      })}
+              ) : null}
+              {render
+                ? Object.values(themes).map(theme => (
+                    <Box key={theme.name} marginBottom="large">
+                      <Box paddingBottom="small">
+                        <Text tone="secondary">Theme: {theme.name}</Text>
+                      </Box>
+                      <BraidProvider theme={theme}>
+                        <Container>
+                          {render({ id: `${index}_${theme.name}`, handler })}
+                        </Container>
+                      </BraidProvider>
+                    </Box>
+                  ))
+                : null}
+              {codeAsString ? (
+                <Fragment>
+                  <Box paddingBottom="small">
+                    <Text tone="secondary">Code:</Text>
+                  </Box>
+                  <Code>{codeAsString}</Code>
+                </Fragment>
+              ) : null}
+            </Box>
+          );
+        })}
 
       <Box paddingBottom="small">
         <ComponentProps componentName={componentName} />

--- a/site/src/App/Components/ComponentRoute.tsx
+++ b/site/src/App/Components/ComponentRoute.tsx
@@ -61,55 +61,65 @@ export const ComponentRoute = ({
           </Text>
         </Box>
       ) : null}
-      {examples.map(
-        ({ label, render, code, Container = DefaultContainer }, index) => {
-          const codeAsString =
-            render && !code
-              ? cleanCodeSnippet(
-                  reactElementToJSXString(render({ id: 'id', handler }), {
-                    useBooleanShorthandSyntax: false,
-                    showDefaultProps: false,
-                    showFunctions: false,
-                    filterProps: ['onChange', 'onBlur', 'onFocus'],
-                  }),
-                )
-              : code
-              ? cleanCodeSnippet(dedent(code))
-              : null;
+      {examples.map((example, index) => {
+        const {
+          label,
+          docsSite = true,
+          render,
+          code,
+          Container = DefaultContainer,
+        } = example;
 
-          return (
-            <Box key={index} marginBottom="xxlarge">
-              {label ? (
-                <Box paddingBottom="small">
-                  <Text>{label}</Text>
-                </Box>
-              ) : null}
-              {render
-                ? Object.values(themes).map(theme => (
-                    <Box key={theme.name} marginBottom="large">
-                      <Box paddingBottom="small">
-                        <Text tone="secondary">Theme: {theme.name}</Text>
-                      </Box>
-                      <BraidProvider theme={theme}>
-                        <Container>
-                          {render({ id: `${index}_${theme.name}`, handler })}
-                        </Container>
-                      </BraidProvider>
+        if (!docsSite) {
+          return null;
+        }
+
+        const codeAsString =
+          render && !code
+            ? cleanCodeSnippet(
+                reactElementToJSXString(render({ id: 'id', handler }), {
+                  useBooleanShorthandSyntax: false,
+                  showDefaultProps: false,
+                  showFunctions: false,
+                  filterProps: ['onChange', 'onBlur', 'onFocus'],
+                }),
+              )
+            : code
+            ? cleanCodeSnippet(dedent(code))
+            : null;
+
+        return (
+          <Box key={index} marginBottom="xxlarge">
+            {label ? (
+              <Box paddingBottom="small">
+                <Text>{label}</Text>
+              </Box>
+            ) : null}
+            {render
+              ? Object.values(themes).map(theme => (
+                  <Box key={theme.name} marginBottom="large">
+                    <Box paddingBottom="small">
+                      <Text tone="secondary">Theme: {theme.name}</Text>
                     </Box>
-                  ))
-                : null}
-              {codeAsString ? (
-                <Fragment>
-                  <Box paddingBottom="small">
-                    <Text tone="secondary">Code:</Text>
+                    <BraidProvider theme={theme}>
+                      <Container>
+                        {render({ id: `${index}_${theme.name}`, handler })}
+                      </Container>
+                    </BraidProvider>
                   </Box>
-                  <Code>{codeAsString}</Code>
-                </Fragment>
-              ) : null}
-            </Box>
-          );
-        },
-      )}
+                ))
+              : null}
+            {codeAsString ? (
+              <Fragment>
+                <Box paddingBottom="small">
+                  <Text tone="secondary">Code:</Text>
+                </Box>
+                <Code>{codeAsString}</Code>
+              </Fragment>
+            ) : null}
+          </Box>
+        );
+      })}
 
       <Box paddingBottom="small">
         <ComponentProps componentName={componentName} />

--- a/site/src/types.d.ts
+++ b/site/src/types.d.ts
@@ -20,6 +20,7 @@ export interface ComponentDocs {
 
 export interface ComponentExample {
   label?: string;
+  docsSite?: boolean;
   render?: (props: {
     id: string;
     handler: (event: SyntheticEvent) => void;


### PR DESCRIPTION
This fixes an issue where text within a `TextField`, `Dropdown` or `Textarea` was white when nested within a `Box` with a dark background (e.g. `<Box background="brand">`).

This PR also ensures that text provides adequate contrast against all `Box` backgrounds.

Before: 
<img width="313" alt="Screen Shot 2019-07-29 at 4 26 04 pm" src="https://user-images.githubusercontent.com/696693/62026181-9f6c9580-b21d-11e9-9579-fd110fce4b28.png">

After:
<img width="311" alt="Screen Shot 2019-07-29 at 4 26 14 pm" src="https://user-images.githubusercontent.com/696693/62026187-a4314980-b21d-11e9-9ea6-6a625381b583.png">

## Development Notes

This issue was caused by the way `Field` works, where we pass classes down to the target field via render props. As a result, the white background of the field wasn't available on context within the `useTextTone` hook, so it was using the background context defined higher in the tree.

To fix this issue, the `useText`, `useHeading` and `useTextTone` hooks now support an optional `backgroundContext` override for times like this where it's not possible to provide a missing context value when using hooks.

I've also added some examples and test cases to make sure that this issue is caught by our test suite, and to make sure that text contrast in general is covered by screenshot tests. In fact, adding this test highlighted some dormant issues with certain combinations, which I've also fixed in this PR.

Because some of the test cases are much more exhaustive than typical documentation, I've added an optional `docsSite` boolean to the examples type which allows you to hide certain examples from the website. These examples will still show up in Storybook, which means that you'll still see them as part of our Chromatic suite.