### PR TITLE
feat: Add "align" to Stack and Inline, add "alignY" to Columns

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -1534,6 +1534,11 @@ exports[`Column 1`] = `
 
 exports[`Columns 1`] = `
 {
+  alignY?: ResponsiveProp<
+    | "bottom"
+    | "center"
+    | "top"
+  >
   children: 
     | ReactElement<ColumnProps, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<...>)>
     | ReactElement<ColumnProps, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<...>)>[]
@@ -3076,6 +3081,11 @@ exports[`IconVideo 1`] = `
 
 exports[`Inline 1`] = `
 {
+  align?: ResponsiveProp<
+    | "center"
+    | "left"
+    | "right"
+  >
   children: ReactNode
   space: ResponsiveProp<
     | "gutter"
@@ -3181,6 +3191,11 @@ exports[`Secondary 1`] = `
 
 exports[`Stack 1`] = `
 {
+  align?: ResponsiveProp<
+    | "center"
+    | "left"
+    | "right"
+  >
   children: ReactNode
   dividers?: boolean
   space: ResponsiveProp<

--- a/lib/components/Bullet/Bullet.tsx
+++ b/lib/components/Bullet/Bullet.tsx
@@ -22,7 +22,7 @@ export const Bullet = ({ children }: BulletProps) => {
       component={component}
       className={classnames(
         useText({ size, baseline: true }),
-        useStackItem({ component, space }),
+        useStackItem({ component, space, align: 'left' }),
         styles.listItem,
       )}
     >

--- a/lib/components/Columns/Columns.docs.tsx
+++ b/lib/components/Columns/Columns.docs.tsx
@@ -106,6 +106,88 @@ const docs: ComponentDocs = {
       ),
     },
     {
+      label: 'Vertically align to center',
+      Example: () => (
+        <Columns space="small" alignY="center">
+          <Column>
+            <HideCode>
+              <Content>Content</Content>
+              <Content>Content</Content>
+            </HideCode>
+          </Column>
+          <Column>
+            <HideCode>
+              <Content>Content</Content>
+              <Content>Content</Content>
+              <Content>Content</Content>
+            </HideCode>
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label: 'Vertically align to bottom',
+      Example: () => (
+        <Columns space="small" alignY="bottom">
+          <Column>
+            <HideCode>
+              <Content>Content</Content>
+              <Content>Content</Content>
+            </HideCode>
+          </Column>
+          <Column>
+            <HideCode>
+              <Content>Content</Content>
+              <Content>Content</Content>
+              <Content>Content</Content>
+            </HideCode>
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label:
+        'Responsive alignment (e.g. top on mobile, center on tablet upwards)',
+      Example: () => (
+        <Columns space="small" alignY={['top', 'center']}>
+          <Column>
+            <HideCode>
+              <Content>Content</Content>
+              <Content>Content</Content>
+            </HideCode>
+          </Column>
+          <Column>
+            <HideCode>
+              <Content>Content</Content>
+              <Content>Content</Content>
+              <Content>Content</Content>
+            </HideCode>
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label: 'Alignment + collapse',
+      docsSite: false,
+      Example: () => (
+        <Columns space="small" collapseBelow="tablet" alignY="center">
+          <Column>
+            <HideCode>
+              <Content>Content</Content>
+              <Content>Content</Content>
+            </HideCode>
+          </Column>
+          <Column>
+            <HideCode>
+              <Content>Content</Content>
+              <Content>Content</Content>
+              <Content>Content</Content>
+            </HideCode>
+          </Column>
+        </Columns>
+      ),
+    },
+    {
       label: 'Collapse below tablet',
       Example: () => (
         <Columns space="small" collapseBelow="tablet">

--- a/lib/components/Columns/Columns.tsx
+++ b/lib/components/Columns/Columns.tsx
@@ -3,11 +3,15 @@ import { Box } from '../Box/Box';
 import { ColumnProps } from '../Column/Column';
 import { Space, ResponsiveSpace } from '../Box/useBoxStyles';
 import { useNegativeOffsetX } from '../../hooks/useNegativeOffset/useNegativeOffset';
-import { normaliseResponsiveProp } from '../../utils/responsiveProp';
+import {
+  normaliseResponsiveProp,
+  ResponsiveProp,
+} from '../../utils/responsiveProp';
 import {
   resolveResponsiveRangeProps,
   ResponsiveRangeProps,
 } from '../../utils/responsiveRangeProps';
+import { AlignY, alignYToFlexAlign } from '../../utils/align';
 
 interface ColumnsContextValue {
   collapseMobile: boolean;
@@ -28,6 +32,7 @@ export interface ColumnsProps {
   children: Array<ReactElement<ColumnProps>> | ReactElement<ColumnProps>;
   collapseBelow?: ResponsiveRangeProps['below'];
   reverse?: boolean;
+  alignY?: ResponsiveProp<AlignY>;
   space: ResponsiveSpace;
 }
 
@@ -36,6 +41,7 @@ export const Columns = ({
   collapseBelow,
   reverse = false,
   space = 'none',
+  alignY,
 }: ColumnsProps) => {
   const [mobileSpace, tabletSpace, desktopSpace] = normaliseResponsiveProp(
     space,
@@ -70,6 +76,7 @@ export const Columns = ({
   return (
     <Box
       display="flex"
+      alignItems={alignYToFlexAlign(alignY)}
       flexDirection={[
         collapseMobile ? 'column' : 'row',
         collapseTablet ? 'column' : rowReverseTablet ? 'rowReverse' : 'row',

--- a/lib/components/Inline/Inline.docs.tsx
+++ b/lib/components/Inline/Inline.docs.tsx
@@ -57,6 +57,61 @@ const docs: ComponentDocs = {
         </Inline>
       ),
     },
+    {
+      label: 'Align to center',
+      Container,
+      Example: () => (
+        <Inline space="small" align="center">
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+        </Inline>
+      ),
+    },
+    {
+      label: 'Align to right',
+      Container,
+      Example: () => (
+        <Inline space="small" align="right">
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+        </Inline>
+      ),
+    },
+    {
+      label:
+        'Responsive alignment (e.g. center on mobile, left from tablet upwards)',
+      Container,
+      Example: () => (
+        <Inline space="small" align={['center', 'left']}>
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+          <Item />
+        </Inline>
+      ),
+    },
   ],
 };
 

--- a/lib/components/Inline/Inline.tsx
+++ b/lib/components/Inline/Inline.tsx
@@ -7,14 +7,17 @@ import {
   useNegativeOffsetX,
   useNegativeOffsetY,
 } from '../../hooks/useNegativeOffset/useNegativeOffset';
+import { ResponsiveProp } from '../../utils/responsiveProp';
+import { Align, alignToFlexAlign } from '../../utils/align';
 import * as styleRefs from './Inline.treat';
 
 export interface InlineProps {
+  align?: ResponsiveProp<Align>;
   space: ResponsiveSpace;
   children: ReactNode;
 }
 
-export const Inline = ({ space = 'none', children }: InlineProps) => {
+export const Inline = ({ space = 'none', align, children }: InlineProps) => {
   const styles = useStyles(styleRefs);
   const negativeOffsetX = useNegativeOffsetX(space);
   const negativeOffsetY = useNegativeOffsetY(space);
@@ -23,6 +26,7 @@ export const Inline = ({ space = 'none', children }: InlineProps) => {
     <Box className={classnames(negativeOffsetY)}>
       <Box
         display="flex"
+        justifyContent={alignToFlexAlign(align)}
         className={classnames(styles.flexWrap, negativeOffsetX)}
       >
         {Children.map(children, child =>

--- a/lib/components/Stack/Stack.docs.tsx
+++ b/lib/components/Stack/Stack.docs.tsx
@@ -53,6 +53,40 @@ const docs: ComponentDocs = {
       ),
     })),
     {
+      label: 'Align to center',
+      Container,
+      Example: () => (
+        <Stack space="gutter" align="center">
+          <Box padding="small" background="info" style={{ width: 50 }} />
+          <Box padding="small" background="info" style={{ width: 70 }} />
+          <Box padding="small" background="info" style={{ width: 100 }} />
+        </Stack>
+      ),
+    },
+    {
+      label: 'Align to right',
+      Container,
+      Example: () => (
+        <Stack space="gutter" align="right">
+          <Box padding="small" background="info" style={{ width: 50 }} />
+          <Box padding="small" background="info" style={{ width: 70 }} />
+          <Box padding="small" background="info" style={{ width: 100 }} />
+        </Stack>
+      ),
+    },
+    {
+      label:
+        'Responsive alignment (e.g. center on mobile, left from tablet upwards)',
+      Container,
+      Example: () => (
+        <Stack space="gutter" align={['center', 'left']}>
+          <Box padding="small" background="info" style={{ width: 50 }} />
+          <Box padding="small" background="info" style={{ width: 70 }} />
+          <Box padding="small" background="info" style={{ width: 100 }} />
+        </Stack>
+      ),
+    },
+    {
       label: 'Dividers',
       Container,
       Example: () => (

--- a/lib/components/Stack/Stack.tsx
+++ b/lib/components/Stack/Stack.tsx
@@ -9,15 +9,28 @@ import * as styleRefs from './Stack.treat';
 import { Box } from '../Box/Box';
 
 export interface UseStackProps {
+  align: ResponsiveProp<Align>;
   component: UseBoxStylesProps['component'];
   space: UseBoxStylesProps['paddingBottom'];
 }
 
-export const useStackItem = ({ component, space }: UseStackProps) => {
+export const useStackItem = ({ align, component, space }: UseStackProps) => {
   const styles = useStyles(styleRefs);
 
   return classnames(
-    useBoxStyles({ component, paddingBottom: space }),
+    useBoxStyles({
+      component,
+      paddingBottom: space,
+      // If we're aligned left across all screen sizes,
+      // there's actually no alignment work to do.
+      ...(align === 'left'
+        ? {}
+        : {
+            display: mapResponsiveProp(align, alignToDisplay),
+            flexDirection: 'column',
+            alignItems: alignToFlexAlign(align),
+          }),
+    }),
     styles.excludingLast,
   );
 };
@@ -41,10 +54,7 @@ export const Stack = ({
   align = 'left',
   dividers = false,
 }: StackProps) => {
-  const stackClasses = useStackItem({
-    component: 'div',
-    space,
-  });
+  const stackClasses = useStackItem({ component: 'div', space, align });
   const stackItems = Children.toArray(children);
 
   if (stackItems.length <= 1 && align === 'left') {
@@ -54,26 +64,14 @@ export const Stack = ({
   return (
     <div>
       {stackItems.map((child, index) => (
-        <Box
-          className={dividers ? undefined : stackClasses}
-          key={index}
-          // If we're aligned left across all screen sizes,
-          // there's actually no work to do.
-          {...(align === 'left'
-            ? {}
-            : {
-                display: mapResponsiveProp(align, alignToDisplay),
-                flexDirection: 'column',
-                alignItems: alignToFlexAlign(align),
-              })}
-        >
+        <div className={dividers ? undefined : stackClasses} key={index}>
           {dividers && index > 0 ? (
             <Box width="full" paddingY={space}>
               <Divider />
             </Box>
           ) : null}
           {child}
-        </Box>
+        </div>
       ))}
     </div>
   );

--- a/lib/components/Stack/Stack.tsx
+++ b/lib/components/Stack/Stack.tsx
@@ -2,6 +2,8 @@ import React, { ReactNode, Children, Fragment } from 'react';
 import classnames from 'classnames';
 import { useStyles } from 'sku/treat';
 import { Divider } from '../Divider/Divider';
+import { Align, alignToFlexAlign } from '../../utils/align';
+import { ResponsiveProp, mapResponsiveProp } from '../../utils/responsiveProp';
 import { useBoxStyles, UseBoxStylesProps } from '../Box/useBoxStyles';
 import * as styleRefs from './Stack.treat';
 import { Box } from '../Box/Box';
@@ -20,34 +22,58 @@ export const useStackItem = ({ component, space }: UseStackProps) => {
   );
 };
 
+const alignToDisplay = {
+  left: 'block',
+  center: 'flex',
+  right: 'flex',
+} as const;
+
 export interface StackProps {
   children: ReactNode;
   space: UseBoxStylesProps['padding'];
+  align?: ResponsiveProp<Align>;
   dividers?: boolean;
 }
 
-export const Stack = ({ children, space, dividers = false }: StackProps) => {
+export const Stack = ({
+  children,
+  space,
+  align = 'left',
+  dividers = false,
+}: StackProps) => {
   const stackClasses = useStackItem({
     component: 'div',
     space,
   });
   const stackItems = Children.toArray(children);
 
-  if (stackItems.length <= 1) {
+  if (stackItems.length <= 1 && align === 'left') {
     return <Fragment>{stackItems}</Fragment>;
   }
 
   return (
     <div>
       {stackItems.map((child, index) => (
-        <div className={dividers ? undefined : stackClasses} key={index}>
+        <Box
+          className={dividers ? undefined : stackClasses}
+          key={index}
+          // If we're aligned left across all screen sizes,
+          // there's actually no work to do.
+          {...(align === 'left'
+            ? {}
+            : {
+                display: mapResponsiveProp(align, alignToDisplay),
+                flexDirection: 'column',
+                alignItems: alignToFlexAlign(align),
+              })}
+        >
           {dividers && index > 0 ? (
-            <Box paddingY={space}>
+            <Box width="full" paddingY={space}>
               <Divider />
             </Box>
           ) : null}
           {child}
-        </div>
+        </Box>
       ))}
     </div>
   );

--- a/lib/utils/align.ts
+++ b/lib/utils/align.ts
@@ -1,0 +1,18 @@
+import { ResponsiveProp, mapResponsiveProp } from './responsiveProp';
+
+export type Align = 'left' | 'center' | 'right';
+export type AlignY = 'top' | 'center' | 'bottom';
+
+export const alignToFlexAlign = (align: ResponsiveProp<Align> | undefined) =>
+  mapResponsiveProp(align, {
+    left: 'flexStart',
+    center: 'center',
+    right: 'flexEnd',
+  });
+
+export const alignYToFlexAlign = (alignY: ResponsiveProp<AlignY> | undefined) =>
+  mapResponsiveProp(alignY, {
+    top: 'flexStart',
+    center: 'center',
+    bottom: 'flexEnd',
+  });

--- a/lib/utils/responsiveProp.test.ts
+++ b/lib/utils/responsiveProp.test.ts
@@ -1,5 +1,6 @@
 import {
   normaliseResponsiveProp,
+  mapResponsiveProp,
   resolveResponsiveProp,
 } from './responsiveProp';
 
@@ -12,6 +13,27 @@ describe('normaliseResponsiveProp', () => {
 
   test.each(testData)('%p returns %p', (props, expected) => {
     expect(normaliseResponsiveProp(props)).toEqual(expected);
+  });
+});
+
+describe('mapResponsiveProp', () => {
+  const mockMap = {
+    foo: 'mappedFoo',
+    bar: 'mappedBar',
+    baz: 'mappedBaz',
+  };
+
+  const testData = [
+    ['foo', mockMap, 'mappedFoo'],
+    [['foo', 'foo'], mockMap, ['mappedFoo', 'mappedFoo', 'mappedFoo']],
+    [['foo', 'foo', 'foo'], mockMap, ['mappedFoo', 'mappedFoo', 'mappedFoo']],
+    [['foo', 'bar'], mockMap, ['mappedFoo', 'mappedBar', 'mappedBar']],
+    [['foo', 'bar', 'bar'], mockMap, ['mappedFoo', 'mappedBar', 'mappedBar']],
+    [['foo', 'bar', 'baz'], mockMap, ['mappedFoo', 'mappedBar', 'mappedBaz']],
+  ] as const;
+
+  test.each(testData)('%p returns %p', (props, map, expected) => {
+    expect(mapResponsiveProp(props, map)).toEqual(expected);
   });
 });
 

--- a/lib/utils/responsiveProp.ts
+++ b/lib/utils/responsiveProp.ts
@@ -24,6 +24,29 @@ export const normaliseResponsiveProp = <Keys extends string>(
   throw new Error(`Invalid responsive prop length: ${JSON.stringify(value)}`);
 };
 
+export const mapResponsiveProp = <
+  Keys extends string,
+  MappedValues extends string
+>(
+  value: ResponsiveProp<Keys> | undefined,
+  valueMap: Record<Keys, MappedValues>,
+): ResponsiveProp<MappedValues> | undefined => {
+  if (value === undefined) {
+    return value;
+  }
+
+  // If it's not a responsive prop, just map it directly
+  if (typeof value === 'string') {
+    return valueMap[value];
+  }
+
+  const [mobileValue, tabletValue, desktopValue] = normaliseResponsiveProp(
+    value,
+  );
+
+  return [valueMap[mobileValue], valueMap[tabletValue], valueMap[desktopValue]];
+};
+
 export const resolveResponsiveProp = <Keys extends string>(
   value: ResponsiveProp<Keys>,
   mobileAtoms: Record<Keys, string>,


### PR DESCRIPTION
This adds alignment support to our suite of layout components. `Stack` and `Inline` can now align content horizontally via the `align` prop, and `Columns` can manage vertical alignment via `alignY`.

All of these props are also responsive, making it easy to customise alignment across multiple screen sizes.

## Example usage

```
<Stack space="small" align="center">...</Stack>
<Stack space="small" align={['center', 'left']}>...</Stack>

<Inline space="small" align="center">...</Stack>
<Inline space="small" align={['center', 'left']}>...</Inline>

<Columns space="small" alignY="center">
  <Column>...</Column>
  <Column>...</Column>
  <Column>...</Column>
</Columns>
```