### PR TITLE
feat(ContentBlock): Add 'ContentBlock' component

### DIFF
--- a/docs/Style Guide Migration.md
+++ b/docs/Style Guide Migration.md
@@ -45,6 +45,7 @@ Since Braid is an entirely new design system, we've taken the opportunity to rev
 - [`FieldMessage`](../lib/components/FieldMessage/FieldMessage.migration.md)
 - [Icons](../lib/components/icons/Icon/Icon.migration.md)
 - [`MonthPicker`](../lib/components/MonthPicker/MonthPicker.migration.md)
+- `PageBlock` -> [`ContentBlock`](../lib/components/ContentBlock/ContentBlock.migration.md)
 - [`Radio`](../lib/components/Radio/Radio.migration.md)
 - [`Secondary`](../lib/components/Secondary/Secondary.migration.md)
 - `SlideToggle` -> [`Toggle`](../lib/components/Toggle/Toggle.migration.md)

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -1497,6 +1497,15 @@ exports[`Columns 1`] = `
 }
 `;
 
+exports[`ContentBlock 1`] = `
+{
+  children: ReactNode
+  width?: 
+    | "large"
+    | "medium"
+}
+`;
+
 exports[`Divider 1`] = `
 {
 }

--- a/lib/components/ContentBlock/ContentBlock.docs.tsx
+++ b/lib/components/ContentBlock/ContentBlock.docs.tsx
@@ -1,0 +1,36 @@
+import React from 'react';
+import { ComponentDocs } from '../../../site/src/types';
+import { Box, Text } from '../';
+import { HideCode } from '../private/HideCode';
+import { ContentBlock } from './ContentBlock';
+
+const docs: ComponentDocs = {
+  examples: [
+    {
+      label: 'Default Content Block',
+      Example: () => (
+        <ContentBlock>
+          <HideCode>
+            <Box padding="gutter" background="infoLight">
+              <Text baseline={false}>Content Block</Text>
+            </Box>
+          </HideCode>
+        </ContentBlock>
+      ),
+    },
+    {
+      label: 'Large Content Block',
+      Example: () => (
+        <ContentBlock width="large">
+          <HideCode>
+            <Box padding="gutter" background="infoLight">
+              <Text baseline={false}>Content Block</Text>
+            </Box>
+          </HideCode>
+        </ContentBlock>
+      ),
+    },
+  ],
+};
+
+export default docs;

--- a/lib/components/ContentBlock/ContentBlock.migration.md
+++ b/lib/components/ContentBlock/ContentBlock.migration.md
@@ -1,0 +1,12 @@
+# ContentBlock Migration Guide
+
+## Diff
+
+```diff
+-<PageBlock>...</PageBlock>
++<ContentBlock>...</ContentBlock>
+```
+
+## Previous Implementations
+
+- [SEEK Style Guide](https://seek-oss.github.io/seek-style-guide/page-block)

--- a/lib/components/ContentBlock/ContentBlock.treat.ts
+++ b/lib/components/ContentBlock/ContentBlock.treat.ts
@@ -1,0 +1,8 @@
+import { style, styleMap } from 'sku/treat';
+import { mapToStyleProperty } from '../../utils';
+
+export const root = style({ margin: '0 auto' });
+
+export const width = styleMap(({ contentWidth }) =>
+  mapToStyleProperty(contentWidth, 'maxWidth'),
+);

--- a/lib/components/ContentBlock/ContentBlock.tsx
+++ b/lib/components/ContentBlock/ContentBlock.tsx
@@ -1,0 +1,23 @@
+import React, { ReactNode } from 'react';
+import { useStyles } from 'sku/treat';
+import classnames from 'classnames';
+import { Box } from '../Box/Box';
+import * as styleRefs from './ContentBlock.treat';
+
+export interface ContentBlockProps {
+  children: ReactNode;
+  width?: keyof typeof styleRefs.width;
+}
+
+export const ContentBlock = ({
+  width = 'medium',
+  children,
+}: ContentBlockProps) => {
+  const styles = useStyles(styleRefs);
+
+  return (
+    <Box className={classnames(styles.root, styles.width[width])}>
+      {children}
+    </Box>
+  );
+};

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -17,6 +17,7 @@ export { Card } from './Card/Card';
 export { Checkbox } from './Checkbox/Checkbox';
 export { Column } from './Column/Column';
 export { Columns } from './Columns/Columns';
+export { ContentBlock } from './ContentBlock/ContentBlock';
 export { Divider } from './Divider/Divider';
 export { Dropdown } from './Dropdown/Dropdown';
 export { FieldLabel } from './FieldLabel/FieldLabel';

--- a/lib/themes/makeTreatTheme.ts
+++ b/lib/themes/makeTreatTheme.ts
@@ -38,6 +38,10 @@ export interface TreatTokens {
     };
   };
   responsiveBreakpoint: number;
+  contentWidth: {
+    medium: number;
+    large: number;
+  };
   grid: number;
   touchableSize: number;
   space: {

--- a/lib/themes/seekAnz/tokens.ts
+++ b/lib/themes/seekAnz/tokens.ts
@@ -116,6 +116,10 @@ const tokens: TreatTokens = {
     },
   },
   responsiveBreakpoint: 740,
+  contentWidth: {
+    medium: 940,
+    large: 1280,
+  },
   grid: 4,
   touchableSize: 12,
   space: {

--- a/lib/themes/seekAsia/makeTokens.ts
+++ b/lib/themes/seekAsia/makeTokens.ts
@@ -138,6 +138,10 @@ export default ({
       },
     },
     responsiveBreakpoint: 768,
+    contentWidth: {
+      medium: 940,
+      large: 1280,
+    },
     grid: 4,
     touchableSize: 10,
     space: {

--- a/lib/themes/wireframe/tokens.ts
+++ b/lib/themes/wireframe/tokens.ts
@@ -114,6 +114,10 @@ const tokens: TreatTokens = {
     },
   },
   responsiveBreakpoint: 768,
+  contentWidth: {
+    medium: 940,
+    large: 1280,
+  },
   grid: 4,
   touchableSize: 12,
   space: {


### PR DESCRIPTION
This serves as the Braid replacement for SEEK Style Guide's [`PageBlock`](https://seek-oss.github.io/seek-style-guide/page-block), providing a centred container with a max-width.

This also adds support for wider page layouts via the `width` prop, e.g. `<ContentBlock width="large">...</ContentBlock>`