### PR TITLE
fix(Textarea): Handle edge case highlight ranges

### DIFF
--- a/lib/components/Textarea/Highlight/Highlight.treat.ts
+++ b/lib/components/Textarea/Highlight/Highlight.treat.ts
@@ -5,5 +5,5 @@ const space = 2;
 export const root = style({
   opacity: 0.18,
   padding: space,
-  marginLeft: -space,
+  margin: -space,
 });

--- a/lib/components/Textarea/formatRanges.test.ts
+++ b/lib/components/Textarea/formatRanges.test.ts
@@ -11,24 +11,7 @@ describe('formatRanges', () => {
     `);
   });
 
-  it('should highlight with critical tone from a start point to the end of a string', () => {
-    const value = 'my string of text';
-    const ranges = [
-      {
-        start: 6,
-      },
-    ];
-    expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
-      Array [
-        "my str",
-        <Highlight>
-          ing of text
-        </Highlight>,
-      ]
-    `);
-  });
-
-  it('should highlight with info tone from a start point to the end of a string', () => {
+  it('should highlight from a start point to the end of a string', () => {
     const value = 'my string of text';
     const ranges = [
       {
@@ -117,6 +100,103 @@ describe('formatRanges', () => {
         <Highlight>
           bbb
         </Highlight>,
+      ]
+    `);
+  });
+
+  it('should not render highlight when range is invalid', () => {
+    const value = 'my longer text';
+    const ranges = [
+      {
+        start: 10,
+        end: 5,
+      },
+    ];
+    expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
+      Array [
+        "my longer text",
+      ]
+    `);
+  });
+
+  it('should highlight only valid ranges', () => {
+    const value = 'aaaaaaaaaabbb';
+    const ranges = [
+      {
+        start: 10,
+        end: 20,
+      },
+      {
+        start: 8,
+        end: 4,
+      },
+    ];
+    expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
+      Array [
+        "aaaaaaaaaa",
+        <Highlight>
+          bbb
+        </Highlight>,
+      ]
+    `);
+  });
+
+  it('should handle out of order ranges', () => {
+    const value = 'some text some text some text some text';
+    const ranges = [
+      { start: 20, end: 24 },
+      { start: 0, end: 4 },
+      { start: 30, end: 34 },
+      { start: 10, end: 14 },
+    ];
+    expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
+      Array [
+        <Highlight>
+          some
+        </Highlight>,
+        " text ",
+        <Highlight>
+          some
+        </Highlight>,
+        " text ",
+        <Highlight>
+          some
+        </Highlight>,
+        " text ",
+        <Highlight>
+          some
+        </Highlight>,
+        " text",
+      ]
+    `);
+  });
+
+  it('should handle overlapping ranges', () => {
+    const value = 'some text some text some text some text some text';
+    const ranges = [
+      { start: 0, end: 4 },
+      { start: 10, end: 32 },
+      { start: 20, end: 24 },
+      { start: 30, end: 34 },
+      { start: 40, end: 44 },
+    ];
+    expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
+      Array [
+        <Highlight>
+          some
+        </Highlight>,
+        " text ",
+        <Highlight>
+          some text some text so
+        </Highlight>,
+        <Highlight>
+          me
+        </Highlight>,
+        " text ",
+        <Highlight>
+          some
+        </Highlight>,
+        " text",
       ]
     `);
   });


### PR DESCRIPTION
Improving the logic powering the textarea highlights. New edge cases handled:
- Range where end character is before the start character is ignored
- Better handling for multiple ranges where some are invalid
- Sort ranges by their start point
- Handle overlapping adjoining by merging them into a single adjoining range.