### PR TITLE
fix: Support 'readonly' arrays for responsive props

### DIFF
--- a/lib/utils/resolveResponsiveProp.ts
+++ b/lib/utils/resolveResponsiveProp.ts
@@ -1,4 +1,6 @@
-export type ResponsiveProp<AtomName> = AtomName | [AtomName, AtomName];
+export type ResponsiveProp<AtomName> =
+  | AtomName
+  | Readonly<[AtomName, AtomName]>;
 export const resolveResponsiveProp = <Keys extends string>(
   value: ResponsiveProp<Keys>,
   mobileAtoms: Record<Keys, string>,

--- a/site/src/App/Documentation/Documentation.tsx
+++ b/site/src/App/Documentation/Documentation.tsx
@@ -49,7 +49,7 @@ const MenuSectionList = ({
   </Stack>
 );
 
-const responsiveGutter: ['gutter', 'large'] = ['gutter', 'large'];
+const responsiveGutter = ['gutter', 'large'] as const;
 
 export const Documentation = () => {
   const location = useLocation();


### PR DESCRIPTION
Currently, the following code fails to type check:

```
const responsiveSpace = ['small', 'large'] as const;

<Box padding={responsiveSpace} />
```

This code causes the following type error: `The type 'readonly ["small", "large"]' is 'readonly' and cannot be assigned to the mutable type '[Space, Space]'.`

This PR fixes this by marking responsive prop arrays as `Readonly`.