### PR TITLE
fix: Rename Badge tone & background `secondary` to `neutral`

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -27,8 +27,8 @@ exports[`Badge 1`] = `
   tone?: 
     | "critical"
     | "info"
+    | "neutral"
     | "positive"
-    | "secondary"
   weight?: 
     | "regular"
     | "strong"
@@ -223,10 +223,10 @@ exports[`Box 1`] = `
     | "infoLight"
     | "input"
     | "inputDisabled"
+    | "neutral"
+    | "neutralLight"
     | "positive"
     | "positiveLight"
-    | "secondary"
-    | "secondaryLight"
     | "selection"
   borderRadius?: "standard"
   boxShadow?: 

--- a/lib/components/Badge/Badge.docs.tsx
+++ b/lib/components/Badge/Badge.docs.tsx
@@ -42,14 +42,14 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label: 'Secondary Badge',
-      Example: () => <Badge tone="secondary">10m ago</Badge>,
+      label: 'Neutral Badge',
+      Example: () => <Badge tone="neutral">Expired</Badge>,
     },
     {
-      label: 'Strong Secondary Badge',
+      label: 'Strong Neutral Badge',
       Example: () => (
-        <Badge tone="secondary" weight="strong">
-          10m ago
+        <Badge tone="neutral" weight="strong">
+          Expired
         </Badge>
       ),
     },

--- a/lib/components/Badge/Badge.migration.md
+++ b/lib/components/Badge/Badge.migration.md
@@ -3,7 +3,7 @@
 ## API Changes
 
 - `strong={boolean}` has moved to `weight="strong"`. Also applies for `isBold={boolean}` in Seek Asia Style Guide.
-- Deprecated `color={'progressing'|'default'|'declined'|'expired'|'new'}` & `tone='accent'|'neutral'}` in favour of `tone={'positive'|'info'|'critical'|'secondary'}`. Please note that this is a breaking change to our design language. When migrating, try to match existing styling as much as possible in consultation with your local designer.
+- Deprecated `color={'progressing'|'default'|'declined'|'expired'|'new'}` & `tone='accent'|'neutral'}` in favour of `tone={'positive'|'info'|'critical'|'neutral'}`. Please note that this is a breaking change to our design language. When migrating, try to match existing styling as much as possible in consultation with your local designer.
 - Deprecated `label` in favour of passing the content as `children`.
 - No longer accepts arbitrary DOM properties, e.g. `className`. Please check that everything you need is exposed via the [public API](https://seek-oss.github.io/braid-design-system/components/Badge).
 

--- a/lib/components/Badge/Badge.tsx
+++ b/lib/components/Badge/Badge.tsx
@@ -4,7 +4,7 @@ import { Text } from '../Text/Text';
 import * as styleRefs from './Badge.treat';
 import { useStyles } from 'sku/treat';
 
-type Tone = 'info' | 'critical' | 'positive' | 'secondary';
+type Tone = 'info' | 'critical' | 'positive' | 'neutral';
 type BadgeWeight = 'strong' | 'regular';
 export interface BadgeProps {
   tone?: Tone;
@@ -30,8 +30,8 @@ const backgroundForTone = (tone: Tone, weight: BadgeWeight) => {
     return 'infoLight';
   }
 
-  if (tone === 'secondary') {
-    return 'secondaryLight';
+  if (tone === 'neutral') {
+    return 'neutralLight';
   }
 };
 

--- a/lib/hooks/typography/typography.treat.ts
+++ b/lib/hooks/typography/typography.treat.ts
@@ -213,8 +213,8 @@ export const backgroundContrast: BackgroundContrast = {
   info: {
     default: textColorForBackground('info'),
   },
-  secondary: {
-    default: textColorForBackground('secondary'),
+  neutral: {
+    default: textColorForBackground('neutral'),
   },
 };
 

--- a/lib/hooks/useBox/box.treat.ts
+++ b/lib/hooks/useBox/box.treat.ts
@@ -172,7 +172,7 @@ export const background = styleMap(({ color }) => ({
   infoLight: { background: getLightVariant(color.background.info) },
   criticalLight: { background: getLightVariant(color.background.critical) },
   positiveLight: { background: getLightVariant(color.background.positive) },
-  secondaryLight: { background: getLightVariant(color.background.secondary) },
+  neutralLight: { background: getLightVariant(color.background.neutral) },
 }));
 
 export const boxShadow = styleMap(

--- a/lib/themes/makeTreatTheme.ts
+++ b/lib/themes/makeTreatTheme.ts
@@ -110,7 +110,7 @@ export interface TreatTokens {
       card: string;
       critical: string;
       positive: string;
-      secondary: string;
+      neutral: string;
     };
   };
 }

--- a/lib/themes/seekAnz/tokens.ts
+++ b/lib/themes/seekAnz/tokens.ts
@@ -8,6 +8,7 @@ const brandAccent = '#e60278';
 const positive = '#169400';
 const critical = brandAccent;
 const info = '#9556b7';
+const neutral = '#747474';
 const black = '#1c1c1c';
 const link = '#2765cf';
 const secondary = '#1c1c1ca1';
@@ -187,7 +188,7 @@ const tokens: TreatTokens = {
       critical,
       info,
       positive,
-      secondary,
+      neutral,
     },
   },
 };

--- a/lib/themes/seekAsia/makeTokens.ts
+++ b/lib/themes/seekAsia/makeTokens.ts
@@ -33,6 +33,7 @@ export default ({
   const linkHover = blue2;
   const selection = blue5;
   const secondary = grey2;
+  const neutral = grey2;
 
   const tokens: TreatTokens = {
     name,
@@ -209,7 +210,7 @@ export default ({
         critical,
         info,
         positive,
-        secondary,
+        neutral,
       },
     },
   };

--- a/lib/themes/wireframe/tokens.ts
+++ b/lib/themes/wireframe/tokens.ts
@@ -10,6 +10,7 @@ const black = '#2b2b2b';
 const white = '#fff';
 const link = '#4c77bb';
 const secondary = '#777';
+const neutral = '#777';
 
 const tokens: TreatTokens = {
   name: 'wireframe',
@@ -185,7 +186,7 @@ const tokens: TreatTokens = {
       critical,
       info,
       positive,
-      secondary,
+      neutral,
     },
   },
 };

--- a/site/src/App/Code/Code.tsx
+++ b/site/src/App/Code/Code.tsx
@@ -21,7 +21,7 @@ const CodeButton = ({
   return (
     <Box
       component={component}
-      background="secondaryLight"
+      background="neutralLight"
       borderRadius="standard"
       paddingY="xxsmall"
       paddingX="xsmall"
@@ -79,7 +79,7 @@ export default ({ children }: CodeProps) => {
         display="flex"
         paddingY="xxsmall"
         paddingRight="xxsmall"
-        background="secondaryLight"
+        background="neutralLight"
         borderRadius="standard"
         className={styles.toolbar}
       >


### PR DESCRIPTION
BREAKING CHANGE: The `secondary` tone for `Badge` has been renamed to `neutral`, as a side effect the `background` property on `Box` has also been updated — `secondary` to `neutral` and `secondaryLight` to `neutralLight`.

### Design background
Following the definition of the global colour usage chart, we are aligning our current component apis to suit. The colour usage chart is designed to map the usage of colour with tone of voice used around the system, to give users a more balanced experience.

We have modelled this consistently already with `critical`, `positive` and `info`. This PR gets alignment for `neutral`, while leaving room to add `promote`, `warning`, `notice` etc.

### Migration Guide
This changed affects two public interfaces:

#### Badge
```diff
-<Badge tone="secondary">
+<Badge tone="neutral">
  Expired
</Badge>
```

#### Box
```diff
-<Box background="secondary">
+<Box background="neutral">
  ...
</Box>
```
```diff
-<Box background="secondaryLight">
+<Box background="neutralLight">
  ...
</Box>
```

