### PR TITLE
MonthPicker: Preserve touchable height on iOS

### DIFF
--- a/.changeset/polite-keys-tap.md
+++ b/.changeset/polite-keys-tap.md
@@ -1,0 +1,7 @@
+---
+'braid-design-system': patch
+---
+
+Monthpicker: Preserve touchable height on iOS
+
+Fix for the native Monthpicker on iOS having a reduced height when no value is provided.

--- a/.changeset/polite-keys-tap.md
+++ b/.changeset/polite-keys-tap.md
@@ -2,6 +2,6 @@
 'braid-design-system': patch
 ---
 
-Monthpicker: Preserve touchable height on iOS
+MonthPicker: Preserve touchable height on iOS
 
-Fix for the native Monthpicker on iOS having a reduced height when no value is provided.
+Fix for the native variant of `MonthPicker` having a reduced height on iOS when no value is provided.

--- a/lib/components/MonthPicker/MonthPicker.treat.ts
+++ b/lib/components/MonthPicker/MonthPicker.treat.ts
@@ -1,7 +1,6 @@
 import { style } from 'sku/treat';
 
 export const nativeInput = style({
-  appearance: 'none',
   selectors: {
     '&::-webkit-inner-spin-button, &::-webkit-calendar-picker-indicator, &::-webkit-clear-button': {
       display: 'none',

--- a/lib/components/MonthPicker/MonthPicker.tsx
+++ b/lib/components/MonthPicker/MonthPicker.tsx
@@ -189,6 +189,7 @@ const MonthPicker = ({
             onBlur={onBlur}
             onFocus={onFocus}
             {...fieldProps}
+            height="touchable"
             className={[className, styles.nativeInput]}
           />
           {overlays}


### PR DESCRIPTION
Fix for the native Monthpicker on iOS having a reduced height when no value is provided.