### PR TITLE
Docs: Merge 'Interaction' component category into 'Content'

### DIFF
--- a/lib/components/Accordion/Accordion.docs.tsx
+++ b/lib/components/Accordion/Accordion.docs.tsx
@@ -4,7 +4,7 @@ import { Accordion, AccordionItem, Stack, Text, TextLink } from '../';
 import { AccordionItem as PlayroomAccordionItem } from '../../playroom/components';
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   screenshotWidths: [320],
   description: (
     <Stack space="large">

--- a/lib/components/Actions/Actions.docs.tsx
+++ b/lib/components/Actions/Actions.docs.tsx
@@ -12,7 +12,7 @@ import {
 import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   migrationGuide: true,
   screenshotWidths: [320, 768],
   examples: [

--- a/lib/components/Autosuggest/Autosuggest.docs.tsx
+++ b/lib/components/Autosuggest/Autosuggest.docs.tsx
@@ -30,7 +30,7 @@ interface Value {
 }
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   migrationGuide: true,
   screenshotWidths: [320],
   examples: [

--- a/lib/components/Button/Button.docs.tsx
+++ b/lib/components/Button/Button.docs.tsx
@@ -8,7 +8,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   migrationGuide: true,
   screenshotWidths: [320],
   description: (

--- a/lib/components/ButtonLink/ButtonLink.docs.tsx
+++ b/lib/components/ButtonLink/ButtonLink.docs.tsx
@@ -8,7 +8,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   migrationGuide: true,
   screenshotWidths: [320],
   description: (

--- a/lib/components/ButtonRenderer/ButtonRenderer.docs.tsx
+++ b/lib/components/ButtonRenderer/ButtonRenderer.docs.tsx
@@ -8,7 +8,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   screenshotWidths: [320],
   description: (
     <Stack space="large">

--- a/lib/components/Checkbox/Checkbox.docs.tsx
+++ b/lib/components/Checkbox/Checkbox.docs.tsx
@@ -4,7 +4,7 @@ import { Checkbox, Text } from '../';
 import { Checkbox as PlayroomCheckbox } from '../../playroom/components';
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   migrationGuide: true,
   screenshotWidths: [320],
   examples: [

--- a/lib/components/Dropdown/Dropdown.docs.tsx
+++ b/lib/components/Dropdown/Dropdown.docs.tsx
@@ -8,7 +8,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   migrationGuide: true,
   screenshotWidths: [320],
   examples: [

--- a/lib/components/FieldLabel/FieldLabel.docs.tsx
+++ b/lib/components/FieldLabel/FieldLabel.docs.tsx
@@ -8,7 +8,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   screenshotWidths: [320],
   examples: [
     {

--- a/lib/components/FieldMessage/FieldMessage.docs.tsx
+++ b/lib/components/FieldMessage/FieldMessage.docs.tsx
@@ -4,7 +4,7 @@ import { FieldMessage, Text } from '../';
 import { FieldMessage as PlayroomFieldMessage } from '../../playroom/components';
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   migrationGuide: true,
   screenshotWidths: [320],
   examples: [

--- a/lib/components/MenuRenderer/MenuRenderer.docs.tsx
+++ b/lib/components/MenuRenderer/MenuRenderer.docs.tsx
@@ -12,7 +12,7 @@ import {
 } from '..';
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   screenshotWidths: [],
   description: (
     <Stack space="large">

--- a/lib/components/MonthPicker/MonthPicker.docs.tsx
+++ b/lib/components/MonthPicker/MonthPicker.docs.tsx
@@ -12,7 +12,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   migrationGuide: true,
   screenshotWidths: [320],
   examples: [

--- a/lib/components/OverflowMenu/OverflowMenu.docs.tsx
+++ b/lib/components/OverflowMenu/OverflowMenu.docs.tsx
@@ -3,7 +3,7 @@ import { ComponentDocs } from '../../../site/src/types';
 import { Box, OverflowMenu, MenuItem } from '../';
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   screenshotWidths: [320],
   examples: [
     {

--- a/lib/components/Radio/Radio.docs.tsx
+++ b/lib/components/Radio/Radio.docs.tsx
@@ -4,7 +4,7 @@ import { Radio, Text } from '../';
 import { Radio as PlayroomRadio } from '../../playroom/components';
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   migrationGuide: true,
   screenshotWidths: [320],
   examples: [

--- a/lib/components/TextDropdown/TextDropdown.docs.tsx
+++ b/lib/components/TextDropdown/TextDropdown.docs.tsx
@@ -8,7 +8,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   description: (
     <Stack space="large">
       <Text>

--- a/lib/components/TextField/TextField.docs.tsx
+++ b/lib/components/TextField/TextField.docs.tsx
@@ -8,7 +8,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   migrationGuide: true,
   screenshotWidths: [320],
   examples: [

--- a/lib/components/TextLink/TextLink.docs.tsx
+++ b/lib/components/TextLink/TextLink.docs.tsx
@@ -14,7 +14,7 @@ import {
 import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   migrationGuide: true,
   screenshotWidths: [320, 768],
   description: (

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.docs.tsx
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.docs.tsx
@@ -3,7 +3,7 @@ import { ComponentDocs } from '../../../site/src/types';
 import { TextLinkRenderer, Stack, Text, TextLink, Box } from '../';
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   screenshotWidths: [320],
   description: (
     <Stack space="large">

--- a/lib/components/Textarea/Textarea.docs.tsx
+++ b/lib/components/Textarea/Textarea.docs.tsx
@@ -8,7 +8,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 );
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   migrationGuide: true,
   screenshotWidths: [320],
   examples: [

--- a/lib/components/Toggle/Toggle.docs.tsx
+++ b/lib/components/Toggle/Toggle.docs.tsx
@@ -8,7 +8,7 @@ const handler = () => {
 };
 
 const docs: ComponentDocs = {
-  category: 'Interaction',
+  category: 'Content',
   migrationGuide: true,
   screenshotWidths: [320],
   examples: [

--- a/site/src/App/SubNavigation/SubNavigation.tsx
+++ b/site/src/App/SubNavigation/SubNavigation.tsx
@@ -90,7 +90,7 @@ export const SubNavigation = ({ onSelect }: SubNavigationProps) => {
         }))}
       />
 
-      {['Layout', 'Content', 'Interaction', 'Logic'].map((category) => (
+      {['Layout', 'Content', 'Logic'].map((category) => (
         <SubNavigationGroup
           key={category}
           title={category}

--- a/site/src/types.d.ts
+++ b/site/src/types.d.ts
@@ -25,7 +25,7 @@ interface DocsSnippet extends Optional<Snippets[number], 'group'> {
 }
 
 export interface ComponentDocs {
-  category: 'Logic' | 'Layout' | 'Content' | 'Interaction' | 'Icon';
+  category: 'Logic' | 'Layout' | 'Content' | 'Icon';
   migrationGuide?: boolean;
   foundation?: boolean;
   screenshotWidths: Array<320 | 768 | 1200>;


### PR DESCRIPTION
This distinction doesn't seem very helpful in practice, so let's drop it.