### PR TITLE
feat: Support for labelling Checkbox & Radio externally

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -1482,12 +1482,13 @@ exports[`Card 1`] = `
 
 exports[`Checkbox 1`] = `
 {
+  aria-labelledby?: string
   checked: boolean
   children?: ReactNode
   data?: Record<string, ReactText>
   disabled?: boolean
   id: string
-  label: ReactNode
+  label?: ReactNode
   message?: ReactNode
   name?: string
   onChange: (event: FormEvent<HTMLFormElement>) => void
@@ -3130,12 +3131,13 @@ exports[`OverflowMenuItem 1`] = `
 
 exports[`Radio 1`] = `
 {
+  aria-labelledby?: string
   checked: boolean
   children?: ReactNode
   data?: Record<string, ReactText>
   disabled?: boolean
   id: string
-  label: ReactNode
+  label?: ReactNode
   name?: string
   onChange: (event: FormEvent<HTMLFormElement>) => void
   ref?: 

--- a/lib/components/Checkbox/Checkbox.docs.tsx
+++ b/lib/components/Checkbox/Checkbox.docs.tsx
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { Checkbox } from './Checkbox';
 import { Text } from '../Text/Text';
+import { Column } from '../Column/Column';
+import { Columns } from '../Columns/Columns';
+import { Box } from '../Box/Box';
 
 const docs: ComponentDocs = {
   migrationGuide: true,
@@ -75,6 +78,42 @@ const docs: ComponentDocs = {
           <Text>This text is visible when the checkbox is checked.</Text>
         </Checkbox>
       ),
+    },
+    {
+      label: 'Standalone custom checkbox usage',
+      Container: ({ children }: { children: ReactNode }) => (
+        <Box style={{ maxWidth: 300 }}>{children}</Box>
+      ),
+      Example: ({ id, handler }) => {
+        const labelElementId = `customLabel_${id}`;
+        return (
+          <Box
+            background="neutralLight"
+            borderRadius="standard"
+            boxShadow="borderStandard"
+            padding="small"
+          >
+            <Columns space="small">
+              <Column>
+                <Box display="flex" alignItems="center" height="full">
+                  <Text component="label" id={labelElementId}>
+                    Custom standalone label
+                  </Text>
+                </Box>
+              </Column>
+              <Column width="content">
+                <Checkbox
+                  id={id}
+                  aria-labelledby={labelElementId}
+                  checked={true}
+                  onChange={handler}
+                  reserveMessageSpace={false}
+                />
+              </Column>
+            </Columns>
+          </Box>
+        );
+      },
     },
   ],
 };

--- a/lib/components/Radio/Radio.docs.tsx
+++ b/lib/components/Radio/Radio.docs.tsx
@@ -1,7 +1,10 @@
-import React from 'react';
+import React, { ReactNode } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { Radio } from './Radio';
 import { Text } from '../Text/Text';
+import { Box } from '../Box/Box';
+import { Columns } from '../Columns/Columns';
+import { Column } from '../Column/Column';
 
 const docs: ComponentDocs = {
   migrationGuide: true,
@@ -49,6 +52,41 @@ const docs: ComponentDocs = {
           <Text>This text is visible when the radio button is checked.</Text>
         </Radio>
       ),
+    },
+    {
+      label: 'Standalone custom radio usage',
+      Container: ({ children }: { children: ReactNode }) => (
+        <Box style={{ maxWidth: 300 }}>{children}</Box>
+      ),
+      Example: ({ id, handler }) => {
+        const labelElementId = `customLabel_${id}`;
+        return (
+          <Box
+            background="neutralLight"
+            borderRadius="standard"
+            boxShadow="borderStandard"
+            padding="small"
+          >
+            <Columns space="small">
+              <Column>
+                <Box display="flex" alignItems="center" height="full">
+                  <Text component="label" id={labelElementId}>
+                    Custom standalone label
+                  </Text>
+                </Box>
+              </Column>
+              <Column width="content">
+                <Radio
+                  id={id}
+                  aria-labelledby={labelElementId}
+                  checked={true}
+                  onChange={handler}
+                />
+              </Column>
+            </Columns>
+          </Box>
+        );
+      },
     },
   ],
 };

--- a/lib/components/private/InlineField/InlineField.treat.ts
+++ b/lib/components/private/InlineField/InlineField.treat.ts
@@ -15,18 +15,25 @@ const fakeFieldBase = style({
   flexShrink: 0,
 });
 
-const fakeFieldSize = style(theme => {
+export const visibleFieldSize = style(theme => {
   const size = getSize(theme);
-  const { touchableSize, grid } = theme;
 
   return {
     height: size,
     width: size,
+  };
+});
+
+export const fakeFieldTopOffset = style(theme => {
+  const size = getSize(theme);
+  const { touchableSize, grid } = theme;
+
+  return {
     marginTop: (grid * touchableSize - size) / 2,
   };
 });
 
-export const fakeField = [fakeFieldSize, fakeFieldBase];
+export const fakeField = [visibleFieldSize, fakeFieldBase];
 
 export const label = style({
   userSelect: 'none',


### PR DESCRIPTION
Adds support for consumers to use `Checkbox` or `Radio` in custom components/layouts while retaining screen reader accessibility by providing the `aria-labelledby` prop.