### PR TITLE
feat: Add BraidLoadableProvider component

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -921,6 +921,15 @@ exports[`Box 1`] = `
 }
 `;
 
+exports[`BraidLoadableProvider 1`] = `
+{
+  children: ReactNode
+  fallback?: ReactNode
+  styleBody?: boolean
+  themeName: string
+}
+`;
+
 exports[`BraidProvider 1`] = `
 {
   children: ReactNode

--- a/lib/components/BraidLoadableProvider/BraidLoadableProvider.docs.tsx
+++ b/lib/components/BraidLoadableProvider/BraidLoadableProvider.docs.tsx
@@ -1,0 +1,19 @@
+import { ComponentDocs } from '../../../site/src/types';
+
+const docs: ComponentDocs = {
+  examples: [
+    {
+      code: `
+        import { BraidProviderLoadable } from 'braid-design-system';
+
+        export default ({ themeName }) => (
+          <BraidProviderLoadable themeName="themeName">
+            ...
+          </BraidProviderLoadable>
+        );
+      `,
+    },
+  ],
+};
+
+export default docs;

--- a/lib/components/BraidLoadableProvider/BraidLoadableProvider.docs.tsx
+++ b/lib/components/BraidLoadableProvider/BraidLoadableProvider.docs.tsx
@@ -4,12 +4,12 @@ const docs: ComponentDocs = {
   examples: [
     {
       code: `
-        import { BraidProviderLoadable } from 'braid-design-system';
+        import { BraidLoadableProvider } from 'braid-design-system';
 
-        export default ({ themeName }) => (
-          <BraidProviderLoadable themeName="themeName">
+        export default () => (
+          <BraidLoadableProvider themeName="wireframe">
             ...
-          </BraidProviderLoadable>
+          </BraidLoadableProvider>
         );
       `,
     },

--- a/lib/components/BraidLoadableProvider/BraidLoadableProvider.tsx
+++ b/lib/components/BraidLoadableProvider/BraidLoadableProvider.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import loadable from 'sku/@loadable/component';
 import {
   BraidProvider,
@@ -10,17 +10,16 @@ const BraidLoadable = loadable.lib(props =>
   import(`../../../themes/${props.themeName}`),
 );
 
-interface BraidProviderLoadableProps extends Omit<BraidProviderProps, 'theme'> {
+interface BraidLoadableProviderProps extends Omit<BraidProviderProps, 'theme'> {
   themeName: string;
-  fallback?: JSX.Element;
+  fallback?: ReactNode;
 }
-export const BraidProviderLoadable = ({
+export const BraidLoadableProvider = ({
   themeName,
   children,
-  fallback,
   ...restProps
-}: BraidProviderLoadableProps) => (
-  <BraidLoadable themeName={themeName} fallback={fallback}>
+}: BraidLoadableProviderProps) => (
+  <BraidLoadable themeName={themeName}>
     {({ default: theme }: any) => (
       <BraidProvider theme={theme} {...restProps}>
         {children}

--- a/lib/components/BraidProviderLoadable/BraidProviderLoadable.tsx
+++ b/lib/components/BraidProviderLoadable/BraidProviderLoadable.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import loadable from 'sku/@loadable/component';
+import {
+  BraidProvider,
+  BraidProviderProps,
+} from '../BraidProvider/BraidProvider';
+
+const BraidLoadable = loadable.lib(props =>
+  // @ts-ignore loadable can not currently type dynamic props
+  import(`../../../themes/${props.themeName}`),
+);
+
+interface BraidProviderLoadableProps extends Omit<BraidProviderProps, 'theme'> {
+  themeName: string;
+}
+export const BraidProviderLoadable = ({
+  themeName,
+  children,
+  ...restProps
+}: BraidProviderLoadableProps) => (
+  <BraidLoadable themeName={themeName}>
+    {({ default: theme }: any) => (
+      <BraidProvider theme={theme} {...restProps}>
+        {children}
+      </BraidProvider>
+    )}
+  </BraidLoadable>
+);

--- a/lib/components/BraidProviderLoadable/BraidProviderLoadable.tsx
+++ b/lib/components/BraidProviderLoadable/BraidProviderLoadable.tsx
@@ -12,13 +12,15 @@ const BraidLoadable = loadable.lib(props =>
 
 interface BraidProviderLoadableProps extends Omit<BraidProviderProps, 'theme'> {
   themeName: string;
+  fallback?: JSX.Element;
 }
 export const BraidProviderLoadable = ({
   themeName,
   children,
+  fallback,
   ...restProps
 }: BraidProviderLoadableProps) => (
-  <BraidLoadable themeName={themeName}>
+  <BraidLoadable themeName={themeName} fallback={fallback}>
     {({ default: theme }: any) => (
       <BraidProvider theme={theme} {...restProps}>
         {children}

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -1,4 +1,7 @@
 export { BraidProvider } from './BraidProvider/BraidProvider';
+export {
+  BraidProviderLoadable,
+} from './BraidProviderLoadable/BraidProviderLoadable';
 export { ThemeNameConsumer } from './ThemeNameConsumer/ThemeNameConsumer';
 export { useThemeName } from './ThemeNameConsumer/ThemeNameContext';
 export { Actions } from './Actions/Actions';

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -1,7 +1,7 @@
 export { BraidProvider } from './BraidProvider/BraidProvider';
 export {
-  BraidProviderLoadable,
-} from './BraidProviderLoadable/BraidProviderLoadable';
+  BraidLoadableProvider,
+} from './BraidLoadableProvider/BraidLoadableProvider';
 export { ThemeNameConsumer } from './ThemeNameConsumer/ThemeNameConsumer';
 export { useThemeName } from './ThemeNameConsumer/ThemeNameContext';
 export { Actions } from './Actions/Actions';


### PR DESCRIPTION
`BraidLoadableProvider` is a code-splitting enabled alternative to `BraidProvider`.