### PR TITLE
fix(Textarea): Ensure default border is visible in IE11

### DIFF
--- a/lib/components/Autosuggest/Autosuggest.tsx
+++ b/lib/components/Autosuggest/Autosuggest.tsx
@@ -542,7 +542,6 @@ export function Autosuggest<Value>({
               overlays,
               {
                 background,
-                boxShadow,
                 borderRadius,
                 paddingX,
                 className,
@@ -555,7 +554,6 @@ export function Autosuggest<Value>({
               <Box {...a11y.rootProps}>
                 <Box
                   component="input"
-                  boxShadow={boxShadow}
                   borderRadius={borderRadius}
                   paddingX={paddingX}
                   {...restFieldProps}

--- a/lib/components/Textarea/Textarea.treat.ts
+++ b/lib/components/Textarea/Textarea.treat.ts
@@ -1,6 +1,10 @@
 import { style } from 'sku/treat';
 
-export const field = style(({ grid }) => ({
-  resize: 'vertical',
-  minHeight: grid * 15,
-}));
+export const field = [
+  style({
+    resize: 'vertical',
+  }),
+  style(({ grid }) => ({
+    minHeight: grid * 15,
+  })),
+];

--- a/lib/components/private/Field/Field.tsx
+++ b/lib/components/private/Field/Field.tsx
@@ -55,7 +55,6 @@ type PassthroughProps =
   | 'autoFocus';
 interface FieldRenderProps extends Pick<FieldProps, PassthroughProps> {
   background: BoxProps['background'];
-  boxShadow: BoxProps['boxShadow'];
   borderRadius: BoxProps['borderRadius'];
   width: BoxProps['width'];
   paddingX: BoxProps['paddingX'];
@@ -110,8 +109,7 @@ export const Field = forwardRef<FieldRef, InternalFieldProps>(
 
     const messageId = `${id}-message`;
     const fieldBackground = disabled ? 'inputDisabled' : 'input';
-    const fieldBoxShadow: BoxProps['boxShadow'] =
-      useBackground() === 'brand' ? 'borderStandardInverted' : 'borderStandard';
+    const showFieldBorder = useBackground() !== 'brand';
 
     const clearHandler = useCallback(() => {
       if (typeof onClear !== 'function') {
@@ -130,6 +128,11 @@ export const Field = forwardRef<FieldRef, InternalFieldProps>(
 
     const overlays = (
       <Fragment>
+        <FieldOverlay variant="default" visible={showFieldBorder} />
+        <FieldOverlay
+          variant="critical"
+          visible={tone === 'critical' && !disabled}
+        />
         <FieldOverlay variant="focus" className={styles.focusOverlay} />
         <FieldOverlay variant="hover" className={styles.hoverOverlay} />
       </Fragment>
@@ -176,10 +179,6 @@ export const Field = forwardRef<FieldRef, InternalFieldProps>(
                 id,
                 name,
                 background: fieldBackground,
-                boxShadow:
-                  tone === 'critical' && !disabled
-                    ? 'borderCritical'
-                    : fieldBoxShadow,
                 width: 'full',
                 paddingX: 'small',
                 borderRadius: 'standard',

--- a/lib/components/private/FieldOverlay/FieldOverlay.tsx
+++ b/lib/components/private/FieldOverlay/FieldOverlay.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { Overlay, OverlayProps } from '../Overlay/Overlay';
 
-type FieldOverlayVariant = 'focus' | 'hover' | 'critical';
+type FieldOverlayVariant = 'default' | 'focus' | 'hover' | 'critical';
 export interface FieldOverlayProps
   extends Pick<
     OverlayProps,
-    'children' | 'background' | 'borderRadius' | 'className'
+    'children' | 'visible' | 'background' | 'borderRadius' | 'className'
   > {
   variant?: FieldOverlayVariant;
 }
@@ -14,6 +14,7 @@ const boxShadowForVariant: Record<
   FieldOverlayVariant,
   OverlayProps['boxShadow']
 > = {
+  default: 'borderStandard',
   focus: 'outlineFocus',
   hover: 'borderFormAccent',
   critical: 'borderCritical',

--- a/lib/components/private/InlineField/InlineField.tsx
+++ b/lib/components/private/InlineField/InlineField.tsx
@@ -51,7 +51,11 @@ const Indicator = ({
   const isCheckbox = type === 'checkbox';
 
   return isCheckbox ? (
-    <Box transition="fast" className={classnames(styles.checkboxIndicator)}>
+    <Box
+      height="full" // Needed for IE11
+      transition="fast"
+      className={classnames(styles.checkboxIndicator)}
+    >
       <IconTick
         size="fill"
         tone={disabled ? 'secondary' : hover ? 'formAccent' : undefined}

--- a/lib/components/private/Overlay/Overlay.treat.ts
+++ b/lib/components/private/Overlay/Overlay.treat.ts
@@ -5,5 +5,8 @@ export const root = style({
   bottom: 0,
   left: 0,
   right: 0,
+});
+
+export const hidden = style({
   opacity: 0,
 });

--- a/lib/components/private/Overlay/Overlay.tsx
+++ b/lib/components/private/Overlay/Overlay.tsx
@@ -4,23 +4,27 @@ import classnames from 'classnames';
 import { Box, BoxProps } from '../../Box/Box';
 import * as styleRefs from './Overlay.treat';
 
-export type OverlayProps = Partial<
-  Pick<
-    BoxProps,
-    | 'children'
-    | 'background'
-    | 'borderRadius'
-    | 'boxShadow'
-    | 'transition'
-    | 'className'
-  >
->;
+export interface OverlayProps
+  extends Partial<
+    Pick<
+      BoxProps,
+      | 'children'
+      | 'background'
+      | 'borderRadius'
+      | 'boxShadow'
+      | 'transition'
+      | 'className'
+    >
+  > {
+  visible?: boolean;
+}
 
 export const Overlay = ({
   background,
   borderRadius,
   boxShadow,
   transition,
+  visible = false,
   className,
   children,
 }: OverlayProps) => {
@@ -34,7 +38,11 @@ export const Overlay = ({
       borderRadius={borderRadius}
       boxShadow={boxShadow}
       transition={transition}
-      className={classnames(styles.root, className)}
+      className={classnames(
+        styles.root,
+        !visible ? styles.hidden : null,
+        className,
+      )}
     >
       {children}
     </Box>


### PR DESCRIPTION
## Development notes

For some reason, IE11 doesn't render inset box shadows on `textarea` elements. To fix this, I've converted the border to a `FieldOverlay`, like all the other states.