### PR TITLE
docs: Add fallback props for interactive components in Playroom

### DIFF
--- a/lib/components/Autosuggest/Autosuggest.playroom.tsx
+++ b/lib/components/Autosuggest/Autosuggest.playroom.tsx
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import { Optional } from 'utility-types';
+import { useFallbackId } from '../../playroom/utils';
+import { Autosuggest, AutosuggestProps } from './Autosuggest';
+
+type PlayroomAutosuggestProps<Value> = Optional<
+  AutosuggestProps<Value>,
+  'id' | 'value' | 'onChange'
+>;
+
+export function PlayroomAutosuggest<Value>({
+  id,
+  value,
+  onChange,
+  ...restProps
+}: PlayroomAutosuggestProps<Value>) {
+  const fallbackId = useFallbackId();
+  const [fallbackValue, setFallbackValue] = useState({ text: '' });
+
+  return (
+    <Autosuggest
+      id={id ?? fallbackId}
+      value={value ?? fallbackValue}
+      onChange={onChange ?? setFallbackValue}
+      {...restProps}
+    />
+  );
+}

--- a/lib/components/Checkbox/Checkbox.playroom.tsx
+++ b/lib/components/Checkbox/Checkbox.playroom.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { Optional } from 'utility-types';
+import { useFallbackId } from '../../playroom/utils';
+import { Checkbox, CheckboxProps } from './Checkbox';
+
+type PlayroomCheckboxProps = Optional<
+  CheckboxProps,
+  'id' | 'checked' | 'onChange'
+>;
+
+export const PlayroomCheckbox = ({
+  id,
+  checked,
+  onChange,
+  ...restProps
+}: PlayroomCheckboxProps) => {
+  const fallbackId = useFallbackId();
+  const [fallbackChecked, setFallbackChecked] = useState(false);
+
+  return (
+    <Checkbox
+      id={id ?? fallbackId}
+      checked={checked ?? fallbackChecked}
+      onChange={
+        onChange
+          ? onChange
+          : event => setFallbackChecked(event.currentTarget.checked)
+      }
+      {...restProps}
+    />
+  );
+};

--- a/lib/components/Checkbox/Checkbox.tsx
+++ b/lib/components/Checkbox/Checkbox.tsx
@@ -4,7 +4,9 @@ import {
   InlineFieldProps,
 } from '../private/InlineField/InlineField';
 
-const NamedCheckbox = forwardRef<HTMLInputElement, InlineFieldProps>(
+export type CheckboxProps = InlineFieldProps;
+
+const NamedCheckbox = forwardRef<HTMLInputElement, CheckboxProps>(
   (props, ref) => (
     <InlineField
       reserveMessageSpace={true}

--- a/lib/components/Dropdown/Dropdown.playroom.tsx
+++ b/lib/components/Dropdown/Dropdown.playroom.tsx
@@ -1,0 +1,34 @@
+import React, { useState } from 'react';
+import { Optional } from 'utility-types';
+import { useFallbackId } from '../../playroom/utils';
+import { Dropdown, DropdownProps } from './Dropdown';
+
+type PlayroomDropdownProps = Optional<
+  DropdownProps,
+  'id' | 'value' | 'onChange'
+>;
+
+export const PlayroomDropdown = ({
+  id,
+  value,
+  onChange,
+  ...restProps
+}: PlayroomDropdownProps) => {
+  const fallbackId = useFallbackId();
+  const [fallbackValue, setFallbackValue] = useState<DropdownProps['value']>(
+    '',
+  );
+
+  return (
+    <Dropdown
+      id={id ?? fallbackId}
+      value={value === undefined ? fallbackValue : value}
+      onChange={
+        onChange
+          ? onChange
+          : event => setFallbackValue(event.currentTarget.value)
+      }
+      {...restProps}
+    />
+  );
+};

--- a/lib/components/Dropdown/Dropdown.tsx
+++ b/lib/components/Dropdown/Dropdown.tsx
@@ -19,7 +19,7 @@ type ValidDropdownChildren = AllHTMLAttributes<
   HTMLOptionElement | HTMLOptGroupElement
 >;
 type SelectProps = AllHTMLAttributes<HTMLSelectElement>;
-interface DropdownProps
+export interface DropdownProps
   extends Omit<FieldProps, 'labelId' | 'secondaryMessage' | 'onClear'> {
   children: ValidDropdownChildren[] | ValidDropdownChildren;
   value: NonNullable<SelectProps['value']>;

--- a/lib/components/MonthPicker/MonthPicker.playroom.tsx
+++ b/lib/components/MonthPicker/MonthPicker.playroom.tsx
@@ -1,0 +1,30 @@
+import React, { useState } from 'react';
+import { Optional } from 'utility-types';
+import { useFallbackId } from '../../playroom/utils';
+import { MonthPicker, MonthPickerProps } from './MonthPicker';
+
+type PlayroomMonthPickerProps = Optional<
+  MonthPickerProps,
+  'id' | 'value' | 'onChange'
+>;
+
+export const PlayroomMonthPicker = ({
+  id,
+  value,
+  onChange,
+  ...restProps
+}: PlayroomMonthPickerProps) => {
+  const fallbackId = useFallbackId();
+  const [fallbackValue, setFallbackValue] = useState<MonthPickerProps['value']>(
+    {},
+  );
+
+  return (
+    <MonthPicker
+      id={id ?? fallbackId}
+      value={value ?? fallbackValue}
+      onChange={onChange ? onChange : setFallbackValue}
+      {...restProps}
+    />
+  );
+};

--- a/lib/components/MonthPicker/MonthPicker.tsx
+++ b/lib/components/MonthPicker/MonthPicker.tsx
@@ -20,7 +20,7 @@ interface MonthPickerValue {
 
 type FocusHandler = () => void;
 type ChangeHandler = (value: MonthPickerValue) => void;
-interface MonthPickerProps
+export interface MonthPickerProps
   extends Omit<
     FieldProps,
     | 'value'

--- a/lib/components/Radio/Radio.playroom.tsx
+++ b/lib/components/Radio/Radio.playroom.tsx
@@ -1,0 +1,29 @@
+import React, { useState } from 'react';
+import { Optional } from 'utility-types';
+import { useFallbackId } from '../../playroom/utils';
+import { Radio, RadioProps } from './Radio';
+
+type PlayroomRadioProps = Optional<RadioProps, 'id' | 'checked' | 'onChange'>;
+
+export const PlayroomRadio = ({
+  id,
+  checked,
+  onChange,
+  ...restProps
+}: PlayroomRadioProps) => {
+  const fallbackId = useFallbackId();
+  const [fallbackChecked, setFallbackChecked] = useState(false);
+
+  return (
+    <Radio
+      id={id ?? fallbackId}
+      checked={checked ?? fallbackChecked}
+      onChange={
+        onChange
+          ? onChange
+          : event => setFallbackChecked(event.currentTarget.checked)
+      }
+      {...restProps}
+    />
+  );
+};

--- a/lib/components/Radio/Radio.tsx
+++ b/lib/components/Radio/Radio.tsx
@@ -5,7 +5,7 @@ import {
   InlineFieldProps,
 } from '../private/InlineField/InlineField';
 
-interface RadioProps
+export interface RadioProps
   extends Omit<InlineFieldProps, 'message' | 'reserveMessageSpace'> {}
 
 const NamedRadio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => (

--- a/lib/components/TextField/TextField.playroom.tsx
+++ b/lib/components/TextField/TextField.playroom.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { Optional } from 'utility-types';
+import { useFallbackId } from '../../playroom/utils';
+import { TextField, TextFieldProps } from './TextField';
+
+type PlayroomTextFieldProps = Optional<
+  TextFieldProps,
+  'id' | 'value' | 'onChange'
+>;
+
+export const PlayroomTextField = ({
+  id,
+  value,
+  onChange,
+  ...restProps
+}: PlayroomTextFieldProps) => {
+  const fallbackId = useFallbackId();
+  const [fallbackValue, setFallbackValue] = useState('');
+
+  return (
+    <TextField
+      id={id ?? fallbackId}
+      value={value ?? fallbackValue}
+      onChange={
+        onChange
+          ? onChange
+          : event => setFallbackValue(event.currentTarget.value)
+      }
+      {...restProps}
+    />
+  );
+};

--- a/lib/components/TextField/TextField.tsx
+++ b/lib/components/TextField/TextField.tsx
@@ -14,7 +14,7 @@ const validTypes = {
 };
 
 type InputProps = AllHTMLAttributes<HTMLInputElement>;
-interface TextFieldProps
+export interface TextFieldProps
   extends Omit<FieldProps, 'labelId' | 'secondaryMessage'> {
   value: NonNullable<InputProps['value']>;
   type?: keyof typeof validTypes;

--- a/lib/components/Textarea/Textarea.playroom.tsx
+++ b/lib/components/Textarea/Textarea.playroom.tsx
@@ -1,0 +1,32 @@
+import React, { useState } from 'react';
+import { Optional } from 'utility-types';
+import { useFallbackId } from '../../playroom/utils';
+import { Textarea, TextareaProps } from './Textarea';
+
+type PlayroomTextareaProps = Optional<
+  TextareaProps,
+  'id' | 'value' | 'onChange'
+>;
+
+export const PlayroomTextarea = ({
+  id,
+  value,
+  onChange,
+  ...restProps
+}: PlayroomTextareaProps) => {
+  const fallbackId = useFallbackId();
+  const [fallbackValue, setFallbackValue] = useState('');
+
+  return (
+    <Textarea
+      id={id ?? fallbackId}
+      value={value ?? fallbackValue}
+      onChange={
+        onChange
+          ? onChange
+          : event => setFallbackValue(event.currentTarget.value)
+      }
+      {...restProps}
+    />
+  );
+};

--- a/lib/components/Textarea/Textarea.tsx
+++ b/lib/components/Textarea/Textarea.tsx
@@ -15,7 +15,7 @@ import { Field, FieldProps } from '../private/Field/Field';
 import * as styleRefs from './Textarea.treat';
 
 type NativeTextareaProps = AllHTMLAttributes<HTMLTextAreaElement>;
-interface TextareaProps
+export interface TextareaProps
   extends Omit<
     FieldProps,
     'labelId' | 'secondaryMessage' | 'onClear' | 'icon'

--- a/lib/components/Toggle/Toggle.playroom.tsx
+++ b/lib/components/Toggle/Toggle.playroom.tsx
@@ -1,0 +1,25 @@
+import React, { useState } from 'react';
+import { Optional } from 'utility-types';
+import { useFallbackId } from '../../playroom/utils';
+import { Toggle, ToggleProps } from './Toggle';
+
+type PlayroomToggleProps = Optional<ToggleProps, 'id' | 'on' | 'onChange'>;
+
+export const PlayroomToggle = ({
+  id,
+  on,
+  onChange,
+  ...restProps
+}: PlayroomToggleProps) => {
+  const fallbackId = useFallbackId();
+  const [fallbackOn, setFallbackOn] = useState(false);
+
+  return (
+    <Toggle
+      id={id ?? fallbackId}
+      on={on ?? fallbackOn}
+      onChange={onChange ? onChange : setFallbackOn}
+      {...restProps}
+    />
+  );
+};

--- a/lib/playroom/components.ts
+++ b/lib/playroom/components.ts
@@ -1,2 +1,11 @@
 import '../reset';
 export * from '../components';
+
+export { PlayroomAutosuggest as Autosuggest } from '../components/Autosuggest/Autosuggest.playroom';
+export { PlayroomCheckbox as Checkbox } from '../components/Checkbox/Checkbox.playroom';
+export { PlayroomDropdown as Dropdown } from '../components/Dropdown/Dropdown.playroom';
+export { PlayroomMonthPicker as MonthPicker } from '../components/MonthPicker/MonthPicker.playroom';
+export { PlayroomRadio as Radio } from '../components/Radio/Radio.playroom';
+export { PlayroomTextField as TextField } from '../components/TextField/TextField.playroom';
+export { PlayroomTextarea as Textarea } from '../components/Textarea/Textarea.playroom';
+export { PlayroomToggle as Toggle } from '../components/Toggle/Toggle.playroom';

--- a/lib/playroom/utils.ts
+++ b/lib/playroom/utils.ts
@@ -1,0 +1,6 @@
+import { useRef } from 'react';
+import uuid from 'uuid/v4';
+
+export const useFallbackId = () => {
+  return useRef(`fallbackId-${uuid()}`).current;
+};

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "@types/react-dom": "^16.8.2",
     "@types/react-router-dom": "^5.1.0",
     "@types/react-transition-group": "^4.2.3",
+    "@types/uuid": "^3.4.6",
     "@types/webpack-env": "^1.14.0",
     "change-case": "^3.1.0",
     "cheerio": "^1.0.0-rc.3",
@@ -116,7 +117,8 @@
     "sku": "9.0.2",
     "surge": "^0.20.1",
     "travis-deploy-once": "^5.0.9",
-    "ts-node": "^8.2.0"
+    "ts-node": "^8.2.0",
+    "uuid": "^3.3.3"
   },
   "resolutions": {
     "acorn": "6.3.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2571,6 +2571,13 @@
   dependencies:
     source-map "^0.6.1"
 
+"@types/uuid@^3.4.6":
+  version "3.4.6"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-3.4.6.tgz#d2c4c48eb85a757bf2927f75f939942d521e3016"
+  integrity sha512-cCdlC/1kGEZdEglzOieLDYBxHsvEOIg7kp/2FYyVR9Pxakq+Qf/inL3RKQ+PA8gOlI/NnL+fXmQH12nwcGzsHw==
+  dependencies:
+    "@types/node" "*"
+
 "@types/webpack-env@^1.13.7", "@types/webpack-env@^1.14.0":
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/@types/webpack-env/-/webpack-env-1.14.1.tgz#0d8a53f308f017c53a5ddc3d07f4d6fa76b790d7"


### PR DESCRIPTION
This PR loosens the requirements on interactive components so that `id`, `value`/`checked`/`on` and `onChange` props are optional. This is achieved via wrapper components that generate the missing props for you, if required. 

This ensures that components in Playroom behave the same as production, even when props have been omitted—as opposed to relying on React's uncontrolled form element behaviour, which our components have not been designed to support.