### PR TITLE
fix(jobsDbRebrand): Update token values

### DIFF
--- a/lib/themes/baseTokens/seekAsiaRebrand.ts
+++ b/lib/themes/baseTokens/seekAsiaRebrand.ts
@@ -145,11 +145,11 @@ export const makeTokens = ({
         standard: {
           mobile: {
             size: 16,
-            rows: 5,
+            rows: 6,
           },
           desktop: {
             size: 16,
-            rows: 5,
+            rows: 6,
           },
         },
         large: {

--- a/lib/themes/baseTokens/seekAsiaRebrand.ts
+++ b/lib/themes/baseTokens/seekAsiaRebrand.ts
@@ -71,7 +71,7 @@ export const makeTokens = ({
       fontWeight: {
         regular: 400,
         medium: 600,
-        strong: 700,
+        strong: 900,
       },
       heading: {
         weight: {

--- a/lib/themes/baseTokens/seekAsiaRebrand.ts
+++ b/lib/themes/baseTokens/seekAsiaRebrand.ts
@@ -170,7 +170,7 @@ export const makeTokens = ({
       large: 1280,
     },
     grid: 4,
-    touchableSize: 12,
+    touchableSize: 11,
     space: {
       gutter: 5,
       xxsmall: 1,


### PR DESCRIPTION
There are several component spec updates on jobsDB Rebrand theme, which cascaded from `seekAsiaRebrand` and will be adapted by jobStreet when rebranding takes place.

1. `<Strong>`: From **Bold** to **ExtraBold**
2. `<Text>`: Normal size lineHeight set from **20px** to **24px** instead
3. `<Button>` and `<TextField>`: Height from **48px** to **44px**