### PR TITLE
docs(Playroom): Provide fallback behaviour for TextLink

### DIFF
--- a/lib/components/TextLink/TextLink.playroom.tsx
+++ b/lib/components/TextLink/TextLink.playroom.tsx
@@ -1,0 +1,14 @@
+import React from 'react';
+import { TextLink, TextLinkProps } from './TextLink';
+
+export const PlayroomTextLink = ({
+  href,
+  onClick,
+  ...restProps
+}: TextLinkProps) => (
+  <TextLink
+    href={href ?? ''}
+    onClick={onClick ? onClick : event => event?.preventDefault()}
+    {...restProps}
+  />
+);

--- a/lib/playroom/components.ts
+++ b/lib/playroom/components.ts
@@ -6,6 +6,7 @@ export { PlayroomCheckbox as Checkbox } from '../components/Checkbox/Checkbox.pl
 export { PlayroomDropdown as Dropdown } from '../components/Dropdown/Dropdown.playroom';
 export { PlayroomMonthPicker as MonthPicker } from '../components/MonthPicker/MonthPicker.playroom';
 export { PlayroomRadio as Radio } from '../components/Radio/Radio.playroom';
-export { PlayroomTextField as TextField } from '../components/TextField/TextField.playroom';
 export { PlayroomTextarea as Textarea } from '../components/Textarea/Textarea.playroom';
+export { PlayroomTextField as TextField } from '../components/TextField/TextField.playroom';
+export { PlayroomTextLink as TextLink } from '../components/TextLink/TextLink.playroom';
 export { PlayroomToggle as Toggle } from '../components/Toggle/Toggle.playroom';


### PR DESCRIPTION
This ensures that, when prototyping, `TextLink` components are interactive even when an `href` hasn't been provided. This also prevents an extra history entry by calling `event.preventDefault()` in the fallback click handler.