### PR TITLE
feat(ButtonRenderer): Add ButtonRenderer component

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -1423,7 +1423,21 @@ exports[`Button 1`] = `
   id?: string
   loading?: boolean
   onClick?: (event: MouseEvent<HTMLButtonElement, MouseEvent>) => void
-  type?: string
+  type?: 
+    | "button"
+    | "reset"
+    | "submit"
+  weight?: 
+    | "regular"
+    | "strong"
+    | "weak"
+}
+`;
+
+exports[`ButtonRenderer 1`] = `
+{
+  children: (ButtonChildren: ComponentType<ButtonChildrenProps>, styleProps: { style: CSSProperties; className: string; }) => ReactNode
+  loading?: boolean
   weight?: 
     | "regular"
     | "strong"

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -1,46 +1,19 @@
 import React, { ReactNode, AllHTMLAttributes } from 'react';
-import { useStyles } from 'sku/react-treat';
-import classnames from 'classnames';
-import { Box, BoxProps } from '../Box/Box';
-import { Text } from '../Text/Text';
-import { FieldOverlay } from '../private/FieldOverlay/FieldOverlay';
-import { useTouchableSpace } from '../../hooks/typography';
-import * as styleRefs from './Button.treat';
-
-type ButtonWeight = 'weak' | 'regular' | 'strong';
-type ButtonState = 'base' | 'hover' | 'active';
+import {
+  ButtonRenderer,
+  ButtonRendererProps,
+} from '../ButtonRenderer/ButtonRenderer';
 
 type NativeButtonProps = AllHTMLAttributes<HTMLButtonElement>;
 export interface ButtonProps {
   id?: NativeButtonProps['id'];
   onClick?: NativeButtonProps['onClick'];
-  type?: NativeButtonProps['type'];
+  type?: 'button' | 'submit' | 'reset';
   children?: ReactNode;
-  weight?: ButtonWeight;
-  loading?: boolean;
+  weight?: ButtonRendererProps['weight'];
+  loading?: ButtonRendererProps['loading'];
   'aria-describedby'?: NativeButtonProps['aria-describedby'];
 }
-
-const background: Record<
-  ButtonState,
-  Record<ButtonWeight, BoxProps['background'] | undefined>
-> = {
-  base: {
-    weak: undefined,
-    regular: 'formAccent',
-    strong: 'brandAccent',
-  },
-  hover: {
-    weak: 'formAccentHover',
-    regular: 'formAccentHover',
-    strong: 'brandAccentHover',
-  },
-  active: {
-    weak: 'formAccentActive',
-    regular: 'formAccentActive',
-    strong: 'brandAccentActive',
-  },
-};
 
 export const Button = ({
   onClick,
@@ -51,86 +24,20 @@ export const Button = ({
   loading = false,
   'aria-describedby': ariaDescribedBy,
 }: ButtonProps) => {
-  const styles = useStyles(styleRefs);
-  const isWeak = weight === 'weak';
-
   return (
-    <Box
-      id={id}
-      component="button"
-      cursor="pointer"
-      type={type}
-      aria-describedby={ariaDescribedBy}
-      width="full"
-      position="relative"
-      display="block"
-      borderRadius="standard"
-      boxShadow={isWeak ? 'borderFormAccentLarge' : undefined}
-      background={background.base[weight]}
-      transform="touchable"
-      transition="touchable"
-      className={classnames(styles.root, {
-        [styles.weak]: isWeak,
-      })}
-      onClick={onClick}
-      disabled={loading}
-    >
-      <FieldOverlay
-        variant="focus"
-        className={classnames(styles.focusOverlay)}
-      />
-      <FieldOverlay
-        background={background.hover[weight]}
-        className={classnames(styles.hoverOverlay)}
-      />
-      <FieldOverlay
-        background={background.active[weight]}
-        className={classnames(styles.activeOverlay)}
-      />
-      <Box
-        position="relative"
-        paddingX="gutter"
-        pointerEvents="none"
-        className={classnames(styles.content, useTouchableSpace('standard'))}
-      >
-        <Text
-          baseline={false}
-          weight="medium"
-          tone={weight === 'weak' ? 'formAccent' : undefined}
+    <ButtonRenderer weight={weight} loading={loading}>
+      {(ButtonChildren, buttonProps) => (
+        <button
+          id={id}
+          type={type}
+          aria-describedby={ariaDescribedBy}
+          onClick={onClick}
+          disabled={loading}
+          {...buttonProps}
         >
-          {children}
-          {loading ? (
-            <Box
-              aria-hidden
-              component="span"
-              display="inlineBlock"
-              position="relative"
-              className={styles.loading}
-            >
-              <Box
-                component="span"
-                display="block"
-                position="absolute"
-                className={styles.ellipsis}
-              >
-                {'\u2026'}
-              </Box>
-              {/*
-                This box ensures that the space reserved for the
-                ellipsis is relative to the theme's font size
-                and character width.
-              */}
-              <Box
-                component="span"
-                display="inline"
-                className={styles.visibilityHidden}
-              >
-                {'\u2026'}
-              </Box>
-            </Box>
-          ) : null}
-        </Text>
-      </Box>
-    </Box>
+          <ButtonChildren>{children}</ButtonChildren>
+        </button>
+      )}
+    </ButtonRenderer>
   );
 };

--- a/lib/components/ButtonRenderer/ButtonRenderer.docs.tsx
+++ b/lib/components/ButtonRenderer/ButtonRenderer.docs.tsx
@@ -1,0 +1,43 @@
+import React, { ReactNode } from 'react';
+import { ComponentDocs } from '../../../site/src/types';
+import { Link } from 'react-router-dom';
+import { ButtonRenderer } from './ButtonRenderer';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div style={{ maxWidth: '300px' }}>{children}</div>
+);
+
+const docs: ComponentDocs = {
+  examples: [
+    {
+      label: 'Button with Custom Renderer',
+      Container,
+      Example: () => (
+        <ButtonRenderer>
+          {(ButtonChildren, buttonProps) => (
+            <Link to="#" {...buttonProps}>
+              <ButtonChildren>Link button</ButtonChildren>
+            </Link>
+          )}
+        </ButtonRenderer>
+      ),
+      code: `
+        import React from 'react';
+        import { Link } from 'react-router-dom';
+        import { ButtonRenderer } from 'braid-design-system';
+
+        export default () => (
+          <ButtonRenderer>
+            {(ButtonChildren, buttonProps) => (
+              <Link to="#" {...buttonProps}>
+                <ButtonChildren>Link button</ButtonChildren>
+              </Link>
+            )}
+          </ButtonRenderer>
+        );
+      `,
+    },
+  ],
+};
+
+export default docs;

--- a/lib/components/ButtonRenderer/ButtonRenderer.treat.ts
+++ b/lib/components/ButtonRenderer/ButtonRenderer.treat.ts
@@ -2,6 +2,7 @@ import { style } from 'sku/treat';
 
 export const root = style({
   outline: 'none',
+  textDecoration: 'none',
 });
 
 export const weak = style({

--- a/lib/components/ButtonRenderer/ButtonRenderer.tsx
+++ b/lib/components/ButtonRenderer/ButtonRenderer.tsx
@@ -136,6 +136,7 @@ export const ButtonRenderer = ({
   const styles = useStyles(styleRefs);
   const isWeak = weight === 'weak';
   const background = backgroundVariants.base[weight];
+
   const buttonStyles = classnames(
     styles.root,
     isWeak ? styles.weak : null,
@@ -152,15 +153,16 @@ export const ButtonRenderer = ({
       transition: 'touchable',
     }),
   );
-  const buttonProps = {
-    style: {},
-    className: buttonStyles,
-  };
 
   const buttonChildrenContextValue = useMemo(() => ({ weight, loading }), [
     weight,
     loading,
   ]);
+
+  const buttonProps = {
+    style: {},
+    className: buttonStyles,
+  };
 
   return (
     <BackgroundProvider value={background}>

--- a/lib/components/ButtonRenderer/ButtonRenderer.tsx
+++ b/lib/components/ButtonRenderer/ButtonRenderer.tsx
@@ -1,0 +1,172 @@
+import React, {
+  createContext,
+  useContext,
+  useMemo,
+  Fragment,
+  ReactNode,
+  CSSProperties,
+  ComponentType,
+} from 'react';
+import classnames from 'classnames';
+import { useStyles } from 'sku/treat';
+import { useBoxStyles, UseBoxStylesProps } from '../Box/useBoxStyles';
+import { BackgroundProvider } from '../Box/BackgroundContext';
+import { Box } from '../Box/Box';
+import { Text } from '../Text/Text';
+import { FieldOverlay } from '../private/FieldOverlay/FieldOverlay';
+import { useTouchableSpace } from '../../hooks/typography';
+import * as styleRefs from './ButtonRenderer.treat';
+
+type ButtonWeight = 'weak' | 'regular' | 'strong';
+type ButtonState = 'base' | 'hover' | 'active';
+
+const backgroundVariants: Record<
+  ButtonState,
+  Record<ButtonWeight, UseBoxStylesProps['background'] | undefined>
+> = {
+  base: {
+    weak: undefined,
+    regular: 'formAccent',
+    strong: 'brandAccent',
+  },
+  hover: {
+    weak: 'formAccentHover',
+    regular: 'formAccentHover',
+    strong: 'brandAccentHover',
+  },
+  active: {
+    weak: 'formAccentActive',
+    regular: 'formAccentActive',
+    strong: 'brandAccentActive',
+  },
+};
+
+const ButtonChildrenContext = createContext<{
+  weight: ButtonWeight;
+  loading: boolean;
+}>({ weight: 'regular', loading: false });
+
+interface ButtonChildrenProps {
+  children: ReactNode;
+}
+
+const ButtonChildren = ({ children }: ButtonChildrenProps) => {
+  const styles = useStyles(styleRefs);
+  const { weight, loading } = useContext(ButtonChildrenContext);
+
+  return (
+    <Fragment>
+      <FieldOverlay
+        variant="focus"
+        className={classnames(styles.focusOverlay)}
+      />
+      <FieldOverlay
+        background={backgroundVariants.hover[weight]}
+        className={classnames(styles.hoverOverlay)}
+      />
+      <FieldOverlay
+        background={backgroundVariants.active[weight]}
+        className={classnames(styles.activeOverlay)}
+      />
+      <Box
+        position="relative"
+        paddingX="gutter"
+        pointerEvents="none"
+        className={classnames(styles.content, useTouchableSpace('standard'))}
+      >
+        <Text
+          baseline={false}
+          weight="medium"
+          tone={weight === 'weak' ? 'formAccent' : undefined}
+        >
+          {children}
+          {loading ? (
+            <Box
+              aria-hidden
+              component="span"
+              display="inlineBlock"
+              position="relative"
+              className={styles.loading}
+            >
+              <Box
+                component="span"
+                display="block"
+                position="absolute"
+                className={styles.ellipsis}
+              >
+                {'\u2026'}
+              </Box>
+              {/*
+                This box ensures that the space reserved for the
+                ellipsis is relative to the theme's font size
+                and character width.
+              */}
+              <Box
+                component="span"
+                display="inline"
+                className={styles.visibilityHidden}
+              >
+                {'\u2026'}
+              </Box>
+            </Box>
+          ) : null}
+        </Text>
+      </Box>
+    </Fragment>
+  );
+};
+
+export interface ButtonRendererProps {
+  weight?: ButtonWeight;
+  loading?: boolean;
+  children: (
+    ButtonChildren: ComponentType<ButtonChildrenProps>,
+    styleProps: {
+      style: CSSProperties;
+      className: string;
+    },
+  ) => ReactNode;
+}
+
+export const ButtonRenderer = ({
+  weight = 'regular',
+  loading = false,
+  children,
+}: ButtonRendererProps) => {
+  const styles = useStyles(styleRefs);
+  const isWeak = weight === 'weak';
+  const background = backgroundVariants.base[weight];
+  const buttonStyles = classnames(
+    styles.root,
+    isWeak ? styles.weak : null,
+    useBoxStyles({
+      component: 'button',
+      cursor: 'pointer',
+      width: 'full',
+      position: 'relative',
+      display: 'block',
+      borderRadius: 'standard',
+      boxShadow: isWeak ? 'borderFormAccentLarge' : undefined,
+      background,
+      transform: 'touchable',
+      transition: 'touchable',
+    }),
+  );
+  const buttonProps = {
+    style: {},
+    className: buttonStyles,
+  };
+
+  const buttonChildrenContextValue = useMemo(() => ({ weight, loading }), [
+    weight,
+    loading,
+  ]);
+
+  return (
+    <BackgroundProvider value={background}>
+      <ButtonChildrenContext.Provider value={buttonChildrenContextValue}>
+        {children(ButtonChildren, buttonProps)}
+      </ButtonChildrenContext.Provider>
+    </BackgroundProvider>
+  );
+};

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -13,6 +13,7 @@ export { BoxRenderer } from './Box/BoxRenderer';
 export { Bullet } from './Bullet/Bullet';
 export { BulletList } from './BulletList/BulletList';
 export { Button } from './Button/Button';
+export { ButtonRenderer } from './ButtonRenderer/ButtonRenderer';
 export { Card } from './Card/Card';
 export { Checkbox } from './Checkbox/Checkbox';
 export { Column } from './Column/Column';


### PR DESCRIPTION
This component allows you to render elements that _look_ like buttons but actually aren't.

Most notably, this is to support links as buttons. For example, if you wanted to render a button that's actually a React Router link:

```js
<ButtonRenderer>
  {(ButtonChildren, buttonProps) => (
    <Link to="#" {...buttonProps}>
      <ButtonChildren>Link button</ButtonChildren>
    </Link>
  )}
</ButtonRenderer>
```