### PR TITLE
fix(seekAsia): Increase medium font weight to 600

### DIFF
--- a/lib/themes/seekAsia/makeTokens.ts
+++ b/lib/themes/seekAsia/makeTokens.ts
@@ -49,7 +49,7 @@ export default ({
       heading: {
         weight: {
           weak: 'regular',
-          regular: 'medium',
+          regular: 'strong',
         },
         level: {
           '1': {

--- a/lib/themes/seekAsia/makeTokens.ts
+++ b/lib/themes/seekAsia/makeTokens.ts
@@ -43,7 +43,7 @@ export default ({
       descenderHeightScale: 0.13,
       fontWeight: {
         regular: 400,
-        medium: 500,
+        medium: 600,
         strong: 700,
       },
       heading: {

--- a/lib/themes/seekAsia/makeTokens.ts
+++ b/lib/themes/seekAsia/makeTokens.ts
@@ -48,8 +48,8 @@ export default ({
       },
       heading: {
         weight: {
-          weak: 'medium',
-          regular: 'strong',
+          weak: 'regular',
+          regular: 'medium',
         },
         level: {
           '1': {


### PR DESCRIPTION
The themes based on the `SeekAsia`, e.g. `JobsDB`, `JobStreet` & `JobStreetClassic`, all specify the `Muli` font as their preferred font family. The current theme sets the medium font weight to 500 which does not exist in this font.

Setting to 600 to align with the weight scale correctly.