### PR TITLE
fix(TextLink,TextLinkRenderer): Remove surrounding space, add hitArea prop

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -3925,6 +3925,9 @@ exports[`TextLink 1`] = `
     | string
   hidden?: boolean
   high?: number
+  hitArea?: 
+    | "large"
+    | "standard"
   href?: string
   hrefLang?: string
   htmlFor?: string
@@ -4203,6 +4206,9 @@ exports[`TextLink 1`] = `
 exports[`TextLinkRenderer 1`] = `
 {
   children: (styleProps: StyleProps) => ReactElement<any, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<...>)>
+  hitArea?: 
+    | "large"
+    | "standard"
   showVisited?: boolean
 }
 `;

--- a/lib/components/Bullet/Bullet.docs.tsx
+++ b/lib/components/Bullet/Bullet.docs.tsx
@@ -2,6 +2,7 @@ import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { Bullet } from './Bullet';
 import { BulletList } from '../BulletList/BulletList';
+import { TextLink } from '../TextLink/TextLink';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -75,6 +76,23 @@ const docs: ComponentDocs = {
           <Bullet>This is a secondary bullet.</Bullet>
           <Bullet>This is a secondary bullet.</Bullet>
           <Bullet>This is a secondary bullet.</Bullet>
+        </BulletList>
+      ),
+    },
+    {
+      label: 'With TextLink',
+      docsSite: false,
+      Example: () => (
+        <BulletList>
+          <Bullet>
+            This is a text <TextLink>link</TextLink>.
+          </Bullet>
+          <Bullet>
+            This is a secondary <TextLink>link</TextLink>.
+          </Bullet>
+          <Bullet>
+            This is a secondary <TextLink>link</TextLink>.
+          </Bullet>
         </BulletList>
       ),
     },

--- a/lib/components/Bullet/Bullet.tsx
+++ b/lib/components/Bullet/Bullet.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, useContext } from 'react';
+import React, { ReactNode, useContext, useMemo } from 'react';
 import { useStyles } from 'sku/treat';
 import classnames from 'classnames';
 import { Box } from '../Box/Box';
@@ -7,6 +7,7 @@ import { BulletListContext } from '../BulletList/BulletList';
 import { useStackItem } from '../Stack/Stack';
 import { useLineHeightContainer } from '../../hooks/useLineHeightContainer/useLineHeightContainer';
 import * as styleRefs from './Bullet.treat';
+import TextContext from '../Text/TextContext';
 
 export interface BulletProps {
   children: ReactNode;
@@ -18,29 +19,49 @@ export const Bullet = ({ children }: BulletProps) => {
   const styles = useStyles(styleRefs);
   const { size, space, tone } = useContext(BulletListContext);
 
+  // Prevent re-renders when context values haven't changed
+  const textContextValue = useMemo(
+    () => ({
+      size,
+      tone,
+      baseline: true,
+    }),
+    [tone, size],
+  );
+
   return (
-    <Box
-      component={component}
-      className={classnames(
-        useText({ size, baseline: true, tone }),
-        useStackItem({ component, space, align: 'left' }),
-      )}
-    >
-      <Box display="flex">
-        <Box
-          display="flex"
-          alignItems="center"
-          className={useLineHeightContainer(size)}
-        >
+    <TextContext.Provider value={textContextValue}>
+      <Box
+        component={component}
+        className={classnames(
+          useText({
+            size,
+            baseline: true,
+            tone,
+          }),
+          useStackItem({
+            component,
+            space,
+            align: 'left',
+          }),
+        )}
+      >
+        <Box display="flex">
           <Box
-            borderRadius="full"
-            className={classnames(styles.currentColor, styles.size[size])}
-          />
-        </Box>
-        <Box paddingLeft={size === 'xsmall' ? 'xsmall' : 'small'}>
-          {children}
+            display="flex"
+            alignItems="center"
+            className={useLineHeightContainer(size)}
+          >
+            <Box
+              borderRadius="full"
+              className={classnames(styles.currentColor, styles.size[size])}
+            />
+          </Box>
+          <Box paddingLeft={size === 'xsmall' ? 'xsmall' : 'small'}>
+            {children}
+          </Box>
         </Box>
       </Box>
-    </Box>
+    </TextContext.Provider>
   );
 };

--- a/lib/components/TextLink/TextLink.docs.tsx
+++ b/lib/components/TextLink/TextLink.docs.tsx
@@ -18,6 +18,14 @@ const docs: ComponentDocs = {
       label: 'Text Link',
       Example: () => (
         <Text>
+          <TextLink href="">Text link</TextLink>
+        </Text>
+      ),
+    },
+    {
+      label: 'Text Link in a sentence',
+      Example: () => (
+        <Text>
           The last word of a sentence is a{' '}
           <TextLink href="">text link.</TextLink>
         </Text>
@@ -32,14 +40,6 @@ const docs: ComponentDocs = {
             visited link.
           </TextLink>
         </Text>
-      ),
-    },
-    {
-      label: 'Block Text Link',
-      Example: () => (
-        <TextLink href="">
-          <Text>Text Link</Text>
-        </TextLink>
       ),
     },
     {
@@ -61,28 +61,12 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label: 'Large Block Text Link',
-      Example: () => (
-        <TextLink href="">
-          <Text size="large">Text Link</Text>
-        </TextLink>
-      ),
-    },
-    {
       label: 'Small Text Link',
       Example: () => (
         <Text size="small">
           The last word of a sentence is a{' '}
           <TextLink href="">text link.</TextLink>
         </Text>
-      ),
-    },
-    {
-      label: 'Small Block Text Link',
-      Example: () => (
-        <TextLink href="">
-          <Text size="small">Text Link</Text>
-        </TextLink>
       ),
     },
     {
@@ -95,23 +79,7 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label: 'Xsmall Block Text Link',
-      Example: () => (
-        <TextLink href="">
-          <Text size="xsmall">Text Link</Text>
-        </TextLink>
-      ),
-    },
-    {
       label: 'Heading Level 1 Link',
-      Example: () => (
-        <TextLink href="">
-          <Heading level="1">Heading link.</Heading>
-        </TextLink>
-      ),
-    },
-    {
-      label: 'Heading Level 1 Link (Inline)',
       Example: () => (
         <Heading level="1">
           The last word of this heading is a <TextLink href="">link.</TextLink>
@@ -121,14 +89,6 @@ const docs: ComponentDocs = {
     {
       label: 'Heading Level 2 Link',
       Example: () => (
-        <TextLink href="">
-          <Heading level="2">Heading link.</Heading>
-        </TextLink>
-      ),
-    },
-    {
-      label: 'Heading Level 2 Link (Inline)',
-      Example: () => (
         <Heading level="2">
           The last word of this heading is a <TextLink href="">link.</TextLink>
         </Heading>
@@ -137,14 +97,6 @@ const docs: ComponentDocs = {
     {
       label: 'Heading Level 3 Link',
       Example: () => (
-        <TextLink href="">
-          <Heading level="3">Heading link.</Heading>
-        </TextLink>
-      ),
-    },
-    {
-      label: 'Heading Level 3 Link (Inline)',
-      Example: () => (
         <Heading level="3">
           The last word of this heading is a <TextLink href="">link.</TextLink>
         </Heading>
@@ -152,14 +104,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Heading Level 4 Link',
-      Example: () => (
-        <TextLink href="">
-          <Heading level="4">Heading link.</Heading>
-        </TextLink>
-      ),
-    },
-    {
-      label: 'Heading Level 4 Link (Inline)',
       Example: () => (
         <Heading level="4">
           The last word of this heading is a <TextLink href="">link.</TextLink>
@@ -178,17 +122,6 @@ const docs: ComponentDocs = {
           </TextLink>
           .
         </Text>
-      ),
-    },
-    {
-      label: 'Block Text Link with icon',
-      docsSite: false,
-      Example: () => (
-        <TextLink href="">
-          <Text>
-            Text Link <IconChevron direction="right" />
-          </Text>
-        </TextLink>
       ),
     },
     {

--- a/lib/components/TextLink/TextLink.docs.tsx
+++ b/lib/components/TextLink/TextLink.docs.tsx
@@ -18,7 +18,9 @@ const docs: ComponentDocs = {
       label: 'Text Link',
       Example: () => (
         <Text>
-          <TextLink href="">Text link</TextLink>
+          <TextLink href="" hitArea="large">
+            Text link
+          </TextLink>
         </Text>
       ),
     },

--- a/lib/components/TextLink/TextLink.tsx
+++ b/lib/components/TextLink/TextLink.tsx
@@ -10,12 +10,8 @@ export interface TextLinkProps
   extends Omit<TextLinkRendererProps, 'children'>,
     Omit<AnchorProps, 'className' | 'style'> {}
 
-export const TextLink = ({
-  showVisited,
-  touchable,
-  ...props
-}: TextLinkProps) => (
-  <TextLinkRenderer showVisited={showVisited} touchable={touchable}>
+export const TextLink = ({ showVisited, hitArea, ...props }: TextLinkProps) => (
+  <TextLinkRenderer showVisited={showVisited} hitArea={hitArea}>
     {styleProps => <a {...props} {...styleProps} />}
   </TextLinkRenderer>
 );

--- a/lib/components/TextLink/TextLink.tsx
+++ b/lib/components/TextLink/TextLink.tsx
@@ -10,8 +10,12 @@ export interface TextLinkProps
   extends Omit<TextLinkRendererProps, 'children'>,
     Omit<AnchorProps, 'className' | 'style'> {}
 
-export const TextLink = ({ showVisited, ...props }: TextLinkProps) => (
-  <TextLinkRenderer showVisited={showVisited}>
+export const TextLink = ({
+  showVisited,
+  touchable,
+  ...props
+}: TextLinkProps) => (
+  <TextLinkRenderer showVisited={showVisited} touchable={touchable}>
     {styleProps => <a {...props} {...styleProps} />}
   </TextLinkRenderer>
 );

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
@@ -25,7 +25,7 @@ interface StyleProps {
 
 export interface TextLinkRendererProps {
   showVisited?: boolean;
-  touchable?: boolean;
+  hitArea?: 'standard' | 'large';
   children: (styleProps: StyleProps) => ReactElement;
 }
 
@@ -70,7 +70,7 @@ function useLinkStyles(showVisited: boolean) {
 
 function InlineLink({
   showVisited = false,
-  touchable = false,
+  hitArea = 'standard',
   children,
 }: TextLinkRendererProps) {
   const virtualTouchableStyle = useVirtualTouchable();
@@ -85,7 +85,7 @@ function InlineLink({
             component: 'a',
             cursor: 'pointer',
           }),
-          touchable && virtualTouchableStyle,
+          hitArea === 'large' && virtualTouchableStyle,
         ),
       })}
     </TextLinkRendererContext.Provider>

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
@@ -97,8 +97,20 @@ const buttonLinkTextProps = {
   tone: 'link',
   baseline: false,
 } as const;
-function ButtonLink({ showVisited = false, children }: TextLinkRendererProps) {
+function ButtonLink({
+  showVisited = false,
+  hitArea,
+  children,
+}: TextLinkRendererProps) {
   const styles = useStyles(styleRefs);
+
+  if (process.env.NODE_ENV !== 'production') {
+    if (typeof hitArea === 'string') {
+      throw new Error(
+        'TextLink components should not set "hitArea" within Actions',
+      );
+    }
+  }
 
   return (
     <Box position="relative">

--- a/lib/hooks/typography/index.ts
+++ b/lib/hooks/typography/index.ts
@@ -29,21 +29,15 @@ export function useText({
   _LEGACY_SPACE_ = false,
 }: UseTextProps) {
   const styles = useStyles(styleRefs);
-  const inTextLinkRenderer = useContext(TextLinkRendererContext);
-  const space = useTouchableSpace(size);
   const textTone = useTextTone({ tone, backgroundContext });
 
   return classnames(
     styles.fontFamily,
     styles.text[size].base,
-    inTextLinkRenderer
-      ? space
-      : [
-          textTone,
-          styles.fontWeight[weight],
-          baseline ? styles.text[size].baseline : null,
-          baseline && !_LEGACY_SPACE_ ? styles.text[size].cropFirstLine : null,
-        ],
+    textTone,
+    styles.fontWeight[weight],
+    baseline ? styles.text[size].baseline : null,
+    baseline && !_LEGACY_SPACE_ ? styles.text[size].cropFirstLine : null,
   );
 }
 

--- a/site/src/App/Documentation/Documentation.tsx
+++ b/site/src/App/Documentation/Documentation.tsx
@@ -93,11 +93,13 @@ export const Documentation = () => {
             width="full"
             className={styles.header}
           >
-            <Link to="/">
-              <Box overflow="hidden" className={styles.logo}>
-                <Logo />
-              </Box>
-            </Link>
+            <Text baseline={false}>
+              <Link to="/">
+                <Box overflow="hidden" className={styles.logo}>
+                  <Logo />
+                </Box>
+              </Link>
+            </Text>
 
             <Hidden screen={!showMenuButton} above="tablet">
               <MenuButton


### PR DESCRIPTION
## Breaking Change
- Block-level `TextLink`/`TestLinkRenderer` components no longer occupy full touchable height in the document flow. You will need to add a `hitArea="large"` prop and reintroduce white space via layout components.
- All `TextLink`/`TestLinkRenderer` components must now be nested within a `Text` component.

## Description

**When TextLink is mentioned below, it refers to both the `TextLink` and `TextLinkRenderer` components.**

Previously Braid had two different TextLink implementations, depending on whether it was nested within a `Text` component or not. The thinking was, TextLinks that are not part of a sentence should reserve surrounding white space to ensure that they satisfied a minimum touchable size. The documentation referred to these as "block links".

Unfortunately, this clashes with our layout philosophy of first-class white space via layout components. It was also a confusing API for consumers due to its implicit nature. 

This PR is removing the concept of block links entirely, in favour of an optional `hitArea` prop that can increase the hit area of the link without adding additional whitespace to the layout.

To help debug this in development mode, you can add a `data-braid-debug` attribute anywhere in the DOM tree to visualise the hit areas nested within it.

**Note: Inline links (i.e. links nested within a Text component) are completely unaffected by this change.**

## Migration Guide

```diff
-<TextLink href="...">
-  <Text>Block link</Text>
-</TextLink>

+<Text>
+  <TextLink hitArea="large" href="...">Block link</TextLink>
+</Text>
```

You may also need to reintroduce white space. This can be done via Braid's [layout components](https://seek-oss.github.io/braid-design-system/foundations/layout).

In simple cases where block links only contains 1–2 words, you can wrap them in a vertically centered touchable Box:

```tsx
<Box height="touchable" display="flex" alignItems="center">
  <Text>
    <TextLink hitArea="large" href="...">Block link</TextLink>
  </Text>
</Box>
```

As always, if you're finding this migration difficult, please reach out so we can give you a hand.