### PR TITLE
fix: Scope z-index elevations in Toggle, Checkbox & Radio

### DIFF
--- a/lib/components/Toggle/Toggle.treat.ts
+++ b/lib/components/Toggle/Toggle.treat.ts
@@ -4,6 +4,12 @@ import getSize from '../private/InlineField/getSize';
 const toggleWidthRatio = 1.6;
 const anticipationRatio = 0.12;
 
+// Reset the z-index at the parent level to scope
+// overrides internally.
+export const root = style({
+  zIndex: 0,
+});
+
 export const realField = style({
   opacity: 0,
   zIndex: 1,

--- a/lib/components/Toggle/Toggle.tsx
+++ b/lib/components/Toggle/Toggle.tsx
@@ -40,6 +40,7 @@ export const Toggle = ({
       position="relative"
       display="flex"
       flexDirection={align === 'right' ? 'rowReverse' : undefined}
+      className={styles.root}
     >
       <Box
         component="input"

--- a/lib/components/private/Field/Field.treat.ts
+++ b/lib/components/private/Field/Field.treat.ts
@@ -1,5 +1,4 @@
 import { style, styleMap } from 'sku/treat';
-import * as zIndex from '../zIndex';
 
 export const field = style({
   outline: 'none',
@@ -18,7 +17,6 @@ export const iconSpace = style(theme => ({
 }));
 
 export const icon = style({
-  zIndex: zIndex.inlineOverlay,
   top: 0,
   left: 0,
 });

--- a/lib/components/private/InlineField/InlineField.treat.ts
+++ b/lib/components/private/InlineField/InlineField.treat.ts
@@ -1,6 +1,12 @@
 import { style } from 'sku/treat';
 import getSize from './getSize';
 
+// Reset the z-index at the parent level to scope
+// overrides internally.
+export const root = style({
+  zIndex: 0,
+});
+
 export const realField = style({
   opacity: 0,
   zIndex: 1,

--- a/lib/components/private/InlineField/InlineField.tsx
+++ b/lib/components/private/InlineField/InlineField.tsx
@@ -104,7 +104,7 @@ export const InlineField = forwardRef<HTMLElement, InternalInlineFieldProps>(
     const accentBackground = disabled ? 'formAccentDisabled' : 'formAccent';
 
     return (
-      <Box position="relative">
+      <Box position="relative" className={styles.root}>
         <Box
           component="input"
           type={type}


### PR DESCRIPTION
Also removes the unnecessary z-index elevation to field icons for `TextField`, `Dropdown` & `Autosuggest`.