### PR TITLE
fix(Loader): Show instantly, add delayVisibility to prevent flicker

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -3103,6 +3103,7 @@ exports[`Inline 1`] = `
 
 exports[`Loader 1`] = `
 {
+  delayVisibility?: boolean
   size?: 
     | "large"
     | "small"

--- a/lib/components/Loader/Loader.docs.tsx
+++ b/lib/components/Loader/Loader.docs.tsx
@@ -12,6 +12,10 @@ const docs: ComponentDocs = {
       Example: () => <Loader />,
     },
     {
+      label: 'Delay visibility (used to prevent loading flicker)',
+      Example: () => <Loader delayVisibility />,
+    },
+    {
       label: 'xsmall',
       Example: () => <Loader size="xsmall" />,
     },

--- a/lib/components/Loader/Loader.treat.ts
+++ b/lib/components/Loader/Loader.treat.ts
@@ -36,7 +36,7 @@ export const indicator = [
   }),
 ];
 
-export const root = style({
+export const delay = style({
   opacity: 0,
   '@keyframes': {
     from: {
@@ -51,7 +51,7 @@ export const root = style({
   animationFillMode: 'forwards',
   animationTimingFunction: 'ease-in',
   animationDuration: '0.25s',
-  animationDelay: '1s',
+  animationDelay: '0.8s',
 });
 
 export const size = styleMap(({ utils, typography }) =>

--- a/lib/components/Loader/Loader.tsx
+++ b/lib/components/Loader/Loader.tsx
@@ -23,14 +23,18 @@ const resolveBgForContext: Partial<
 
 interface LoaderProps {
   size?: keyof typeof styleRefs.size;
+  delayVisibility?: boolean;
 }
 
-export const Loader = ({ size = 'standard' }: LoaderProps) => {
+export const Loader = ({
+  size = 'standard',
+  delayVisibility = false,
+}: LoaderProps) => {
   const styles = useStyles(styleRefs);
   const backgroundContext = useBackground();
 
   return (
-    <Box display="flex" className={styles.root}>
+    <Box display="flex" className={delayVisibility ? styles.delay : undefined}>
       {indicators.map((_, index) => (
         <Box
           key={index}


### PR DESCRIPTION
Move the delayed presentation of the `Loader` to being opt-in via a prop rather than default behaviour. The delay is useful for scenarios where showing a loading indicator can hurt user perceived performance.