### PR TITLE
docs: Manage scroll position with 'react-router-scroll-memory'

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,6 +110,7 @@
     "react-element-to-jsx-string": "^14.0.1",
     "react-router": "^5.1.2",
     "react-router-dom": "^5.1.2",
+    "react-router-scroll-memory": "^2.0.5",
     "react-syntax-highlighter": "^11.0.2",
     "react-transition-group": "^4.3.0",
     "renovate-config-seek": "0.4.0",

--- a/site/src/App/App.tsx
+++ b/site/src/App/App.tsx
@@ -1,8 +1,7 @@
 // Import all themes up front so CSS overrides work
 import * as themes from '../../../lib/themes';
-import React, { StrictMode, useEffect } from 'react';
+import React, { StrictMode } from 'react';
 import { Route } from 'react-router';
-import { useLocation } from 'react-router-dom';
 import { CSSTransition } from 'react-transition-group';
 
 import '../../../lib/reset';
@@ -21,46 +20,27 @@ const routes = [
   },
 ];
 
-export const App = () => {
-  const { pathname } = useLocation();
-
-  useEffect(() => {
-    if ('scrollBehavior' in window.document.documentElement.style) {
-      window.scrollTo({
-        top: 0,
-        left: 0,
-        behavior: 'smooth',
-      });
-    } else {
-      window.scrollTo(0, 0);
-    }
-  }, [pathname]);
-
-  return (
-    <BraidProvider theme={themes.wireframe}>
-      <div>
-        {routes.map(({ path, exact, Component }) => (
-          <Route key={path} exact={exact} path={path}>
-            {({ match }) => (
-              <CSSTransition
-                in={match != null}
-                timeout={350}
-                classNames={{ ...styles }}
-                unmountOnExit
-              >
-                <StrictMode>
-                  <Box
-                    position="absolute"
-                    className={styles.transitionContainer}
-                  >
-                    <Component />
-                  </Box>
-                </StrictMode>
-              </CSSTransition>
-            )}
-          </Route>
-        ))}
-      </div>
-    </BraidProvider>
-  );
-};
+export const App = () => (
+  <BraidProvider theme={themes.wireframe}>
+    <div>
+      {routes.map(({ path, exact, Component }) => (
+        <Route key={path} exact={exact} path={path}>
+          {({ match }) => (
+            <CSSTransition
+              in={match != null}
+              timeout={350}
+              classNames={{ ...styles }}
+              unmountOnExit
+            >
+              <StrictMode>
+                <Box position="absolute" className={styles.transitionContainer}>
+                  <Component />
+                </Box>
+              </StrictMode>
+            </CSSTransition>
+          )}
+        </Route>
+      ))}
+    </div>
+  </BraidProvider>
+);

--- a/site/src/client.tsx
+++ b/site/src/client.tsx
@@ -2,6 +2,8 @@ import 'focus-visible';
 import React from 'react';
 import { hydrate } from 'react-dom';
 import { BrowserRouter } from 'react-router-dom';
+// @ts-ignore
+import ScrollMemory from 'react-router-scroll-memory';
 import { App } from './App/App';
 import { RenderContext } from './types';
 import { ConfigProvider } from './App/ConfigContext';
@@ -10,6 +12,7 @@ export default (app: RenderContext) => {
   hydrate(
     <BrowserRouter basename={app.routerBasename}>
       <ConfigProvider value={app.appConfig}>
+        <ScrollMemory />
         <App />
       </ConfigProvider>
     </BrowserRouter>,

--- a/yarn.lock
+++ b/yarn.lock
@@ -13875,6 +13875,11 @@ react-router-dom@^5.1.2:
     tiny-invariant "^1.0.2"
     tiny-warning "^1.0.0"
 
+react-router-scroll-memory@^2.0.5:
+  version "2.0.5"
+  resolved "https://registry.yarnpkg.com/react-router-scroll-memory/-/react-router-scroll-memory-2.0.5.tgz#3afcdf2e7c51310f95950c40f6a2d316e8cb0641"
+  integrity sha512-UI3NvDR7GktewfaeI05BKgKQ4nEhhf9M5sFhIBxhu8ZYOmlRQqsXy16EabHOEPEPzwQZXSb1swKucwsN8zy3bA==
+
 react-router@5.1.2, react-router@^5.1.2:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/react-router/-/react-router-5.1.2.tgz#6ea51d789cb36a6be1ba5f7c0d48dd9e817d3418"


### PR DESCRIPTION
There are a few issues with our current scroll position management solution that this aims to address:

- During development, hot reload resets your scroll position to the top.
- Clicking back or forwards also resets your scroll position to the top.
- The animated `scrollTo` call causes you to momentarily maintain your existing scroll position when navigating to a new page.

Instead, by using [react-router-scroll-memory](https://www.npmjs.com/package/react-router-scroll-memory), our scroll management now behaves much more like a traditional non-SPA site.