### PR TITLE
feat: Add truncate support to Text and Heading

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -836,6 +836,11 @@ exports[`Box 1`] = `
   onWheelCapture?: (event: WheelEvent<HTMLElement>) => void
   open?: boolean
   optimum?: number
+  overflow?: 
+    | "auto"
+    | "hidden"
+    | "scroll"
+    | "visible"
   padding?: ResponsiveProp<
     | "gutter"
     | "large"
@@ -1317,6 +1322,11 @@ exports[`BoxRenderer 1`] = `
     | "xxlarge"
     | "xxsmall"
   >
+  overflow?: 
+    | "auto"
+    | "hidden"
+    | "scroll"
+    | "visible"
   padding?: ResponsiveProp<
     | "gutter"
     | "large"
@@ -1835,6 +1845,7 @@ exports[`Heading 1`] = `
     | "2"
     | "3"
     | "4"
+  truncate?: boolean
   weight?: 
     | "regular"
     | "weak"
@@ -3493,6 +3504,7 @@ exports[`Text 1`] = `
     | "positive"
     | "promote"
     | "secondary"
+  truncate?: boolean
   weight?: 
     | "medium"
     | "regular"

--- a/lib/components/Badge/Badge.treat.ts
+++ b/lib/components/Badge/Badge.treat.ts
@@ -6,7 +6,3 @@ export const outer = style(({ utils, grid, typography }) =>
     tablet: { height: grid * typography.text.xsmall.tablet.rows },
   }),
 );
-
-export const inner = style({
-  overflow: 'hidden',
-});

--- a/lib/components/Badge/Badge.tsx
+++ b/lib/components/Badge/Badge.tsx
@@ -52,16 +52,22 @@ export const Badge = ({
   }
 
   return (
-    <Box className={styles.outer}>
+    <Box display="flex" className={styles.outer}>
       <Box
         id={id}
-        display="inlineBlock"
+        title={children}
         background={backgroundForTone(tone, weight)}
         paddingX="xsmall"
         borderRadius="standard"
-        className={styles.inner}
+        overflow="hidden"
       >
-        <Text component="span" weight="medium" size="xsmall" baseline={false}>
+        <Text
+          component="span"
+          weight="medium"
+          size="xsmall"
+          truncate
+          baseline={false}
+        >
           {children}
         </Text>
       </Box>

--- a/lib/components/Box/Box.tsx
+++ b/lib/components/Box/Box.tsx
@@ -40,6 +40,7 @@ const NamedBox = forwardRef<HTMLElement, BoxProps>(
       position,
       cursor,
       pointerEvents,
+      overflow,
       className,
       ...restProps
     },
@@ -76,6 +77,7 @@ const NamedBox = forwardRef<HTMLElement, BoxProps>(
       position,
       cursor,
       pointerEvents,
+      overflow,
     });
 
     const element = createElement(component, {

--- a/lib/components/Box/useBoxStyles.treat.ts
+++ b/lib/components/Box/useBoxStyles.treat.ts
@@ -302,3 +302,11 @@ export const textAlignDesktop = styleMap(({ utils: { responsiveStyle } }) =>
     }),
   ),
 );
+
+const overflowRules = {
+  hidden: 'hidden',
+  scroll: 'scroll',
+  visible: 'visible',
+  auto: 'auto',
+};
+export const overflow = styleMap(mapToStyleProperty(overflowRules, 'overflow'));

--- a/lib/components/Box/useBoxStyles.ts
+++ b/lib/components/Box/useBoxStyles.ts
@@ -43,6 +43,7 @@ export interface UseBoxStylesProps {
   position?: keyof typeof styleRefs.position;
   cursor?: keyof typeof styleRefs.cursor;
   pointerEvents?: keyof typeof styleRefs.pointerEvents;
+  overflow?: keyof typeof styleRefs.overflow;
 }
 
 export const useBoxStyles = ({
@@ -76,6 +77,7 @@ export const useBoxStyles = ({
   position,
   cursor,
   pointerEvents,
+  overflow,
 }: UseBoxStylesProps) => {
   const resetStyles = useStyles(resetStyleRefs);
   const styles = useStyles(styleRefs);
@@ -103,6 +105,7 @@ export const useBoxStyles = ({
     styles.position[position!],
     styles.cursor[cursor!],
     styles.pointerEvents[pointerEvents!],
+    styles.overflow[overflow!],
     resolvedMarginTop &&
       resolveResponsiveProp(
         resolvedMarginTop,

--- a/lib/components/ButtonRenderer/ButtonRenderer.treat.ts
+++ b/lib/components/ButtonRenderer/ButtonRenderer.treat.ts
@@ -45,10 +45,7 @@ export const focusOverlay = style({
 });
 
 export const content = style({
-  overflow: 'hidden',
-  textOverflow: 'ellipsis',
   userSelect: 'none',
-  whiteSpace: 'nowrap',
 });
 
 export const loading = style({

--- a/lib/components/ButtonRenderer/ButtonRenderer.tsx
+++ b/lib/components/ButtonRenderer/ButtonRenderer.tsx
@@ -101,6 +101,7 @@ const ButtonChildren = ({ children }: ButtonChildrenProps) => {
         paddingX="gutter"
         pointerEvents="none"
         textAlign="center"
+        overflow="hidden"
         className={classnames(styles.content, useTouchableSpace('standard'))}
       >
         <Text baseline={false} weight="medium" tone={buttonVariant.textTone}>

--- a/lib/components/Heading/Heading.docs.tsx
+++ b/lib/components/Heading/Heading.docs.tsx
@@ -68,9 +68,9 @@ const docs: ComponentDocs = {
     {
       label: 'Truncate a long heading',
       Example: () => (
-        <Box style={{ width: 150 }}>
+        <Box style={{ width: 160 }}>
           <Heading level="2" truncate>
-            Long heading
+            Really long heading
           </Heading>
         </Box>
       ),

--- a/lib/components/Heading/Heading.docs.tsx
+++ b/lib/components/Heading/Heading.docs.tsx
@@ -66,6 +66,16 @@ const docs: ComponentDocs = {
       ),
     },
     {
+      label: 'Truncate a long heading',
+      Example: () => (
+        <Box style={{ width: 150 }}>
+          <Heading level="2" truncate>
+            Long heading
+          </Heading>
+        </Box>
+      ),
+    },
+    {
       label: 'Heading Spacing',
       docsSite: false,
       Example: () => {

--- a/lib/components/Heading/Heading.tsx
+++ b/lib/components/Heading/Heading.tsx
@@ -3,6 +3,7 @@ import HeadingContext from './HeadingContext';
 import { Box, BoxProps } from '../Box/Box';
 import {
   useHeading,
+  useTruncate,
   HeadingLevel,
   HeadingWeight,
 } from '../../hooks/typography';
@@ -22,6 +23,7 @@ export interface HeadingProps {
   align?: BoxProps['textAlign'];
   component?: BoxProps['component'];
   id?: string;
+  truncate?: boolean;
   _LEGACY_SPACE_?: boolean;
 }
 
@@ -44,17 +46,41 @@ export const Heading = ({
   children,
   align,
   id,
+  truncate = false,
   _LEGACY_SPACE_ = false,
-}: HeadingProps) => (
-  <HeadingContext.Provider value={true}>
+}: HeadingProps) => {
+  const truncateStyles = useTruncate();
+  const content = truncate ? (
     <Box
-      id={id}
-      component={component || resolveDefaultComponent[level]}
-      paddingBottom={_LEGACY_SPACE_ ? resolvePaddingForLevel(level) : undefined}
-      textAlign={align}
-      className={useHeading({ weight, level, baseline: true, _LEGACY_SPACE_ })}
+      component="span"
+      display="block"
+      overflow="hidden"
+      className={truncateStyles}
     >
       {children}
     </Box>
-  </HeadingContext.Provider>
-);
+  ) : (
+    children
+  );
+
+  return (
+    <HeadingContext.Provider value={true}>
+      <Box
+        id={id}
+        component={component || resolveDefaultComponent[level]}
+        paddingBottom={
+          _LEGACY_SPACE_ ? resolvePaddingForLevel(level) : undefined
+        }
+        textAlign={align}
+        className={useHeading({
+          weight,
+          level,
+          baseline: true,
+          _LEGACY_SPACE_,
+        })}
+      >
+        {content}
+      </Box>
+    </HeadingContext.Provider>
+  );
+};

--- a/lib/components/Text/Text.docs.tsx
+++ b/lib/components/Text/Text.docs.tsx
@@ -28,6 +28,14 @@ const docs: ComponentDocs = {
       Example: () => <Text size="large">Large text.</Text>,
     },
     {
+      label: 'Truncating long text',
+      Example: () => (
+        <Box style={{ width: 90 }}>
+          <Text truncate>Long piece of text</Text>
+        </Box>
+      ),
+    },
+    {
       label: 'Text on Brand Background',
       Container,
       Example: () => (

--- a/lib/components/Text/Text.tsx
+++ b/lib/components/Text/Text.tsx
@@ -1,7 +1,8 @@
 import React, { ReactNode, useContext, useMemo } from 'react';
+import classnames from 'classnames';
 import TextContext from './TextContext';
 import { Box, BoxProps } from '../Box/Box';
-import { useText, UseTextProps } from '../../hooks/typography';
+import { useText, UseTextProps, useTruncate } from '../../hooks/typography';
 
 export interface TextProps extends Pick<BoxProps, 'component'> {
   id?: string;
@@ -11,6 +12,7 @@ export interface TextProps extends Pick<BoxProps, 'component'> {
   weight?: UseTextProps['weight'];
   baseline?: UseTextProps['baseline'];
   align?: BoxProps['textAlign'];
+  truncate?: boolean;
   _LEGACY_SPACE_?: boolean;
 }
 
@@ -22,10 +24,12 @@ export const Text = ({
   align,
   weight,
   baseline = true,
+  truncate = false,
   _LEGACY_SPACE_ = false,
   children,
 }: TextProps) => {
   const textStyles = useText({ weight, size, baseline, tone, _LEGACY_SPACE_ });
+  const truncateStyles = useTruncate();
 
   // Prevent re-renders when context values haven't changed
   const textContextValue = useMemo(
@@ -57,7 +61,7 @@ export const Text = ({
         display="block"
         component={component}
         textAlign={align}
-        className={textStyles}
+        className={classnames(textStyles, truncate ? truncateStyles : '')}
       >
         {children}
       </Box>

--- a/lib/components/Text/Text.tsx
+++ b/lib/components/Text/Text.tsx
@@ -1,5 +1,4 @@
 import React, { ReactNode, useContext, useMemo } from 'react';
-import classnames from 'classnames';
 import TextContext from './TextContext';
 import { Box, BoxProps } from '../Box/Box';
 import { useText, UseTextProps, useTruncate } from '../../hooks/typography';
@@ -54,6 +53,19 @@ export const Text = ({
     }
   }
 
+  const content = truncate ? (
+    <Box
+      component="span"
+      display="block"
+      overflow="hidden"
+      className={truncateStyles}
+    >
+      {children}
+    </Box>
+  ) : (
+    children
+  );
+
   return (
     <TextContext.Provider value={textContextValue}>
       <Box
@@ -61,9 +73,9 @@ export const Text = ({
         display="block"
         component={component}
         textAlign={align}
-        className={classnames(textStyles, truncate ? truncateStyles : '')}
+        className={textStyles}
       >
-        {children}
+        {content}
       </Box>
     </TextContext.Provider>
   );

--- a/lib/components/Toggle/Toggle.treat.ts
+++ b/lib/components/Toggle/Toggle.treat.ts
@@ -48,7 +48,6 @@ export const slideTrack = style(theme => {
     height,
     borderRadius: height / 2,
     backgroundColor: theme.border.color.standard,
-    overflow: 'hidden',
     // Fix for Safari border-radius, overflow hidden, transform bug:
     // https://gist.github.com/ayamflow/b602ab436ac9f05660d9c15190f4fd7b
     '-webkit-mask-image': '-webkit-radial-gradient(white, black)',

--- a/lib/components/Toggle/Toggle.tsx
+++ b/lib/components/Toggle/Toggle.tsx
@@ -57,7 +57,12 @@ export const Toggle = ({
         alignItems="center"
         className={classnames(styles.slideContainer, styles.fieldSize)}
       >
-        <Box position="absolute" width="full" className={styles.slideTrack}>
+        <Box
+          position="absolute"
+          width="full"
+          overflow="hidden"
+          className={styles.slideTrack}
+        >
           <Box
             position="absolute"
             width="full"

--- a/lib/hooks/typography/index.ts
+++ b/lib/hooks/typography/index.ts
@@ -129,3 +129,7 @@ export function useTextTone({
 export function useTouchableSpace(size: keyof typeof styleRefs.touchable) {
   return useStyles(styleRefs).touchable[size];
 }
+
+export function useTruncate() {
+  return useStyles(styleRefs).truncate;
+}

--- a/lib/hooks/typography/typography.treat.ts
+++ b/lib/hooks/typography/typography.treat.ts
@@ -201,3 +201,13 @@ export const touchable = styleMap(
       }),
     ),
 );
+
+export const truncate = style({
+  whiteSpace: 'nowrap',
+  overflow: 'hidden',
+  textOverflow: 'ellipsis',
+  // Allows ascenders/descenders to overflow container
+  // Padding one extra to offset basekick styles, need better solution to handle `baseline={false}`
+  padding: '11px 0px !important',
+  margin: '-10px 0px',
+});

--- a/lib/hooks/typography/typography.treat.ts
+++ b/lib/hooks/typography/typography.treat.ts
@@ -204,10 +204,5 @@ export const touchable = styleMap(
 
 export const truncate = style({
   whiteSpace: 'nowrap',
-  overflow: 'hidden',
   textOverflow: 'ellipsis',
-  // Allows ascenders/descenders to overflow container
-  // Padding one extra to offset basekick styles, need better solution to handle `baseline={false}`
-  padding: '11px 0px !important',
-  margin: '-10px 0px',
 });

--- a/site/src/App/Documentation/Documentation.treat.ts
+++ b/site/src/App/Documentation/Documentation.treat.ts
@@ -33,7 +33,6 @@ export const menu = style(theme => ({
   left: 0,
   bottom: 0,
   right: 0,
-  overflow: 'auto',
   transition: 'opacity .2s ease, transform .2s ease',
   '@media': {
     [`screen and (max-width: ${theme.breakpoint.desktop - 1}px)`]: {
@@ -57,7 +56,6 @@ export const menu = style(theme => ({
 
 export const logo = style({
   width: 36,
-  overflow: 'hidden',
 });
 
 export const content = style(theme => ({

--- a/site/src/App/Documentation/Documentation.tsx
+++ b/site/src/App/Documentation/Documentation.tsx
@@ -94,7 +94,7 @@ export const Documentation = () => {
             className={styles.header}
           >
             <Link to="/">
-              <Box className={styles.logo}>
+              <Box overflow="hidden" className={styles.logo}>
                 <Logo />
               </Box>
             </Link>
@@ -118,6 +118,7 @@ export const Documentation = () => {
                 paddingTop="small"
                 paddingBottom="xlarge"
                 paddingX={responsiveGutter}
+                overflow="auto"
                 className={styles.menu}
               >
                 <Stack space="xlarge">


### PR DESCRIPTION
### Description
Adds the ability to truncate long running text with an ellipsis to support instances where text wrapping is not desired.

```jsx
<Text truncate>
  Long heading
</Text>
```
or
```jsx
<Heading level="2" truncate>
  Long heading
</Heading>
```

[Playroom demo](https://braid-design-system--5be8ab2c7558d4a5c4efee3dd17beca59272ae8c.surge.sh/playroom/#?code=N4Igxg9gJgpiBcIA8BhAhgJygPgDoDsACQpAZQBc0wBrQgZwAcqYBeXEAG0wHMZ28ixEiggcArgFt8dekzCt2EmFACWk-gSFDUoyfgFatSABIw0q-N0IcYANxgc2IAMztC5DGPxg05GAcMtABkIS0IACzMLK3Jw30IAdxhCKFDyRLR8dPIIRIw0Bk1AkgB6U3MVSwCjEpFxKWrtOr1ElShYp0gsmCyNQUCkAHl7DAAzDggEgFkesUaB4ZgxienZgEk-CWwAEQcYPyQSxeXJmfwxDZgtooGjkfHT2fnS5oabl90pOgF3skoaWTMJx0CRoDgcPoDAAqMAAHtlQgoQHQYF0oJgAJ5uDxeHx+Z7EJBrLohPEqUKEErYQgAJTM4Ix1lCVgYKlRyQgo3ccOycXSSRSaQyWXcuQS+UK-W0JRh8J+UsJsoR+CRKLRmOxnm8vn87yMxNCU0RjKphAAgvgILEloQMPSOIyJmFWezCJzufD3HzEslUiKEpkEXqhOKCsHDkrGocKFRqAFo-84wRDugsAIQAAaEDWpR0BAAbWRMBg1AtAC8QABdLMJNqxPPwfPOABMAAZKwBfIA)

### Developer notes
Add support for `overflow` to `Box`
