### PR TITLE
fix: Disable WebKit tap highlight

### DIFF
--- a/lib/reset/reset.treat.ts
+++ b/lib/reset/reset.treat.ts
@@ -8,6 +8,7 @@ export const base = style({
   fontSize: '100%',
   font: 'inherit',
   verticalAlign: 'baseline',
+  WebkitTapHighlightColor: 'transparent',
 });
 
 // HTML5 display-role reset for older browsers


### PR DESCRIPTION
This PR removes the rectangular overlay that flashes over the top of interactive elements when tapping on them on mobile. This is something that was provided by previous style guide work but was missed when migrating to Braid.