### PR TITLE
Divider: Rename 'standard' weight to 'regular'

### DIFF
--- a/.changeset/good-apples-confess.md
+++ b/.changeset/good-apples-confess.md
@@ -1,0 +1,5 @@
+---
+'braid-design-system': patch
+---
+
+Divider: Rename 'standard' weight to 'regular'.

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -1709,7 +1709,7 @@ Object {
   exportType: component,
   props: {
     weight?: 
-        | "standard"
+        | "regular"
         | "strong"
 },
 }
@@ -4226,7 +4226,7 @@ Object {
         | "ol"
         | "ul"
     dividers?: 
-        | "standard"
+        | "regular"
         | "strong"
         | false
         | true
@@ -5115,7 +5115,7 @@ Object {
         | 6
     >
     dividers?: 
-        | "standard"
+        | "regular"
         | "strong"
         | false
         | true

--- a/lib/components/Divider/Divider.docs.tsx
+++ b/lib/components/Divider/Divider.docs.tsx
@@ -7,7 +7,7 @@ const docs: ComponentDocs = {
   screenshotWidths: [320],
   examples: [
     {
-      label: 'Standard Divider',
+      label: 'Divider',
       Example: () => <Divider />,
     },
     {
@@ -16,7 +16,7 @@ const docs: ComponentDocs = {
     },
   ],
   snippets: [
-    { name: 'Standard', code: <Divider /> },
+    { name: 'Regular', code: <Divider /> },
     { name: 'Strong', code: <Divider weight="strong" /> },
   ],
 };

--- a/lib/components/Divider/Divider.treat.ts
+++ b/lib/components/Divider/Divider.treat.ts
@@ -5,6 +5,6 @@ export const base = style(theme => ({
 }));
 
 export const weight = styleMap(theme => ({
-  standard: { background: theme.border.color.standard },
+  regular: { background: theme.border.color.standard },
   strong: { background: theme.color.foreground.neutral },
 }));

--- a/lib/components/Divider/Divider.tsx
+++ b/lib/components/Divider/Divider.tsx
@@ -7,7 +7,7 @@ export interface DividerProps {
   weight?: keyof typeof styleRefs.weight;
 }
 
-const defaultWeight = 'standard';
+const defaultWeight = 'regular';
 export const Divider = ({ weight = defaultWeight }: DividerProps) => {
   const styles = useStyles(styleRefs);
 


### PR DESCRIPTION
I accidentally named this differently to the other weights in the system. Given this was only just released minutes ago and it only affects the naming of the default case, I decided to mark this as a patch rather than a breaking change.