### PR TITLE
Textarea: Fix trailing new line highlight issue

### DIFF
--- a/.changeset/twelve-fireants-teach.md
+++ b/.changeset/twelve-fireants-teach.md
@@ -1,0 +1,11 @@
+---
+"braid-design-system": patch
+---
+
+Textarea: Fix trailing new line highlight issue
+
+**BUG FIXES**
+
+**`Textarea`**
+
+Fix for `highlightRanges`, where the highlights could get out of sync with the field value, if the value contained trailing new lines.

--- a/.changeset/twelve-fireants-teach.md
+++ b/.changeset/twelve-fireants-teach.md
@@ -1,5 +1,5 @@
 ---
-"braid-design-system": patch
+'braid-design-system': patch
 ---
 
 Textarea: Fix trailing new line highlight issue

--- a/lib/components/Textarea/Textarea.treat.ts
+++ b/lib/components/Textarea/Textarea.treat.ts
@@ -19,4 +19,9 @@ export const highlights = style({
   color: 'transparent !important',
   wordBreak: 'break-word',
   whiteSpace: 'pre-wrap',
+  selectors: {
+    '&:after': {
+      content: '"\\A"',
+    },
+  },
 });

--- a/lib/components/Textarea/Textarea.treat.ts
+++ b/lib/components/Textarea/Textarea.treat.ts
@@ -19,9 +19,7 @@ export const highlights = style({
   color: 'transparent !important',
   wordBreak: 'break-word',
   whiteSpace: 'pre-wrap',
-  selectors: {
-    '&:after': {
-      content: '"\\A"',
-    },
+  ':after': {
+    content: '"\\A"',
   },
 });


### PR DESCRIPTION
This is a bug fix for an issue with the new highlighting feature in Textarea. If you add a trailing new line and then scroll, the highlight elements fall out of sync with the text in the textarea. This was previously an issue in the seek styleguide and this was the fix: https://github.com/seek-oss/seek-style-guide/blob/master/react/Textarea/Textarea.less#L95. I'm applying the same fix here

Playroom to showing the problem (scroll inside the textarea):

https://seek-oss.github.io/braid-design-system/playroom/#?code=N4Igxg9gJgpiBcIA8AVGAPALgQwE42wB0A7AAlNgGcxcBLAB01omIF5CQBhACz2zEwxclUgE4AtACZJpPDFK1iAN2wAbWlA4ly3WgHNu6g5gBK2YnpiVWwANrbypYA8ekYxKPFLSANC8eUOLiYXqL+AL4OALqRZApQ7CAaWnGq2ABGMKqJACIQpACeEACupOoA1vIAQrjYGgD8KeQqqsUwNgDkLW3Y2JRQAGZ9g8ND-WMj46OEJDPEcx2xAPQAfCQgPiAA7hqY3JQItgCMAAySACwxQA

Playroom showing the fixed version:

http://braid-design-system--35812b43e9ff0e95e19435945acbd0552da1db36.surge.sh/playroom/#?code=N4Igxg9gJgpiBcIA8AVGAPALgQwE42wB0A7AAlNgGcxcBLAB01omIF5CQBhACz2zEwxclUgE4AtACZJpPDFK1iAN2wAbWlA4ly3WgHNu6g5gBK2YnpiVWwANrbypYA8ekYxKPFLSANC8eUOLiYXqL+AL4OALqRZApQ7CAaWnGq2ABGMKqJACIQpACeEACupOoA1vIAQrjYGgD8KeQqqsUwNgDkLW3Y2JRQAGZ9g8ND-WMj46OEJDPEcx2xAPQAfCQgPiAA7hqY3JQItgCMAAySACwxQA