### PR TITLE
feat: Add full box shadow scale

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -272,7 +272,9 @@ exports[`Box 1`] = `
     | "borderFormAccentLarge"
     | "borderStandard"
     | "large"
+    | "medium"
     | "outlineFocus"
+    | "small"
   capture?: 
     | false
     | string
@@ -996,7 +998,9 @@ exports[`BoxRenderer 1`] = `
     | "borderFormAccentLarge"
     | "borderStandard"
     | "large"
+    | "medium"
     | "outlineFocus"
+    | "small"
   children: (className: string) => ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<any, any, any>)> | null
   component: 
     | "a"

--- a/lib/components/Autosuggest/Autosuggest.tsx
+++ b/lib/components/Autosuggest/Autosuggest.tsx
@@ -552,7 +552,7 @@ export function Autosuggest<Value>({
                   position="absolute"
                   background="card"
                   borderRadius="standard"
-                  boxShadow="large"
+                  boxShadow="medium"
                   width="full"
                   marginTop="xxsmall"
                   paddingY="xxsmall"

--- a/lib/themes/baseTokens/seekAnz.ts
+++ b/lib/themes/baseTokens/seekAnz.ts
@@ -157,6 +157,7 @@ export const makeTokens = ({
     border: {
       radius: {
         standard: '2px',
+        large: '4px',
       },
       width: {
         standard: 1,
@@ -170,7 +171,12 @@ export const makeTokens = ({
       },
     },
     shadows: {
-      large: '0 9px 30px rgba(0,0,0,.4)',
+      small:
+        '0 2px 4px 0px rgba(28,28,28,.1), 0 2px 2px -2px rgba(28,28,28,.1), 0 4px 4px -4px rgba(28,28,28,.2)',
+      medium:
+        '0 2px 4px 0px rgba(28,28,28,.1), 0 8px 8px -4px rgba(28,28,28,.1), 0 12px 12px -8px rgba(28,28,28,.2)',
+      large:
+        '0 2px 4px 0px rgba(28,28,28,.1), 0 12px 12px -4px rgba(28,28,28,.1), 0 20px 20px -12px rgba(28,28,28,.2)',
     },
     color: {
       foreground: {

--- a/lib/themes/baseTokens/seekAnz.ts
+++ b/lib/themes/baseTokens/seekAnz.ts
@@ -157,7 +157,6 @@ export const makeTokens = ({
     border: {
       radius: {
         standard: '2px',
-        large: '4px',
       },
       width: {
         standard: 1,

--- a/lib/themes/baseTokens/seekAsia.ts
+++ b/lib/themes/baseTokens/seekAsia.ts
@@ -166,7 +166,6 @@ export const makeTokens = ({
     border: {
       radius: {
         standard: '4px',
-        large: '8px',
       },
       width: {
         standard: 1,

--- a/lib/themes/baseTokens/seekAsia.ts
+++ b/lib/themes/baseTokens/seekAsia.ts
@@ -166,6 +166,7 @@ export const makeTokens = ({
     border: {
       radius: {
         standard: '4px',
+        large: '8px',
       },
       width: {
         standard: 1,
@@ -179,7 +180,12 @@ export const makeTokens = ({
       },
     },
     shadows: {
-      large: '0 9px 30px rgba(0,0,0,.4)',
+      small:
+        '0 2px 4px 0px rgba(28,28,28,.1), 0 2px 2px -2px rgba(28,28,28,.1), 0 4px 4px -4px rgba(28,28,28,.2)',
+      medium:
+        '0 2px 4px 0px rgba(28,28,28,.1), 0 8px 8px -4px rgba(28,28,28,.1), 0 12px 12px -8px rgba(28,28,28,.2)',
+      large:
+        '0 2px 4px 0px rgba(28,28,28,.1), 0 12px 12px -4px rgba(28,28,28,.1), 0 20px 20px -12px rgba(28,28,28,.2)',
     },
     color: {
       foreground: {

--- a/lib/themes/baseTokens/seekAsiaRebrand.ts
+++ b/lib/themes/baseTokens/seekAsiaRebrand.ts
@@ -191,7 +191,6 @@ export const makeTokens = ({
     border: {
       radius: {
         standard: '4px',
-        large: '8px',
       },
       width: {
         standard: 1,

--- a/lib/themes/baseTokens/seekAsiaRebrand.ts
+++ b/lib/themes/baseTokens/seekAsiaRebrand.ts
@@ -191,6 +191,7 @@ export const makeTokens = ({
     border: {
       radius: {
         standard: '4px',
+        large: '8px',
       },
       width: {
         standard: 1,
@@ -204,7 +205,12 @@ export const makeTokens = ({
       },
     },
     shadows: {
-      large: '0 9px 30px rgba(0,0,0,.4)',
+      small:
+        '0 2px 4px 0px rgba(28,28,28,.1), 0 2px 2px -2px rgba(28,28,28,.1), 0 4px 4px -4px rgba(28,28,28,.2)',
+      medium:
+        '0 2px 4px 0px rgba(28,28,28,.1), 0 8px 8px -4px rgba(28,28,28,.1), 0 12px 12px -8px rgba(28,28,28,.2)',
+      large:
+        '0 2px 4px 0px rgba(28,28,28,.1), 0 12px 12px -4px rgba(28,28,28,.1), 0 20px 20px -12px rgba(28,28,28,.2)',
     },
     color: {
       foreground: {

--- a/lib/themes/makeTreatTheme.ts
+++ b/lib/themes/makeTreatTheme.ts
@@ -66,7 +66,6 @@ export interface TreatTokens {
   border: {
     radius: {
       standard: string;
-      large: string;
     };
     width: {
       standard: number;

--- a/lib/themes/makeTreatTheme.ts
+++ b/lib/themes/makeTreatTheme.ts
@@ -66,6 +66,7 @@ export interface TreatTokens {
   border: {
     radius: {
       standard: string;
+      large: string;
     };
     width: {
       standard: number;
@@ -79,6 +80,8 @@ export interface TreatTokens {
     };
   };
   shadows: {
+    small: string;
+    medium: string;
     large: string;
   };
   color: {

--- a/lib/themes/wireframe/tokens.ts
+++ b/lib/themes/wireframe/tokens.ts
@@ -142,7 +142,6 @@ const tokens: TreatTokens = {
   border: {
     radius: {
       standard: '4px',
-      large: '10px',
     },
     width: {
       standard: 1,

--- a/lib/themes/wireframe/tokens.ts
+++ b/lib/themes/wireframe/tokens.ts
@@ -142,6 +142,7 @@ const tokens: TreatTokens = {
   border: {
     radius: {
       standard: '4px',
+      large: '10px',
     },
     width: {
       standard: 1,
@@ -155,7 +156,12 @@ const tokens: TreatTokens = {
     },
   },
   shadows: {
-    large: '0 9px 30px rgba(0,0,0,.4)',
+    small:
+      '0 2px 4px 0px rgba(28,28,28,.1), 0 2px 2px -2px rgba(28,28,28,.1), 0 4px 4px -4px rgba(28,28,28,.2)',
+    medium:
+      '0 2px 4px 0px rgba(28,28,28,.1), 0 8px 8px -4px rgba(28,28,28,.1), 0 12px 12px -8px rgba(28,28,28,.2)',
+    large:
+      '0 2px 4px 0px rgba(28,28,28,.1), 0 12px 12px -4px rgba(28,28,28,.1), 0 20px 20px -12px rgba(28,28,28,.2)',
   },
   color: {
     foreground: {


### PR DESCRIPTION
Introduce a full scale for box-shadow usage to better demonstrate elevation between different components.

Box shadow scale:
- small __(new)__ 
  - Examples: Cards, content containers, etc
- medium __(new)__
  - Examples: Overflow menus, Autosuggest list, etc
- large
  - Examples: Toasts, sticky/fixed components, etc

[Playroom](https://braid-design-system--15a8f2904a1968fc6f7690d9bc32016657c0c643.surge.sh/playroom/#?code=PEJveCBiYWNrZ3JvdW5kPSJjYXJkIiBwYWRkaW5nPSJtZWRpdW0iPgogIDxTdGFjayBzcGFjZT0ieGxhcmdlIj4KICAgIDxCb3ggc3R5bGU9e3sgYm94U2hhZG93OiAiMCA5cHggMzBweCByZ2JhKDAsMCwwLC40KSIgfX0gcGFkZGluZz0ibWVkaXVtIj4KICAgICAgPFRleHQ-TGFyZ2UgKG9sZCk8L1RleHQ-CiAgICA8L0JveD4KICAgIDxEaXZpZGVyIC8-CiAgICA8Qm94IGJveFNoYWRvdz0ic21hbGwiIHBhZGRpbmc9Im1lZGl1bSI-CiAgICAgIDxUZXh0PlNtYWxsPC9UZXh0PgogICAgPC9Cb3g-CiAgICA8Qm94IGJveFNoYWRvdz0ibWVkaXVtIiBwYWRkaW5nPSJtZWRpdW0iPgogICAgICA8VGV4dD5NZWRpdW08L1RleHQ-CiAgICA8L0JveD4KICAgIDxCb3ggYm94U2hhZG93PSJsYXJnZSIgcGFkZGluZz0ibWVkaXVtIj4KICAgICAgPFRleHQ-TGFyZ2UgKG5ldyk8L1RleHQ-CiAgICA8L0JveD4KICA8L1N0YWNrPgo8L0JveD4K)
 

BREAKING CHANGE: Review any usages of `<Box boxShadow="large" />` and update to the most appropriate value in the scale. If you're not sure what value to change to, reach out to #braid-design-support.
