### PR TITLE
fix(Stack): Ignore empty string children

### DIFF
--- a/lib/components/Stack/Stack.tsx
+++ b/lib/components/Stack/Stack.tsx
@@ -55,7 +55,7 @@ export const Stack = ({
   dividers = false,
 }: StackProps) => {
   const stackClasses = useStackItem({ component: 'div', space, align });
-  const stackItems = Children.toArray(children);
+  const stackItems = Children.toArray(children).filter(child => Boolean(child));
 
   if (stackItems.length <= 1 && align === 'left') {
     return <Fragment>{stackItems}</Fragment>;


### PR DESCRIPTION
I noticed some inconsistencies in spacing when rendering a list of items with Stack and discovered that in the following scenario (see playroom link), the node with the condition wrapped around is still rendered by Stack. It turns out that `Children.toArray(children)` will return an array with 4 nodes and an empty string in this scenario. This causes padding inconsistencies. 

https://seek-oss.github.io/braid-design-system/playroom/#?code=N4Igxg9gJgpiBcJgAoAuMDOqAEBebAOiEQJQC+BAdgDwDCAhgE5QB8V221AyqvWANbYMABz4xcRADZMA5jCJtKHDtQAqMAB6oWARmoB6dVsXLOR7QCYD5k8rWbtAZmsPbKmwBYXx9suDosbAAyILMHbFQISnEiYQgMAEtUBIA3eRAWAFZvbQolTn0ePn5bey0IqJjwRiSEsHpJBQA2HMUDBmZFKmoAEVSE2EZsfS6aDtZfbl4BIVEwKulGOQVfd1c9Q1dVsOMrTZ98teNnfe1tsu0vU7dsYAAhCAhJGHpKNExUEmDQi4roiRAcUSyTSCmy1zyKkK0xKk3MfyqYBqyXqjQyLWu3X040UIAANCAAO4DVAACwwCAA2o4LAAGAC6ZCAA

This can be easily fixed in an apps using braid by wrapping the empty string in a `Boolean()` but I figured it'd be worth submitted a PR in case this catches someone else out one day