### PR TITLE
feat(Stack): Allow Stacks to be semantic lists

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -3214,6 +3214,10 @@ exports[`Stack 1`] = `
     | "right"
   >
   children: ReactNode
+  component?: 
+    | "div"
+    | "ol"
+    | "ul"
   dividers?: boolean
   space: ResponsiveProp<
     | "gutter"

--- a/lib/components/Stack/Stack.test.tsx
+++ b/lib/components/Stack/Stack.test.tsx
@@ -1,0 +1,62 @@
+import '@testing-library/jest-dom/extend-expect';
+import React from 'react';
+import { render, cleanup } from '@testing-library/react';
+import { BraidProvider, Stack, Text } from '..';
+import { wireframe } from '../../themes';
+
+afterEach(cleanup);
+
+describe('Stack', () => {
+  it('should not render a list by default', () => {
+    const { queryAllByRole } = render(
+      <BraidProvider theme={wireframe}>
+        <Stack space="small">
+          <Text>1</Text>
+          <Text>2</Text>
+          <Text>3</Text>
+        </Stack>
+      </BraidProvider>,
+    );
+
+    expect(queryAllByRole('list').length).toBe(0);
+    expect(queryAllByRole('listItem').length).toBe(0);
+  });
+
+  it('should render a valid unordered list when "component" is "ul"', () => {
+    const { getByRole } = render(
+      <BraidProvider theme={wireframe}>
+        <Stack component="ul" space="small">
+          <Text>1</Text>
+          <Text>2</Text>
+          <Text>3</Text>
+        </Stack>
+      </BraidProvider>,
+    );
+
+    const list = getByRole('list');
+    expect(list.nodeName).toBe('UL');
+
+    expect(
+      Array.from(list.childNodes).map(childNode => childNode.nodeName),
+    ).toEqual(['LI', 'LI', 'LI']);
+  });
+
+  it('should render a valid unordered list when "component" is "ol"', () => {
+    const { getByRole } = render(
+      <BraidProvider theme={wireframe}>
+        <Stack component="ol" space="small">
+          <Text>1</Text>
+          <Text>2</Text>
+          <Text>3</Text>
+        </Stack>
+      </BraidProvider>,
+    );
+
+    const list = getByRole('list');
+    expect(list.nodeName).toBe('OL');
+
+    expect(
+      Array.from(list.childNodes).map(childNode => childNode.nodeName),
+    ).toEqual(['LI', 'LI', 'LI']);
+  });
+});

--- a/lib/components/Stack/Stack.test.tsx
+++ b/lib/components/Stack/Stack.test.tsx
@@ -41,7 +41,7 @@ describe('Stack', () => {
     ).toEqual(['LI', 'LI', 'LI']);
   });
 
-  it('should render a valid unordered list when "component" is "ol"', () => {
+  it('should render a valid ordered list when "component" is "ol"', () => {
     const { getByRole } = render(
       <BraidProvider theme={wireframe}>
         <Stack component="ol" space="small">

--- a/lib/components/Stack/Stack.tsx
+++ b/lib/components/Stack/Stack.tsx
@@ -41,7 +41,10 @@ export const useStackItem = ({ align, component, space }: UseStackProps) => {
   );
 };
 
+const validStackComponents = ['div', 'ol', 'ul'] as const;
+
 export interface StackProps {
+  component?: typeof validStackComponents[number];
   children: ReactNode;
   space: UseBoxStylesProps['padding'];
   align?: ResponsiveProp<Align>;
@@ -49,30 +52,45 @@ export interface StackProps {
 }
 
 export const Stack = ({
+  component = 'div',
   children,
   space,
   align = 'left',
   dividers = false,
 }: StackProps) => {
-  const stackClasses = useStackItem({ component: 'div', space, align });
+  if (
+    process.env.NODE_ENV === 'development' &&
+    !validStackComponents.includes(component)
+  ) {
+    throw new Error(`Invalid Stack component: ${component}`);
+  }
+
+  const stackClasses = useStackItem({ component, space, align });
   const stackItems = Children.toArray(children);
 
-  if (stackItems.length <= 1 && align === 'left') {
+  const isList = component === 'ol' || component === 'ul';
+  const stackItemComponent = isList ? 'li' : 'div';
+
+  if (stackItems.length <= 1 && align === 'left' && !isList) {
     return <Fragment>{stackItems}</Fragment>;
   }
 
   return (
-    <div>
+    <Box component={component}>
       {stackItems.map((child, index) => (
-        <div className={dividers ? undefined : stackClasses} key={index}>
+        <Box
+          component={stackItemComponent}
+          className={dividers ? undefined : stackClasses}
+          key={index}
+        >
           {dividers && index > 0 ? (
             <Box width="full" paddingY={space}>
               <Divider />
             </Box>
           ) : null}
           {child}
-        </div>
+        </Box>
       ))}
-    </div>
+    </Box>
   );
 };


### PR DESCRIPTION
This adds a `component` prop to `Stack` to customise the wrapper element, and if `ol` or `ul` are specified, each stack item is wrapped in an `li` element rather than a `div`.

For now, only `div`, `ol` and `ul` are supported. Any other values will throw an error in dev mode.

Because this is quite easy to break and can't be picked up in a visual test, I've added a few Jest tests to ensure the semantics are being managed correctly.