### PR TITLE
feat(Tiles): Support 6 columns and full height content

### DIFF
--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -5052,6 +5052,7 @@ Object {
         | 3
         | 4
         | 5
+        | 6
     >
     dividers?: boolean
     space: ResponsiveProp<

--- a/lib/components/Tiles/Tiles.docs.tsx
+++ b/lib/components/Tiles/Tiles.docs.tsx
@@ -9,7 +9,7 @@ const docs: ComponentDocs = {
   category: 'Layout',
   screenshotWidths: [320, 768],
   examples: [
-    ...([1, 2, 3, 4, 5] as const).map(columns => ({
+    ...([1, 2, 3, 4, 5, 6] as const).map(columns => ({
       label: `${columns} column${columns === 1 ? '' : 's'}`,
       docsSite: columns === 3,
       Example: () => (

--- a/lib/components/Tiles/Tiles.treat.ts
+++ b/lib/components/Tiles/Tiles.treat.ts
@@ -8,6 +8,7 @@ const columnsWidths = {
   '3': `${100 / 3}%`,
   '4': `${100 / 4}%`,
   '5': `${100 / 5}%`,
+  '6': `${100 / 6}%`,
 } as const;
 
 const makeColumnsAtoms = (breakpoint: keyof TreatTokens['breakpoint']) =>

--- a/lib/components/Tiles/Tiles.treat.ts
+++ b/lib/components/Tiles/Tiles.treat.ts
@@ -3,14 +3,16 @@ import mapValues from 'lodash/mapValues';
 import { TreatTokens } from '../../themes/makeBraidTheme';
 
 const columnsWidths = {
-  '1': '100%',
-  '2': `${100 / 2}%`,
-  '3': `${100 / 3}%`,
-  '4': `${100 / 4}%`,
-  '5': `${100 / 5}%`,
-  '6': `${100 / 6}%`,
+  1: '100%',
+  2: `${100 / 2}%`,
+  3: `${100 / 3}%`,
+  4: `${100 / 4}%`,
+  5: `${100 / 5}%`,
+  6: `${100 / 6}%`,
 } as const;
 
+// Remove this when 'styleMap' supports numbers as keys and it's been released to sku consumers,
+type ColumnWidths = Record<keyof typeof columnsWidths, string>;
 const makeColumnsAtoms = (breakpoint: keyof TreatTokens['breakpoint']) =>
   styleMap(
     theme =>
@@ -18,7 +20,7 @@ const makeColumnsAtoms = (breakpoint: keyof TreatTokens['breakpoint']) =>
         theme.utils.responsiveStyle({ [breakpoint]: { flex: `0 0 ${width}` } }),
       ),
     `columns_${breakpoint}`,
-  );
+  ) as ColumnWidths;
 
 export const columnsMobile = makeColumnsAtoms('mobile');
 export const columnsTablet = makeColumnsAtoms('tablet');

--- a/lib/components/Tiles/Tiles.tsx
+++ b/lib/components/Tiles/Tiles.tsx
@@ -9,6 +9,7 @@ import {
 } from '../../hooks/useNegativeMargin/useNegativeMargin';
 import {
   normaliseResponsiveProp,
+  resolveResponsiveProp,
   ResponsiveProp,
 } from '../../utils/responsiveProp';
 import * as styleRefs from './Tiles.treat';
@@ -45,13 +46,12 @@ export const Tiles = ({
       <Box display="flex" flexWrap="wrap" className={negativeMarginLeft}>
         {Children.map(children, (child, i) => (
           <Box
-            className={{
-              [styles.columnsMobile[mobileColumns]]: true,
-              [styles.columnsTablet[tabletColumns]]:
-                tabletColumns !== mobileColumns,
-              [styles.columnsDesktop[desktopColumns]]:
-                desktopColumns !== tabletColumns,
-            }}
+            className={resolveResponsiveProp(
+              columns,
+              styles.columnsMobile,
+              styles.columnsTablet,
+              styles.columnsDesktop,
+            )}
           >
             <Box
               height="full"

--- a/lib/components/Tiles/Tiles.tsx
+++ b/lib/components/Tiles/Tiles.tsx
@@ -17,7 +17,7 @@ import { ReactNodeNoStrings } from '../private/ReactNodeNoStrings';
 export interface TilesProps {
   children: ReactNodeNoStrings;
   space: ResponsiveSpace;
-  columns: ResponsiveProp<1 | 2 | 3 | 4 | 5>;
+  columns: ResponsiveProp<1 | 2 | 3 | 4 | 5 | 6>;
   dividers?: boolean;
 }
 
@@ -45,13 +45,16 @@ export const Tiles = ({
       <Box display="flex" flexWrap="wrap" className={negativeMarginLeft}>
         {Children.map(children, (child, i) => (
           <Box
-            className={[
-              styles.columnsMobile[mobileColumns],
-              styles.columnsTablet[tabletColumns],
-              styles.columnsDesktop[desktopColumns],
-            ]}
+            className={{
+              [styles.columnsMobile[mobileColumns]]: true,
+              [styles.columnsTablet[tabletColumns]]:
+                tabletColumns !== mobileColumns,
+              [styles.columnsDesktop[desktopColumns]]:
+                desktopColumns !== tabletColumns,
+            }}
           >
             <Box
+              height="full"
               // This needs to be a separate element to support IE11.
               paddingTop={responsiveSpace}
               paddingLeft={responsiveSpace}

--- a/lib/utils/responsiveProp.ts
+++ b/lib/utils/responsiveProp.ts
@@ -13,13 +13,18 @@ export const normaliseResponsiveProp = <Keys extends string | number>(
   if ('length' in value) {
     const { length } = value;
 
+    if (length === 2) {
+      const [mobileValue, tabletValue] = value;
+      return [mobileValue, tabletValue, tabletValue];
+    }
+
     if (length === 3) {
       return value as Readonly<[Keys, Keys, Keys]>;
     }
 
-    if (length === 2) {
-      const [mobileValue, tabletValue] = value;
-      return [mobileValue, tabletValue, tabletValue];
+    if (length === 1) {
+      const [mobileValue] = value;
+      return [mobileValue, mobileValue, mobileValue];
     }
 
     throw new Error(`Invalid responsive prop length: ${JSON.stringify(value)}`);


### PR DESCRIPTION
Add support for specifying 6 columns tiled layouts. Also supports full height content, if the layout is rendering full height children they will all be uniform height.

[Playroom preview](https://braid-design-system--de587df565aaa97d6c514855ac3349e06d5b38cb.surge.sh/playroom/#?code=N4Igxg9gJgpiBcIA8AVAlgGxgZwASQwFcBbAO2wF5gA2AX12wAcBDMGCgHRG2OYwy4A+DqVy4kAIQgAPXACNWAawDmAJwiFSUTuGaqoXXAAsYaZUYAuOgGaF+hllChpSynTz4CQw0WPEAFDFYYIwgMWFVjU3MrYABGAAYE+gB6HzEkFKlpdPFs+SU1DS0dMD0DECizSxs7L1xHZ1d3XntvET8AoLZQ8JhIk2rYgBYk1NzM7In8hTAVdU1tLjL9Q0GY2raG5icXNy4PNtyMwODeiKqN4AAmMdw0jvEsmWmZArmixdLyteiarlsW0aexaniEjxO3RCYQu6xqNwArMl7hNnjlHpI3rN5sUlrpVpU4VYAXUHDsmvtuK0vMcumcYf1LvCAMx3B6+SYvDEzQoLErLH6Ev7EkCA+rA5oHang3yQ+l9AbCqhxJHjDFonyZdBYbA+EAAGhAFhMxBwCAA2twYDBFABBUgALxAAF1DQB3NBQY3YC0AdmoAA5nbQgA)