### PR TITLE
feat(Icons): Remove `inline` & infer size from usage

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -38,7 +38,6 @@ exports[`Badge 1`] = `
 exports[`BookmarkIcon 1`] = `
 {
   active?: boolean
-  inline?: boolean
   size?: 
     | "fill"
     | "xsmall"
@@ -934,7 +933,6 @@ exports[`ChevronIcon 1`] = `
     | "right"
     | "up"
     | "down"
-  inline?: boolean
   size?: 
     | "fill"
     | "xsmall"
@@ -1008,7 +1006,6 @@ exports[`Dropdown 1`] = `
 
 exports[`ErrorIcon 1`] = `
 {
-  inline?: boolean
   size?: 
     | "fill"
     | "xsmall"
@@ -1257,7 +1254,6 @@ exports[`Hidden 1`] = `
 
 exports[`InfoIcon 1`] = `
 {
-  inline?: boolean
   size?: 
     | "fill"
     | "xsmall"
@@ -2130,7 +2126,6 @@ exports[`ThemeNameConsumer 1`] = `
 
 exports[`TickCircleIcon 1`] = `
 {
-  inline?: boolean
   size?: 
     | "fill"
     | "xsmall"
@@ -2150,7 +2145,6 @@ exports[`TickCircleIcon 1`] = `
 
 exports[`TickIcon 1`] = `
 {
-  inline?: boolean
   size?: 
     | "fill"
     | "xsmall"

--- a/lib/components/Alert/Alert.tsx
+++ b/lib/components/Alert/Alert.tsx
@@ -62,7 +62,7 @@ export const Alert = ({
       display="flex"
     >
       {Icon ? (
-        <Box paddingRight="small" display="flex" className={styles.icon}>
+        <Box paddingRight="small" className={styles.icon}>
           <Icon />
         </Box>
       ) : null}

--- a/lib/components/FieldMessage/FieldMessage.tsx
+++ b/lib/components/FieldMessage/FieldMessage.tsx
@@ -21,8 +21,8 @@ export interface FieldMessageProps {
 }
 
 const Icon: Record<'critical' | 'positive', ReactNode> = {
-  critical: <ErrorIcon tone="critical" size="small" inline />,
-  positive: <TickCircleIcon tone="positive" size="small" inline />,
+  critical: <ErrorIcon tone="critical" />,
+  positive: <TickCircleIcon tone="positive" />,
 };
 export const FieldMessage = ({
   id,

--- a/lib/components/private/examplesForIcon.tsx
+++ b/lib/components/private/examplesForIcon.tsx
@@ -20,7 +20,7 @@ export default (Icon: ComponentType<UseIconProps>) => {
       label: 'Standard Inline',
       render: () => (
         <Text>
-          Standard <Icon inline /> text
+          Standard <Icon /> text
         </Text>
       ),
     },
@@ -41,7 +41,7 @@ export default (Icon: ComponentType<UseIconProps>) => {
       label: 'Large Inline',
       render: () => (
         <Text size="large">
-          Large <Icon size="large" inline /> text
+          Large <Icon /> text
         </Text>
       ),
     },

--- a/lib/hooks/typography/typography.treat.ts
+++ b/lib/hooks/typography/typography.treat.ts
@@ -151,13 +151,16 @@ const textColorForBackground = (
     }
   };
 
-  return style(theme => ({
-    color:
-      resolveOverride(theme) ||
-      (isLight(theme.color.background[background])
-        ? theme.color.foreground.neutral
-        : theme.color.foreground.neutralInverted),
-  }));
+  return style(
+    theme => ({
+      color:
+        resolveOverride(theme) ||
+        (isLight(theme.color.background[background])
+          ? theme.color.foreground.neutral
+          : theme.color.foreground.neutralInverted),
+    }),
+    `textColorForBackground-${background}`,
+  );
 };
 
 type Foreground = keyof typeof tone;

--- a/lib/hooks/useIcon/icon.treat.ts
+++ b/lib/hooks/useIcon/icon.treat.ts
@@ -4,18 +4,11 @@ import mapValues from 'lodash/mapValues';
 export const inline = style({
   verticalAlign: 'middle',
   top: '-0.105em', // Arbitrary magic number, to vertically align to text
+  width: '1em',
+  height: '1em',
 });
 
 const makeSizeRules = (size: number) => ({ width: size, height: size });
-
-export const inlineSizes = styleMap(({ utils, typography }) =>
-  mapValues(typography.text, ({ mobile, desktop }) =>
-    utils.responsiveStyles(
-      makeSizeRules(mobile.size),
-      makeSizeRules(desktop.size),
-    ),
-  ),
-);
 
 export const blockSizes = styleMap(({ utils, typography }) =>
   mapValues(typography.text, ({ mobile, desktop }) =>

--- a/lib/hooks/useIcon/index.ts
+++ b/lib/hooks/useIcon/index.ts
@@ -1,6 +1,9 @@
+import { useContext } from 'react';
 import { useStyles } from 'sku/react-treat';
 import classnames from 'classnames';
 import { BoxProps } from '../../components/Box/Box';
+import TextContext from '../../components/Text/TextContext';
+import HeadingContext from '../../components/Heading/HeadingContext';
 import { useTextTone, UseTextProps } from '../../hooks/typography';
 import * as styleRefs from './icon.treat';
 
@@ -8,17 +11,26 @@ type IconSize = NonNullable<UseTextProps['size']> | 'fill';
 
 export interface UseIconProps {
   size?: IconSize;
-  inline?: boolean;
   tone?: UseTextProps['tone'];
 }
 
-export default ({
-  size = 'standard',
-  inline = false,
-  tone,
-}: UseIconProps): BoxProps => {
+export default ({ size, tone }: UseIconProps): BoxProps => {
   const styles = useStyles(styleRefs);
+  const inText = useContext(TextContext);
+  const inHeading = useContext(HeadingContext);
+
   const defaultStyles = [styles.currentColor, useTextTone({ tone })];
+  const isInline = inText || inHeading;
+
+  if (process.env.NODE_ENV !== 'production') {
+    if (isInline && size) {
+      throw new Error(
+        `Specifying a custom \`size\` for an \`Icon\` inside the context of a \`<${
+          inText ? 'Text' : 'Heading'
+        }>\` component is invalid. See the documentation for correct usage: https://seek-oss.github.io/braid-design-system/components/`,
+      );
+    }
+  }
 
   if (size === 'fill') {
     return {
@@ -30,13 +42,11 @@ export default ({
   }
 
   return {
-    display: inline ? 'inlineBlock' : 'block',
-    position: inline ? 'relative' : undefined,
+    display: isInline ? 'inlineBlock' : 'block',
+    position: isInline ? 'relative' : undefined,
     className: classnames(
       defaultStyles,
-      inline
-        ? [styles.inline, styles.inlineSizes[size]]
-        : styles.blockSizes[size],
+      isInline ? styles.inline : styles.blockSizes[size || 'standard'],
     ),
   };
 };

--- a/site/src/App/Code/Code.tsx
+++ b/site/src/App/Code/Code.tsx
@@ -87,7 +87,7 @@ export default ({ children }: CodeProps) => {
         className={styles.toolbar}
       >
         <CodeButton onClick={() => copy(children)} title="Copy to clipboard">
-          <CopyIcon size="xsmall" inline /> Copy
+          <CopyIcon /> Copy
         </CodeButton>
         {/^import/m.test(children) ? null : (
           <Fragment>
@@ -99,7 +99,7 @@ export default ({ children }: CodeProps) => {
               style={{ textDecoration: 'none' }}
               title="Open in Playroom"
             >
-              <PlayIcon size="xsmall" inline /> Open in Playroom
+              <PlayIcon /> Open in Playroom
             </CodeButton>
           </Fragment>
         )}


### PR DESCRIPTION
### Breaking Change
Removes `inline` in favour of inferring this from the context of use. Nesting an icon inside a `<Text>` or `<Heading>` component will determine its size and position — no longer requiring the `inline` modifier or allowing a `size` that differs from the parent text.

### Migration Guide
#### Removed `inline` prop
An example migration, ie. determined as inline based on it being a child of `<Text>`.
```diff
<Text>
-  An inline icon <Icon inline />  amongst text
+  An inline icon <Icon />  amongst text
</Text>
```

#### Inferred `size` prop
An example migration, ie. determined as being `size="large"` based on it being a child of `<Text size="large">`.
```diff
<Text size="large">
-  An large icon <Icon size="large" />  amongst large text
+  An large icon <Icon />  amongst large text
</Text>
```

Note: Having different sizes is no longer permitted. Eg: 
```diff
<Text size="large">
-  An large icon <Icon size="small" />  amongst large text
+  An large icon <Icon />  amongst large text
</Text>
```

### Developer Notes
- Added a more detailed `debugIdent` to `textColorForBackground` util to ease debugging.
- Removed redundant `display="flex"` around the icon inside `Alert`

