### PR TITLE
fix(Textarea): Better scroll support for highlighted ranges

### DIFF
--- a/lib/components/Textarea/Highlight/Highlight.treat.ts
+++ b/lib/components/Textarea/Highlight/Highlight.treat.ts
@@ -6,6 +6,4 @@ export const root = style({
   opacity: 0.18,
   padding: space,
   marginLeft: -space,
-  wordBreak: 'break-word',
-  whiteSpace: 'pre-wrap',
 });

--- a/lib/components/Textarea/Textarea.treat.ts
+++ b/lib/components/Textarea/Textarea.treat.ts
@@ -20,4 +20,5 @@ export const highlights = style({
   left: 0,
   color: 'transparent !important',
   wordBreak: 'break-word',
+  whiteSpace: 'pre-wrap',
 });

--- a/lib/components/Textarea/formatRanges.tsx
+++ b/lib/components/Textarea/formatRanges.tsx
@@ -5,7 +5,7 @@ import { Highlight } from './Highlight/Highlight';
 
 export const formatRanges = (
   value: string,
-  highlightRanges: NonNullable<TextareaProps['highlightRanges']>,
+  highlightRanges: TextareaProps['highlightRanges'],
 ): ReactChild[] => {
   if (highlightRanges && value) {
     const textToHighlight: string[] = [];


### PR DESCRIPTION
Some small issues with the new `highlightRanges` feature on `Textarea`. Highlighted ranges now scroll with the textarea on scroll and on change of the textarea. Also fixed a white space wrapping bug where the highlights could get out of sync with the textarea value.