### PR TITLE
feat(BulletList): Add support for changing text size & bullet spacing

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -980,6 +980,20 @@ exports[`Bullet 1`] = `
 exports[`BulletList 1`] = `
 {
   children: ReactNode
+  size?: 
+    | "large"
+    | "small"
+    | "standard"
+    | "xsmall"
+  space?: 
+    | "large"
+    | "medium"
+    | "none"
+    | "small"
+    | "xlarge"
+    | "xsmall"
+    | "xxlarge"
+    | "xxsmall"
 }
 `;
 

--- a/lib/components/Bullet/Bullet.docs.tsx
+++ b/lib/components/Bullet/Bullet.docs.tsx
@@ -16,6 +16,46 @@ const docs: ComponentDocs = {
         </BulletList>
       ),
     },
+    {
+      label: 'Small Bullets',
+      Example: () => (
+        <BulletList size="small">
+          <Bullet>This is a small bullet.</Bullet>
+          <Bullet>This is a small bullet.</Bullet>
+          <Bullet>This is a small bullet.</Bullet>
+        </BulletList>
+      ),
+    },
+    {
+      label: 'Large Bullets',
+      Example: () => (
+        <BulletList size="large">
+          <Bullet>This is a large bullet.</Bullet>
+          <Bullet>This is a large bullet.</Bullet>
+          <Bullet>This is a large bullet.</Bullet>
+        </BulletList>
+      ),
+    },
+    {
+      label: 'No additional space between Bullets',
+      Example: () => (
+        <BulletList space="none">
+          <Bullet>No additional space below bullet.</Bullet>
+          <Bullet>No additional space below bullet.</Bullet>
+          <Bullet>No additional space below bullet.</Bullet>
+        </BulletList>
+      ),
+    },
+    {
+      label: 'Increased space between Bullets',
+      Example: () => (
+        <BulletList space="medium">
+          <Bullet>Increased space below bullet.</Bullet>
+          <Bullet>Increased space below bullet.</Bullet>
+          <Bullet>Increased space below bullet.</Bullet>
+        </BulletList>
+      ),
+    },
   ],
 };
 

--- a/lib/components/Bullet/Bullet.treat.ts
+++ b/lib/components/Bullet/Bullet.treat.ts
@@ -3,5 +3,5 @@ import { style } from 'sku/treat';
 export const listItem = style({
   display: 'list-item',
   listStyle: 'disc',
-  marginLeft: '1.3em',
+  marginLeft: '1.12em',
 });

--- a/lib/components/Bullet/Bullet.tsx
+++ b/lib/components/Bullet/Bullet.tsx
@@ -1,10 +1,10 @@
 import React, { ReactNode, useContext } from 'react';
+import { useStyles } from 'sku/treat';
 import classnames from 'classnames';
 import { Box } from '../Box/Box';
 import { useText } from '../../hooks/typography';
 import { BulletListContext } from '../BulletList/BulletList';
 import * as styleRefs from './Bullet.treat';
-import { useStyles } from 'sku/treat';
 
 export interface BulletProps {
   children: ReactNode;

--- a/lib/components/Bullet/Bullet.tsx
+++ b/lib/components/Bullet/Bullet.tsx
@@ -1,15 +1,26 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useContext } from 'react';
+import classnames from 'classnames';
 import { Box } from '../Box/Box';
-import { Text } from '../Text/Text';
+import { useText } from '../../hooks/typography';
+import { BulletListContext } from '../BulletList/BulletList';
+import * as styleRefs from './Bullet.treat';
+import { useStyles } from 'sku/treat';
 
 export interface BulletProps {
   children: ReactNode;
 }
 
-export const Bullet = ({ children }: BulletProps) => (
-  <Text component="li">
-    <Box display="block" component="span" paddingBottom="xxsmall">
+export const Bullet = ({ children }: BulletProps) => {
+  const styles = useStyles(styleRefs);
+  const { size, space } = useContext(BulletListContext);
+
+  return (
+    <Box
+      component="li"
+      paddingBottom={space}
+      className={classnames(useText({ size, baseline: true }), styles.listItem)}
+    >
       {children}
     </Box>
-  </Text>
-);
+  );
+};

--- a/lib/components/BulletList/BulletList.tsx
+++ b/lib/components/BulletList/BulletList.tsx
@@ -1,10 +1,44 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, createContext, Children } from 'react';
 import { Box } from '../Box/Box';
+import { UseTextProps } from '../../hooks/typography';
+import { SpaceY } from '../../hooks/useBox';
+
+const defaultSize = 'standard';
+const defaultSpace = 'xxsmall';
+interface BulletListContext {
+  size: UseTextProps['size'];
+  space?: SpaceY;
+}
+export const BulletListContext = createContext<BulletListContext>({
+  size: defaultSize,
+  space: defaultSpace,
+});
 
 export interface BulletListProps {
   children: ReactNode;
+  size?: UseTextProps['size'];
+  space?: SpaceY;
 }
 
-export const BulletList = ({ children }: BulletListProps) => (
-  <Box component="ul">{children}</Box>
-);
+export const BulletList = ({
+  children,
+  size = defaultSize,
+  space = defaultSpace,
+}: BulletListProps) => {
+  const bullets = Children.toArray(children);
+
+  return (
+    <Box component="ul">
+      {bullets.map((child, index) => (
+        <BulletListContext.Provider
+          value={{
+            size,
+            space: index !== bullets.length - 1 ? space : undefined,
+          }}
+        >
+          {child}
+        </BulletListContext.Provider>
+      ))}
+    </Box>
+  );
+};

--- a/lib/components/Column/Column.docs.tsx
+++ b/lib/components/Column/Column.docs.tsx
@@ -44,7 +44,7 @@ const docs: ComponentDocs = {
       Example: () => (
         <Fragment>
           {widths.map(width => (
-            <Columns>
+            <Columns key={width}>
               <Column width={width}>
                 <HideCode>
                   <Content>{width}</Content>

--- a/lib/components/Text/Text.tsx
+++ b/lib/components/Text/Text.tsx
@@ -1,10 +1,8 @@
 import React, { ReactNode, useContext, useMemo } from 'react';
-import { useStyles } from 'sku/react-treat';
 import classnames from 'classnames';
 import TextContext from './TextContext';
 import { Box, BoxProps } from '../Box/Box';
 import { useText, UseTextProps } from '../../hooks/typography';
-import * as styleRefs from './Text.treat';
 
 export interface TextProps extends Pick<BoxProps, 'component'> {
   id?: string;
@@ -24,8 +22,6 @@ export const Text = ({
   baseline = true,
   children,
 }: TextProps) => {
-  const styles = useStyles(styleRefs);
-  const isListItem = typeof component === 'string' && /^li$/i.test(component);
   const textStyles = useText({ weight, size, baseline, tone });
 
   // Prevent re-renders when context values haven't changed
@@ -53,9 +49,9 @@ export const Text = ({
     <TextContext.Provider value={textContextValue}>
       <Box
         id={id}
-        display={!isListItem ? 'block' : undefined}
+        display="block"
         component={component}
-        className={classnames(textStyles, isListItem && styles.listItem)}
+        className={classnames(textStyles)}
       >
         {children}
       </Box>

--- a/lib/components/Text/Text.tsx
+++ b/lib/components/Text/Text.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode, useContext, useMemo } from 'react';
-import classnames from 'classnames';
 import TextContext from './TextContext';
 import { Box, BoxProps } from '../Box/Box';
 import { useText, UseTextProps } from '../../hooks/typography';
@@ -47,12 +46,7 @@ export const Text = ({
 
   return (
     <TextContext.Provider value={textContextValue}>
-      <Box
-        id={id}
-        display="block"
-        component={component}
-        className={classnames(textStyles)}
-      >
+      <Box id={id} display="block" component={component} className={textStyles}>
         {children}
       </Box>
     </TextContext.Provider>

--- a/lib/hooks/useBox/index.ts
+++ b/lib/hooks/useBox/index.ts
@@ -17,7 +17,7 @@ type SpaceBottom = DirectionalSpace<'bottom'>;
 type SpaceLeft = DirectionalSpace<'left'>;
 type SpaceRight = DirectionalSpace<'right'>;
 export type SpaceX = Extract<SpaceLeft, SpaceRight>;
-type SpaceY = Extract<SpaceTop, SpaceBottom>;
+export type SpaceY = Extract<SpaceTop, SpaceBottom>;
 type Space = Extract<SpaceX, SpaceY>;
 
 export interface UseBoxProps {


### PR DESCRIPTION
BREAKING CHANGE: Setting `component="li"` on `Text` no longer renders a bullet. Please migrate to `Bullet`. Also no longer renders white space after the last `Bullet`, please validate your usage.

See usage: https://seek-oss.github.io/braid-design-system/components/BulletList.

### Migration Guide
Setting the `component` prop on `Text` to `"li"` no longer renders a bullet list item. Consumers depending on this behaviour should migrate to `Bullet` and leverage the new apis on `BulletList` to achieve the desired outcome.

#### Text size of bullets
Consumers using `Text` instead of `Bullet` to support customising the text size should now migrate to `Bullet` and set the `size` on `BulletList` as follows:
```diff
-<BulletList>
+<BulletList size="small">
-  <Text component="li" size="small">...</Text>
+  <Bullet>...</Bullet>
   ...
</BulletList>
```

#### Space between bullets
Consumers using `Text` to remove default spacing in between `Bullet`s should now migrate to `Bullet` and instead configure the `space` on `BulletList`. Eg:
```diff
-<BulletList>
+<BulletList space="none">
-  <Text component="li">...</Text>
+  <Bullet>...</Bullet>
   ...
</BulletList>
```

Alternatively you can also increase the spacing as required, using the space scale, eg:
```diff
-<BulletList>
+<BulletList space="large">
  <Bullet>...</Bullet>
   ...
</BulletList>
```