### PR TITLE
fix(Dropdown): Resolve oversized chevron on iOS

### DIFF
--- a/lib/components/Dropdown/Dropdown.treat.ts
+++ b/lib/components/Dropdown/Dropdown.treat.ts
@@ -6,6 +6,7 @@ export const chevron = style(({ utils, spacing }) => ({
   right: 0,
   alignItems: 'center',
   height: utils.rows(spacing.touchableRows),
+  width: utils.rows(spacing.touchableRows),
 }));
 
 export const field = style(({ spacing, grid, typography }) => ({


### PR DESCRIPTION
Rectifies an issue where the chevron within the `Dropdown` component is oversized on mobile devices. This is a result of using the `fill` size for the icon without a horizontal constraint being provided to the container.