### PR TITLE
fix(Column): Support full height content

### DIFF
--- a/lib/components/Column/Column.tsx
+++ b/lib/components/Column/Column.tsx
@@ -22,6 +22,7 @@ export const Column = ({ children, width }: ColumnProps) => {
       <Box
         paddingLeft={[collapse ? 'none' : mobileSpace, desktopSpace]}
         paddingTop={collapse ? [mobileSpace, 'none'] : undefined}
+        height="full"
         className={styles.columnContent}
       >
         {children}


### PR DESCRIPTION
Allows consumer to vertically center elements within column layouts by ensuring all `Column` components are full height. See [Playroom example](https://braid-design-system--612777060c8ea61789940cee47313560ee491317.surge.sh/playroom/#?code=N4Igxg9gJgpiBcIA8BhCAbArgWwHYGcA+AHVwAIzUMdcTyLKAhCADzICMBDMAawHMAThEy4oAXmIhcMTABcBndJLIB3AJZRZACwkgAZpnRKQZfLICe6GGODAyWmGr5bZ8MpIDMAJgAMABxZlAF8gsgB6OgokMLQsPEjKWJoEqOY2BycXXQMjZSg1fD90TnNsq0CTRSdcAElZGGx8XTAYXHqBSRSGJAAVGBZZUzUAL2tJYoE+GE6UVvayKr5pKDIANxgBWTUwRXRzBfQIXD58DRgh9nQ1Y7JIONxovoGu6LSE6KT40g-qPCJSEBBIA) 