### PR TITLE
docs(site): Categorise components in site menu

### DIFF
--- a/lib/components/Actions/Actions.docs.tsx
+++ b/lib/components/Actions/Actions.docs.tsx
@@ -5,6 +5,7 @@ import { Button } from '../Button/Button';
 import { TextLink } from '../TextLink/TextLink';
 
 const docs: ComponentDocs = {
+  category: 'Interaction',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/Alert/Alert.docs.tsx
+++ b/lib/components/Alert/Alert.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../site/src/types';
 import { Alert } from './Alert';
 
 const docs: ComponentDocs = {
+  category: 'Content',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/Autosuggest/Autosuggest.docs.tsx
+++ b/lib/components/Autosuggest/Autosuggest.docs.tsx
@@ -32,6 +32,7 @@ interface Value {
 }
 
 const docs: ComponentDocs = {
+  category: 'Interaction',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/Badge/Badge.docs.tsx
+++ b/lib/components/Badge/Badge.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../site/src/types';
 import { Badge } from './Badge';
 
 const docs: ComponentDocs = {
+  category: 'Content',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/Box/Box.docs.tsx
+++ b/lib/components/Box/Box.docs.tsx
@@ -8,6 +8,7 @@ type Space = keyof typeof tokens.space;
 const spaceScale = Object.keys(tokens.space) as Space[];
 
 const docs: ComponentDocs = {
+  category: 'Layout',
   storybook: false,
   examples: spaceScale.map(
     (space): ComponentExample => ({

--- a/lib/components/Box/BoxRenderer.docs.tsx
+++ b/lib/components/Box/BoxRenderer.docs.tsx
@@ -4,6 +4,7 @@ import { BoxRenderer } from './BoxRenderer';
 import { Text } from '../Text/Text';
 
 const docs: ComponentDocs = {
+  category: 'Layout',
   examples: [
     {
       label: 'Standard BoxRenderer',

--- a/lib/components/BraidLoadableProvider/BraidLoadableProvider.docs.tsx
+++ b/lib/components/BraidLoadableProvider/BraidLoadableProvider.docs.tsx
@@ -1,6 +1,7 @@
 import { ComponentDocs } from '../../../site/src/types';
 
 const docs: ComponentDocs = {
+  category: 'Logic',
   examples: [
     {
       code: `

--- a/lib/components/BraidProvider/BraidProvider.docs.tsx
+++ b/lib/components/BraidProvider/BraidProvider.docs.tsx
@@ -1,6 +1,7 @@
 import { ComponentDocs } from '../../../site/src/types';
 
 const docs: ComponentDocs = {
+  category: 'Logic',
   examples: [
     {
       code: `

--- a/lib/components/Bullet/Bullet.docs.tsx
+++ b/lib/components/Bullet/Bullet.docs.tsx
@@ -4,6 +4,7 @@ import { Bullet } from './Bullet';
 import { BulletList } from '../BulletList/BulletList';
 
 const docs: ComponentDocs = {
+  category: 'Content',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/BulletList/BulletList.docs.tsx
+++ b/lib/components/BulletList/BulletList.docs.tsx
@@ -2,6 +2,7 @@ import bulletDocs from '../Bullet/Bullet.docs';
 import { ComponentDocs } from '../../../site/src/types';
 
 const docs: ComponentDocs = {
+  category: 'Content',
   examples: bulletDocs.examples,
 };
 

--- a/lib/components/Button/Button.docs.tsx
+++ b/lib/components/Button/Button.docs.tsx
@@ -8,6 +8,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
+  category: 'Interaction',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/ButtonRenderer/ButtonRenderer.docs.tsx
+++ b/lib/components/ButtonRenderer/ButtonRenderer.docs.tsx
@@ -8,6 +8,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
+  category: 'Interaction',
   examples: [
     {
       label: 'Button with Custom Renderer',

--- a/lib/components/Card/Card.docs.tsx
+++ b/lib/components/Card/Card.docs.tsx
@@ -5,6 +5,7 @@ import { Box } from '../Box/Box';
 import { Text } from '../Text/Text';
 
 const docs: ComponentDocs = {
+  category: 'Layout',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/Checkbox/Checkbox.docs.tsx
+++ b/lib/components/Checkbox/Checkbox.docs.tsx
@@ -4,6 +4,7 @@ import { Checkbox } from './Checkbox';
 import { Text } from '../Text/Text';
 
 const docs: ComponentDocs = {
+  category: 'Interaction',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/Column/Column.docs.tsx
+++ b/lib/components/Column/Column.docs.tsx
@@ -16,6 +16,7 @@ const Content = ({ children = 'Column' }) => (
 );
 
 const docs: ComponentDocs = {
+  category: 'Layout',
   examples: [
     {
       label: 'Standard Columns',

--- a/lib/components/Columns/Columns.docs.tsx
+++ b/lib/components/Columns/Columns.docs.tsx
@@ -13,6 +13,7 @@ const Content = ({ children = 'Column' }) => (
 );
 
 const docs: ComponentDocs = {
+  category: 'Layout',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/ContentBlock/ContentBlock.docs.tsx
+++ b/lib/components/ContentBlock/ContentBlock.docs.tsx
@@ -5,6 +5,7 @@ import { HideCode } from '../private/HideCode';
 import { ContentBlock } from './ContentBlock';
 
 const docs: ComponentDocs = {
+  category: 'Layout',
   examples: [
     {
       label: 'Default Content Block',

--- a/lib/components/Divider/Divider.docs.tsx
+++ b/lib/components/Divider/Divider.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../site/src/types';
 import { Divider } from './Divider';
 
 const docs: ComponentDocs = {
+  category: 'Layout',
   examples: [
     {
       label: 'Standard Divider',

--- a/lib/components/Dropdown/Dropdown.docs.tsx
+++ b/lib/components/Dropdown/Dropdown.docs.tsx
@@ -9,6 +9,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
+  category: 'Interaction',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/FieldLabel/FieldLabel.docs.tsx
+++ b/lib/components/FieldLabel/FieldLabel.docs.tsx
@@ -8,6 +8,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
+  category: 'Interaction',
   examples: [
     {
       label: 'Standard Field Label',

--- a/lib/components/FieldMessage/FieldMessage.docs.tsx
+++ b/lib/components/FieldMessage/FieldMessage.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../site/src/types';
 import { FieldMessage } from './FieldMessage';
 
 const docs: ComponentDocs = {
+  category: 'Interaction',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/Heading/Heading.docs.tsx
+++ b/lib/components/Heading/Heading.docs.tsx
@@ -11,6 +11,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
+  category: 'Content',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/Hidden/Hidden.docs.tsx
+++ b/lib/components/Hidden/Hidden.docs.tsx
@@ -5,6 +5,7 @@ import { Text } from '../Text/Text';
 import { Stack } from '../Stack/Stack';
 
 const docs: ComponentDocs = {
+  category: 'Layout',
   examples: [
     {
       label: 'Hidden below tablet',

--- a/lib/components/Inline/Inline.docs.tsx
+++ b/lib/components/Inline/Inline.docs.tsx
@@ -19,6 +19,7 @@ const Item = () => (
 );
 
 const docs: ComponentDocs = {
+  category: 'Layout',
   examples: [
     ...spaces.map(space => ({
       label: `Space: ${space}`,

--- a/lib/components/Loader/Loader.docs.tsx
+++ b/lib/components/Loader/Loader.docs.tsx
@@ -5,6 +5,7 @@ import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
 import { Box } from '../Box/Box';
 
 const docs: ComponentDocs = {
+  category: 'Content',
   examples: [
     {
       label: 'Default',

--- a/lib/components/MonthPicker/MonthPicker.docs.tsx
+++ b/lib/components/MonthPicker/MonthPicker.docs.tsx
@@ -11,6 +11,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
+  category: 'Interaction',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/OverflowMenu/OverflowMenu.docs.tsx
+++ b/lib/components/OverflowMenu/OverflowMenu.docs.tsx
@@ -5,6 +5,7 @@ import { OverflowMenu } from './OverflowMenu';
 import { OverflowMenuItem } from '../OverflowMenuItem/OverflowMenuItem';
 
 const docs: ComponentDocs = {
+  category: 'Interaction',
   examples: [
     {
       label: 'Default',

--- a/lib/components/OverflowMenuItem/OverflowMenuItem.docs.tsx
+++ b/lib/components/OverflowMenuItem/OverflowMenuItem.docs.tsx
@@ -5,6 +5,7 @@ import { OverflowMenuItem } from './OverflowMenuItem';
 import { OverflowMenu } from '../OverflowMenu/OverflowMenu';
 
 const docs: ComponentDocs = {
+  category: 'Interaction',
   examples: [
     {
       label: 'Default',

--- a/lib/components/Radio/Radio.docs.tsx
+++ b/lib/components/Radio/Radio.docs.tsx
@@ -4,6 +4,7 @@ import { Radio } from './Radio';
 import { Text } from '../Text/Text';
 
 const docs: ComponentDocs = {
+  category: 'Interaction',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/Secondary/Secondary.docs.tsx
+++ b/lib/components/Secondary/Secondary.docs.tsx
@@ -4,6 +4,7 @@ import { Secondary } from './Secondary';
 import { Text } from '../Text/Text';
 
 const docs: ComponentDocs = {
+  category: 'Content',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/Stack/Stack.docs.tsx
+++ b/lib/components/Stack/Stack.docs.tsx
@@ -32,6 +32,7 @@ const Header = ({ children = 'Content' }: { children?: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
+  category: 'Layout',
   migrationGuide: true,
   examples: [
     ...spaces.map(space => ({

--- a/lib/components/Strong/Strong.docs.tsx
+++ b/lib/components/Strong/Strong.docs.tsx
@@ -4,6 +4,7 @@ import { Strong } from './Strong';
 import { Text } from '../Text/Text';
 
 const docs: ComponentDocs = {
+  category: 'Content',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/Text/Text.docs.tsx
+++ b/lib/components/Text/Text.docs.tsx
@@ -12,6 +12,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
+  category: 'Content',
   migrationGuide: true,
   examples: [
     { label: 'Standard Text', Example: () => <Text>Standard text.</Text> },

--- a/lib/components/TextField/TextField.docs.tsx
+++ b/lib/components/TextField/TextField.docs.tsx
@@ -10,6 +10,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
+  category: 'Interaction',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/TextLink/TextLink.docs.tsx
+++ b/lib/components/TextLink/TextLink.docs.tsx
@@ -10,6 +10,7 @@ import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
 import { Box } from '../Box/Box';
 
 const docs: ComponentDocs = {
+  category: 'Interaction',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.docs.tsx
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.docs.tsx
@@ -5,6 +5,7 @@ import { TextLinkRenderer } from './TextLinkRenderer';
 import { Text } from '../Text/Text';
 
 const docs: ComponentDocs = {
+  category: 'Interaction',
   examples: [
     {
       label: 'TextLink with Custom Renderer',

--- a/lib/components/Textarea/Textarea.docs.tsx
+++ b/lib/components/Textarea/Textarea.docs.tsx
@@ -8,6 +8,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
+  category: 'Interaction',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/ThemeNameConsumer/ThemeNameConsumer.docs.tsx
+++ b/lib/components/ThemeNameConsumer/ThemeNameConsumer.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../site/src/types';
 import { ThemeNameConsumer } from './ThemeNameConsumer';
 
 const docs: ComponentDocs = {
+  category: 'Logic',
   storybook: false,
   examples: [
     {

--- a/lib/components/Toggle/Toggle.docs.tsx
+++ b/lib/components/Toggle/Toggle.docs.tsx
@@ -7,6 +7,7 @@ const handler = () => {
 };
 
 const docs: ComponentDocs = {
+  category: 'Interaction',
   migrationGuide: true,
   examples: [
     {

--- a/lib/components/icons/IconAdd/IconAdd.docs.tsx
+++ b/lib/components/icons/IconAdd/IconAdd.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconAdd } from './IconAdd';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconBookmark/IconBookmark.docs.tsx
+++ b/lib/components/icons/IconBookmark/IconBookmark.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconBookmark } from './IconBookmark';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconChevron/IconChevron.docs.tsx
+++ b/lib/components/icons/IconChevron/IconChevron.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconChevron } from './IconChevron';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconClear/IconClear.docs.tsx
+++ b/lib/components/icons/IconClear/IconClear.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconClear } from './IconClear';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconCompany/IconCompany.docs.tsx
+++ b/lib/components/icons/IconCompany/IconCompany.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconCompany } from './IconCompany';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconCompose/IconCompose.docs.tsx
+++ b/lib/components/icons/IconCompose/IconCompose.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconCompose } from './IconCompose';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconCopy/IconCopy.docs.tsx
+++ b/lib/components/icons/IconCopy/IconCopy.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconCopy } from './IconCopy';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconCreditCard/IconCreditCard.docs.tsx
+++ b/lib/components/icons/IconCreditCard/IconCreditCard.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconCreditCard } from './IconCreditCard';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconCritical/IconCritical.docs.tsx
+++ b/lib/components/icons/IconCritical/IconCritical.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconCritical } from './IconCritical';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconDate/IconDate.docs.tsx
+++ b/lib/components/icons/IconDate/IconDate.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconDate } from './IconDate';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconDelete/IconDelete.docs.tsx
+++ b/lib/components/icons/IconDelete/IconDelete.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconDelete } from './IconDelete';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconDocument/IconDocument.docs.tsx
+++ b/lib/components/icons/IconDocument/IconDocument.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconDocument } from './IconDocument';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconDownload/IconDownload.docs.tsx
+++ b/lib/components/icons/IconDownload/IconDownload.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconDownload } from './IconDownload';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconEdit/IconEdit.docs.tsx
+++ b/lib/components/icons/IconEdit/IconEdit.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconEdit } from './IconEdit';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconEducation/IconEducation.docs.tsx
+++ b/lib/components/icons/IconEducation/IconEducation.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconEducation } from './IconEducation';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconFilter/IconFilter.docs.tsx
+++ b/lib/components/icons/IconFilter/IconFilter.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconFilter } from './IconFilter';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconGrid/IconGrid.docs.tsx
+++ b/lib/components/icons/IconGrid/IconGrid.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconGrid } from './IconGrid';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconHeart/IconHeart.docs.tsx
+++ b/lib/components/icons/IconHeart/IconHeart.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconHeart } from './IconHeart';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconHelp/IconHelp.docs.tsx
+++ b/lib/components/icons/IconHelp/IconHelp.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconHelp } from './IconHelp';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconHistory/IconHistory.docs.tsx
+++ b/lib/components/icons/IconHistory/IconHistory.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconHistory } from './IconHistory';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconHome/IconHome.docs.tsx
+++ b/lib/components/icons/IconHome/IconHome.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconHome } from './IconHome';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconImage/IconImage.docs.tsx
+++ b/lib/components/icons/IconImage/IconImage.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconImage } from './IconImage';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconInfo/IconInfo.docs.tsx
+++ b/lib/components/icons/IconInfo/IconInfo.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconInfo } from './IconInfo';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconInvoice/IconInvoice.docs.tsx
+++ b/lib/components/icons/IconInvoice/IconInvoice.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconInvoice } from './IconInvoice';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconList/IconList.docs.tsx
+++ b/lib/components/icons/IconList/IconList.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconList } from './IconList';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconLocation/IconLocation.docs.tsx
+++ b/lib/components/icons/IconLocation/IconLocation.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconLocation } from './IconLocation';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconMail/IconMail.docs.tsx
+++ b/lib/components/icons/IconMail/IconMail.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconMail } from './IconMail';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconMinus/IconMinus.docs.tsx
+++ b/lib/components/icons/IconMinus/IconMinus.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconMinus } from './IconMinus';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconMoney/IconMoney.docs.tsx
+++ b/lib/components/icons/IconMoney/IconMoney.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconMoney } from './IconMoney';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconNewWindow/IconNewWindow.docs.tsx
+++ b/lib/components/icons/IconNewWindow/IconNewWindow.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconNewWindow } from './IconNewWindow';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconNote/IconNote.docs.tsx
+++ b/lib/components/icons/IconNote/IconNote.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconNote } from './IconNote';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconOverflow/IconOverflow.docs.tsx
+++ b/lib/components/icons/IconOverflow/IconOverflow.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconOverflow } from './IconOverflow';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconPeople/IconPeople.docs.tsx
+++ b/lib/components/icons/IconPeople/IconPeople.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconPeople } from './IconPeople';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconPersonAdd/IconPersonAdd.docs.tsx
+++ b/lib/components/icons/IconPersonAdd/IconPersonAdd.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconPersonAdd } from './IconPersonAdd';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconPersonVerified/IconPersonVerified.docs.tsx
+++ b/lib/components/icons/IconPersonVerified/IconPersonVerified.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconPersonVerified } from './IconPersonVerified';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconPhone/IconPhone.docs.tsx
+++ b/lib/components/icons/IconPhone/IconPhone.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconPhone } from './IconPhone';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconPositive/IconPositive.docs.tsx
+++ b/lib/components/icons/IconPositive/IconPositive.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconPositive } from './IconPositive';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconPrint/IconPrint.docs.tsx
+++ b/lib/components/icons/IconPrint/IconPrint.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconPrint } from './IconPrint';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconProfile/IconProfile.docs.tsx
+++ b/lib/components/icons/IconProfile/IconProfile.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconProfile } from './IconProfile';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconPromote/IconPromote.docs.tsx
+++ b/lib/components/icons/IconPromote/IconPromote.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconPromote } from './IconPromote';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconRecommended/IconRecommended.docs.tsx
+++ b/lib/components/icons/IconRecommended/IconRecommended.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconRecommended } from './IconRecommended';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconResume/IconResume.docs.tsx
+++ b/lib/components/icons/IconResume/IconResume.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconResume } from './IconResume';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconSearch/IconSearch.docs.tsx
+++ b/lib/components/icons/IconSearch/IconSearch.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconSearch } from './IconSearch';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconSecurity/IconSecurity.docs.tsx
+++ b/lib/components/icons/IconSecurity/IconSecurity.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconSecurity } from './IconSecurity';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconSend/IconSend.docs.tsx
+++ b/lib/components/icons/IconSend/IconSend.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconSend } from './IconSend';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconSent/IconSent.docs.tsx
+++ b/lib/components/icons/IconSent/IconSent.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconSent } from './IconSent';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconSettings/IconSettings.docs.tsx
+++ b/lib/components/icons/IconSettings/IconSettings.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconSettings } from './IconSettings';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconShare/IconShare.docs.tsx
+++ b/lib/components/icons/IconShare/IconShare.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconShare } from './IconShare';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconSocialFacebook/IconSocialFacebook.docs.tsx
+++ b/lib/components/icons/IconSocialFacebook/IconSocialFacebook.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconSocialFacebook } from './IconSocialFacebook';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconSocialGitHub/IconSocialGitHub.docs.tsx
+++ b/lib/components/icons/IconSocialGitHub/IconSocialGitHub.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconSocialGitHub } from './IconSocialGitHub';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconSocialInstagram/IconSocialInstagram.docs.tsx
+++ b/lib/components/icons/IconSocialInstagram/IconSocialInstagram.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconSocialInstagram } from './IconSocialInstagram';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconSocialLinkedIn/IconSocialLinkedIn.docs.tsx
+++ b/lib/components/icons/IconSocialLinkedIn/IconSocialLinkedIn.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconSocialLinkedIn } from './IconSocialLinkedIn';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconSocialMedium/IconSocialMedium.docs.tsx
+++ b/lib/components/icons/IconSocialMedium/IconSocialMedium.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconSocialMedium } from './IconSocialMedium';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconSocialTwitter/IconSocialTwitter.docs.tsx
+++ b/lib/components/icons/IconSocialTwitter/IconSocialTwitter.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconSocialTwitter } from './IconSocialTwitter';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconStar/IconStar.docs.tsx
+++ b/lib/components/icons/IconStar/IconStar.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconStar } from './IconStar';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconSubCategory/IconSubCategory.docs.tsx
+++ b/lib/components/icons/IconSubCategory/IconSubCategory.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconSubCategory } from './IconSubCategory';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconTag/IconTag.docs.tsx
+++ b/lib/components/icons/IconTag/IconTag.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconTag } from './IconTag';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconTick/IconTick.docs.tsx
+++ b/lib/components/icons/IconTick/IconTick.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconTick } from './IconTick';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconTime/IconTime.docs.tsx
+++ b/lib/components/icons/IconTime/IconTime.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconTime } from './IconTime';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconUpload/IconUpload.docs.tsx
+++ b/lib/components/icons/IconUpload/IconUpload.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconUpload } from './IconUpload';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/IconVideo/IconVideo.docs.tsx
+++ b/lib/components/icons/IconVideo/IconVideo.docs.tsx
@@ -3,6 +3,7 @@ import { ComponentDocs } from '../../../../site/src/types';
 import { IconVideo } from './IconVideo';
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   storybook: false,

--- a/lib/components/icons/Icons.docs.tsx
+++ b/lib/components/icons/Icons.docs.tsx
@@ -27,6 +27,7 @@ const Icons = ({ tone }: { tone?: UseIconProps['tone'] }) => (
 );
 
 const docs: ComponentDocs = {
+  category: 'Icon',
   migrationGuide: true,
   foundation: true,
   examples: [

--- a/scripts/generateIcons.js
+++ b/scripts/generateIcons.js
@@ -162,6 +162,7 @@ const iconComponentsDir = path.join(baseDir, 'lib/components/icons');
           import { ${iconName} } from './${iconName}';
 
           const docs: ComponentDocs = {
+            category: 'Icon',
             migrationGuide: true,
             foundation: true,
             storybook: false,

--- a/site/src/App/Documentation/Documentation.treat.ts
+++ b/site/src/App/Documentation/Documentation.treat.ts
@@ -1,6 +1,6 @@
 import { globalStyle, style } from 'sku/treat';
 
-const desktopMenuWidth = '276px';
+const desktopMenuWidth = '284px';
 const headerHeight = '100px';
 
 export const isOpen = style({});

--- a/site/src/App/Documentation/Documentation.tsx
+++ b/site/src/App/Documentation/Documentation.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useStyles } from 'sku/treat';
 import map from 'lodash/map';
+import groupBy from 'lodash/groupBy';
 import guides from '../guides';
 import { Route, useLocation } from 'react-router-dom';
 import * as components from '../../../../lib/components';
@@ -11,9 +12,10 @@ import { Tones } from './Tones';
 import { Link, ExternalLink } from './Link';
 import { MenuButton } from '../MenuButton/MenuButton';
 import { ConfigConsumer } from '../ConfigContext';
+import { ComponentDocs } from '../../types';
 import * as styleRefs from './Documentation.treat';
 
-const { Heading, Text, Box, Hidden, Stack } = components;
+const { Text, Box, Hidden, Stack } = components;
 
 interface MenuItem {
   name: string;
@@ -29,9 +31,9 @@ const MenuSectionList = ({
   items: MenuItem[];
 }) => (
   <Stack space="large">
-    <Heading level="4" component="h2">
+    <Text weight="strong" component="h2">
       {title}
-    </Heading>
+    </Text>
 
     <Stack space="gutter">
       {items.map(({ name, path, onClick, external }) => (
@@ -64,6 +66,18 @@ export const Documentation = () => {
   const isComponentsHome = location.pathname === '/components';
   const showMenuButton = /(\/(guides|components|foundations)\/).*/.test(
     location.pathname,
+  );
+
+  const componentsByCategory = groupBy(
+    Object.keys(components)
+      .filter(name => !/^(Icon|use|BoxRenderer)/.test(name))
+      .map(name => {
+        const docs: ComponentDocs = require(`../../../../lib/components/${name}/${name}.docs.tsx`)
+          .default;
+
+        return { name, ...docs };
+      }),
+    component => component.category,
   );
 
   return (
@@ -154,8 +168,24 @@ export const Documentation = () => {
                     ]}
                   />
 
+                  {['Layout', 'Content', 'Interaction', 'Logic'].map(
+                    category => (
+                      <MenuSectionList
+                        title={`${category} Components`}
+                        items={componentsByCategory[category].map(
+                          ({ name }) => ({
+                            name,
+                            path: `/components/${name}`,
+                            external: false,
+                            onClick: () => setMenuOpen(false),
+                          }),
+                        )}
+                      />
+                    ),
+                  )}
+
                   <MenuSectionList
-                    title="Components"
+                    title="All Components"
                     items={Object.keys(components)
                       .filter(x => !/^(Icon|use|BoxRenderer)/.test(x))
                       .sort()

--- a/site/src/types.d.ts
+++ b/site/src/types.d.ts
@@ -18,6 +18,7 @@ export interface Page {
 }
 
 export interface ComponentDocs {
+  category: 'Logic' | 'Layout' | 'Content' | 'Interaction' | 'Icon';
   migrationGuide?: boolean;
   foundation?: boolean;
   storybook?: boolean;


### PR DESCRIPTION
In order make the components a little easier to discover without over-classifying them, I looked for a minimal set of categories with clear boundaries that actually help people learn about the components in the right order.

As a result, I landed on the following categories, in order:
- Layout Components, for _general purpose_ layout management. Any layout components that are coupled to specific component(s) don't belong in here, e.g. `Actions`, which instead belongs in the category of its child components.
- Content Components, for displaying static content.
- Interaction Components, for components that are primarily intended for user interaction.
- Logic Components, for things like `BraidProvider`, `ThemeNameConsumer` etc.

Happy to revisit this once we have more guides on these topics, which are likely to serve as a better onboarding mechanism for our component suite.