### PR TITLE
Add HiddenVisually, infer 'inline' prop for Hidden within text

### DIFF
--- a/.changeset/eighty-panthers-knock.md
+++ b/.changeset/eighty-panthers-knock.md
@@ -1,0 +1,18 @@
+---
+'braid-design-system': minor
+---
+
+Hidden: Infer 'inline' prop when nested inside Text or Heading
+
+Currently, if you want to hide content using the `Hidden` component in an inline context (e.g. hiding part of a sentence), you need to remember to set the `inline` boolean prop.
+
+Since most usages of this feature are within text, we now infer this for you automatically within the context of a `Text` or `Heading` component.
+
+**MIGRATION GUIDE**
+
+This change is not strictly required, but you can now clean up your code like this:
+
+```diff
+-<Text>The end of this sentence is... <Hidden inline below="tablet">hidden on mobile.</Hidden>
++<Text>The end of this sentence is... <Hidden below="tablet">hidden on mobile.</Hidden>
+```

--- a/.changeset/eighty-panthers-knock.md
+++ b/.changeset/eighty-panthers-knock.md
@@ -2,7 +2,7 @@
 'braid-design-system': patch
 ---
 
-Hidden: Infer 'inline' prop when nested inside Text or Heading
+Hidden: Infer `inline` prop when nested inside Text or Heading
 
 Currently, if you want to hide content using the `Hidden` component in an inline context (e.g. hiding part of a sentence), you need to remember to set the `inline` boolean prop.
 

--- a/.changeset/eighty-panthers-knock.md
+++ b/.changeset/eighty-panthers-knock.md
@@ -1,5 +1,5 @@
 ---
-'braid-design-system': minor
+'braid-design-system': patch
 ---
 
 Hidden: Infer 'inline' prop when nested inside Text or Heading

--- a/.changeset/shy-jokes-watch.md
+++ b/.changeset/shy-jokes-watch.md
@@ -1,0 +1,16 @@
+---
+'braid-design-system': minor
+---
+
+Add `HiddenVisually` component
+
+You can now easily provide content to assistive technologies while hiding it from the screen.
+
+```js
+<Text>
+  This content is available to everyone.
+  <HiddenVisually>
+    This content is only available to screen readers.
+  </HiddenVisually>
+</Text>
+```

--- a/docs/Style Guide Migration.md
+++ b/docs/Style Guide Migration.md
@@ -50,6 +50,7 @@ Since Braid is an entirely new design system, we've taken the opportunity to rev
 - `Paragraph` -> [`Text`](../lib/components/Text/Text.migration.md)
 - `Pill` -> [`Tag`](../lib/components/Tag/Tag.migration.md)
 - [`Radio`](../lib/components/Radio/Radio.migration.md)
+- `ScreenReaderOnly` -> [`HiddenVisually`](../lib/components/HiddenVisually/HiddenVisually.migration.md)
 - [`Secondary`](../lib/components/Secondary/Secondary.migration.md)
 - `SlideToggle` -> [`Toggle`](../lib/components/Toggle/Toggle.migration.md)
 - [`Strong`](../lib/components/Strong/Strong.migration.md)

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -2478,6 +2478,15 @@ Object {
 }
 `;
 
+exports[`HiddenVisually 1`] = `
+Object {
+  exportType: component,
+  props: {
+    children: ReactNode
+},
+}
+`;
+
 exports[`IconAdd 1`] = `
 Object {
   exportType: component,

--- a/lib/components/Hidden/Hidden.docs.tsx
+++ b/lib/components/Hidden/Hidden.docs.tsx
@@ -131,6 +131,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden on screen (inline)',
+      docsSite: false,
       Example: () => (
         <Text>
           The following text node is hidden on screen:{' '}

--- a/lib/components/Hidden/Hidden.docs.tsx
+++ b/lib/components/Hidden/Hidden.docs.tsx
@@ -79,9 +79,7 @@ const docs: ComponentDocs = {
       Example: () => (
         <Text>
           The following text node is hidden below tablet:{' '}
-          <Hidden inline below="tablet">
-            Hidden below tablet.
-          </Hidden>
+          <Hidden below="tablet">Hidden below tablet.</Hidden>
         </Text>
       ),
     },
@@ -90,9 +88,7 @@ const docs: ComponentDocs = {
       Example: () => (
         <Text>
           The following text node is hidden below desktop:{' '}
-          <Hidden inline below="desktop">
-            Hidden below desktop.
-          </Hidden>
+          <Hidden below="desktop">Hidden below desktop.</Hidden>
         </Text>
       ),
     },
@@ -101,9 +97,7 @@ const docs: ComponentDocs = {
       Example: () => (
         <Text>
           The following text node is hidden above mobile:{' '}
-          <Hidden inline above="mobile">
-            Hidden above mobile.
-          </Hidden>
+          <Hidden above="mobile">Hidden above mobile.</Hidden>
         </Text>
       ),
     },
@@ -112,9 +106,7 @@ const docs: ComponentDocs = {
       Example: () => (
         <Text>
           The following text node is hidden above tablet:{' '}
-          <Hidden inline above="tablet">
-            Hidden above tablet.
-          </Hidden>
+          <Hidden above="tablet">Hidden above tablet.</Hidden>
         </Text>
       ),
     },
@@ -123,9 +115,7 @@ const docs: ComponentDocs = {
       Example: () => (
         <Text>
           The following text node is hidden on print:{' '}
-          <Hidden inline print>
-            Hidden on print.
-          </Hidden>
+          <Hidden print>Hidden on print.</Hidden>
         </Text>
       ),
     },
@@ -134,9 +124,7 @@ const docs: ComponentDocs = {
       Example: () => (
         <Text>
           The following text node is hidden on screen:{' '}
-          <Hidden inline screen>
-            Hidden on screen.
-          </Hidden>
+          <Hidden screen>Hidden on screen.</Hidden>
         </Text>
       ),
     },

--- a/lib/components/Hidden/Hidden.docs.tsx
+++ b/lib/components/Hidden/Hidden.docs.tsx
@@ -3,9 +3,18 @@ import { ComponentDocs } from '../../../site/src/types';
 import { Hidden } from './Hidden';
 import { Text } from '../Text/Text';
 import { Stack } from '../Stack/Stack';
+import { TextLink } from '../TextLink/TextLink';
 
 const docs: ComponentDocs = {
   category: 'Layout',
+  description: (
+    <Text>
+      Allows you to hide content responsively. If you’re looking to hide content
+      visually while making it available to assistive technologies, use{' '}
+      <TextLink href="/components/HiddenVisually">HiddenVisually</TextLink>{' '}
+      instead.
+    </Text>
+  ),
   screenshotWidths: [320, 768, 1200],
   examples: [
     {
@@ -65,6 +74,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden on Screen',
+      docsSite: false, // Looking to deprecate this, but we'll leave it in the test suite for now
       Example: () => (
         <Stack space="small">
           <Text>The following line is hidden on screen:</Text>

--- a/lib/components/Hidden/Hidden.tsx
+++ b/lib/components/Hidden/Hidden.tsx
@@ -1,11 +1,13 @@
-import React, { ReactNode } from 'react';
+import React, { useContext, ReactNode } from 'react';
 import { useStyles } from 'sku/react-treat';
 import { Box } from '../Box/Box';
-import * as styleRefs from './Hidden.treat';
+import TextContext from '../Text/TextContext';
+import HeadingContext from '../Heading/HeadingContext';
 import {
   resolveResponsiveRangeProps,
   ResponsiveRangeProps,
 } from '../../utils/responsiveRangeProps';
+import * as styleRefs from './Hidden.treat';
 
 export interface HiddenProps extends ResponsiveRangeProps {
   children: ReactNode;
@@ -20,18 +22,28 @@ export const Hidden = ({
   below,
   screen,
   print,
-  inline,
+  inline: inlineProp,
 }: HiddenProps) => {
+  if (process.env.NODE_ENV === 'development' && screen) {
+    // eslint-disable-next-line no-console
+    console.warn(
+      `You used the "screen" prop on Hidden, but this probably doesn't do what you expect. If you're trying to provide content to screen readers without rendering it to the screen, use the <HiddenVisually> component instead. The "screen" prop is likely to be deprecated in an future release.`,
+    );
+  }
+
+  const styles = useStyles(styleRefs);
+  const inText = Boolean(useContext(TextContext));
+  const inHeading = Boolean(useContext(HeadingContext));
+
   const hiddenOnScreen = Boolean(screen);
   const hiddenOnPrint = Boolean(print);
-
   const [
     hiddenOnMobile,
     hiddenOnTablet,
     hiddenOnDesktop,
   ] = resolveResponsiveRangeProps({ above, below });
 
-  const styles = useStyles(styleRefs);
+  const inline = inlineProp || inText || inHeading;
   const display = inline ? 'inline' : 'block';
 
   return (

--- a/lib/components/Hidden/Hidden.tsx
+++ b/lib/components/Hidden/Hidden.tsx
@@ -43,7 +43,7 @@ export const Hidden = ({
     hiddenOnDesktop,
   ] = resolveResponsiveRangeProps({ above, below });
 
-  const inline = inlineProp || inText || inHeading;
+  const inline = inlineProp !== undefined ? inlineProp : inText || inHeading;
   const display = inline ? 'inline' : 'block';
 
   return (

--- a/lib/components/Hidden/Hidden.tsx
+++ b/lib/components/Hidden/Hidden.tsx
@@ -43,7 +43,7 @@ export const Hidden = ({
     hiddenOnDesktop,
   ] = resolveResponsiveRangeProps({ above, below });
 
-  const inline = inlineProp !== undefined ? inlineProp : inText || inHeading;
+  const inline = inlineProp ?? (inText || inHeading);
   const display = inline ? 'inline' : 'block';
 
   return (

--- a/lib/components/Hidden/Hidden.tsx
+++ b/lib/components/Hidden/Hidden.tsx
@@ -27,7 +27,7 @@ export const Hidden = ({
   if (process.env.NODE_ENV === 'development' && screen) {
     // eslint-disable-next-line no-console
     console.warn(
-      `You used the "screen" prop on Hidden, but this probably doesn't do what you expect. If you're trying to provide content to screen readers without rendering it to the screen, use the <HiddenVisually> component instead. The "screen" prop is likely to be deprecated in an future release.`,
+      `You used the "screen" prop on Hidden, but this probably doesn't do what you expect. If you're trying to provide content to screen readers without rendering it to the screen, use the <HiddenVisually> component instead. The "screen" prop is likely to be deprecated in a future release.`,
     );
   }
 

--- a/lib/components/HiddenVisually/HiddenVisually.docs.tsx
+++ b/lib/components/HiddenVisually/HiddenVisually.docs.tsx
@@ -5,7 +5,6 @@ import { Text } from '../Text/Text';
 
 const docs: ComponentDocs = {
   category: 'Layout',
-  foundation: true,
   description: (
     <Text>
       Provides content to assistive technologies while hiding it from the
@@ -13,6 +12,7 @@ const docs: ComponentDocs = {
     </Text>
   ),
   screenshotWidths: [320],
+  screenshotOnlyInWireframe: true,
   examples: [
     {
       label: 'Inside Text',

--- a/lib/components/HiddenVisually/HiddenVisually.docs.tsx
+++ b/lib/components/HiddenVisually/HiddenVisually.docs.tsx
@@ -5,6 +5,7 @@ import { Text } from '../Text/Text';
 
 const docs: ComponentDocs = {
   category: 'Layout',
+  foundation: true,
   description: (
     <Text>
       Provides content to assistive technologies while hiding it from the

--- a/lib/components/HiddenVisually/HiddenVisually.docs.tsx
+++ b/lib/components/HiddenVisually/HiddenVisually.docs.tsx
@@ -14,7 +14,7 @@ const docs: ComponentDocs = {
   screenshotWidths: [320],
   examples: [
     {
-      label: 'Hidden below tablet',
+      label: 'Inside Text',
       Example: () => (
         <Text>
           The next sentence is only available to screen readers.

--- a/lib/components/HiddenVisually/HiddenVisually.docs.tsx
+++ b/lib/components/HiddenVisually/HiddenVisually.docs.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { ComponentDocs } from '../../../site/src/types';
+import { HiddenVisually } from './HiddenVisually';
+import { Text } from '../Text/Text';
+
+const docs: ComponentDocs = {
+  category: 'Layout',
+  description: (
+    <Text>
+      Provides content to assistive technologies while hiding it from the
+      screen.
+    </Text>
+  ),
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Hidden below tablet',
+      Example: () => (
+        <Text>
+          The next sentence is only available to screen readers.
+          <HiddenVisually> Hello world.</HiddenVisually>
+        </Text>
+      ),
+    },
+  ],
+};
+
+export default docs;

--- a/lib/components/HiddenVisually/HiddenVisually.migration.md
+++ b/lib/components/HiddenVisually/HiddenVisually.migration.md
@@ -1,0 +1,19 @@
+# HiddenVisually Migration Guide
+
+## API Changes
+
+- No longer accepts a `component` prop. This is now inferred internally based on whether it's nested within a `Text` or `Heading` component.
+- No longer accepts arbitrary DOM properties, e.g. `className`. Please check that everything you need is exposed via the [public API.](https://seek-oss.github.io/braid-design-system/components/HiddenVisually)
+
+## Diff
+
+### SEEK Style Guide
+
+```diff
+-<ScreenReaderOnly>...</ScreenReaderOnly>
++<HiddenVisually>...</HiddenVisually>
+```
+
+## Previous Implementations
+
+- [SEEK Style Guide](https://seek-oss.github.io/seek-style-guide/screen-reader-only)

--- a/lib/components/HiddenVisually/HiddenVisually.treat.ts
+++ b/lib/components/HiddenVisually/HiddenVisually.treat.ts
@@ -1,0 +1,8 @@
+import { style } from 'sku/treat';
+
+export const root = style({
+  width: 1,
+  height: 1,
+  clip: 'rect(1px, 1px, 1px, 1px)',
+  whiteSpace: 'nowrap',
+});

--- a/lib/components/HiddenVisually/HiddenVisually.tsx
+++ b/lib/components/HiddenVisually/HiddenVisually.tsx
@@ -1,0 +1,29 @@
+import React, { useContext } from 'react';
+import { useStyles } from 'sku/react-treat';
+import { Box, BoxProps } from '../Box/Box';
+import TextContext from '../Text/TextContext';
+import HeadingContext from '../Heading/HeadingContext';
+import * as styleRefs from './HiddenVisually.treat';
+
+interface HiddenVisuallyProps {
+  children: BoxProps['children'];
+}
+
+export const HiddenVisually = ({ children }: HiddenVisuallyProps) => {
+  const styles = useStyles(styleRefs);
+  const inText = Boolean(useContext(TextContext));
+  const inHeading = Boolean(useContext(HeadingContext));
+
+  const component = inText || inHeading ? 'span' : 'div';
+
+  return (
+    <Box
+      component={component}
+      position="absolute"
+      overflow="hidden"
+      className={styles.root}
+    >
+      {children}
+    </Box>
+  );
+};

--- a/lib/components/index.ts
+++ b/lib/components/index.ts
@@ -33,6 +33,7 @@ export { FieldLabel } from './FieldLabel/FieldLabel';
 export { FieldMessage } from './FieldMessage/FieldMessage';
 export { Heading } from './Heading/Heading';
 export { Hidden } from './Hidden/Hidden';
+export { HiddenVisually } from './HiddenVisually/HiddenVisually';
 export { Inline } from './Inline/Inline';
 export { Link } from './Link/Link';
 export { Loader } from './Loader/Loader';

--- a/lib/stories/all.stories.tsx
+++ b/lib/stories/all.stories.tsx
@@ -42,8 +42,10 @@ req.keys().forEach((filename) => {
     return;
   }
 
-  const storyThemes = values(themes).filter(
-    (theme) => theme.name !== 'wireframe',
+  const storyThemes = values(themes).filter((theme) =>
+    docs.screenshotOnlyInWireframe
+      ? theme.name === 'wireframe'
+      : theme.name !== 'wireframe',
   );
 
   storyThemes.forEach((theme) => {

--- a/site/src/types.d.ts
+++ b/site/src/types.d.ts
@@ -29,6 +29,7 @@ export interface ComponentDocs {
   migrationGuide?: boolean;
   foundation?: boolean;
   screenshotWidths: Array<320 | 768 | 1200>;
+  screenshotOnlyInWireframe?: boolean;
   examples: ComponentExample[];
   snippets?: DocsSnippet[];
   description?: ReactNodeNoStrings;


### PR DESCRIPTION
See changesets for details.

This PR also starts the process of deprecating the `screen` boolean prop on `Hidden` since people *think* it's the same behaviour as `HiddenVisually`. In practice, `<Hidden screen>` hides the content for _everyone_, but makes it available on print, which is a total edge case that our system doesn't need to explicitly cater to.