### PR TITLE
chore(Playroom): Add support for round placeholders

### DIFF
--- a/lib/components/private/Placeholder/Placeholder.tsx
+++ b/lib/components/private/Placeholder/Placeholder.tsx
@@ -10,12 +10,14 @@ export interface PlaceholderProps {
   height: string | number;
   width?: string | number;
   label?: string;
+  shape?: 'rectangle' | 'round';
 }
 
 export const Placeholder = ({
   label,
   width = 'auto',
   height = 120,
+  shape = 'rectangle',
 }: PlaceholderProps) => {
   const styles = useStyles(styleRefs);
   const backgroundLightness = useBackgroundLightness();
@@ -35,6 +37,7 @@ export const Placeholder = ({
         display="flex"
         alignItems="center"
         justifyContent="center"
+        borderRadius={shape === 'round' ? 'full' : undefined}
         className={styles.box[backgroundLightness]}
         style={{ width, height }}
       >


### PR DESCRIPTION
For example:

```tsx
<Placeholder width={80} height={80} shape="round" label="Logo" />
```

<img width="99" alt="Screen Shot 2020-01-20 at 11 51 55 am" src="https://user-images.githubusercontent.com/696693/72691701-86fd8800-3b7b-11ea-827c-31bbeb10d3cd.png">

*(If you're wondering why it's not called `"circle"`, it's because it's not necessarily a circle, e.g. `<Placeholder width={160} height={80} shape="round" />`)*