### PR TITLE
feat(Tiles): Add ‘Tiles’ layout component

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -4042,6 +4042,31 @@ exports[`ThemeNameConsumer 1`] = `
 }
 `;
 
+exports[`Tiles 1`] = `
+{
+  children: ReactNode
+  columns: ResponsiveProp<
+    | 1
+    | 2
+    | 3
+    | 4
+    | 5
+  >
+  dividers?: boolean
+  space: ResponsiveProp<
+    | "gutter"
+    | "large"
+    | "medium"
+    | "none"
+    | "small"
+    | "xlarge"
+    | "xsmall"
+    | "xxlarge"
+    | "xxsmall"
+  >
+}
+`;
+
 exports[`Toggle 1`] = `
 {
   align?: 

--- a/lib/components/Tiles/Tiles.docs.tsx
+++ b/lib/components/Tiles/Tiles.docs.tsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import { ComponentDocs } from '../../../site/src/types';
+import { Tiles } from './Tiles';
+import { Box } from '../Box/Box';
+import { Text } from '../Text/Text';
+
+const exampleRows = 3;
+
+const docs: ComponentDocs = {
+  category: 'Layout',
+  examples: [
+    ...([1, 2, 3, 4, 5] as const).map(columns => ({
+      label: `${columns} column${columns === 1 ? '' : 's'}`,
+      docsSite: columns === 3,
+      Example: () => (
+        <Tiles space="small" columns={columns}>
+          {[...new Array(columns * exampleRows)].map((_, i) => (
+            <Box key={i} background="infoLight" padding="small">
+              <Text>Tile</Text>
+            </Box>
+          ))}
+        </Tiles>
+      ),
+    })),
+    {
+      label: 'Responsive columns (e.g. 1 on mobile, 4 from tablet upwards',
+      Example: () => (
+        <Tiles space="xsmall" columns={[1, 4]}>
+          {[...new Array(4 * exampleRows)].map((_, i) => (
+            <Box key={i} background="infoLight" padding="small">
+              <Text>Tile</Text>
+            </Box>
+          ))}
+        </Tiles>
+      ),
+    },
+    {
+      label: 'Dividers (when in a single column)',
+      Example: () => (
+        <Tiles space={['none', 'small']} columns={[1, 2]} dividers>
+          {[...new Array(2 * exampleRows)].map((_, i) => (
+            <Box key={i} background="neutralLight" padding="xsmall">
+              <Text>Tile</Text>
+            </Box>
+          ))}
+        </Tiles>
+      ),
+    },
+  ],
+};
+
+export default docs;

--- a/lib/components/Tiles/Tiles.treat.ts
+++ b/lib/components/Tiles/Tiles.treat.ts
@@ -1,0 +1,28 @@
+import { style, styleMap } from 'sku/treat';
+import mapValues from 'lodash/mapValues';
+import { TreatTokens } from '../../themes/makeBraidTheme';
+
+export const flexWrap = style({
+  flexWrap: 'wrap',
+});
+
+const columnsWidths = {
+  '1': '100%',
+  '2': `${100 / 2}%`,
+  '3': `${100 / 3}%`,
+  '4': `${100 / 4}%`,
+  '5': `${100 / 5}%`,
+} as const;
+
+const makeColumnsAtoms = (breakpoint: keyof TreatTokens['breakpoint']) =>
+  styleMap(
+    theme =>
+      mapValues(columnsWidths, width =>
+        theme.utils.responsiveStyle({ [breakpoint]: { flex: `0 0 ${width}` } }),
+      ),
+    `columns_${breakpoint}`,
+  );
+
+export const columnsMobile = makeColumnsAtoms('mobile');
+export const columnsTablet = makeColumnsAtoms('tablet');
+export const columnsDesktop = makeColumnsAtoms('desktop');

--- a/lib/components/Tiles/Tiles.tsx
+++ b/lib/components/Tiles/Tiles.tsx
@@ -1,0 +1,81 @@
+import React, { Children, ReactNode } from 'react';
+import { useStyles } from 'sku/react-treat';
+import classnames from 'classnames';
+import { Box } from '../Box/Box';
+import { Divider } from '../Divider/Divider';
+import { ResponsiveSpace } from '../Box/useBoxStyles';
+import {
+  useNegativeMarginTop,
+  useNegativeMarginLeft,
+} from '../../hooks/useNegativeMargin/useNegativeMargin';
+import {
+  normaliseResponsiveProp,
+  ResponsiveProp,
+} from '../../utils/responsiveProp';
+import * as styleRefs from './Tiles.treat';
+
+export interface TilesProps {
+  children: ReactNode;
+  space: ResponsiveSpace;
+  columns: ResponsiveProp<1 | 2 | 3 | 4 | 5>;
+  dividers?: boolean;
+}
+
+export const Tiles = ({
+  children,
+  space = 'none',
+  columns = 1,
+  dividers = false,
+}: TilesProps) => {
+  const styles = useStyles(styleRefs);
+
+  const responsiveSpace = normaliseResponsiveProp(space);
+
+  const [
+    mobileColumns,
+    tabletColumns,
+    desktopColumns,
+  ] = normaliseResponsiveProp(columns);
+
+  const negativeMarginTop = useNegativeMarginTop(responsiveSpace);
+  const negativeMarginLeft = useNegativeMarginLeft(responsiveSpace);
+
+  return (
+    <Box className={negativeMarginTop}>
+      <Box
+        display="flex"
+        className={classnames(styles.flexWrap, negativeMarginLeft)}
+      >
+        {Children.map(children, (child, i) => (
+          <Box
+            className={classnames(
+              styles.columnsMobile[mobileColumns],
+              styles.columnsTablet[tabletColumns],
+              styles.columnsDesktop[desktopColumns],
+            )}
+          >
+            <Box
+              // This needs to be a separate element to support IE11.
+              paddingTop={responsiveSpace}
+              paddingLeft={responsiveSpace}
+            >
+              {dividers && i > 0 ? (
+                <Box
+                  paddingBottom={responsiveSpace}
+                  display={[
+                    mobileColumns === 1 ? 'block' : 'none',
+                    tabletColumns === 1 ? 'block' : 'none',
+                    desktopColumns === 1 ? 'block' : 'none',
+                  ]}
+                >
+                  <Divider />
+                </Box>
+              ) : null}
+              {child}
+            </Box>
+          </Box>
+        ))}
+      </Box>
+    </Box>
+  );
+};

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -37,6 +37,7 @@ export { Textarea } from './Textarea/Textarea';
 export { TextField } from './TextField/TextField';
 export { TextLink } from './TextLink/TextLink';
 export { TextLinkRenderer } from './TextLinkRenderer/TextLinkRenderer';
+export { Tiles } from './Tiles/Tiles';
 export { Toggle } from './Toggle/Toggle';
 
 export * from './icons';

--- a/lib/utils/responsiveProp.ts
+++ b/lib/utils/responsiveProp.ts
@@ -3,29 +3,33 @@ export type ResponsiveProp<AtomName> =
   | Readonly<[AtomName, AtomName]>
   | Readonly<[AtomName, AtomName, AtomName]>;
 
-export const normaliseResponsiveProp = <Keys extends string>(
+export const normaliseResponsiveProp = <Keys extends string | number>(
   value: ResponsiveProp<Keys>,
 ): Readonly<[Keys, Keys, Keys]> => {
-  if (typeof value === 'string') {
+  if (typeof value === 'string' || typeof value === 'number') {
     return [value, value, value];
   }
 
-  const { length } = value;
+  if ('length' in value) {
+    const { length } = value;
 
-  if (length === 3) {
-    return value as Readonly<[Keys, Keys, Keys]>;
+    if (length === 3) {
+      return value as Readonly<[Keys, Keys, Keys]>;
+    }
+
+    if (length === 2) {
+      const [mobileValue, tabletValue] = value;
+      return [mobileValue, tabletValue, tabletValue];
+    }
+
+    throw new Error(`Invalid responsive prop length: ${JSON.stringify(value)}`);
   }
 
-  if (length === 2) {
-    const [mobileValue, tabletValue] = value;
-    return [mobileValue, tabletValue, tabletValue];
-  }
-
-  throw new Error(`Invalid responsive prop length: ${JSON.stringify(value)}`);
+  throw new Error(`Invalid responsive prop value: ${JSON.stringify(value)}`);
 };
 
 export const mapResponsiveProp = <
-  Keys extends string,
+  Keys extends string | number,
   MappedValues extends string
 >(
   value: ResponsiveProp<Keys> | undefined,
@@ -36,7 +40,7 @@ export const mapResponsiveProp = <
   }
 
   // If it's not a responsive prop, just map it directly
-  if (typeof value === 'string') {
+  if (typeof value === 'string' || typeof value === 'number') {
     return valueMap[value];
   }
 
@@ -47,13 +51,13 @@ export const mapResponsiveProp = <
   return [valueMap[mobileValue], valueMap[tabletValue], valueMap[desktopValue]];
 };
 
-export const resolveResponsiveProp = <Keys extends string>(
+export const resolveResponsiveProp = <Keys extends string | number>(
   value: ResponsiveProp<Keys>,
   mobileAtoms: Record<Keys, string>,
   tabletAtoms: Record<Keys, string>,
   desktopAtoms: Record<Keys, string>,
 ) => {
-  if (typeof value === 'string') {
+  if (typeof value === 'string' || typeof value === 'number') {
     return mobileAtoms[value!];
   }
 

--- a/site/src/App/foundations/layout/layout.tsx
+++ b/site/src/App/foundations/layout/layout.tsx
@@ -14,6 +14,7 @@ import {
   IconPromote,
   Badge,
   Inline,
+  Tiles,
   ContentBlock,
   OverflowMenu,
   OverflowMenuItem,
@@ -26,13 +27,15 @@ import tokens from '../../../../../lib/themes/wireframe/tokens';
 import { Page } from '../../../types';
 import * as styleRefs from './layout.treat';
 
+const slugify = (string: string) => string.replace(/ /, '-');
+
 interface LinkableHeadingProps {
   level?: HeadingProps['level'];
   children: string;
 }
 const LinkableHeading = ({ children, level = '3' }: LinkableHeadingProps) => {
   const styles = useStyles(styleRefs);
-  const slug = children.toLowerCase().replace(/ /, '-');
+  const slug = slugify(children);
 
   return (
     <Box className={styles.linkableHeading}>
@@ -46,6 +49,10 @@ const LinkableHeading = ({ children, level = '3' }: LinkableHeadingProps) => {
     </Box>
   );
 };
+
+const HeadingLink = ({ children }: { children: string }) => (
+  <TextLink href={`#${slugify(children)}`}>{children}</TextLink>
+);
 
 type Space = 'none' | keyof typeof tokens.space;
 const spaceScale = ['none', ...Object.keys(tokens.space)] as Space[];
@@ -62,6 +69,28 @@ const page: Page = {
     return (
       <TextStack>
         <Heading level="2">Layout</Heading>
+
+        <Divider />
+
+        <BulletList>
+          {[
+            'Spacing',
+            'Box',
+            'Card',
+            'Stack',
+            'Inline',
+            'Columns',
+            'Tiles',
+            'ContentBlock',
+          ].map(section => (
+            <Bullet key={section}>
+              <HeadingLink>{section}</HeadingLink>
+            </Bullet>
+          ))}
+        </BulletList>
+
+        <Divider />
+
         <Text>
           The guiding principle for layout in Braid is that components should
           not provide surrounding white space. Instead, spacing between elements
@@ -477,6 +506,121 @@ const page: Page = {
               </Card>
             </Column>
           </Columns>
+        </Code>
+
+        <Divider />
+
+        <LinkableHeading>Tiles</LinkableHeading>
+        <Text>
+          If you’d like to render a grid of components with equal spacing
+          between them, Braid provides a ‘Tiles’ component:
+        </Text>
+
+        <Code>
+          <Tiles columns={3} space="small">
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+          </Tiles>
+        </Code>
+
+        <Text>
+          If you need to customise the spacing and number of columns per screen
+          size, the ‘columns’ prop is responsive. For example, if you wanted a
+          single column on mobile and three columns from tablet upwards:
+        </Text>
+
+        <Code>
+          <Tiles columns={[1, 3]} space={['xsmall', 'small']}>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+          </Tiles>
+        </Code>
+
+        <Text>
+          When the tiles are collapsed to a single column, you can optionally
+          show dividers between them with the ‘dividers’ prop:
+        </Text>
+
+        <Code>
+          <Tiles columns={[1, 3]} space={['none', 'small']} dividers>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+            <Card>
+              <Text>Tile</Text>
+            </Card>
+          </Tiles>
         </Code>
 
         <Divider />


### PR DESCRIPTION
This introduces a new layout component called `Tiles` which allows you to freely flow content while defining the desired number of columns.

For example, if you wanted a 3 column grid layout with "medium" space:

```jsx
<Tiles columns={3} space="medium">
  <Card>...</Card>
  <Card>...</Card>
  <Card>...</Card>
  <Card>...</Card>
  <Card>...</Card>
  <Card>...</Card>
</Tiles>
```

[Playroom demo](https://braid-design-system--6b46b74c24f384e2f0cc3907fa8fdbd871ad2f75.surge.sh/playroom/#?code=N4Igxg9gJgpiBcIA8AVAlgGxgZwASQwFcBbAO2wF5gBmAX12wAcBDMGCgHRGJijRK4A+DqVy4kAYWYAnKIIB0ipAHops4aPFq5i+Su0axkmTqWqThrRd36LIowZvn19q+qcGRK9FmyCQADQgAC4AFjA82AgA2iDYMDAA1gCCpABeIAC6tEA)

---

The `columns` prop is also responsive, allowing you to specify the number of columns for each screen size.

For example, if you wanted the tiles to collapse to a single column on mobile:

```jsx
<Tiles columns={[1, 3]} space="medium">
  <Card>...</Card>
  <Card>...</Card>
  <Card>...</Card>
  <Card>...</Card>
  <Card>...</Card>
  <Card>...</Card>
</Tiles>
```

[Playroom demo](https://braid-design-system--6b46b74c24f384e2f0cc3907fa8fdbd871ad2f75.surge.sh/playroom/#?code=N4Igxg9gJgpiBcIA8AVAlgGxgZwASQwFcBbAO2wF5gBtARgBpcBmAXQF9dsAHAQzBgoAdEMRhQ0JYQD5BpXLiQBhHgCcoUgHRakAemVqZchfvVaNuk4flLVp7XttXjjsxcezrl1w4MfnB70tZXXQsbCkQehAAFwALGFFsBGoQbBgYAGsAQVIALxB2IA)

---


When tiles are in a single column, you can also show dividers between them with the `dividers` prop:

```jsx
<Tiles columns={[1, 3]} space={['none', 'medium']} dividers>
  <Card>...</Card>
  <Card>...</Card>
  <Card>...</Card>
  <Card>...</Card>
  <Card>...</Card>
  <Card>...</Card>
</Tiles>
```

[Playroom demo](https://braid-design-system--6b46b74c24f384e2f0cc3907fa8fdbd871ad2f75.surge.sh/playroom/#?code=N4Igxg9gJgpiBcIA8AVAlgGxgZwASQwFcBbAO2wF5gBtARgBpcBmAXQF9dsAHAQzBirUA5KQikYQxkOIwoaEkPa45ANzSwATtgB8AHVK5cSAMI8NUbQDprSAPSnzeg0YcXrlu66eGTZtzfs-bxcg908g-R8vMMDHSJDHGK99O3QsHRB6EAAXAAsYGWwEahBsGBgAawBBUgAvEHYgA)