### PR TITLE
Improve field border contrast ratio

### DIFF
--- a/.changeset/brown-paws-brush.md
+++ b/.changeset/brown-paws-brush.md
@@ -1,0 +1,7 @@
+---
+'braid-design-system': patch
+---
+
+Toggle: Hide border on dark backgrounds
+
+Following the pattern of other bordered elements and hiding the border when on dark backgrounds. Reduces visual noise and cleans results in cleaner lines.

--- a/.changeset/brown-paws-brush.md
+++ b/.changeset/brown-paws-brush.md
@@ -4,4 +4,4 @@
 
 Toggle: Hide border on dark backgrounds
 
-Following the pattern of other bordered elements, we now hide the border when on dark backgrounds. This reduces visual noise and results in cleaner lines.
+In order to reduce visual noise, similar to other fields, we now hide the border on `Toggle` elements when rendered on dark backgrounds.

--- a/.changeset/brown-paws-brush.md
+++ b/.changeset/brown-paws-brush.md
@@ -4,4 +4,4 @@
 
 Toggle: Hide border on dark backgrounds
 
-Following the pattern of other bordered elements and hiding the border when on dark backgrounds. Reduces visual noise and cleans results in cleaner lines.
+Following the pattern of other bordered elements, we now hide the border when on dark backgrounds. This reduces visual noise and results in cleaner lines.

--- a/.changeset/cold-ways-move.md
+++ b/.changeset/cold-ways-move.md
@@ -2,6 +2,6 @@
 'braid-design-system': patch
 ---
 
-Dropdown: Dim chevron in the field when disabled
+Dropdown: Lighten chevron when disabled
 
-Decreases the prominence of the chevron icon when `disabled`.
+The visual prominence of the chevron icon is now lower when `disabled` is set to `true`.

--- a/.changeset/cold-ways-move.md
+++ b/.changeset/cold-ways-move.md
@@ -1,0 +1,7 @@
+---
+'braid-design-system': patch
+---
+
+Dropdown: Dim chevron in the field when disabled
+
+Decreases the prominence of the chevron icon when `disabled`.

--- a/.changeset/lucky-sloths-cover.md
+++ b/.changeset/lucky-sloths-cover.md
@@ -2,13 +2,13 @@
 'braid-design-system': minor
 ---
 
-seekAnz, seekBusiness, catho: Improve field border contrast ratio
+Improve field border contrast ratio
 
-Themes can now configure the colour of field borders separately to standard border colours. This facilitates using a higher contrast border colour on fields to further improve accessibility.
+To improve accessibility, field borders have been darkened for the following themes:
 
-Themes with updated field borders include:
+- `seekAnz`
+- `seekBusiness`
+- `seekUnifiedBeta`
+- `catho` (based on referencing Quantum)
 
-- seekAnz
-- seekBusiness
-- seekUnifiedBeta
-- catho (based on referencing Quantum)
+Since this is a noticeable visual change that may introduce inconsistincies with custom design elements, **design review is recommended.**

--- a/.changeset/lucky-sloths-cover.md
+++ b/.changeset/lucky-sloths-cover.md
@@ -1,0 +1,14 @@
+---
+'braid-design-system': minor
+---
+
+seekAnz, seekBusiness, catho: Improve field border contrast ratio
+
+Themes can now configure the colour of field borders separately to standard border colours. This facilitates using a higher contrast border colour on fields to further improve accessibility.
+
+Themes with updated field borders include:
+
+- seekAnz
+- seekBusiness
+- seekUnifiedBeta
+- catho (based on referencing Quantum)

--- a/.changeset/soft-chairs-joke.md
+++ b/.changeset/soft-chairs-joke.md
@@ -4,4 +4,4 @@
 
 Autosuggest: Apply darker background when disabled
 
-`Autosuggest` respected the `disabled` state while not visually darkening the background. This change brings it into line with the other form fields.
+When disabled, `Autosuggest` elements didn't have the same dark background as other disabled fields. This has now been fixed.

--- a/.changeset/soft-chairs-joke.md
+++ b/.changeset/soft-chairs-joke.md
@@ -1,0 +1,7 @@
+---
+'braid-design-system': patch
+---
+
+Autosuggest: Apply darker background when disabled
+
+`Autosuggest` respected the `disabled` state while not visually darkening the background. This change brings it into line with the other form fields.

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -332,6 +332,7 @@ Object {
     boxShadow?: 
         | "borderCaution"
         | "borderCritical"
+        | "borderField"
         | "borderFormAccent"
         | "borderFormAccentLarge"
         | "borderFormHover"
@@ -1123,6 +1124,7 @@ Object {
     boxShadow?: 
         | "borderCaution"
         | "borderCritical"
+        | "borderField"
         | "borderFormAccent"
         | "borderFormAccentLarge"
         | "borderFormHover"

--- a/lib/components/Autosuggest/Autosuggest.tsx
+++ b/lib/components/Autosuggest/Autosuggest.tsx
@@ -577,21 +577,14 @@ export function Autosuggest<Value>({
               ) : null
             }
           >
-            {(
-              overlays,
-              { background, borderRadius, className, ...restFieldProps },
-              icon,
-              secondaryIcon,
-            ) => (
+            {(overlays, fieldProps, icon, secondaryIcon) => (
               <Box {...a11y.rootProps}>
                 <Box
                   component="input"
-                  borderRadius={borderRadius}
-                  {...restFieldProps}
+                  {...fieldProps}
                   {...a11y.inputProps}
                   {...inputProps}
                   position="relative"
-                  className={className}
                   ref={inputRef}
                 />
                 {icon}

--- a/lib/components/Box/useBoxStyles.treat.ts
+++ b/lib/components/Box/useBoxStyles.treat.ts
@@ -268,6 +268,9 @@ export const boxShadow = styleMap(
     outlineFocus: {
       boxShadow: `0 0 0 ${borderWidth.large}px ${color.focus}`,
     },
+    borderField: {
+      boxShadow: `inset 0 0 0 ${borderWidth.standard}px ${color.field}`,
+    },
     borderStandard: {
       boxShadow: `inset 0 0 0 ${borderWidth.standard}px ${color.standard}`,
     },

--- a/lib/components/Dropdown/Dropdown.tsx
+++ b/lib/components/Dropdown/Dropdown.tsx
@@ -29,6 +29,7 @@ const NamedDropdown = forwardRef<HTMLSelectElement, DropdownProps>(
       onBlur,
       onFocus,
       placeholder,
+      disabled,
       ...restProps
     } = props;
 
@@ -36,6 +37,7 @@ const NamedDropdown = forwardRef<HTMLSelectElement, DropdownProps>(
     return (
       <Field
         {...restProps}
+        disabled={disabled}
         labelId={undefined}
         secondaryMessage={null}
         value={value}
@@ -73,7 +75,7 @@ const NamedDropdown = forwardRef<HTMLSelectElement, DropdownProps>(
               right={0}
             >
               <Text baseline={false}>
-                <IconChevron />
+                <IconChevron tone={disabled ? 'secondary' : undefined} />
               </Text>
             </Box>
           </Fragment>

--- a/lib/components/Toggle/Toggle.tsx
+++ b/lib/components/Toggle/Toggle.tsx
@@ -5,8 +5,8 @@ import { FieldOverlay } from '../private/FieldOverlay/FieldOverlay';
 import { Text } from '../Text/Text';
 import { IconTick } from '../icons';
 import { useVirtualTouchable } from '../private/touchable/useVirtualTouchable';
-import * as styleRefs from './Toggle.treat';
 import { useBackgroundLightness } from '../Box/BackgroundContext';
+import * as styleRefs from './Toggle.treat';
 
 type HTMLInputProps = AllHTMLAttributes<HTMLInputElement>;
 type ChangeHandler = (value: boolean) => void;

--- a/lib/components/Toggle/Toggle.tsx
+++ b/lib/components/Toggle/Toggle.tsx
@@ -76,7 +76,7 @@ export const Toggle = ({
         <Box
           position="absolute"
           background="input"
-          boxShadow="borderStandard"
+          boxShadow="borderField"
           transition="fast"
           display="flex"
           alignItems="center"

--- a/lib/components/Toggle/Toggle.tsx
+++ b/lib/components/Toggle/Toggle.tsx
@@ -6,6 +6,7 @@ import { Text } from '../Text/Text';
 import { IconTick } from '../icons';
 import { useVirtualTouchable } from '../private/touchable/useVirtualTouchable';
 import * as styleRefs from './Toggle.treat';
+import { useBackgroundLightness } from '../Box/BackgroundContext';
 
 type HTMLInputProps = AllHTMLAttributes<HTMLInputElement>;
 type ChangeHandler = (value: boolean) => void;
@@ -33,6 +34,7 @@ export const Toggle = ({
   align = 'left',
 }: ToggleProps) => {
   const styles = useStyles(styleRefs);
+  const showBorder = useBackgroundLightness() === 'light';
 
   return (
     <Box
@@ -76,7 +78,7 @@ export const Toggle = ({
         <Box
           position="absolute"
           background="input"
-          boxShadow="borderField"
+          boxShadow={showBorder ? 'borderField' : undefined}
           transition="fast"
           display="flex"
           alignItems="center"

--- a/lib/components/private/Field/Field.tsx
+++ b/lib/components/private/Field/Field.tsx
@@ -94,7 +94,7 @@ export const Field = ({
   const messageId = `${id}-message`;
   const fieldBackground = disabled ? 'inputDisabled' : 'input';
   const showFieldBorder =
-    (useBackgroundLightness() === 'light' && tone !== 'critical') || disabled;
+    useBackgroundLightness() === 'light' && (tone !== 'critical' || disabled);
 
   const hasValue = typeof value === 'string' ? value.length > 0 : value != null;
 

--- a/lib/components/private/Field/Field.tsx
+++ b/lib/components/private/Field/Field.tsx
@@ -93,13 +93,17 @@ export const Field = ({
 
   const messageId = `${id}-message`;
   const fieldBackground = disabled ? 'inputDisabled' : 'input';
-  const showFieldBorder = useBackgroundLightness() === 'light';
+  const showFieldBorder =
+    (useBackgroundLightness() === 'light' && tone !== 'critical') || disabled;
 
   const hasValue = typeof value === 'string' ? value.length > 0 : value != null;
 
   const overlays = (
     <Fragment>
-      <FieldOverlay variant="default" visible={showFieldBorder} />
+      <FieldOverlay
+        variant={disabled ? 'disabled' : 'default'}
+        visible={showFieldBorder}
+      />
       <FieldOverlay
         variant="critical"
         visible={tone === 'critical' && !disabled}

--- a/lib/components/private/FieldOverlay/FieldOverlay.tsx
+++ b/lib/components/private/FieldOverlay/FieldOverlay.tsx
@@ -1,7 +1,12 @@
 import React from 'react';
 import { Overlay, OverlayProps } from '../Overlay/Overlay';
 
-type FieldOverlayVariant = 'default' | 'focus' | 'hover' | 'critical';
+type FieldOverlayVariant =
+  | 'default'
+  | 'disabled'
+  | 'focus'
+  | 'hover'
+  | 'critical';
 export interface FieldOverlayProps
   extends Pick<
     OverlayProps,
@@ -19,7 +24,8 @@ const boxShadowForVariant: Record<
   FieldOverlayVariant,
   OverlayProps['boxShadow']
 > = {
-  default: 'borderStandard',
+  default: 'borderField',
+  disabled: 'borderStandard',
   focus: 'outlineFocus',
   hover: 'borderFormHover',
   critical: 'borderCritical',

--- a/lib/components/private/InlineField/InlineField.tsx
+++ b/lib/components/private/InlineField/InlineField.tsx
@@ -113,7 +113,7 @@ export const InlineField = forwardRef<HTMLElement, InternalInlineFieldProps>(
     const accentBackground = disabled ? 'formAccentDisabled' : 'formAccent';
     const hasMessage = message || reserveMessageSpace;
     const showFieldBorder =
-      (useBackgroundLightness() === 'light' && tone !== 'critical') || disabled;
+      useBackgroundLightness() === 'light' && (tone !== 'critical' || disabled);
 
     return (
       <Box position="relative" className={styles.root}>

--- a/lib/components/private/InlineField/InlineField.tsx
+++ b/lib/components/private/InlineField/InlineField.tsx
@@ -11,6 +11,7 @@ import { Text } from '../../Text/Text';
 import { IconTick } from '../../icons';
 import { useVirtualTouchable } from '../touchable/useVirtualTouchable';
 import buildDataAttributes, { DataAttributeMap } from '../buildDataAttributes';
+import { useBackgroundLightness } from '../../Box/BackgroundContext';
 import * as styleRefs from './InlineField.treat';
 
 const tones = ['neutral', 'critical'] as const;
@@ -111,6 +112,8 @@ export const InlineField = forwardRef<HTMLElement, InternalInlineFieldProps>(
     const fieldBorderRadius = isCheckbox ? 'standard' : 'full';
     const accentBackground = disabled ? 'formAccentDisabled' : 'formAccent';
     const hasMessage = message || reserveMessageSpace;
+    const showFieldBorder =
+      (useBackgroundLightness() === 'light' && tone !== 'critical') || disabled;
 
     return (
       <Box position="relative" className={styles.root}>
@@ -139,12 +142,17 @@ export const InlineField = forwardRef<HTMLElement, InternalInlineFieldProps>(
             className={styles.fakeField}
             background={disabled ? 'inputDisabled' : 'input'}
             borderRadius={fieldBorderRadius}
-            boxShadow={
-              tone === 'critical' && !disabled
-                ? 'borderCritical'
-                : 'borderStandard'
-            }
           >
+            <FieldOverlay
+              variant={disabled ? 'disabled' : 'default'}
+              borderRadius={fieldBorderRadius}
+              visible={showFieldBorder}
+            />
+            <FieldOverlay
+              variant="critical"
+              borderRadius={fieldBorderRadius}
+              visible={tone === 'critical' && !disabled}
+            />
             <FieldOverlay
               variant={tone === 'critical' && isCheckbox ? tone : undefined}
               background={isCheckbox ? accentBackground : undefined}

--- a/lib/themes/baseTokens/seekAnz.ts
+++ b/lib/themes/baseTokens/seekAnz.ts
@@ -176,6 +176,7 @@ export const makeTokens = ({
       color: {
         standard: '#d6d6d6',
         standardInverted: white,
+        field: '#898989',
         focus,
         formHover: formAccent,
         critical,

--- a/lib/themes/baseTokens/seekAsia.ts
+++ b/lib/themes/baseTokens/seekAsia.ts
@@ -187,6 +187,7 @@ export const makeTokens = ({
       color: {
         standard: grey4,
         standardInverted: white,
+        field: grey4,
         focus,
         critical,
         info,

--- a/lib/themes/catho/tokens.ts
+++ b/lib/themes/catho/tokens.ts
@@ -157,8 +157,9 @@ const tokens: TreatTokens = {
       large: 2,
     },
     color: {
-      standard: '#999999',
+      standard: '#e0e0e0',
       standardInverted: white,
+      field: '#999999',
       focus,
       critical,
       info,

--- a/lib/themes/makeBraidTheme.ts
+++ b/lib/themes/makeBraidTheme.ts
@@ -83,6 +83,7 @@ export interface TreatTokens {
     color: {
       standard: string;
       standardInverted: string;
+      field: string;
       focus: string;
       critical: string;
       info: string;

--- a/lib/themes/occ/tokens.ts
+++ b/lib/themes/occ/tokens.ts
@@ -160,6 +160,7 @@ const tokens: TreatTokens = {
     color: {
       standard: '#dddddd',
       standardInverted: white,
+      field: '#dddddd',
       focus,
       critical,
       info,

--- a/lib/themes/seekUnifiedBeta/tokens.ts
+++ b/lib/themes/seekUnifiedBeta/tokens.ts
@@ -160,6 +160,7 @@ const tokens: TreatTokens = {
     color: {
       standard: '#d6d6d6',
       standardInverted: white,
+      field: '#898989',
       focus,
       formHover: formAccent,
       critical,

--- a/lib/themes/wireframe/tokens.ts
+++ b/lib/themes/wireframe/tokens.ts
@@ -158,6 +158,7 @@ const tokens: TreatTokens = {
     color: {
       standard: '#777',
       standardInverted: white,
+      field: '#333',
       focus,
       critical,
       info,

--- a/site/src/theme/tokens.ts
+++ b/site/src/theme/tokens.ts
@@ -158,6 +158,7 @@ const tokens: TreatTokens = {
     color: {
       standard: '#777',
       standardInverted: white,
+      field: '#777',
       focus,
       critical,
       info,


### PR DESCRIPTION
Themes can now configure the colour of field borders separately to standard border colours. This facilitates using a higher contrast border colour on fields to further improve accessibility.

Updated themes include:

- seekAnz
- seekBusiness
- seekUnifiedBeta
- catho (based on referencing Quantum)