### PR TITLE
docs(site): Convert example render functions to components

### DIFF
--- a/lib/components/Actions/Actions.docs.tsx
+++ b/lib/components/Actions/Actions.docs.tsx
@@ -9,7 +9,7 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Actions with Strong Button and TextLink',
-      render: () => (
+      Example: () => (
         <Actions>
           <Button weight="strong">Strong</Button>
           <TextLink href="#">TextLink</TextLink>
@@ -18,7 +18,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Actions with Regular Button and Weak Button',
-      render: () => (
+      Example: () => (
         <Actions>
           <Button weight="regular">Regular</Button>
           <Button weight="weak">Weak</Button>
@@ -27,7 +27,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Actions with Weak Buttons and Regular Button',
-      render: () => (
+      Example: () => (
         <Actions>
           <Button weight="weak">Weak</Button>
           <Button weight="weak">Weak</Button>

--- a/lib/components/Alert/Alert.docs.tsx
+++ b/lib/components/Alert/Alert.docs.tsx
@@ -7,13 +7,13 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Info Alert',
-      render: () => (
+      Example: () => (
         <Alert tone="info">This is an important piece of information.</Alert>
       ),
     },
     {
       label: 'Strong Info Alert',
-      render: () => (
+      Example: () => (
         <Alert weight="strong" tone="info">
           This is an important piece of information.
         </Alert>
@@ -21,13 +21,13 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Critical Alert',
-      render: () => (
+      Example: () => (
         <Alert tone="critical">This is a critical piece of information.</Alert>
       ),
     },
     {
       label: 'Strong Critical Alert',
-      render: () => (
+      Example: () => (
         <Alert weight="strong" tone="critical">
           This is a critical piece of information.
         </Alert>
@@ -35,13 +35,13 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Positive Alert',
-      render: () => (
+      Example: () => (
         <Alert tone="positive">This is a positive piece of information.</Alert>
       ),
     },
     {
       label: 'Strong Positive Alert',
-      render: () => (
+      Example: () => (
         <Alert weight="strong" tone="positive">
           This is a positive piece of information.
         </Alert>

--- a/lib/components/Badge/Badge.docs.tsx
+++ b/lib/components/Badge/Badge.docs.tsx
@@ -7,11 +7,11 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Info Badge',
-      render: () => <Badge tone="info">Featured</Badge>,
+      Example: () => <Badge tone="info">Featured</Badge>,
     },
     {
       label: 'Strong Info Badge',
-      render: () => (
+      Example: () => (
         <Badge tone="info" weight="strong">
           Featured
         </Badge>
@@ -19,11 +19,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Critical Badge',
-      render: () => <Badge tone="critical">Overdue</Badge>,
+      Example: () => <Badge tone="critical">Overdue</Badge>,
     },
     {
       label: 'Strong Critical Badge',
-      render: () => (
+      Example: () => (
         <Badge tone="critical" weight="strong">
           Overdue
         </Badge>
@@ -31,11 +31,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Positive Badge',
-      render: () => <Badge tone="positive">New</Badge>,
+      Example: () => <Badge tone="positive">New</Badge>,
     },
     {
       label: 'Strong Positive Badge',
-      render: () => (
+      Example: () => (
         <Badge tone="positive" weight="strong">
           New
         </Badge>
@@ -43,11 +43,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Secondary Badge',
-      render: () => <Badge tone="secondary">10m ago</Badge>,
+      Example: () => <Badge tone="secondary">10m ago</Badge>,
     },
     {
       label: 'Strong Secondary Badge',
-      render: () => (
+      Example: () => (
         <Badge tone="secondary" weight="strong">
           10m ago
         </Badge>

--- a/lib/components/Box/Box.docs.tsx
+++ b/lib/components/Box/Box.docs.tsx
@@ -20,7 +20,7 @@ const docs: ComponentDocs = {
           {children}
         </Box>
       ),
-      render: () => (
+      Example: () => (
         <Box
           {...(space === 'gutter'
             ? {

--- a/lib/components/Bullet/Bullet.docs.tsx
+++ b/lib/components/Bullet/Bullet.docs.tsx
@@ -8,7 +8,7 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Standard Bullets',
-      render: () => (
+      Example: () => (
         <BulletList>
           <Bullet>This is a bullet.</Bullet>
           <Bullet>This is a bullet.</Bullet>

--- a/lib/components/Button/Button.docs.tsx
+++ b/lib/components/Button/Button.docs.tsx
@@ -12,17 +12,17 @@ const docs: ComponentDocs = {
     {
       label: 'Default Button',
       Container,
-      render: () => <Button>Submit</Button>,
+      Example: () => <Button>Submit</Button>,
     },
     {
       label: 'Strong Button',
       Container,
-      render: () => <Button weight="strong">Submit</Button>,
+      Example: () => <Button weight="strong">Submit</Button>,
     },
     {
       label: 'Weak Button',
       Container,
-      render: () => <Button weight="weak">Submit</Button>,
+      Example: () => <Button weight="weak">Submit</Button>,
     },
   ],
 };

--- a/lib/components/Card/Card.docs.tsx
+++ b/lib/components/Card/Card.docs.tsx
@@ -18,7 +18,7 @@ const docs: ComponentDocs = {
           {children}
         </Box>
       ),
-      render: () => (
+      Example: () => (
         <Fragment>
           <Card>
             <Text>This text is inside a card.</Text>

--- a/lib/components/Checkbox/Checkbox.docs.tsx
+++ b/lib/components/Checkbox/Checkbox.docs.tsx
@@ -8,13 +8,13 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Standard Checkbox',
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Checkbox id={id} checked={false} onChange={handler} label="Label" />
       ),
     },
     {
       label: 'Checkbox without Message Placeholder',
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Checkbox
           id={id}
           checked={false}
@@ -26,7 +26,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Checked Checkbox',
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Checkbox
           id={id}
           checked={true}
@@ -38,7 +38,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Disabled Checkbox',
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Checkbox
           id={id}
           disabled={true}
@@ -51,7 +51,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Critical Checkbox',
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Checkbox
           id={id}
           checked={false}
@@ -64,7 +64,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Nested Checkbox',
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Checkbox
           id={id}
           checked={true}

--- a/lib/components/Column/Column.docs.tsx
+++ b/lib/components/Column/Column.docs.tsx
@@ -19,7 +19,7 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Standard Columns',
-      render: () => (
+      Example: () => (
         <Columns>
           <Column>
             <HideCode>
@@ -41,7 +41,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Available widths',
-      render: () => (
+      Example: () => (
         <Fragment>
           {widths.map(width => (
             <Columns>
@@ -65,7 +65,7 @@ const docs: ComponentDocs = {
     {
       label: 'Gutter align',
       docsSite: false,
-      render: () => (
+      Example: () => (
         <Fragment>
           <Box marginBottom="medium">
             <Columns>

--- a/lib/components/Columns/Columns.docs.tsx
+++ b/lib/components/Columns/Columns.docs.tsx
@@ -17,7 +17,7 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Default',
-      render: () => (
+      Example: () => (
         <Columns>
           <Column>
             <HideCode>
@@ -39,7 +39,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Collapse on mobile',
-      render: () => (
+      Example: () => (
         <Columns collapse>
           <Column>
             <HideCode>
@@ -56,7 +56,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Custom gutter size, e.g. `small`',
-      render: () => (
+      Example: () => (
         <Columns gutter="small">
           <Column>
             <HideCode>
@@ -73,7 +73,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'No gutter',
-      render: () => (
+      Example: () => (
         <Columns gutter="none">
           <Column>
             <HideCode>
@@ -90,7 +90,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Reverse',
-      render: () => (
+      Example: () => (
         <Columns reverse>
           <Column>
             <HideCode>

--- a/lib/components/Divider/Divider.docs.tsx
+++ b/lib/components/Divider/Divider.docs.tsx
@@ -6,7 +6,7 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Standard Divider',
-      render: () => <Divider />,
+      Example: () => <Divider />,
     },
   ],
 };

--- a/lib/components/Dropdown/Dropdown.docs.tsx
+++ b/lib/components/Dropdown/Dropdown.docs.tsx
@@ -13,7 +13,7 @@ const docs: ComponentDocs = {
     {
       label: 'Dropdown with placeholder',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Dropdown
           label="Job Title"
           id={id}
@@ -29,7 +29,7 @@ const docs: ComponentDocs = {
     {
       label: 'Dropdown with options group',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Dropdown
           label="Location"
           id={id}
@@ -48,7 +48,7 @@ const docs: ComponentDocs = {
     {
       label: 'Dropdown without placeholder',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Dropdown label="Job Title" id={id} onChange={handler} value="">
           <option value="1">Developer</option>
           <option value="2">Designer</option>
@@ -58,7 +58,7 @@ const docs: ComponentDocs = {
     {
       label: 'Dropdown in invalid state',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Dropdown
           label="Job Title"
           id={id}
@@ -75,7 +75,7 @@ const docs: ComponentDocs = {
     {
       label: 'Dropdown on Brand Background',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Box background="brand" paddingX="small">
           <Dropdown
             label="Job Title"

--- a/lib/components/FieldLabel/FieldLabel.docs.tsx
+++ b/lib/components/FieldLabel/FieldLabel.docs.tsx
@@ -12,12 +12,12 @@ const docs: ComponentDocs = {
     {
       label: 'Standard Field Label',
       Container,
-      render: () => <FieldLabel htmlFor="id" label="This is a field label" />,
+      Example: () => <FieldLabel htmlFor="id" label="This is a field label" />,
     },
     {
       label: 'Field Label with secondary',
       Container,
-      render: () => (
+      Example: () => (
         <FieldLabel
           htmlFor="id"
           label="Username"
@@ -28,7 +28,7 @@ const docs: ComponentDocs = {
     {
       label: 'Field Label with tertiary label',
       Container,
-      render: () => (
+      Example: () => (
         <FieldLabel
           htmlFor="id"
           label="Password"
@@ -39,7 +39,7 @@ const docs: ComponentDocs = {
     {
       label: 'Field Label with all types',
       Container,
-      render: () => (
+      Example: () => (
         <FieldLabel
           htmlFor="id"
           label="Title"

--- a/lib/components/FieldMessage/FieldMessage.docs.tsx
+++ b/lib/components/FieldMessage/FieldMessage.docs.tsx
@@ -7,7 +7,7 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Critical Field Message',
-      render: ({ id }) => (
+      Example: ({ id }) => (
         <FieldMessage
           id={id}
           tone="critical"
@@ -17,7 +17,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Positive Field Message',
-      render: ({ id }) => (
+      Example: ({ id }) => (
         <FieldMessage
           id={id}
           tone="positive"
@@ -30,7 +30,7 @@ const docs: ComponentDocs = {
       Container: ({ children }) => (
         <div style={{ maxWidth: '300px' }}>{children}</div>
       ),
-      render: ({ id }) => (
+      Example: ({ id }) => (
         <FieldMessage
           id={id}
           tone="critical"

--- a/lib/components/Heading/Heading.docs.tsx
+++ b/lib/components/Heading/Heading.docs.tsx
@@ -13,11 +13,11 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Level 1',
-      render: () => <Heading level="1">Heading Level 1</Heading>,
+      Example: () => <Heading level="1">Heading Level 1</Heading>,
     },
     {
       label: 'Level 1 Weak',
-      render: () => (
+      Example: () => (
         <Heading level="1" weight="weak">
           Heading Level 1 Weak
         </Heading>
@@ -25,11 +25,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Level 2',
-      render: () => <Heading level="2">Heading Level 2</Heading>,
+      Example: () => <Heading level="2">Heading Level 2</Heading>,
     },
     {
       label: 'Level 2 Weak',
-      render: () => (
+      Example: () => (
         <Heading level="2" weight="weak">
           Heading Level 2 Weak
         </Heading>
@@ -37,11 +37,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Level 3',
-      render: () => <Heading level="3">Heading Level 3</Heading>,
+      Example: () => <Heading level="3">Heading Level 3</Heading>,
     },
     {
       label: 'Level 3 Weak',
-      render: () => (
+      Example: () => (
         <Heading level="3" weight="weak">
           Heading Level 3 Weak
         </Heading>
@@ -49,11 +49,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Level 4',
-      render: () => <Heading level="4">Heading Level 4</Heading>,
+      Example: () => <Heading level="4">Heading Level 4</Heading>,
     },
     {
       label: 'Level 4 Weak',
-      render: () => (
+      Example: () => (
         <Heading level="4" weight="weak">
           Heading Level 4 Weak
         </Heading>
@@ -63,7 +63,7 @@ const docs: ComponentDocs = {
       label: 'Heading Contrast',
       docsSite: false,
       Container,
-      render: () => {
+      Example: () => {
         const backgrounds = Object.keys(boxBackgrounds) as Array<
           keyof typeof boxBackgrounds
         >;

--- a/lib/components/Hidden/Hidden.docs.tsx
+++ b/lib/components/Hidden/Hidden.docs.tsx
@@ -7,7 +7,7 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Hidden on Mobile',
-      render: () => (
+      Example: () => (
         <Fragment>
           <Text>The following line is hidden on mobile:</Text>
           <Hidden mobile>
@@ -18,7 +18,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden on Desktop',
-      render: () => (
+      Example: () => (
         <Fragment>
           <Text>The following line is hidden on desktop:</Text>
           <Hidden desktop>
@@ -29,7 +29,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden on Print',
-      render: () => (
+      Example: () => (
         <Fragment>
           <Text>The following line is hidden on print:</Text>
           <Hidden print>
@@ -40,7 +40,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden on Screen',
-      render: () => (
+      Example: () => (
         <Fragment>
           <Text>The following line is hidden on screen:</Text>
           <Hidden screen>
@@ -51,7 +51,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden on Mobile (Inline)',
-      render: () => (
+      Example: () => (
         <Text>
           The following text node is hidden on mobile:{' '}
           <Hidden inline mobile>
@@ -62,7 +62,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden on Desktop (Inline)',
-      render: () => (
+      Example: () => (
         <Text>
           The following text node is hidden on desktop:{' '}
           <Hidden inline desktop>
@@ -73,7 +73,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden on Print (Inline)',
-      render: () => (
+      Example: () => (
         <Text>
           The following text node is hidden on print:{' '}
           <Hidden inline print>
@@ -84,7 +84,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden on Screen (Inline)',
-      render: () => (
+      Example: () => (
         <Text>
           The following text node is hidden on screen:{' '}
           <Hidden inline screen>

--- a/lib/components/MonthPicker/MonthPicker.docs.tsx
+++ b/lib/components/MonthPicker/MonthPicker.docs.tsx
@@ -16,7 +16,7 @@ const docs: ComponentDocs = {
     {
       label: 'Default',
       Container,
-      render: ({ id }) => (
+      Example: ({ id }) => (
         <MonthPicker
           id={id}
           label="Started"
@@ -28,7 +28,7 @@ const docs: ComponentDocs = {
     {
       label: 'Selected values',
       Container,
-      render: ({ id }) => (
+      Example: ({ id }) => (
         <MonthPicker
           id={id}
           label="Started"
@@ -40,7 +40,7 @@ const docs: ComponentDocs = {
     {
       label: 'Critical message',
       Container,
-      render: ({ id }) => (
+      Example: ({ id }) => (
         <MonthPicker
           id={id}
           label="Started"

--- a/lib/components/Paragraph/Paragraph.docs.tsx
+++ b/lib/components/Paragraph/Paragraph.docs.tsx
@@ -7,7 +7,7 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Standard Paragraph',
-      render: () => (
+      Example: () => (
         <Paragraph>
           <Text>Standard</Text>
           <Text>Paragraph</Text>

--- a/lib/components/Radio/Radio.docs.tsx
+++ b/lib/components/Radio/Radio.docs.tsx
@@ -8,19 +8,19 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Standard Radio Button',
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Radio id={id} checked={false} onChange={handler} label="Label" />
       ),
     },
     {
       label: 'Checked Radio Button',
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Radio id={id} checked={true} onChange={handler} label="Label" />
       ),
     },
     {
       label: 'Disabled Radio Button',
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Radio
           id={id}
           disabled={true}
@@ -32,7 +32,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Critical Radio Button',
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Radio
           id={id}
           checked={false}
@@ -44,7 +44,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Nested Radio Button',
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Radio id={id} checked={true} onChange={handler} label="Label">
           <Text>This text is visible when the radio button is checked.</Text>
         </Radio>

--- a/lib/components/Secondary/Secondary.docs.tsx
+++ b/lib/components/Secondary/Secondary.docs.tsx
@@ -7,7 +7,7 @@ const docs: ComponentDocs = {
   migrationGuide: true,
   examples: [
     {
-      render: () => (
+      Example: () => (
         <Text>
           The word in the <Secondary>middle</Secondary> is secondary text.
         </Text>

--- a/lib/components/Strong/Strong.docs.tsx
+++ b/lib/components/Strong/Strong.docs.tsx
@@ -7,7 +7,7 @@ const docs: ComponentDocs = {
   migrationGuide: true,
   examples: [
     {
-      render: () => (
+      Example: () => (
         <Text>
           The last word of this sentence is <Strong>strong.</Strong>
         </Text>

--- a/lib/components/Text/Text.docs.tsx
+++ b/lib/components/Text/Text.docs.tsx
@@ -11,19 +11,19 @@ const Container = ({ children }: { children: ReactNode }) => (
 const docs: ComponentDocs = {
   migrationGuide: true,
   examples: [
-    { label: 'Standard Text', render: () => <Text>Standard text.</Text> },
+    { label: 'Standard Text', Example: () => <Text>Standard text.</Text> },
     {
       label: 'Small Text',
-      render: () => <Text size="small">Small text.</Text>,
+      Example: () => <Text size="small">Small text.</Text>,
     },
     {
       label: 'Large Text',
-      render: () => <Text size="large">Large text.</Text>,
+      Example: () => <Text size="large">Large text.</Text>,
     },
     {
       label: 'Text on Brand Background',
       Container,
-      render: () => (
+      Example: () => (
         <Box background="brand" paddingBottom="xsmall" paddingLeft="xsmall">
           <Text>Brand background.</Text>
         </Box>
@@ -33,7 +33,7 @@ const docs: ComponentDocs = {
       label: 'Text Contrast',
       docsSite: false,
       Container,
-      render: () => {
+      Example: () => {
         const backgrounds = Object.keys(boxBackgrounds) as Array<
           keyof typeof boxBackgrounds
         >;

--- a/lib/components/TextField/TextField.docs.tsx
+++ b/lib/components/TextField/TextField.docs.tsx
@@ -14,7 +14,7 @@ const docs: ComponentDocs = {
     {
       label: 'TextField',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <TextField
           label="Job Title"
           id={id}
@@ -26,7 +26,7 @@ const docs: ComponentDocs = {
     {
       label: 'TextField with message',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <TextField
           label="Job Title"
           id={id}
@@ -39,7 +39,7 @@ const docs: ComponentDocs = {
     {
       label: 'TextField with secondary label',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <TextField
           label="Title"
           secondaryLabel="Optional"
@@ -52,7 +52,7 @@ const docs: ComponentDocs = {
     {
       label: 'TextField with tertiary label',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <TextField
           label="Title"
           secondaryLabel="Optional"
@@ -66,7 +66,7 @@ const docs: ComponentDocs = {
     {
       label: 'TextField with error',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <TextField
           label="Do you like Braid?"
           tone="critical"
@@ -80,7 +80,7 @@ const docs: ComponentDocs = {
     {
       label: 'TextField with postive message',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <TextField
           label="Do you like Braid?"
           id={id}
@@ -94,7 +94,7 @@ const docs: ComponentDocs = {
     {
       label: 'TextField on Brand Background',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Box background="brand" paddingX="small">
           <TextField
             label="Job Title"

--- a/lib/components/TextLink/TextLink.docs.tsx
+++ b/lib/components/TextLink/TextLink.docs.tsx
@@ -11,7 +11,7 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Text Link',
-      render: () => (
+      Example: () => (
         <Text>
           The last word of a sentence is a{' '}
           <TextLink href="">text link.</TextLink>
@@ -20,7 +20,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Block Text Link',
-      render: () => (
+      Example: () => (
         <TextLink href="">
           <Text>Text Link</Text>
         </TextLink>
@@ -28,7 +28,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Text Link inside Actions',
-      render: () => (
+      Example: () => (
         <Actions>
           <Button>Button</Button>
           <TextLink href="">Text Link</TextLink>
@@ -37,7 +37,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Large Text Link',
-      render: () => (
+      Example: () => (
         <Text size="large">
           The last word of a sentence is a{' '}
           <TextLink href="">text link.</TextLink>
@@ -46,7 +46,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Large Block Text Link',
-      render: () => (
+      Example: () => (
         <TextLink href="">
           <Text size="large">Text Link</Text>
         </TextLink>
@@ -54,7 +54,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Small Text Link',
-      render: () => (
+      Example: () => (
         <Text size="small">
           The last word of a sentence is a{' '}
           <TextLink href="">text link.</TextLink>
@@ -63,7 +63,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Small Block Text Link',
-      render: () => (
+      Example: () => (
         <TextLink href="">
           <Text size="small">Text Link</Text>
         </TextLink>
@@ -71,7 +71,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Xsmall Text Link',
-      render: () => (
+      Example: () => (
         <Text size="xsmall">
           The last word of a sentence is a{' '}
           <TextLink href="">text link.</TextLink>
@@ -80,7 +80,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Xsmall Block Text Link',
-      render: () => (
+      Example: () => (
         <TextLink href="">
           <Text size="xsmall">Text Link</Text>
         </TextLink>
@@ -88,7 +88,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Heading Level 1 Link',
-      render: () => (
+      Example: () => (
         <TextLink href="">
           <Heading level="1">Heading link.</Heading>
         </TextLink>
@@ -96,7 +96,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Heading Level 1 Link (Inline)',
-      render: () => (
+      Example: () => (
         <Heading level="1">
           The last word of this heading is a <TextLink href="">link.</TextLink>
         </Heading>
@@ -104,7 +104,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Heading Level 2 Link',
-      render: () => (
+      Example: () => (
         <TextLink href="">
           <Heading level="2">Heading link.</Heading>
         </TextLink>
@@ -112,7 +112,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Heading Level 2 Link (Inline)',
-      render: () => (
+      Example: () => (
         <Heading level="2">
           The last word of this heading is a <TextLink href="">link.</TextLink>
         </Heading>
@@ -120,7 +120,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Heading Level 3 Link',
-      render: () => (
+      Example: () => (
         <TextLink href="">
           <Heading level="3">Heading link.</Heading>
         </TextLink>
@@ -128,7 +128,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Heading Level 3 Link (Inline)',
-      render: () => (
+      Example: () => (
         <Heading level="3">
           The last word of this heading is a <TextLink href="">link.</TextLink>
         </Heading>
@@ -136,7 +136,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Heading Level 4 Link',
-      render: () => (
+      Example: () => (
         <TextLink href="">
           <Heading level="4">Heading link.</Heading>
         </TextLink>
@@ -144,7 +144,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Heading Level 4 Link (Inline)',
-      render: () => (
+      Example: () => (
         <Heading level="4">
           The last word of this heading is a <TextLink href="">link.</TextLink>
         </Heading>

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.docs.tsx
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.docs.tsx
@@ -8,7 +8,7 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'TextLink with Custom Renderer',
-      render: () => (
+      Example: () => (
         <Text>
           The last word of this sentence is a{' '}
           <TextLinkRenderer>

--- a/lib/components/Textarea/Textarea.docs.tsx
+++ b/lib/components/Textarea/Textarea.docs.tsx
@@ -13,7 +13,7 @@ const docs: ComponentDocs = {
     {
       label: 'Textarea',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Textarea
           id={id}
           value="Senior Developer"
@@ -25,7 +25,7 @@ const docs: ComponentDocs = {
     {
       label: 'Textarea with message',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Textarea
           id={id}
           value=""
@@ -38,7 +38,7 @@ const docs: ComponentDocs = {
     {
       label: 'Textarea with secondary label',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Textarea
           id={id}
           value=""
@@ -51,7 +51,7 @@ const docs: ComponentDocs = {
     {
       label: 'Textarea with tertiary label',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Textarea
           id={id}
           value=""
@@ -65,7 +65,7 @@ const docs: ComponentDocs = {
     {
       label: 'Textarea with error',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Textarea
           id={id}
           value="No"
@@ -79,7 +79,7 @@ const docs: ComponentDocs = {
     {
       label: 'Textarea with postive message',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Textarea
           id={id}
           value="Yes"
@@ -93,7 +93,7 @@ const docs: ComponentDocs = {
     {
       label: 'Textarea with a limit',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Textarea
           id={id}
           value=""
@@ -106,7 +106,7 @@ const docs: ComponentDocs = {
     {
       label: 'Textarea with value exceeding limit',
       Container,
-      render: ({ id, handler }) => (
+      Example: ({ id, handler }) => (
         <Textarea
           id={id}
           value="Yes I do"

--- a/lib/components/ThemeNameConsumer/ThemeNameConsumer.docs.tsx
+++ b/lib/components/ThemeNameConsumer/ThemeNameConsumer.docs.tsx
@@ -6,7 +6,7 @@ const docs: ComponentDocs = {
   storybook: false,
   examples: [
     {
-      render: () => (
+      Example: () => (
         <ThemeNameConsumer>
           {themeName => <span>The active theme is {themeName}.</span>}
         </ThemeNameConsumer>

--- a/lib/components/Toggle/Toggle.docs.tsx
+++ b/lib/components/Toggle/Toggle.docs.tsx
@@ -11,13 +11,13 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Toggle off',
-      render: ({ id }) => (
+      Example: ({ id }) => (
         <Toggle on={false} label="Toggled off" id={id} onChange={handler} />
       ),
     },
     {
       label: 'Toggle on',
-      render: ({ id }) => (
+      Example: ({ id }) => (
         <Toggle on={true} label="Toggled on" id={id} onChange={handler} />
       ),
     },
@@ -26,7 +26,7 @@ const docs: ComponentDocs = {
       Container: ({ children }) => (
         <div style={{ maxWidth: '300px' }}>{children}</div>
       ),
-      render: ({ id }) => (
+      Example: ({ id }) => (
         <Toggle
           on={true}
           align="right"

--- a/lib/components/icons/BookmarkIcon/BookmarkIcon.docs.tsx
+++ b/lib/components/icons/BookmarkIcon/BookmarkIcon.docs.tsx
@@ -8,11 +8,11 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Default',
-      render: () => <BookmarkIcon />,
+      Example: () => <BookmarkIcon />,
     },
     {
       label: 'Active',
-      render: () => <BookmarkIcon active={true} />,
+      Example: () => <BookmarkIcon active={true} />,
     },
     ...examplesForIcon(BookmarkIcon),
   ],

--- a/lib/components/icons/ChevronIcon/ChevronIcon.docs.tsx
+++ b/lib/components/icons/ChevronIcon/ChevronIcon.docs.tsx
@@ -8,23 +8,23 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Default',
-      render: () => <ChevronIcon />,
+      Example: () => <ChevronIcon />,
     },
     {
       label: 'Left',
-      render: () => <ChevronIcon direction="left" />,
+      Example: () => <ChevronIcon direction="left" />,
     },
     {
       label: 'Right',
-      render: () => <ChevronIcon direction="right" />,
+      Example: () => <ChevronIcon direction="right" />,
     },
     {
       label: 'Up',
-      render: () => <ChevronIcon direction="up" />,
+      Example: () => <ChevronIcon direction="up" />,
     },
     {
       label: 'Down',
-      render: () => <ChevronIcon direction="down" />,
+      Example: () => <ChevronIcon direction="down" />,
     },
     ...examplesForIcon(ChevronIcon),
   ],

--- a/lib/components/private/examplesForIcon.tsx
+++ b/lib/components/private/examplesForIcon.tsx
@@ -13,7 +13,7 @@ export default (Icon: ComponentType<UseIconProps>) => {
   return [
     {
       label: 'Standard',
-      render: () => (
+      Example: () => (
         <Box display="flex" style={{ alignItems: 'center' }}>
           <Box marginRight="xsmall">
             <Icon />
@@ -24,7 +24,7 @@ export default (Icon: ComponentType<UseIconProps>) => {
     },
     {
       label: 'Standard Inline',
-      render: () => (
+      Example: () => (
         <Text>
           Standard <Icon /> text
         </Text>
@@ -32,7 +32,7 @@ export default (Icon: ComponentType<UseIconProps>) => {
     },
     {
       label: 'Large',
-      render: () => (
+      Example: () => (
         <Box display="flex" style={{ alignItems: 'center' }}>
           <Box marginRight="xsmall">
             <Icon size="large" />
@@ -45,7 +45,7 @@ export default (Icon: ComponentType<UseIconProps>) => {
     },
     {
       label: 'Large Inline',
-      render: () => (
+      Example: () => (
         <Text size="large">
           Large <Icon /> text
         </Text>
@@ -53,7 +53,7 @@ export default (Icon: ComponentType<UseIconProps>) => {
     },
     {
       label: 'Fill to container, eg. 100x100',
-      render: () => (
+      Example: () => (
         <Box style={{ height: '100px', width: '100px' }}>
           <Icon size="fill" />
         </Box>
@@ -62,7 +62,7 @@ export default (Icon: ComponentType<UseIconProps>) => {
     {
       label: 'Blocks sizes (i.e. full line height)',
       docsSite: false,
-      render: () => {
+      Example: () => {
         const sizes = Object.keys(textSizes) as Array<keyof typeof textSizes>;
 
         return (
@@ -86,7 +86,7 @@ export default (Icon: ComponentType<UseIconProps>) => {
     {
       label: 'Auto size (via TextContext)',
       docsSite: false,
-      render: () => {
+      Example: () => {
         const sizes = Object.keys(textSizes) as Array<keyof typeof textSizes>;
 
         return (
@@ -103,7 +103,7 @@ export default (Icon: ComponentType<UseIconProps>) => {
     {
       label: 'Auto Size (via HeadingContext)',
       docsSite: false,
-      render: () => {
+      Example: () => {
         const headings = Object.keys(headingSizes) as Array<
           keyof typeof headingSizes
         >;
@@ -122,7 +122,7 @@ export default (Icon: ComponentType<UseIconProps>) => {
     {
       label: 'Auto Tone (via TextContext)',
       docsSite: false,
-      render: () => {
+      Example: () => {
         const iconTones = Object.keys(tones) as Array<keyof typeof tones>;
 
         return (
@@ -142,7 +142,7 @@ export default (Icon: ComponentType<UseIconProps>) => {
     {
       label: 'Auto Tone with Background Contrast (via TextContext)',
       docsSite: false,
-      render: () => (
+      Example: () => (
         <Box background="brand">
           <Text baseline={false}>
             Default <Icon />, explicitly positive <Icon tone="positive" />

--- a/lib/stories/all.stories.tsx
+++ b/lib/stories/all.stories.tsx
@@ -27,7 +27,7 @@ req.keys().forEach(filename => {
 
   if (
     docs.storybook === false ||
-    !docs.examples.some(({ render }) => typeof render === 'function')
+    !docs.examples.some(({ Example }) => typeof Example === 'function')
   ) {
     return;
   }
@@ -40,10 +40,14 @@ req.keys().forEach(filename => {
           <BraidProvider theme={theme} styleBody={false}>
             {docs.examples.map(
               (
-                { label = componentName, render, Container = DefaultContainer },
+                {
+                  label = componentName,
+                  Example,
+                  Container = DefaultContainer,
+                },
                 i,
               ) =>
-                render ? (
+                Example ? (
                   <div
                     key={i}
                     style={{
@@ -64,7 +68,9 @@ req.keys().forEach(filename => {
                     >
                       {label}
                     </h4>
-                    <Container>{render({ id: 'id', handler })}</Container>
+                    <Container>
+                      <Example id="id" handler={handler} />
+                    </Container>
                     <div style={{ paddingTop: 18 }}>
                       <hr
                         style={{

--- a/site/src/App/Components/ComponentRoute.tsx
+++ b/site/src/App/Components/ComponentRoute.tsx
@@ -64,17 +64,25 @@ export const ComponentRoute = ({
       {examples
         .filter(example => example.docsSite !== false)
         .map((example, index) => {
-          const { label, render, code, Container = DefaultContainer } = example;
+          const {
+            label,
+            Example,
+            code,
+            Container = DefaultContainer,
+          } = example;
 
           const codeAsString =
-            render && !code
+            Example && !code
               ? cleanCodeSnippet(
-                  reactElementToJSXString(render({ id: 'id', handler }), {
-                    useBooleanShorthandSyntax: false,
-                    showDefaultProps: false,
-                    showFunctions: false,
-                    filterProps: ['onChange', 'onBlur', 'onFocus'],
-                  }),
+                  reactElementToJSXString(
+                    <Example id="id" handler={handler} />,
+                    {
+                      useBooleanShorthandSyntax: false,
+                      showDefaultProps: false,
+                      showFunctions: false,
+                      filterProps: ['onChange', 'onBlur', 'onFocus'],
+                    },
+                  ),
                 )
               : code
               ? cleanCodeSnippet(dedent(code))
@@ -87,7 +95,7 @@ export const ComponentRoute = ({
                   <Text>{label}</Text>
                 </Box>
               ) : null}
-              {render
+              {Example
                 ? Object.values(themes).map(theme => (
                     <Box key={theme.name} marginBottom="large">
                       <Box paddingBottom="small">
@@ -95,7 +103,10 @@ export const ComponentRoute = ({
                       </Box>
                       <BraidProvider theme={theme}>
                         <Container>
-                          {render({ id: `${index}_${theme.name}`, handler })}
+                          <Example
+                            id={`${index}_${theme.name}`}
+                            handler={handler}
+                          />
                         </Container>
                       </BraidProvider>
                     </Box>

--- a/site/src/types.d.ts
+++ b/site/src/types.d.ts
@@ -15,13 +15,13 @@ export interface RenderContext {
 export interface ComponentDocs {
   migrationGuide?: boolean;
   storybook?: boolean;
-  examples: Array<ComponentExample>;
+  examples: ComponentExample[];
 }
 
 export interface ComponentExample {
   label?: string;
   docsSite?: boolean;
-  render?: (props: {
+  Example?: (props: {
     id: string;
     handler: (event: SyntheticEvent) => void;
   }) => JSX.Element;


### PR DESCRIPTION
This fixes an issue with the docs site where a state change in a single component example will trigger a re-render of the entire page. This is because each example isn't isolated to its own component instance, instead sharing a single scope with the `ComponentRoute` page.