### PR TITLE
chore(ci): Cache node_modules between runs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,6 +21,12 @@ jobs:
         with:
           node-version: 12.x
 
+      - name: Yarn cache
+        uses: actions/cache@v1
+        with:
+          path: node_modules/
+          key: ${{ hashFiles('yarn.lock') }}
+          
       - name: Install Dependencies
         run: yarn
 


### PR DESCRIPTION
With this PR I aim to allow caching of node_modules to make builds run faster for you.

One addition could also be to cache the the yarn cache dir instead?