### PR TITLE
feat(TextLink): Add support for visited link styles

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -3935,6 +3935,7 @@ exports[`TextLink 1`] = `
   security?: string
   selected?: boolean
   shape?: string
+  showVisited?: boolean
   size?: number
   sizes?: string
   slot?: string
@@ -3976,6 +3977,7 @@ exports[`TextLink 1`] = `
 exports[`TextLinkRenderer 1`] = `
 {
   children: (styleProps: StyleProps) => ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<...>)>
+  showVisited?: boolean
 }
 `;
 

--- a/lib/components/TextLink/TextLink.docs.tsx
+++ b/lib/components/TextLink/TextLink.docs.tsx
@@ -23,6 +23,17 @@ const docs: ComponentDocs = {
       ),
     },
     {
+      label: 'Visited Text Link',
+      Example: () => (
+        <Text>
+          The last word of a sentence is a{' '}
+          <TextLink href="" showVisited>
+            visited link.
+          </TextLink>
+        </Text>
+      ),
+    },
+    {
       label: 'Block Text Link',
       Example: () => (
         <TextLink href="">

--- a/lib/components/TextLink/TextLink.tsx
+++ b/lib/components/TextLink/TextLink.tsx
@@ -10,8 +10,8 @@ export interface TextLinkProps
   extends Omit<TextLinkRendererProps, 'children'>,
     Omit<AnchorProps, 'className' | 'style'> {}
 
-export const TextLink = (props: TextLinkProps) => (
-  <TextLinkRenderer>
+export const TextLink = ({ showVisited, ...props }: TextLinkProps) => (
+  <TextLinkRenderer showVisited={showVisited}>
     {styleProps => <a {...props} {...styleProps} />}
   </TextLinkRenderer>
 );

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.treat.ts
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.treat.ts
@@ -11,6 +11,12 @@ export const underlineOnHoverOnly = style({
   },
 });
 
+export const visited = style(theme => ({
+  ':visited': {
+    color: theme.color.foreground.linkVisited,
+  },
+}));
+
 export const button = style({
   outline: 'none',
 });

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
@@ -23,6 +23,7 @@ interface StyleProps {
 }
 
 export interface TextLinkRendererProps {
+  showVisited?: boolean;
   children: (styleProps: StyleProps) => ReactElement;
 }
 
@@ -42,7 +43,7 @@ export const TextLinkRenderer = (props: TextLinkRendererProps) => {
   return <InlineLink {...props} />;
 };
 
-function useLinkStyles() {
+function useLinkStyles(showVisited: boolean) {
   const styles = useStyles(styleRefs);
   const inHeading = useContext(HeadingContext);
   const backgroundContext = useBackground();
@@ -56,16 +57,17 @@ function useLinkStyles() {
       tone: highlightLink ? 'link' : undefined,
     }),
     !inHeading ? mediumWeight : null,
+    showVisited ? styles.visited : null,
   ];
 }
 
-function InlineLink({ children }: TextLinkRendererProps) {
+function InlineLink({ showVisited = false, children }: TextLinkRendererProps) {
   return (
     <TextLinkRendererContext.Provider value={true}>
       {children({
         style: {},
         className: classnames(
-          useLinkStyles(),
+          useLinkStyles(showVisited),
           useBoxStyles({
             component: 'a',
             cursor: 'pointer',
@@ -76,14 +78,17 @@ function InlineLink({ children }: TextLinkRendererProps) {
   );
 }
 
-function TouchableLink({ children }: TextLinkRendererProps) {
+function TouchableLink({
+  showVisited = false,
+  children,
+}: TextLinkRendererProps) {
   return (
     <TextLinkRendererContext.Provider value={true}>
       <Box display="flex">
         {children({
           style: {},
           className: classnames(
-            useLinkStyles(),
+            useLinkStyles(showVisited),
             useBoxStyles({
               component: 'a',
               cursor: 'pointer',
@@ -101,7 +106,7 @@ const buttonLinkTextProps = {
   tone: 'link',
   baseline: false,
 } as const;
-function ButtonLink({ children }: TextLinkRendererProps) {
+function ButtonLink({ showVisited = false, children }: TextLinkRendererProps) {
   const styles = useStyles(styleRefs);
 
   return (
@@ -111,7 +116,7 @@ function ButtonLink({ children }: TextLinkRendererProps) {
           style: {},
           className: classnames(
             styles.button,
-            useLinkStyles(),
+            useLinkStyles(showVisited),
             useText(buttonLinkTextProps),
             useTouchableSpace(buttonLinkTextProps.size),
             useBoxStyles({

--- a/lib/hooks/typography/typography.treat.ts
+++ b/lib/hooks/typography/typography.treat.ts
@@ -108,7 +108,9 @@ export const tone = styleMap(theme => {
   const {
     linkHover,
     link,
-    neutralInverted, // Omit from public API
+    // Omit from public API
+    linkVisited,
+    neutralInverted,
     ...foreground
   } = theme.color.foreground;
 

--- a/lib/themes/baseTokens/seekAnz.ts
+++ b/lib/themes/baseTokens/seekAnz.ts
@@ -26,6 +26,7 @@ export const makeTokens = ({
   const neutral = '#747474';
   const black = '#1c1c1c';
   const link = '#2765cf';
+  const linkVisited = '#733d90';
   const secondary = '#1c1c1ca1';
 
   const tokens: TreatTokens = {
@@ -189,6 +190,7 @@ export const makeTokens = ({
       foreground: {
         link,
         linkHover: link,
+        linkVisited,
         neutral: black,
         neutralInverted: white,
         formAccent,

--- a/lib/themes/baseTokens/seekAsia.ts
+++ b/lib/themes/baseTokens/seekAsia.ts
@@ -33,6 +33,7 @@ export const makeTokens = ({
   const focus = blue3;
   const link = blue2;
   const linkHover = blue2;
+  const linkVisited = '#3f11a3';
   const selection = blue5;
   const secondary = grey2;
   const neutral = grey2;
@@ -198,6 +199,7 @@ export const makeTokens = ({
       foreground: {
         link,
         linkHover,
+        linkVisited,
         neutral: grey1,
         neutralInverted: white,
         formAccent,

--- a/lib/themes/baseTokens/seekAsiaRebrand.ts
+++ b/lib/themes/baseTokens/seekAsiaRebrand.ts
@@ -56,6 +56,7 @@ export const makeTokens = ({
   const formAccent = palette.formAccent;
   const formAccentDisabled = palette.saGrayLight;
   const link = palette.saLink;
+  const linkVisited = palette.saPurple;
   const disabled = palette.saGrayLighter;
   const textNeutral = palette.saGrayDarker;
   const secondary = palette.saGrayDark;
@@ -224,6 +225,7 @@ export const makeTokens = ({
       foreground: {
         link,
         linkHover: link,
+        linkVisited,
         neutral: textNeutral,
         neutralInverted: white,
         formAccent,

--- a/lib/themes/makeTreatTheme.ts
+++ b/lib/themes/makeTreatTheme.ts
@@ -93,6 +93,7 @@ export interface TreatTokens {
     foreground: {
       link: string;
       linkHover: string;
+      linkVisited: string;
       neutral: string;
       neutralInverted: string;
       formAccent: string;

--- a/lib/themes/wireframe/tokens.ts
+++ b/lib/themes/wireframe/tokens.ts
@@ -10,6 +10,7 @@ const focus = 'DeepSkyBlue';
 const black = '#2b2b2b';
 const white = '#fff';
 const link = '#4c77bb';
+const linkVisited = 'DarkViolet';
 const secondary = '#777';
 const neutral = '#d0d9e6';
 
@@ -173,6 +174,7 @@ const tokens: TreatTokens = {
     foreground: {
       link,
       linkHover: link,
+      linkVisited,
       neutral: black,
       neutralInverted: white,
       formAccent,


### PR DESCRIPTION
In order to support visited link styles, you can now pass a `showVisited` boolean prop to `TextLink` and `TextLinkRenderer`.

Example usage:

```tsx
<TextLink showVisited href="/">...</TextLink>
```