### PR TITLE
fix(OverflowMenu): Stop click events from bubbling

### DIFF
--- a/lib/components/OverflowMenu/OverflowMenu.tsx
+++ b/lib/components/OverflowMenu/OverflowMenu.tsx
@@ -221,7 +221,10 @@ export const OverflowMenu = ({
             ref={buttonRef}
             onKeyUp={onTriggerKeyUp}
             onKeyDown={onTriggerKeyDown}
-            onClick={() => dispatch({ type: MENU_TRIGGER_CLICK })}
+            onClick={event => {
+              event.stopPropagation();
+              dispatch({ type: MENU_TRIGGER_CLICK });
+            }}
           />
         </Box>
 
@@ -264,7 +267,10 @@ export const OverflowMenu = ({
 
       {open ? (
         <Box
-          onClick={() => dispatch({ type: BACKDROP_CLICK })}
+          onClick={event => {
+            event.stopPropagation();
+            dispatch({ type: BACKDROP_CLICK });
+          }}
           position="fixed"
           className={styles.backdrop}
         />

--- a/lib/components/OverflowMenuItem/OverflowMenuItem.tsx
+++ b/lib/components/OverflowMenuItem/OverflowMenuItem.tsx
@@ -120,7 +120,8 @@ export const OverflowMenuItem = ({
       onKeyUp={onKeyUp}
       onKeyDown={onKeyDown}
       onMouseEnter={() => dispatch({ type: MENU_ITEM_HOVER, value: index })}
-      onClick={() => {
+      onClick={event => {
+        event.stopPropagation();
         dispatch({ type: MENU_ITEM_CLICK });
         clickHandler();
       }}


### PR DESCRIPTION
Click events should never bubble out of the `OverflowMenu` component. This can cause issues when the menu is inside a clickable container. Stopping propagation of the event prevents the click handler of the parent container firing.