### PR TITLE
fix(Stack,Inline,Tiles): Disallow strings as children

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -3162,7 +3162,7 @@ exports[`Inline 1`] = `
     | "left"
     | "right"
   >
-  children: ReactNode
+  children: ReactNodeNoStrings
   space: ResponsiveProp<
     | "gutter"
     | "large"
@@ -3275,7 +3275,7 @@ exports[`Stack 1`] = `
     | "left"
     | "right"
   >
-  children: ReactNode
+  children: ReactNodeNoStrings
   component?: 
     | "div"
     | "ol"
@@ -4111,7 +4111,7 @@ exports[`ThemeNameConsumer 1`] = `
 
 exports[`Tiles 1`] = `
 {
-  children: ReactNode
+  children: ReactNodeNoStrings
   columns: ResponsiveProp<
     | 1
     | 2

--- a/generate-component-docs/generate.ts
+++ b/generate-component-docs/generate.ts
@@ -27,6 +27,13 @@ const reactNodeTypes = [
   'ReactPortal',
 ];
 
+const reactNodeNoStringsTypes = [
+  'false',
+  'true',
+  'ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<any, any, any>)>',
+  'ReactNodeArray',
+];
+
 export interface NormalisedInterface {
   type: 'interface';
   props: {
@@ -169,14 +176,18 @@ export default () => {
         checker.typeToString(unionItem),
       );
 
-      return isEqual(types, reactNodeTypes)
-        ? 'ReactNode'
-        : {
-            type: 'union',
-            types: type.types.map(unionItem =>
-              normaliseType(unionItem, propsObj),
-            ),
-          };
+      if (isEqual(types, reactNodeTypes)) {
+        return 'ReactNode';
+      }
+
+      if (isEqual(types, reactNodeNoStringsTypes)) {
+        return 'ReactNodeNoStrings';
+      }
+
+      return {
+        type: 'union',
+        types: type.types.map(unionItem => normaliseType(unionItem, propsObj)),
+      };
     }
 
     if (type.isClassOrInterface()) {

--- a/lib/components/Inline/Inline.tsx
+++ b/lib/components/Inline/Inline.tsx
@@ -1,4 +1,4 @@
-import React, { Children, ReactNode } from 'react';
+import React, { Children } from 'react';
 import classnames from 'classnames';
 import { useStyles } from 'sku/treat';
 import { Box } from '../Box/Box';
@@ -10,11 +10,12 @@ import {
 import { ResponsiveProp } from '../../utils/responsiveProp';
 import { Align, alignToFlexAlign } from '../../utils/align';
 import * as styleRefs from './Inline.treat';
+import { ReactNodeNoStrings } from '../private/ReactNodeNoStrings';
 
 export interface InlineProps {
   align?: ResponsiveProp<Align>;
   space: ResponsiveSpace;
-  children: ReactNode;
+  children: ReactNodeNoStrings;
 }
 
 export const Inline = ({ space = 'none', align, children }: InlineProps) => {

--- a/lib/components/Stack/Stack.tsx
+++ b/lib/components/Stack/Stack.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, Children, Fragment } from 'react';
+import React, { Children, Fragment } from 'react';
 import classnames from 'classnames';
 import { useStyles } from 'sku/treat';
 import { Divider } from '../Divider/Divider';
@@ -7,6 +7,7 @@ import { ResponsiveProp, mapResponsiveProp } from '../../utils/responsiveProp';
 import { useBoxStyles, UseBoxStylesProps } from '../Box/useBoxStyles';
 import * as styleRefs from './Stack.treat';
 import { Box } from '../Box/Box';
+import { ReactNodeNoStrings } from '../private/ReactNodeNoStrings';
 
 export interface UseStackProps {
   align: ResponsiveProp<Align>;
@@ -45,7 +46,7 @@ const validStackComponents = ['div', 'ol', 'ul'] as const;
 
 export interface StackProps {
   component?: typeof validStackComponents[number];
-  children: ReactNode;
+  children: ReactNodeNoStrings;
   space: UseBoxStylesProps['padding'];
   align?: ResponsiveProp<Align>;
   dividers?: boolean;

--- a/lib/components/Tiles/Tiles.tsx
+++ b/lib/components/Tiles/Tiles.tsx
@@ -1,4 +1,4 @@
-import React, { Children, ReactNode } from 'react';
+import React, { Children } from 'react';
 import { useStyles } from 'sku/react-treat';
 import classnames from 'classnames';
 import { Box } from '../Box/Box';
@@ -13,9 +13,10 @@ import {
   ResponsiveProp,
 } from '../../utils/responsiveProp';
 import * as styleRefs from './Tiles.treat';
+import { ReactNodeNoStrings } from '../private/ReactNodeNoStrings';
 
 export interface TilesProps {
-  children: ReactNode;
+  children: ReactNodeNoStrings;
   space: ResponsiveSpace;
   columns: ResponsiveProp<1 | 2 | 3 | 4 | 5>;
   dividers?: boolean;

--- a/lib/components/private/FieldGroup/FieldGroup.tsx
+++ b/lib/components/private/FieldGroup/FieldGroup.tsx
@@ -1,4 +1,4 @@
-import React, { AllHTMLAttributes, ReactNode } from 'react';
+import React, { AllHTMLAttributes } from 'react';
 import { Box } from '../../Box/Box';
 import { FieldLabel, FieldLabelProps } from '../../FieldLabel/FieldLabel';
 import {
@@ -6,6 +6,7 @@ import {
   FieldMessageProps,
 } from '../../FieldMessage/FieldMessage';
 import { Stack } from '../../Stack/Stack';
+import { ReactNodeNoStrings } from '../ReactNodeNoStrings';
 
 type FormElementProps = AllHTMLAttributes<HTMLFormElement>;
 export interface FieldGroupProps {
@@ -26,7 +27,7 @@ interface FieldGroupRenderProps {
 }
 
 interface InternalFieldGroupProps extends FieldGroupProps {
-  children(props: FieldGroupRenderProps): ReactNode;
+  children(props: FieldGroupRenderProps): ReactNodeNoStrings;
 }
 
 export const FieldGroup = ({

--- a/lib/components/private/ReactNodeNoStrings.ts
+++ b/lib/components/private/ReactNodeNoStrings.ts
@@ -1,0 +1,9 @@
+import { ReactElement } from 'react';
+
+interface ReactNodeArray extends Array<ReactNodeNoStrings> {}
+export type ReactNodeNoStrings =
+  | ReactElement
+  | ReactNodeArray
+  | boolean
+  | null
+  | undefined;

--- a/site/src/App/TextStack/TextStack.tsx
+++ b/site/src/App/TextStack/TextStack.tsx
@@ -1,11 +1,12 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { useStyles } from 'sku/react-treat';
 import { Box, Stack } from '../../../../lib/components';
 import * as styleRefs from './TextStack.treat';
 import { StackProps } from '../../../../lib/components/Stack/Stack';
+import { ReactNodeNoStrings } from '../../../../lib/components/private/ReactNodeNoStrings';
 
 interface TextStackProps {
-  children: ReactNode;
+  children: ReactNodeNoStrings;
   space?: StackProps['space'];
 }
 


### PR DESCRIPTION
This change is designed to highlight the issue of accidentally passing strings to Layout components. This can happen unintendedly when using conditional rendering logic with potentially empty strings. 

e.g.
```jsx
// when description = ''
<Stack space="small">
  {description && <Text>{description}</Text>}
</Stack>
```