### PR TITLE
fix: Ensure responsive props work in dynamically loaded chunks

### DIFF
--- a/lib/utils/resolveResponsiveProp.ts
+++ b/lib/utils/resolveResponsiveProp.ts
@@ -8,7 +8,7 @@ export const resolveResponsiveProp = <Keys extends string>(
 ) => {
   if (typeof value === 'string') {
     return mobileAtoms[value!];
-  } else if (value instanceof Array) {
+  } else if (Array.isArray(value)) {
     const [mobileValue, desktopValue] = value;
     return mobileValue !== desktopValue
       ? [mobileAtoms[mobileValue!], desktopAtoms[desktopValue!]]


### PR DESCRIPTION
The `instanceof Array` check returns false when the array was generated in a different global context, i.e. there are multiple `Array` globals in play. This fixes it by using `Array.isArray()` instead.