### PR TITLE
fix(Button): Support data attribute mapping

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -1446,6 +1446,7 @@ exports[`Button 1`] = `
 {
   aria-describedby?: string
   children?: ReactNode
+  data?: Record<string, ReactText>
   id?: string
   loading?: boolean
   onClick?: (event: MouseEvent<HTMLButtonElement, MouseEvent>) => void

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -3,6 +3,9 @@ import {
   ButtonRenderer,
   ButtonRendererProps,
 } from '../ButtonRenderer/ButtonRenderer';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 
 type NativeButtonProps = AllHTMLAttributes<HTMLButtonElement>;
 export interface ButtonProps {
@@ -13,6 +16,7 @@ export interface ButtonProps {
   weight?: ButtonRendererProps['weight'];
   loading?: ButtonRendererProps['loading'];
   'aria-describedby'?: NativeButtonProps['aria-describedby'];
+  data?: DataAttributeMap;
 }
 
 export const Button = ({
@@ -23,6 +27,7 @@ export const Button = ({
   id,
   loading = false,
   'aria-describedby': ariaDescribedBy,
+  data,
 }: ButtonProps) => {
   return (
     <ButtonRenderer weight={weight} loading={loading}>
@@ -34,6 +39,7 @@ export const Button = ({
           onClick={onClick}
           disabled={loading}
           {...buttonProps}
+          {...buildDataAttributes(data)}
         >
           <ButtonChildren>{children}</ButtonChildren>
         </button>


### PR DESCRIPTION
Adds support for passing data attributes to `Button` components, eg:

```jsx
<Button data={{ testId: 'save' }}>
  Save
</Button>
// => <button data-testId="save">Save</button>
```