### PR TITLE
feat(Box): Support flex align, touchable size, full border radius

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -71,6 +71,11 @@ exports[`Box 1`] = `
   acceptCharset?: string
   accessKey?: string
   action?: string
+  alignItems?: ResponsiveProp<
+    | "center"
+    | "flexEnd"
+    | "flexStart"
+  >
   allowFullScreen?: boolean
   allowTransparency?: boolean
   alt?: string
@@ -257,7 +262,9 @@ exports[`Box 1`] = `
     | "positive"
     | "positiveLight"
     | "selection"
-  borderRadius?: "standard"
+  borderRadius?: 
+    | "full"
+    | "standard"
   boxShadow?: 
     | "borderCritical"
     | "borderFormAccent"
@@ -468,6 +475,7 @@ exports[`Box 1`] = `
   controls?: boolean
   coords?: string
   crossOrigin?: string
+  cursor?: "pointer"
   dangerouslySetInnerHTML?: { __html: string; }
   data?: string
   datatype?: string
@@ -506,7 +514,9 @@ exports[`Box 1`] = `
     | number
     | string
   headers?: string
-  height?: "full"
+  height?: 
+    | "full"
+    | "touchable"
   hidden?: boolean
   high?: number
   href?: string
@@ -523,6 +533,12 @@ exports[`Box 1`] = `
   itemRef?: string
   itemScope?: boolean
   itemType?: string
+  justifyContent?: ResponsiveProp<
+    | "center"
+    | "flexEnd"
+    | "flexStart"
+    | "spaceBetween"
+  >
   keyParams?: string
   keyType?: string
   kind?: string
@@ -861,6 +877,7 @@ exports[`Box 1`] = `
   pattern?: string
   placeholder?: string
   playsInline?: boolean
+  pointerEvents?: "none"
   position?: 
     | "absolute"
     | "fixed"
@@ -925,7 +942,9 @@ exports[`Box 1`] = `
     | string
     | string[]
   vocab?: string
-  width?: "full"
+  width?: 
+    | "full"
+    | "touchable"
   wmode?: string
   wrap?: string
 }

--- a/lib/components/Box/Box.tsx
+++ b/lib/components/Box/Box.tsx
@@ -27,6 +27,8 @@ const NamedBox = forwardRef<HTMLElement, BoxProps>(
       marginRight,
       display,
       flexDirection,
+      alignItems,
+      justifyContent,
       borderRadius,
       background,
       boxShadow,
@@ -35,6 +37,8 @@ const NamedBox = forwardRef<HTMLElement, BoxProps>(
       height,
       width,
       position,
+      cursor,
+      pointerEvents,
       className,
       ...restProps
     },
@@ -58,6 +62,8 @@ const NamedBox = forwardRef<HTMLElement, BoxProps>(
       marginRight,
       display,
       flexDirection,
+      alignItems,
+      justifyContent,
       borderRadius,
       background,
       boxShadow,
@@ -66,6 +72,8 @@ const NamedBox = forwardRef<HTMLElement, BoxProps>(
       height,
       width,
       position,
+      cursor,
+      pointerEvents,
     });
 
     const element = createElement(component, {

--- a/lib/components/Button/Button.treat.ts
+++ b/lib/components/Button/Button.treat.ts
@@ -1,7 +1,6 @@
 import { style } from 'sku/treat';
 
 export const root = style({
-  cursor: 'pointer',
   outline: 'none',
 });
 
@@ -58,7 +57,6 @@ export const focusOverlay = [
 
 export const content = style({
   zIndex: 1,
-  pointerEvents: 'none',
   overflow: 'hidden',
   textOverflow: 'ellipsis',
   userSelect: 'none',

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -56,6 +56,7 @@ export const Button = ({
     <Box
       id={id}
       component="button"
+      cursor="pointer"
       type={type}
       aria-describedby={ariaDescribedBy}
       width="full"
@@ -86,6 +87,7 @@ export const Button = ({
       <Box
         position="relative"
         paddingX="gutter"
+        pointerEvents="none"
         className={classnames(styles.content, useTouchableSpace('standard'))}
       >
         <Text

--- a/lib/components/Dropdown/Dropdown.treat.ts
+++ b/lib/components/Dropdown/Dropdown.treat.ts
@@ -1,10 +1,8 @@
 import { style } from 'sku/treat';
 
 export const chevron = style(({ utils, spacing }) => ({
-  pointerEvents: 'none',
   top: 0,
   right: 0,
-  alignItems: 'center',
   height: utils.rows(spacing.touchableRows),
   width: utils.rows(spacing.touchableRows),
 }));

--- a/lib/components/Dropdown/Dropdown.tsx
+++ b/lib/components/Dropdown/Dropdown.tsx
@@ -97,6 +97,8 @@ const NamedDropdown = forwardRef<HTMLSelectElement, DropdownProps>(
               paddingX={paddingX}
               position="absolute"
               display="flex"
+              alignItems="center"
+              pointerEvents="none"
               className={styles.chevron}
             >
               <IconChevron size="fill" />

--- a/lib/components/FieldLabel/FieldLabel.treat.ts
+++ b/lib/components/FieldLabel/FieldLabel.treat.ts
@@ -1,5 +1,0 @@
-import { style } from 'sku/treat';
-
-export const spaceBetween = style({
-  justifyContent: 'space-between',
-});

--- a/lib/components/FieldLabel/FieldLabel.tsx
+++ b/lib/components/FieldLabel/FieldLabel.tsx
@@ -1,10 +1,8 @@
 import React, { ReactNode } from 'react';
-import { useStyles } from 'sku/react-treat';
 import { Box } from '../Box/Box';
 import { Secondary } from '../Secondary/Secondary';
 import { Strong } from '../Strong/Strong';
 import { Text } from '../Text/Text';
-import * as styleRefs from './FieldLabel.treat';
 
 export interface FieldLabelProps {
   id?: string;
@@ -23,8 +21,6 @@ export const FieldLabel = ({
   tertiaryLabel,
   description,
 }: FieldLabelProps) => {
-  const styles = useStyles(styleRefs);
-
   if (!label) {
     return null;
   }
@@ -38,7 +34,7 @@ export const FieldLabel = ({
 
   return (
     <Box paddingBottom="xsmall">
-      <Box component="span" display="flex" className={styles.spaceBetween}>
+      <Box component="span" display="flex" justifyContent="spaceBetween">
         {htmlFor === false ? (
           labelEl
         ) : (

--- a/lib/components/FieldMessage/FieldMessage.treat.ts
+++ b/lib/components/FieldMessage/FieldMessage.treat.ts
@@ -1,9 +1,5 @@
 import { style } from 'sku/treat';
 
-export const root = style({
-  justifyContent: 'flex-end',
-});
-
 export const grow = style({
   flexGrow: 1,
 });

--- a/lib/components/FieldMessage/FieldMessage.tsx
+++ b/lib/components/FieldMessage/FieldMessage.tsx
@@ -53,7 +53,7 @@ export const FieldMessage = ({
       id={id}
       paddingBottom={isSeekAu ? 'xxsmall' : 'xsmall'}
       display="flex"
-      className={styles.root}
+      justifyContent="flexEnd"
     >
       <Box className={classnames(styles.grow, styles.minHeight)}>
         {showMessage ? (

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.treat.ts
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.treat.ts
@@ -1,7 +1,6 @@
 import { style } from 'sku/treat';
 
 export const root = style({
-  cursor: 'pointer',
   textDecoration: 'none',
   ':hover': {
     textDecoration: 'underline',

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
@@ -58,7 +58,13 @@ function InlineLink({ children }: TextLinkRendererProps) {
     <TextLinkRendererContext.Provider value={true}>
       {children({
         style: {},
-        className: classnames(useLinkStyles(), useBox({ component: 'a' })),
+        className: classnames(
+          useLinkStyles(),
+          useBox({
+            component: 'a',
+            cursor: 'pointer',
+          }),
+        ),
       })}
     </TextLinkRendererContext.Provider>
   );
@@ -72,7 +78,11 @@ function TouchableLink({ children }: TextLinkRendererProps) {
           style: {},
           className: classnames(
             useLinkStyles(),
-            useBox({ component: 'a', display: 'block' }),
+            useBox({
+              component: 'a',
+              cursor: 'pointer',
+              display: 'block',
+            }),
           ),
         })}
       </Box>
@@ -100,6 +110,7 @@ function ButtonLink({ children }: TextLinkRendererProps) {
             useTouchableSpace(buttonLinkTextProps.size),
             useBox({
               component: 'a',
+              cursor: 'pointer',
               display: 'block',
               width: 'full',
               paddingX: 'small',

--- a/lib/components/Toggle/Toggle.treat.ts
+++ b/lib/components/Toggle/Toggle.treat.ts
@@ -32,9 +32,7 @@ export const fieldSize = style(theme => {
   };
 });
 
-export const slideContainer = style({
-  alignItems: 'center',
-});
+export const slideContainer = style({});
 
 export const slideTrack = style(theme => {
   const size = getSize(theme);
@@ -63,10 +61,6 @@ export const slideTrackSelected = style(theme => {
   };
 });
 
-export const circle = style({
-  borderRadius: '100%',
-});
-
 export const slider = style(theme => {
   const size = getSize(theme);
   const trackWidth = size * toggleWidthRatio;
@@ -76,8 +70,6 @@ export const slider = style(theme => {
   return {
     height: size,
     width: size,
-    alignItems: 'center',
-    justifyContent: 'center',
     selectors: {
       [`${realField}:active + ${slideContainer} &`]: {
         transform: `translateX(-${anticipation}px)`,

--- a/lib/components/Toggle/Toggle.tsx
+++ b/lib/components/Toggle/Toggle.tsx
@@ -52,6 +52,7 @@ export const Toggle = ({
       <Box
         position="relative"
         display="flex"
+        alignItems="center"
         className={classnames(styles.slideContainer, styles.fieldSize)}
       >
         <Box position="absolute" width="full" className={styles.slideTrack}>
@@ -70,20 +71,23 @@ export const Toggle = ({
           boxShadow="borderStandard"
           transition="fast"
           display="flex"
-          className={classnames(styles.slider, styles.circle)}
+          alignItems="center"
+          justifyContent="center"
+          borderRadius="full"
+          className={styles.slider}
         >
           <FieldOverlay className={styles.icon}>
             <IconTick tone="formAccent" size="fill" />
           </FieldOverlay>
           <FieldOverlay
             variant="focus"
-            borderRadius={undefined}
-            className={classnames(styles.focusOverlay, styles.circle)}
+            borderRadius="full"
+            className={styles.focusOverlay}
           />
           <FieldOverlay
             variant="hover"
-            borderRadius={undefined}
-            className={classnames(styles.hoverOverlay, styles.circle)}
+            borderRadius="full"
+            className={styles.hoverOverlay}
           />
         </Box>
       </Box>

--- a/lib/components/private/InlineField/InlineField.treat.ts
+++ b/lib/components/private/InlineField/InlineField.treat.ts
@@ -57,10 +57,6 @@ export const children = style(theme => {
   };
 });
 
-export const circle = style({
-  borderRadius: '100%',
-});
-
 export const selected = style({
   selectors: {
     [`${realFieldBase}:checked + * > ${fakeFieldBase} > &`]: {
@@ -113,4 +109,4 @@ const radioScale = style({
   },
 });
 
-export const radioIndicator = [indicator, circle, radioScale];
+export const radioIndicator = [indicator, radioScale];

--- a/lib/components/private/InlineField/InlineField.tsx
+++ b/lib/components/private/InlineField/InlineField.tsx
@@ -132,7 +132,7 @@ export const InlineField = forwardRef<HTMLElement, InternalInlineFieldProps>(
               variant={tone === 'critical' && isCheckbox ? tone : undefined}
               background={isCheckbox ? accentBackground : undefined}
               borderRadius={fieldBorderRadius}
-              className={classnames(styles.selected)}
+              className={styles.selected}
             >
               <Indicator type={type} disabled={disabled} />
             </FieldOverlay>
@@ -140,12 +140,12 @@ export const InlineField = forwardRef<HTMLElement, InternalInlineFieldProps>(
             <FieldOverlay
               variant="focus"
               borderRadius={fieldBorderRadius}
-              className={classnames(styles.focusOverlay)}
+              className={styles.focusOverlay}
             />
             <FieldOverlay
               variant="hover"
               borderRadius={fieldBorderRadius}
-              className={classnames(styles.hoverOverlay)}
+              className={styles.hoverOverlay}
             >
               <Indicator type={type} hover={true} />
             </FieldOverlay>

--- a/lib/components/private/InlineField/InlineField.tsx
+++ b/lib/components/private/InlineField/InlineField.tsx
@@ -63,6 +63,7 @@ const Indicator = ({
       transition="fast"
       width="full"
       height="full"
+      borderRadius="full"
       className={classnames(styles.radioIndicator)}
     />
   );
@@ -95,10 +96,7 @@ export const InlineField = forwardRef<HTMLElement, InternalInlineFieldProps>(
 
     const messageId = `${id}-message`;
     const isCheckbox = type === 'checkbox';
-    const circleIfRadio = {
-      [styles.circle]: type === 'radio',
-    };
-    const fieldBorderRadius = isCheckbox ? 'standard' : undefined;
+    const fieldBorderRadius = isCheckbox ? 'standard' : 'full';
     const accentBackground = disabled ? 'formAccentDisabled' : 'formAccent';
 
     return (
@@ -121,7 +119,7 @@ export const InlineField = forwardRef<HTMLElement, InternalInlineFieldProps>(
         <Box display="flex">
           <Box
             position="relative"
-            className={classnames(styles.fakeField, circleIfRadio)}
+            className={classnames(styles.fakeField)}
             background={disabled ? 'inputDisabled' : 'input'}
             borderRadius={fieldBorderRadius}
             boxShadow={
@@ -134,7 +132,7 @@ export const InlineField = forwardRef<HTMLElement, InternalInlineFieldProps>(
               variant={tone === 'critical' && isCheckbox ? tone : undefined}
               background={isCheckbox ? accentBackground : undefined}
               borderRadius={fieldBorderRadius}
-              className={classnames(styles.selected, circleIfRadio)}
+              className={classnames(styles.selected)}
             >
               <Indicator type={type} disabled={disabled} />
             </FieldOverlay>
@@ -142,12 +140,12 @@ export const InlineField = forwardRef<HTMLElement, InternalInlineFieldProps>(
             <FieldOverlay
               variant="focus"
               borderRadius={fieldBorderRadius}
-              className={classnames(styles.focusOverlay, circleIfRadio)}
+              className={classnames(styles.focusOverlay)}
             />
             <FieldOverlay
               variant="hover"
               borderRadius={fieldBorderRadius}
-              className={classnames(styles.hoverOverlay, circleIfRadio)}
+              className={classnames(styles.hoverOverlay)}
             >
               <Indicator type={type} hover={true} />
             </FieldOverlay>

--- a/lib/components/private/Overlay/Overlay.treat.ts
+++ b/lib/components/private/Overlay/Overlay.treat.ts
@@ -1,7 +1,6 @@
 import { style } from 'sku/treat';
 
 export const root = style({
-  pointerEvents: 'none',
   top: 0,
   bottom: 0,
   left: 0,

--- a/lib/components/private/Overlay/Overlay.tsx
+++ b/lib/components/private/Overlay/Overlay.tsx
@@ -29,6 +29,7 @@ export const Overlay = ({
   return (
     <Box
       position="absolute"
+      pointerEvents="none"
       background={background}
       borderRadius={borderRadius}
       boxShadow={boxShadow}

--- a/lib/components/private/examplesForIcon.tsx
+++ b/lib/components/private/examplesForIcon.tsx
@@ -14,7 +14,7 @@ export default (Icon: ComponentType<UseIconProps>) => {
     {
       label: 'Standard',
       Example: () => (
-        <Box display="flex" style={{ alignItems: 'center' }}>
+        <Box display="flex" alignItems="center">
           <Box marginRight="xsmall">
             <Icon />
           </Box>
@@ -33,7 +33,7 @@ export default (Icon: ComponentType<UseIconProps>) => {
     {
       label: 'Large',
       Example: () => (
-        <Box display="flex" style={{ alignItems: 'center' }}>
+        <Box display="flex" alignItems="center">
           <Box marginRight="xsmall">
             <Icon size="large" />
           </Box>
@@ -68,11 +68,7 @@ export default (Icon: ComponentType<UseIconProps>) => {
         return (
           <Fragment>
             {sizes.map(size => (
-              <Box
-                display="flex"
-                marginBottom="xxsmall"
-                style={{ alignItems: 'center' }}
-              >
+              <Box display="flex" marginBottom="xxsmall" alignItems="center">
                 <Box marginRight="xxsmall">
                   <Icon size={size} />
                 </Box>

--- a/lib/hooks/useBox/box.treat.ts
+++ b/lib/hooks/useBox/box.treat.ts
@@ -98,19 +98,45 @@ export const transition = styleMap(({ transitions }) =>
   mapToStyleProperty(transitions, 'transition'),
 );
 
-export const borderRadius = styleMap(({ border }) =>
-  mapToStyleProperty(border.radius, 'borderRadius'),
-);
+const borderRadiusRules = {
+  full: '100%',
+};
+export const borderRadius = {
+  ...styleMap(
+    mapToStyleProperty(borderRadiusRules, 'borderRadius'),
+    'borderRadius',
+  ),
+  ...styleMap(
+    ({ border }) => mapToStyleProperty(border.radius, 'borderRadius'),
+    'borderRadius',
+  ),
+};
 
 const widthRules = {
   full: '100%',
 };
-export const width = styleMap(mapToStyleProperty(widthRules, 'width'));
+export const width = {
+  ...styleMap(mapToStyleProperty(widthRules, 'width'), 'width'),
+  ...styleMap(
+    theme => ({
+      touchable: { width: theme.grid.row * theme.spacing.touchableRows },
+    }),
+    'width',
+  ),
+};
 
 const heightRules = {
   full: '100%',
 };
-export const height = styleMap(mapToStyleProperty(heightRules, 'height'));
+export const height = {
+  ...styleMap(mapToStyleProperty(heightRules, 'height'), 'height'),
+  ...styleMap(
+    theme => ({
+      touchable: { height: theme.grid.row * theme.spacing.touchableRows },
+    }),
+    'height',
+  ),
+};
 
 const positionRules = {
   absolute: 'absolute',
@@ -132,6 +158,42 @@ export const displayDesktop = styleMap(({ utils: { desktopStyles } }) =>
     desktopStyles({
       [propertyName]: value,
     }),
+  ),
+);
+
+const alignItemsRules = {
+  flexStart: 'flex-start',
+  center: 'center',
+  flexEnd: 'flex-end',
+};
+export const alignItems = styleMap(
+  mapToStyleProperty(alignItemsRules, 'alignItems'),
+);
+export const alignItemsDesktop = styleMap(({ utils: { desktopStyles } }) =>
+  mapToStyleProperty(alignItemsRules, 'alignItems', (value, propertyName) =>
+    desktopStyles({
+      [propertyName]: value,
+    }),
+  ),
+);
+
+const justifyContentRules = {
+  flexStart: 'flex-start',
+  center: 'center',
+  flexEnd: 'flex-end',
+  spaceBetween: 'space-between',
+};
+export const justifyContent = styleMap(
+  mapToStyleProperty(justifyContentRules, 'justifyContent'),
+);
+export const justifyContentDesktop = styleMap(({ utils: { desktopStyles } }) =>
+  mapToStyleProperty(
+    justifyContentRules,
+    'justifyContent',
+    (value, propertyName) =>
+      desktopStyles({
+        [propertyName]: value,
+      }),
   ),
 );
 
@@ -195,3 +257,11 @@ export const boxShadow = styleMap(
     },
   }),
 );
+
+export const cursor = styleMap({
+  pointer: { cursor: 'pointer' },
+});
+
+export const pointerEvents = styleMap({
+  none: { pointerEvents: 'none' },
+});

--- a/lib/hooks/useBox/index.ts
+++ b/lib/hooks/useBox/index.ts
@@ -38,6 +38,8 @@ export interface UseBoxProps {
   marginRight?: ResponsiveProp<SpaceRight>;
   display?: ResponsiveProp<keyof typeof styleRefs.display>;
   flexDirection?: ResponsiveProp<keyof typeof styleRefs.flexDirection>;
+  alignItems?: ResponsiveProp<keyof typeof styleRefs.alignItems>;
+  justifyContent?: ResponsiveProp<keyof typeof styleRefs.justifyContent>;
   borderRadius?: keyof typeof styleRefs.borderRadius;
   background?: keyof typeof styleRefs.background;
   boxShadow?: keyof typeof styleRefs.boxShadow;
@@ -46,6 +48,8 @@ export interface UseBoxProps {
   height?: keyof typeof styleRefs.height;
   width?: keyof typeof styleRefs.width;
   position?: keyof typeof styleRefs.position;
+  cursor?: keyof typeof styleRefs.cursor;
+  pointerEvents?: keyof typeof styleRefs.pointerEvents;
 }
 
 function getResponsiveClasses<PropName extends string>(
@@ -81,6 +85,8 @@ export default ({
   marginRight,
   display,
   flexDirection,
+  alignItems,
+  justifyContent,
   borderRadius,
   background,
   boxShadow,
@@ -89,6 +95,8 @@ export default ({
   height,
   width,
   position,
+  cursor,
+  pointerEvents,
 }: UseBoxProps) => {
   const resetStyles = useStyles(resetStyleRefs);
   const styles = useStyles(styleRefs);
@@ -114,6 +122,8 @@ export default ({
     styles.height[height!],
     styles.width[width!],
     styles.position[position!],
+    styles.cursor[cursor!],
+    styles.pointerEvents[pointerEvents!],
     resolvedMarginTop &&
       getResponsiveClasses(
         styles.margin.top,
@@ -169,6 +179,18 @@ export default ({
         styles.flexDirection,
         styles.flexDirectionDesktop,
         flexDirection,
+      ),
+    alignItems &&
+      getResponsiveClasses(
+        styles.alignItems,
+        styles.alignItemsDesktop,
+        alignItems,
+      ),
+    justifyContent &&
+      getResponsiveClasses(
+        styles.justifyContent,
+        styles.justifyContentDesktop,
+        justifyContent,
       ),
   );
 };

--- a/site/src/App/Code/Code.treat.ts
+++ b/site/src/App/Code/Code.treat.ts
@@ -7,13 +7,11 @@ export const code = style({
 });
 
 export const toolbar = style({
-  justifyContent: 'flex-end',
   borderTopLeftRadius: '0 !important',
   borderTopRightRadius: '0 !important',
 });
 
 export const button = style({
-  cursor: 'pointer',
   outline: 'none',
 });
 
@@ -48,6 +46,5 @@ export const focusOverlay = [
 ];
 
 export const buttonText = style({
-  pointerEvents: 'none',
   userSelect: 'none',
 });

--- a/site/src/App/Code/Code.tsx
+++ b/site/src/App/Code/Code.tsx
@@ -21,6 +21,7 @@ const CodeButton = ({
   return (
     <Box
       component={component}
+      cursor="pointer"
       background="neutralLight"
       borderRadius="standard"
       paddingY="xxsmall"
@@ -38,7 +39,12 @@ const CodeButton = ({
         className={classnames(styles.hoverOverlay)}
       />
       <FieldOverlay className={classnames(styles.activeOverlay)} />
-      <Box component="span" position="relative" className={styles.buttonText}>
+      <Box
+        component="span"
+        position="relative"
+        pointerEvents="none"
+        className={styles.buttonText}
+      >
         <Text size="xsmall" baseline={false}>
           {children}
         </Text>
@@ -77,6 +83,7 @@ export default ({ children }: CodeProps) => {
       </Box>
       <Box
         display="flex"
+        justifyContent="flexEnd"
         paddingY="xxsmall"
         paddingRight="xxsmall"
         background="neutralLight"

--- a/site/src/App/Components/Components.treat.ts
+++ b/site/src/App/Components/Components.treat.ts
@@ -12,8 +12,6 @@ export const isOpen = style({});
 
 export const header = style({
   background: 'white',
-  alignItems: 'center',
-  justifyContent: 'space-between',
   zIndex: 3,
   '@media': {
     [desktop]: {

--- a/site/src/App/Components/Components.tsx
+++ b/site/src/App/Components/Components.tsx
@@ -27,6 +27,8 @@ export const Components = withRouter(({ location }: RouteComponentProps) => {
             paddingX="gutter"
             position="absolute"
             display="flex"
+            alignItems="center"
+            justifyContent="spaceBetween"
             width="full"
             className={styles.header}
           >

--- a/site/src/App/Home/Home.treat.ts
+++ b/site/src/App/Home/Home.treat.ts
@@ -20,8 +20,6 @@ export const sourceLink = style({
 
 export const content = style({
   height: '100vh',
-  alignItems: 'center',
-  justifyContent: 'center',
 });
 
 export const container = style({
@@ -50,7 +48,6 @@ export const linkButton = style({
 
 export const subtitle = style({
   flexWrap: 'wrap',
-  justifyContent: 'center',
 });
 
 globalStyle(`${subtitle} > *`, {

--- a/site/src/App/Home/Home.tsx
+++ b/site/src/App/Home/Home.tsx
@@ -26,6 +26,8 @@ export const Home = () => {
             display="flex"
             flexDirection="column"
             paddingX="gutter"
+            alignItems="center"
+            justifyContent="center"
             className={styles.content}
           >
             <Box
@@ -45,6 +47,7 @@ export const Home = () => {
                 <Box
                   component="span"
                   display="flex"
+                  justifyContent="center"
                   className={styles.subtitle}
                 >
                   <span>Themeable design system</span>&nbsp;

--- a/site/src/App/MenuButton/MenuButton.treat.ts
+++ b/site/src/App/MenuButton/MenuButton.treat.ts
@@ -4,7 +4,6 @@ export const isOpen = style({});
 export const isHidden = style({});
 
 export const root = style({
-  cursor: 'pointer',
   width: '31px',
   height: '27px',
   border: 0,

--- a/site/src/App/MenuButton/MenuButton.tsx
+++ b/site/src/App/MenuButton/MenuButton.tsx
@@ -16,6 +16,7 @@ export const MenuButton = ({ open = false, onClick }: MenuButtonProps) => {
     <Hidden print>
       <Box
         component="button"
+        cursor="pointer"
         position="relative"
         className={classnames({
           [styles.root]: true,


### PR DESCRIPTION
Adds the following options to `Box`:

- `alignItems={'center' | 'flexStart' | 'flexEnd'}`
- `justifyContent={'center' | 'flexStart' | 'flexEnd' | 'spaceBetween'}`
- `width="touchable"`
- `height="touchable"`
- `borderRadius="full"`
- `cursor="pointer"`
- `pointerEvents="none"`

Note that `alignItems` and `justifyContent` are responsive props, which means that you can also provide an array of values for mobile and desktop, e.g.

```
<Box alignItems={['center', 'flexStart']}>
```