### PR TITLE
fix(Textarea): Show character count correctly

### DIFF
--- a/lib/components/FieldMessage/FieldMessage.tsx
+++ b/lib/components/FieldMessage/FieldMessage.tsx
@@ -35,7 +35,7 @@ export const FieldMessage = ({
     throw new Error(`Invalid tone: ${tone}`);
   }
 
-  if (!message && !reserveMessageSpace) {
+  if (!message && !secondaryMessage && !reserveMessageSpace) {
     return null;
   }
 

--- a/lib/components/MonthPicker/MonthPicker.tsx
+++ b/lib/components/MonthPicker/MonthPicker.tsx
@@ -116,7 +116,7 @@ const makeChangeHandler = <
   }
 };
 
-export const MonthPicker = ({
+const MonthPicker = ({
   id,
   value,
   label,
@@ -257,3 +257,7 @@ export const MonthPicker = ({
 
   return renderNativeInput ? nativeField : customFieldGroup;
 };
+
+MonthPicker.displayName = 'MonthPicker';
+
+export { MonthPicker };

--- a/lib/components/Textarea/Textarea.docs.tsx
+++ b/lib/components/Textarea/Textarea.docs.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode } from 'react';
+import React, { ReactNode, useState } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { Textarea } from './Textarea';
 import { TextLink } from '../TextLink/TextLink';
@@ -79,7 +79,7 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label: 'Textarea with postive message',
+      label: 'Textarea with positive message',
       Container,
       Example: ({ id, handler }) => (
         <Textarea
@@ -93,30 +93,59 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label: 'Textarea with a limit',
+      label: 'Textarea grow field with typing, limited to 6 lines',
       Container,
-      Example: ({ id, handler }) => (
-        <Textarea
-          id={id}
-          value=""
-          onChange={handler}
-          label="Do you like Braid?"
-          lineLimit={100}
-        />
-      ),
+      Example: ({ id }) => {
+        const [value, setValue] = useState('');
+
+        return (
+          <Textarea
+            id={id}
+            value={value}
+            onChange={e => setValue(e.currentTarget.value)}
+            label="Do you like Braid?"
+            lineLimit={6}
+          />
+        );
+      },
     },
     {
-      label: 'Textarea with value exceeding limit',
+      label: 'Textarea nearing character limit, eg. 50 characters',
       Container,
-      Example: ({ id, handler }) => (
-        <Textarea
-          id={id}
-          value="Yes I do"
-          onChange={handler}
-          label="Do you like Braid?"
-          lineLimit={5}
-        />
-      ),
+      Example: ({ id }) => {
+        const [value, setValue] = useState(
+          'The text is nearing the 50 character limit',
+        );
+
+        return (
+          <Textarea
+            id={id}
+            value={value}
+            onChange={e => setValue(e.currentTarget.value)}
+            label="Do you like Braid?"
+            characterLimit={50}
+          />
+        );
+      },
+    },
+    {
+      label: 'Textarea exceeding character limit, eg. > 50 characters',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState(
+          'The long piece of text exceeding the specified 50 character limit',
+        );
+
+        return (
+          <Textarea
+            id={id}
+            value={value}
+            onChange={e => setValue(e.currentTarget.value)}
+            label="Do you like Braid?"
+            characterLimit={50}
+          />
+        );
+      },
     },
   ],
 };

--- a/lib/components/private/Field/Field.tsx
+++ b/lib/components/private/Field/Field.tsx
@@ -236,7 +236,7 @@ export const Field = forwardRef<FieldRef, InternalFieldProps>(
           </BackgroundProvider>
         </Box>
 
-        {message || reserveMessageSpace ? (
+        {message || secondaryMessage || reserveMessageSpace ? (
           <FieldMessage
             id={messageId}
             tone={tone}


### PR DESCRIPTION
The character count was not rendering when approaching or exceeding the limit due to a falsey check on the rendering conditions around the field message.

Also adding `displayname` to `MonthPicker` to fix docs site code examples.