### PR TITLE
Improve support for field buttons with browser extensions

### DIFF
--- a/.changeset/fuzzy-cycles-dream.md
+++ b/.changeset/fuzzy-cycles-dream.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+Improved support for field buttons with browser extensions.
+
+Change to how internal padding is handled to better support a more browser extenstions.
+
+Affects the following components:
+
+- PasswordField: visibility toggle button
+- TextField: clear button
+- Autosuggest: clear button

--- a/.changeset/fuzzy-cycles-dream.md
+++ b/.changeset/fuzzy-cycles-dream.md
@@ -2,7 +2,7 @@
 'braid-design-system': patch
 ---
 
-Improved support for field buttons with browser extensions.
+TextField, Autosuggest, PasswordField: Improved support for field buttons with browser extensions.
 
 The implementation of internal spacing within fields has been adjusted to better support browser extensions for password managers.
 

--- a/.changeset/fuzzy-cycles-dream.md
+++ b/.changeset/fuzzy-cycles-dream.md
@@ -4,7 +4,7 @@
 
 Improved support for field buttons with browser extensions.
 
-Change to how internal padding is handled to better support a more browser extenstions.
+The implementation of internal spacing within fields has been adjusted to better support browser extensions for password managers.
 
 Affects the following components:
 

--- a/.changeset/proud-sloths-sing.md
+++ b/.changeset/proud-sloths-sing.md
@@ -3,3 +3,5 @@
 ---
 
 Textarea: Fix border radius on dark backgrounds
+
+When rendering a `Textarea` on a background other than white, the field background extended out beyond the field's border radius.

--- a/.changeset/proud-sloths-sing.md
+++ b/.changeset/proud-sloths-sing.md
@@ -1,0 +1,5 @@
+---
+'braid-design-system': patch
+---
+
+Textarea: Fix border radius on dark backgrounds

--- a/.changeset/tall-snails-divide.md
+++ b/.changeset/tall-snails-divide.md
@@ -4,7 +4,7 @@
 
 Prevent field buttons firing on right click
 
-Field buttons, such as clear and password visibility toggle, fire on mouse down to ensure focus is retained on the relevant field. We now ensure the the button only recognises left mouse button clicks.
+Field buttons, such as clear and password visibility toggle, fire on mouse down to ensure focus is retained on the relevant field. We now ensure that the button only recognises left mouse button clicks.
 
 Affects the following components:
 

--- a/.changeset/tall-snails-divide.md
+++ b/.changeset/tall-snails-divide.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+Prevent field buttons firing on right click
+
+Field buttons, such as clear and password visibility toggle, fire on mouse down to ensure focus is retained on the relevant field. We now ensure the the button only recognises left mouse button clicks.
+
+Affects the following components:
+
+- PasswordField: visibility toggle button
+- TextField: clear button
+- Autosuggest: clear button

--- a/.changeset/tall-snails-divide.md
+++ b/.changeset/tall-snails-divide.md
@@ -2,7 +2,7 @@
 'braid-design-system': patch
 ---
 
-Prevent field buttons firing on right click
+TextField, Autosuggest, PasswordField: Prevent field buttons firing on right click
 
 Field buttons, such as clear and password visibility toggle, fire on mouse down to ensure focus is retained on the relevant field. We now ensure that the button only recognises left mouse button clicks.
 

--- a/lib/components/Autosuggest/Autosuggest.tsx
+++ b/lib/components/Autosuggest/Autosuggest.tsx
@@ -579,13 +579,7 @@ export function Autosuggest<Value>({
           >
             {(
               overlays,
-              {
-                background,
-                borderRadius,
-                paddingX,
-                className,
-                ...restFieldProps
-              },
+              { background, borderRadius, className, ...restFieldProps },
               icon,
               secondaryIcon,
             ) => (
@@ -593,7 +587,6 @@ export function Autosuggest<Value>({
                 <Box
                   component="input"
                   borderRadius={borderRadius}
-                  paddingX={paddingX}
                   {...restFieldProps}
                   {...a11y.inputProps}
                   {...inputProps}

--- a/lib/components/Dropdown/Dropdown.treat.ts
+++ b/lib/components/Dropdown/Dropdown.treat.ts
@@ -1,0 +1,5 @@
+import { style } from 'sku/treat';
+
+export const field = style(({ space, grid, typography }) => ({
+  paddingRight: space.small * grid * 2 + typography.text.standard.mobile.size,
+}));

--- a/lib/components/Dropdown/Dropdown.tsx
+++ b/lib/components/Dropdown/Dropdown.tsx
@@ -1,7 +1,9 @@
 import React, { Fragment, AllHTMLAttributes, forwardRef } from 'react';
+import { useStyles } from 'sku/react-treat';
 import { Box } from '../Box/Box';
 import { Field, FieldProps } from '../private/Field/Field';
 import { IconChevron } from '../icons';
+import * as styleRefs from './Dropdown.treat';
 import { Text } from '../Text/Text';
 
 type ValidDropdownChildren = AllHTMLAttributes<
@@ -30,19 +32,15 @@ const NamedDropdown = forwardRef<HTMLSelectElement, DropdownProps>(
       ...restProps
     } = props;
 
+    const styles = useStyles(styleRefs);
     return (
       <Field
         {...restProps}
         labelId={undefined}
         secondaryMessage={null}
         value={value}
-        secondaryIcon={
-          <Text baseline={false}>
-            <IconChevron />
-          </Text>
-        }
       >
-        {(overlays, fieldProps, icon, secondaryIcon) => (
+        {(overlays, { className, paddingRight, ...fieldProps }, icon) => (
           <Fragment>
             {icon}
             <Box
@@ -53,6 +51,7 @@ const NamedDropdown = forwardRef<HTMLSelectElement, DropdownProps>(
               onBlur={onBlur}
               onFocus={onFocus}
               placeholder={placeholder}
+              className={[styles.field, className]}
               {...fieldProps}
               ref={ref}
             >
@@ -62,7 +61,21 @@ const NamedDropdown = forwardRef<HTMLSelectElement, DropdownProps>(
               {children}
             </Box>
             {overlays}
-            <Box pointerEvents="none">{secondaryIcon}</Box>
+            <Box
+              position="absolute"
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              pointerEvents="none"
+              height="touchable"
+              width="touchable"
+              top={0}
+              right={0}
+            >
+              <Text baseline={false}>
+                <IconChevron />
+              </Text>
+            </Box>
           </Fragment>
         )}
       </Field>

--- a/lib/components/PasswordField/PasswordField.tsx
+++ b/lib/components/PasswordField/PasswordField.tsx
@@ -5,6 +5,7 @@ import React, {
   Fragment,
   useCallback,
   useRef,
+  MouseEvent,
 } from 'react';
 
 import { Field, FieldProps } from '../private/Field/Field';
@@ -43,18 +44,25 @@ const NamedPasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
     const inputRef = forwardedRef || defaultRef;
 
     const [visible, setVisibile] = useState(false);
-    const visibilityHandler = useCallback(() => {
-      const newState = !visible;
-      setVisibile(newState);
+    const visibilityHandler = useCallback(
+      (event: MouseEvent<HTMLButtonElement>) => {
+        if (event.button !== 0) {
+          return;
+        }
 
-      if (typeof onVisibilityToggle === 'function') {
-        onVisibilityToggle(newState);
-      }
+        const newState = !visible;
+        setVisibile(newState);
 
-      if (inputRef && typeof inputRef === 'object' && inputRef.current) {
-        inputRef.current.focus();
-      }
-    }, [visible, onVisibilityToggle, inputRef]);
+        if (typeof onVisibilityToggle === 'function') {
+          onVisibilityToggle(newState);
+        }
+
+        if (inputRef && typeof inputRef === 'object' && inputRef.current) {
+          inputRef.current.focus();
+        }
+      },
+      [visible, onVisibilityToggle, inputRef],
+    );
 
     return (
       <Field

--- a/lib/components/Textarea/Textarea.docs.tsx
+++ b/lib/components/Textarea/Textarea.docs.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useState } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { Textarea, TextLink } from '../';
-import { Textarea as PlayroomTextarea } from '../../playroom/components';
+import { Textarea as PlayroomTextarea, Box } from '../../playroom/components';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -164,6 +164,24 @@ const docs: ComponentDocs = {
             description="Characters 9-22 are invalid"
             highlightRanges={[{ start: 9, end: 22 }]}
           />
+        );
+      },
+    },
+    {
+      label: 'Textarea on Brand Background',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('');
+
+        return (
+          <Box background="brand" padding="small">
+            <Textarea
+              label="Do you like Braid?"
+              id={id}
+              onChange={(e) => setValue(e.currentTarget.value)}
+              value={value}
+            />
+          </Box>
         );
       },
     },

--- a/lib/components/Textarea/Textarea.tsx
+++ b/lib/components/Textarea/Textarea.tsx
@@ -124,10 +124,11 @@ const NamedTextarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
           value,
         })}
       >
-        {(overlays, { className, background, ...fieldProps }) => (
+        {(overlays, { className, borderRadius, background, ...fieldProps }) => (
           <Box
             position="relative"
             background={background}
+            borderRadius={borderRadius}
             className={styles.resetZIndex}
           >
             {hasHighlights ? (

--- a/lib/components/private/Field/ClearField.tsx
+++ b/lib/components/private/Field/ClearField.tsx
@@ -1,4 +1,4 @@
-import React, { Ref, useCallback } from 'react';
+import React, { Ref, useCallback, MouseEvent } from 'react';
 import { Box } from '../../Box/Box';
 import { ClearButton } from '../../iconButtons/ClearButton/ClearButton';
 
@@ -8,17 +8,20 @@ interface Props {
   hide?: boolean;
 }
 export const ClearField = ({ hide = false, onClear, inputRef }: Props) => {
-  const clearHandler = useCallback(() => {
-    if (typeof onClear !== 'function') {
-      return;
-    }
+  const clearHandler = useCallback(
+    (event: MouseEvent<HTMLButtonElement>) => {
+      if (typeof onClear !== 'function' || event.button !== 0) {
+        return;
+      }
 
-    onClear();
+      onClear();
 
-    if (inputRef && typeof inputRef === 'object' && inputRef.current) {
-      inputRef.current.focus();
-    }
-  }, [onClear, inputRef]);
+      if (inputRef && typeof inputRef === 'object' && inputRef.current) {
+        inputRef.current.focus();
+      }
+    },
+    [onClear, inputRef],
+  );
 
   return (
     <Box

--- a/lib/components/private/Field/Field.tsx
+++ b/lib/components/private/Field/Field.tsx
@@ -51,7 +51,8 @@ interface FieldRenderProps extends Pick<FieldProps, PassthroughProps> {
   background: BoxProps['background'];
   borderRadius: BoxProps['borderRadius'];
   width: BoxProps['width'];
-  paddingX: BoxProps['paddingX'];
+  paddingLeft: BoxProps['paddingLeft'];
+  paddingRight: BoxProps['paddingRight'];
   outline: BoxProps['outline'];
   'aria-describedby'?: string;
   'aria-required'?: boolean;
@@ -124,7 +125,10 @@ export const Field = ({
         />
       ) : null}
 
-      <Box position="relative">
+      <Box
+        position="relative"
+        className={secondaryIcon ? styles.secondaryIconSpace : null}
+      >
         <BackgroundProvider value={fieldBackground}>
           {children(
             overlays,
@@ -133,7 +137,8 @@ export const Field = ({
               name,
               background: fieldBackground,
               width: 'full',
-              paddingX: 'small',
+              paddingLeft: 'small',
+              paddingRight: secondaryIcon ? undefined : 'small',
               borderRadius: 'standard',
               outline: 'none',
               ...((message || ariaDescribedBy) && {
@@ -154,7 +159,6 @@ export const Field = ({
                   baseline: false,
                 }),
                 useTouchableSpace('standard'),
-                secondaryIcon ? styles.secondaryIconSpace : null,
                 icon ? styles.iconSpace : null,
               ),
             },

--- a/lib/components/private/Field/Field.tsx
+++ b/lib/components/private/Field/Field.tsx
@@ -2,10 +2,7 @@ import React, { Fragment, ReactNode, AllHTMLAttributes } from 'react';
 import { useStyles } from 'sku/react-treat';
 import classnames from 'classnames';
 import { Box, BoxProps } from '../../Box/Box';
-import {
-  BackgroundProvider,
-  useBackgroundLightness,
-} from '../../Box/BackgroundContext';
+import { useBackgroundLightness } from '../../Box/BackgroundContext';
 import { FieldLabel, FieldLabelProps } from '../../FieldLabel/FieldLabel';
 import {
   FieldMessage,
@@ -125,77 +122,75 @@ export const Field = ({
         />
       ) : null}
 
-      <BackgroundProvider value={fieldBackground}>
-        <Box
-          position="relative"
-          background={fieldBackground}
-          borderRadius="standard"
-          className={secondaryIcon ? styles.secondaryIconSpace : undefined}
-        >
-          {children(
-            overlays,
-            {
-              id,
-              name,
-              background: fieldBackground,
-              width: 'full',
-              paddingLeft: 'small',
-              paddingRight: secondaryIcon ? undefined : 'small',
-              borderRadius: 'standard',
-              outline: 'none',
-              ...((message || ariaDescribedBy) && {
-                'aria-describedby': ariaDescribedBy || messageId,
+      <Box
+        position="relative"
+        background={fieldBackground}
+        borderRadius="standard"
+        className={secondaryIcon ? styles.secondaryIconSpace : undefined}
+      >
+        {children(
+          overlays,
+          {
+            id,
+            name,
+            background: fieldBackground,
+            width: 'full',
+            paddingLeft: 'small',
+            paddingRight: secondaryIcon ? undefined : 'small',
+            borderRadius: 'standard',
+            outline: 'none',
+            ...((message || ariaDescribedBy) && {
+              'aria-describedby': ariaDescribedBy || messageId,
+            }),
+            'aria-required': required,
+            disabled,
+            autoComplete,
+            autoFocus,
+            ...buildDataAttributes(data),
+            className: classnames(
+              styles.field,
+              styles.placeholderColor,
+              useText({
+                backgroundContext: fieldBackground,
+                tone: hasValue ? 'neutral' : 'secondary',
+                size: 'standard',
+                baseline: false,
               }),
-              'aria-required': required,
-              disabled,
-              autoComplete,
-              autoFocus,
-              ...buildDataAttributes(data),
-              className: classnames(
-                styles.field,
-                styles.placeholderColor,
-                useText({
-                  backgroundContext: fieldBackground,
-                  tone: hasValue ? 'neutral' : 'secondary',
-                  size: 'standard',
-                  baseline: false,
-                }),
-                useTouchableSpace('standard'),
-                icon ? styles.iconSpace : null,
-              ),
-            },
-            icon ? (
-              <Box
-                display="flex"
-                alignItems="center"
-                justifyContent="center"
-                position="absolute"
-                height="touchable"
-                width="touchable"
-                pointerEvents="none"
-                top={0}
-                left={0}
-              >
-                <Text baseline={false}>{icon}</Text>
-              </Box>
-            ) : null,
-            secondaryIcon ? (
-              <Box
-                position="absolute"
-                width="touchable"
-                height="touchable"
-                display="flex"
-                alignItems="center"
-                justifyContent="center"
-                top={0}
-                right={0}
-              >
-                {secondaryIcon}
-              </Box>
-            ) : null,
-          )}
-        </Box>
-      </BackgroundProvider>
+              useTouchableSpace('standard'),
+              icon ? styles.iconSpace : null,
+            ),
+          },
+          icon ? (
+            <Box
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              position="absolute"
+              height="touchable"
+              width="touchable"
+              pointerEvents="none"
+              top={0}
+              left={0}
+            >
+              <Text baseline={false}>{icon}</Text>
+            </Box>
+          ) : null,
+          secondaryIcon ? (
+            <Box
+              position="absolute"
+              width="touchable"
+              height="touchable"
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              top={0}
+              right={0}
+            >
+              {secondaryIcon}
+            </Box>
+          ) : null,
+        )}
+      </Box>
 
       {message || secondaryMessage || reserveMessageSpace ? (
         <FieldMessage

--- a/lib/components/private/Field/Field.tsx
+++ b/lib/components/private/Field/Field.tsx
@@ -128,7 +128,8 @@ export const Field = ({
       <BackgroundProvider value={fieldBackground}>
         <Box
           position="relative"
-          background={secondaryIcon ? fieldBackground : undefined}
+          background={fieldBackground}
+          borderRadius="standard"
           className={secondaryIcon ? styles.secondaryIconSpace : undefined}
         >
           {children(

--- a/lib/components/private/Field/Field.tsx
+++ b/lib/components/private/Field/Field.tsx
@@ -125,11 +125,12 @@ export const Field = ({
         />
       ) : null}
 
-      <Box
-        position="relative"
-        className={secondaryIcon ? styles.secondaryIconSpace : null}
-      >
-        <BackgroundProvider value={fieldBackground}>
+      <BackgroundProvider value={fieldBackground}>
+        <Box
+          position="relative"
+          background={secondaryIcon ? fieldBackground : undefined}
+          className={secondaryIcon ? styles.secondaryIconSpace : undefined}
+        >
           {children(
             overlays,
             {
@@ -192,8 +193,8 @@ export const Field = ({
               </Box>
             ) : null,
           )}
-        </BackgroundProvider>
-      </Box>
+        </Box>
+      </BackgroundProvider>
 
       {message || secondaryMessage || reserveMessageSpace ? (
         <FieldMessage


### PR DESCRIPTION
Also rolled back `Dropdown` from using the `secondaryIcon` feature on `Field` internally as we want the right side padding on the select not the container.