### PR TITLE
Add 'body' background to Box, improve examples on docs site

### DIFF
--- a/.changeset/orange-starfishes-destroy.md
+++ b/.changeset/orange-starfishes-destroy.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': minor
+---
+
+Box: Add `body` background
+
+You can now use the theme's body background on arbitrary elements within the page.
+
+**EXAMPLE USAGE**
+
+```jsx
+<Box background="body">...</Box>
+```

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ lib/components/icons/*/*Svg.tsx
 # managed by sku
 .eslintrc
 .prettierrc
+.ssl
 coverage/
 dist-storybook/
 report/

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -301,6 +301,7 @@ Object {
     autoPlay?: boolean
     autoSave?: string
     background?: 
+        | "body"
         | "brand"
         | "brandAccent"
         | "brandAccentActive"
@@ -1093,6 +1094,7 @@ Object {
         | "flexStart"
     >
     background?: 
+        | "body"
         | "brand"
         | "brandAccent"
         | "brandAccentActive"

--- a/lib/components/Actions/Actions.docs.tsx
+++ b/lib/components/Actions/Actions.docs.tsx
@@ -54,10 +54,10 @@ const docs: ComponentDocs = {
 
         return (
           <Fragment>
-            {[undefined, ...backgrounds.sort()].map((background, i) => (
+            {backgrounds.sort().map((background, i) => (
               <Box key={i} background={background} padding="xsmall">
                 <Stack space="xsmall">
-                  <Text size="small">{background || 'No background'}</Text>
+                  <Text size="small">{background}</Text>
                   <Actions>
                     <Button weight="strong">Strong</Button>
                     <TextLink href="#">

--- a/lib/components/Alert/Alert.docs.tsx
+++ b/lib/components/Alert/Alert.docs.tsx
@@ -1,6 +1,15 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Alert, Text, Strong, Stack, TextLink, BulletList, Bullet } from '../';
+import {
+  Alert,
+  Card,
+  Text,
+  Strong,
+  Stack,
+  TextLink,
+  BulletList,
+  Bullet,
+} from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -27,6 +36,16 @@ const docs: ComponentDocs = {
         <Alert tone="info">
           <Text>This is an important piece of information.</Text>
         </Alert>
+      ),
+    },
+    {
+      label: 'Info Alert Inside Card',
+      Example: () => (
+        <Card>
+          <Alert tone="info">
+            <Text>This is an important piece of information.</Text>
+          </Alert>
+        </Card>
       ),
     },
     {
@@ -64,11 +83,31 @@ const docs: ComponentDocs = {
       ),
     },
     {
+      label: 'Promote Alert Inside Card',
+      Example: () => (
+        <Card>
+          <Alert tone="promote">
+            <Text>This is a promoted piece of information.</Text>
+          </Alert>
+        </Card>
+      ),
+    },
+    {
       label: 'Caution Alert',
       Example: () => (
         <Alert tone="caution">
           <Text>This is a cautionary piece of information.</Text>
         </Alert>
+      ),
+    },
+    {
+      label: 'Caution Alert Inside Card',
+      Example: () => (
+        <Card>
+          <Alert tone="caution">
+            <Text>This is a cautionary piece of information.</Text>
+          </Alert>
+        </Card>
       ),
     },
     {
@@ -80,11 +119,31 @@ const docs: ComponentDocs = {
       ),
     },
     {
+      label: 'Critical Alert Inside Card',
+      Example: () => (
+        <Card>
+          <Alert tone="critical">
+            <Text>This is a critical piece of information.</Text>
+          </Alert>
+        </Card>
+      ),
+    },
+    {
       label: 'Positive Alert',
       Example: () => (
         <Alert tone="positive">
           <Text>This is a positive piece of information.</Text>
         </Alert>
+      ),
+    },
+    {
+      label: 'Positive Alert Inside Card',
+      Example: () => (
+        <Card>
+          <Alert tone="positive">
+            <Text>This is a positive piece of information.</Text>
+          </Alert>
+        </Card>
       ),
     },
   ],

--- a/lib/components/Alert/Alert.docs.tsx
+++ b/lib/components/Alert/Alert.docs.tsx
@@ -1,15 +1,6 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import {
-  Alert,
-  Card,
-  Text,
-  Strong,
-  Stack,
-  TextLink,
-  BulletList,
-  Bullet,
-} from '../';
+import { Alert, Text, Strong, Stack, TextLink, BulletList, Bullet } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -40,12 +31,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Info Alert Inside Card',
+      background: 'card',
       Example: () => (
-        <Card>
-          <Alert tone="info">
-            <Text>This is an important piece of information.</Text>
-          </Alert>
-        </Card>
+        <Alert tone="info">
+          <Text>This is an important piece of information.</Text>
+        </Alert>
       ),
     },
     {
@@ -84,12 +74,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Promote Alert Inside Card',
+      background: 'card',
       Example: () => (
-        <Card>
-          <Alert tone="promote">
-            <Text>This is a promoted piece of information.</Text>
-          </Alert>
-        </Card>
+        <Alert tone="promote">
+          <Text>This is a promoted piece of information.</Text>
+        </Alert>
       ),
     },
     {
@@ -102,12 +91,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Caution Alert Inside Card',
+      background: 'card',
       Example: () => (
-        <Card>
-          <Alert tone="caution">
-            <Text>This is a cautionary piece of information.</Text>
-          </Alert>
-        </Card>
+        <Alert tone="caution">
+          <Text>This is a cautionary piece of information.</Text>
+        </Alert>
       ),
     },
     {
@@ -120,12 +108,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Critical Alert Inside Card',
+      background: 'card',
       Example: () => (
-        <Card>
-          <Alert tone="critical">
-            <Text>This is a critical piece of information.</Text>
-          </Alert>
-        </Card>
+        <Alert tone="critical">
+          <Text>This is a critical piece of information.</Text>
+        </Alert>
       ),
     },
     {
@@ -138,12 +125,11 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Positive Alert Inside Card',
+      background: 'card',
       Example: () => (
-        <Card>
-          <Alert tone="positive">
-            <Text>This is a positive piece of information.</Text>
-          </Alert>
-        </Card>
+        <Alert tone="positive">
+          <Text>This is a positive piece of information.</Text>
+        </Alert>
       ),
     },
   ],

--- a/lib/components/Autosuggest/Autosuggest.docs.tsx
+++ b/lib/components/Autosuggest/Autosuggest.docs.tsx
@@ -1,7 +1,7 @@
 import React, { useState, ReactNode } from 'react';
 import matchHighlights from 'autosuggest-highlight/match';
 import { ComponentDocs } from '../../../site/src/types';
-import { Autosuggest, Box, IconSearch, IconLocation } from '../';
+import { Autosuggest, IconSearch, IconLocation } from '../';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -238,24 +238,23 @@ const docs: ComponentDocs = {
       label: 'Standard suggestions with brand background and mobile backdrop',
       storybook: false,
       Container,
+      background: 'brand',
       Example: ({ id }) => {
         const [value, setValue] = useState<Value>({ text: '' });
 
         return (
-          <Box background="brand" padding="small">
-            <Autosuggest
-              showMobileBackdrop
-              label="I like to eat"
-              id={id}
-              value={value}
-              onChange={setValue}
-              onClear={() => setValue({ text: '' })}
-              suggestions={makeSuggestions(
-                ['Apples', 'Bananas', 'Broccoli', 'Carrots'],
-                value.text,
-              )}
-            />
-          </Box>
+          <Autosuggest
+            showMobileBackdrop
+            label="I like to eat"
+            id={id}
+            value={value}
+            onChange={setValue}
+            onClear={() => setValue({ text: '' })}
+            suggestions={makeSuggestions(
+              ['Apples', 'Bananas', 'Broccoli', 'Carrots'],
+              value.text,
+            )}
+          />
         );
       },
     },

--- a/lib/components/Badge/Badge.docs.tsx
+++ b/lib/components/Badge/Badge.docs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Badge, Inline } from '../';
+import { Badge, Card, Inline } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -9,74 +9,110 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Info Badge',
-      Example: () => <Badge tone="info">Info</Badge>,
+      Example: () => (
+        <Card>
+          <Badge tone="info">Info</Badge>
+        </Card>
+      ),
     },
     {
       label: 'Strong Info Badge',
       Example: () => (
-        <Badge tone="info" weight="strong">
-          Info
-        </Badge>
+        <Card>
+          <Badge tone="info" weight="strong">
+            Info
+          </Badge>
+        </Card>
       ),
     },
     {
       label: 'Critical Badge',
-      Example: () => <Badge tone="critical">Critical</Badge>,
+      Example: () => (
+        <Card>
+          <Badge tone="critical">Critical</Badge>
+        </Card>
+      ),
     },
     {
       label: 'Strong Critical Badge',
       Example: () => (
-        <Badge tone="critical" weight="strong">
-          Critical
-        </Badge>
+        <Card>
+          <Badge tone="critical" weight="strong">
+            Critical
+          </Badge>
+        </Card>
       ),
     },
     {
       label: 'Caution Badge',
-      Example: () => <Badge tone="caution">Caution</Badge>,
+      Example: () => (
+        <Card>
+          <Badge tone="caution">Caution</Badge>
+        </Card>
+      ),
     },
     {
       label: 'Strong Caution Badge',
       Example: () => (
-        <Badge tone="caution" weight="strong">
-          Caution
-        </Badge>
+        <Card>
+          <Badge tone="caution" weight="strong">
+            Caution
+          </Badge>
+        </Card>
       ),
     },
     {
       label: 'Positive Badge',
-      Example: () => <Badge tone="positive">Positive</Badge>,
+      Example: () => (
+        <Card>
+          <Badge tone="positive">Positive</Badge>
+        </Card>
+      ),
     },
     {
       label: 'Strong Positive Badge',
       Example: () => (
-        <Badge tone="positive" weight="strong">
-          Positive
-        </Badge>
+        <Card>
+          <Badge tone="positive" weight="strong">
+            Positive
+          </Badge>
+        </Card>
       ),
     },
     {
       label: 'Promote Badge',
-      Example: () => <Badge tone="promote">Promote</Badge>,
+      Example: () => (
+        <Card>
+          <Badge tone="promote">Promote</Badge>
+        </Card>
+      ),
     },
     {
       label: 'Strong Promote Badge',
       Example: () => (
-        <Badge tone="promote" weight="strong">
-          Promote
-        </Badge>
+        <Card>
+          <Badge tone="promote" weight="strong">
+            Promote
+          </Badge>
+        </Card>
       ),
     },
     {
       label: 'Neutral Badge',
-      Example: () => <Badge tone="neutral">Neutral</Badge>,
+      Example: () => (
+        <Card>
+          <Badge tone="neutral">Neutral</Badge>
+        </Card>
+      ),
     },
     {
       label: 'Strong Neutral Badge',
       Example: () => (
-        <Badge tone="neutral" weight="strong">
-          Neutral
-        </Badge>
+        <Card>
+          <Badge tone="neutral" weight="strong">
+            Neutral
+          </Badge>
+        </Card>
       ),
     },
   ],

--- a/lib/components/Badge/Badge.docs.tsx
+++ b/lib/components/Badge/Badge.docs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Badge, Card, Inline } from '../';
+import { Badge, Inline } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -9,110 +9,80 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Info Badge',
-      Example: () => (
-        <Card>
-          <Badge tone="info">Info</Badge>
-        </Card>
-      ),
+      background: 'card',
+      Example: () => <Badge tone="info">Info</Badge>,
     },
     {
       label: 'Strong Info Badge',
       Example: () => (
-        <Card>
-          <Badge tone="info" weight="strong">
-            Info
-          </Badge>
-        </Card>
+        <Badge tone="info" weight="strong">
+          Info
+        </Badge>
       ),
     },
     {
       label: 'Critical Badge',
-      Example: () => (
-        <Card>
-          <Badge tone="critical">Critical</Badge>
-        </Card>
-      ),
+      background: 'card',
+      Example: () => <Badge tone="critical">Critical</Badge>,
     },
     {
       label: 'Strong Critical Badge',
       Example: () => (
-        <Card>
-          <Badge tone="critical" weight="strong">
-            Critical
-          </Badge>
-        </Card>
+        <Badge tone="critical" weight="strong">
+          Critical
+        </Badge>
       ),
     },
     {
       label: 'Caution Badge',
-      Example: () => (
-        <Card>
-          <Badge tone="caution">Caution</Badge>
-        </Card>
-      ),
+      background: 'card',
+      Example: () => <Badge tone="caution">Caution</Badge>,
     },
     {
       label: 'Strong Caution Badge',
       Example: () => (
-        <Card>
-          <Badge tone="caution" weight="strong">
-            Caution
-          </Badge>
-        </Card>
+        <Badge tone="caution" weight="strong">
+          Caution
+        </Badge>
       ),
     },
     {
       label: 'Positive Badge',
-      Example: () => (
-        <Card>
-          <Badge tone="positive">Positive</Badge>
-        </Card>
-      ),
+      background: 'card',
+      Example: () => <Badge tone="positive">Positive</Badge>,
     },
     {
       label: 'Strong Positive Badge',
       Example: () => (
-        <Card>
-          <Badge tone="positive" weight="strong">
-            Positive
-          </Badge>
-        </Card>
+        <Badge tone="positive" weight="strong">
+          Positive
+        </Badge>
       ),
     },
     {
       label: 'Promote Badge',
-      Example: () => (
-        <Card>
-          <Badge tone="promote">Promote</Badge>
-        </Card>
-      ),
+      background: 'card',
+      Example: () => <Badge tone="promote">Promote</Badge>,
     },
     {
       label: 'Strong Promote Badge',
       Example: () => (
-        <Card>
-          <Badge tone="promote" weight="strong">
-            Promote
-          </Badge>
-        </Card>
+        <Badge tone="promote" weight="strong">
+          Promote
+        </Badge>
       ),
     },
     {
       label: 'Neutral Badge',
-      Example: () => (
-        <Card>
-          <Badge tone="neutral">Neutral</Badge>
-        </Card>
-      ),
+      background: 'card',
+      Example: () => <Badge tone="neutral">Neutral</Badge>,
     },
     {
       label: 'Strong Neutral Badge',
       Example: () => (
-        <Card>
-          <Badge tone="neutral" weight="strong">
-            Neutral
-          </Badge>
-        </Card>
+        <Badge tone="neutral" weight="strong">
+          Neutral
+        </Badge>
       ),
     },
   ],

--- a/lib/components/Box/BackgroundContext.tsx
+++ b/lib/components/Box/BackgroundContext.tsx
@@ -3,16 +3,16 @@ import { BoxProps } from './Box';
 import { useBraidTheme } from '../BraidProvider/BraidProvider';
 
 export type BackgroundVariant =
-  | BoxProps['background']
+  | NonNullable<BoxProps['background']>
   | 'UNKNOWN_DARK'
   | 'UNKNOWN_LIGHT';
 
-const backgroundContext = createContext<BackgroundVariant | null>(null);
+const backgroundContext = createContext<BackgroundVariant>('body');
 
 export const BackgroundProvider = backgroundContext.Provider;
 
 export const renderBackgroundProvider = (
-  background: BackgroundVariant,
+  background: BackgroundVariant | undefined,
   element: ReactElement | null,
 ) =>
   background ? (

--- a/lib/components/Box/Box.docs.tsx
+++ b/lib/components/Box/Box.docs.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import { ComponentDocs, ComponentExample } from '../../../site/src/types';
 import { Box } from './Box';
 import { Placeholder } from '../private/Placeholder/Placeholder';
@@ -14,17 +14,15 @@ const docs: ComponentDocs = {
     (space): ComponentExample => ({
       label: `"${space}" space`,
       Container: ({ children }) => (
-        <Box
-          background="neutralLight"
-          style={{ overflow: 'auto', maxWidth: '300px' }}
-        >
-          {children}
-        </Box>
+        <Box style={{ overflow: 'auto', maxWidth: '300px' }}>{children}</Box>
       ),
       Example: () => (
-        <Box padding={space}>
-          <Placeholder height={100} />
-        </Box>
+        <Fragment>
+          <Box paddingBottom={space}>
+            <Placeholder height={40} />
+          </Box>
+          <Placeholder height={40} />
+        </Fragment>
       ),
     }),
   ),

--- a/lib/components/Box/useBoxStyles.treat.ts
+++ b/lib/components/Box/useBoxStyles.treat.ts
@@ -1,6 +1,5 @@
 import { style, styleMap } from 'sku/treat';
 import { Properties } from 'csstype';
-import omit from 'lodash/omit';
 import { mapToStyleProperty } from '../../utils';
 import { Theme } from 'treat/theme';
 
@@ -259,7 +258,7 @@ export const flexGrow = styleMap(
 ) as Record<keyof typeof flexGrowRules, string>; // Remove this when 'styleMap' supports numbers as keys and it's been released to sku consumers
 
 export const background = styleMap(({ color }) =>
-  mapToStyleProperty(omit(color.background, 'body'), 'background'),
+  mapToStyleProperty(color.background, 'background'),
 );
 
 export const boxShadow = styleMap(

--- a/lib/components/Button/Button.docs.tsx
+++ b/lib/components/Button/Button.docs.tsx
@@ -44,12 +44,9 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Weak Button on Brand Background',
+      background: 'brand',
       Container,
-      Example: () => (
-        <Box background="brand" padding="medium">
-          <Button weight="weak">Submit</Button>
-        </Box>
-      ),
+      Example: () => <Button weight="weak">Submit</Button>,
     },
     {
       label: 'Loading Button',

--- a/lib/components/Card/Card.docs.tsx
+++ b/lib/components/Card/Card.docs.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import {
   Card,
-  Box,
   Text,
   Stack,
   Heading,
@@ -19,11 +18,6 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Default',
-      Container: ({ children }) => (
-        <Box padding="gutter" background="neutralLight">
-          {children}
-        </Box>
-      ),
       Example: () => (
         <Card>
           <Text>This text is inside a card.</Text>

--- a/lib/components/Checkbox/Checkbox.docs.tsx
+++ b/lib/components/Checkbox/Checkbox.docs.tsx
@@ -28,6 +28,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Disabled Checkbox',
+      background: 'card',
       Example: ({ id, handler }) => (
         <Checkbox
           id={id}

--- a/lib/components/Column/Column.docs.tsx
+++ b/lib/components/Column/Column.docs.tsx
@@ -18,13 +18,13 @@ const docs: ComponentDocs = {
       Example: () => (
         <Columns space="small">
           <Column>
-            <Placeholder height={60} label="Column" />
+            <Placeholder height={60} />
           </Column>
           <Column>
-            <Placeholder height={60} label="Column" />
+            <Placeholder height={60} />
           </Column>
           <Column>
-            <Placeholder height={60} label="Column" />
+            <Placeholder height={60} />
           </Column>
         </Columns>
       ),

--- a/lib/components/Column/Column.docs.tsx
+++ b/lib/components/Column/Column.docs.tsx
@@ -12,6 +12,7 @@ const widths = [
 const docs: ComponentDocs = {
   category: 'Layout',
   screenshotWidths: [320],
+  screenshotOnlyInWireframe: true,
   examples: [
     {
       label: 'Standard Columns',

--- a/lib/components/Columns/Columns.docs.tsx
+++ b/lib/components/Columns/Columns.docs.tsx
@@ -7,6 +7,7 @@ const docs: ComponentDocs = {
   category: 'Layout',
   migrationGuide: true,
   screenshotWidths: [320, 768, 1200],
+  screenshotOnlyInWireframe: true,
   examples: [
     {
       label: 'No space',

--- a/lib/components/ContentBlock/ContentBlock.docs.tsx
+++ b/lib/components/ContentBlock/ContentBlock.docs.tsx
@@ -11,7 +11,7 @@ const docs: ComponentDocs = {
       label: 'Default Content Block',
       Example: () => (
         <ContentBlock>
-          <Placeholder height={100} label="Content block" />
+          <Placeholder height={100} />
         </ContentBlock>
       ),
     },
@@ -19,7 +19,7 @@ const docs: ComponentDocs = {
       label: 'Large Content Block',
       Example: () => (
         <ContentBlock width="large">
-          <Placeholder height={100} label="Content block" />
+          <Placeholder height={100} />
         </ContentBlock>
       ),
     },
@@ -29,7 +29,7 @@ const docs: ComponentDocs = {
       name: 'Standard',
       code: (
         <ContentBlock>
-          <Placeholder height={100} label="Content block" />
+          <Placeholder height={100} />
         </ContentBlock>
       ),
     },
@@ -37,7 +37,7 @@ const docs: ComponentDocs = {
       name: 'Large',
       code: (
         <ContentBlock width="large">
-          <Placeholder height={100} label="Content block" />
+          <Placeholder height={100} />
         </ContentBlock>
       ),
     },

--- a/lib/components/ContentBlock/ContentBlock.docs.tsx
+++ b/lib/components/ContentBlock/ContentBlock.docs.tsx
@@ -1,11 +1,7 @@
-import React, { ReactNode } from 'react';
+import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { Placeholder } from '../private/Placeholder/Placeholder';
-import { ContentBlock, Box } from '../';
-
-const Container = ({ children }: { children: ReactNode }) => (
-  <Box background="neutralLight">{children}</Box>
-);
+import { ContentBlock } from '../';
 
 const docs: ComponentDocs = {
   category: 'Layout',
@@ -13,7 +9,6 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Default Content Block',
-      Container,
       Example: () => (
         <ContentBlock>
           <Placeholder height={100} label="Content block" />
@@ -22,7 +17,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Large Content Block',
-      Container,
       Example: () => (
         <ContentBlock width="large">
           <Placeholder height={100} label="Content block" />

--- a/lib/components/Dropdown/Dropdown.docs.tsx
+++ b/lib/components/Dropdown/Dropdown.docs.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Box, Dropdown, IconLocation } from '../';
+import { Dropdown, IconLocation } from '../';
 import { Dropdown as PlayroomDropdown } from '../../playroom/components';
 
 const Container = ({ children }: { children: ReactNode }) => (
@@ -93,20 +93,19 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Dropdown on Brand Background',
+      background: 'brand',
       Container,
       Example: ({ id, handler }) => (
-        <Box background="brand" padding="small">
-          <Dropdown
-            label="Job Title"
-            id={id}
-            onChange={handler}
-            value=""
-            placeholder="Please select a role title"
-          >
-            <option value="1">Developer</option>
-            <option value="2">Designer</option>
-          </Dropdown>
-        </Box>
+        <Dropdown
+          label="Job Title"
+          id={id}
+          onChange={handler}
+          value=""
+          placeholder="Please select a role title"
+        >
+          <option value="1">Developer</option>
+          <option value="2">Designer</option>
+        </Dropdown>
       ),
     },
   ],

--- a/lib/components/Heading/Heading.docs.tsx
+++ b/lib/components/Heading/Heading.docs.tsx
@@ -77,6 +77,7 @@ const docs: ComponentDocs = {
     {
       label: 'Heading Spacing',
       docsSite: false,
+      background: 'card',
       Example: () => {
         const levels = Object.keys(headingLevels) as Array<
           keyof typeof headingLevels
@@ -138,6 +139,7 @@ const docs: ComponentDocs = {
     {
       label: 'Heading Spacing (Legacy)',
       docsSite: false,
+      background: 'card',
       Example: () => {
         const levels = Object.keys(headingLevels) as Array<
           keyof typeof headingLevels

--- a/lib/components/Hidden/Hidden.docs.tsx
+++ b/lib/components/Hidden/Hidden.docs.tsx
@@ -16,6 +16,7 @@ const docs: ComponentDocs = {
     </Text>
   ),
   screenshotWidths: [320, 768, 1200],
+  screenshotOnlyInWireframe: true,
   examples: [
     {
       label: 'Hidden below tablet',

--- a/lib/components/Hidden/Hidden.docs.tsx
+++ b/lib/components/Hidden/Hidden.docs.tsx
@@ -19,6 +19,7 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Hidden below tablet',
+      showCodeByDefault: true,
       Example: () => (
         <Stack space="small">
           <Text>The following line is hidden below tablet:</Text>
@@ -30,6 +31,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden below desktop',
+      showCodeByDefault: true,
       Example: () => (
         <Stack space="small">
           <Text>The following line is hidden below desktop:</Text>
@@ -41,6 +43,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden above mobile',
+      showCodeByDefault: true,
       Example: () => (
         <Stack space="small">
           <Text>The following line is hidden above mobile:</Text>
@@ -52,6 +55,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden above tablet',
+      showCodeByDefault: true,
       Example: () => (
         <Stack space="small">
           <Text>The following line is hidden above tablet:</Text>
@@ -63,6 +67,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden on print',
+      showCodeByDefault: true,
       Example: () => (
         <Stack space="small">
           <Text>The following line is hidden on print:</Text>
@@ -86,6 +91,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden below tablet (inline)',
+      showCodeByDefault: true,
       Example: () => (
         <Text>
           The following text node is hidden below tablet:{' '}
@@ -95,6 +101,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden below desktop (inline)',
+      showCodeByDefault: true,
       Example: () => (
         <Text>
           The following text node is hidden below desktop:{' '}
@@ -104,6 +111,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden above mobile (inline)',
+      showCodeByDefault: true,
       Example: () => (
         <Text>
           The following text node is hidden above mobile:{' '}
@@ -113,6 +121,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden above tablet (inline)',
+      showCodeByDefault: true,
       Example: () => (
         <Text>
           The following text node is hidden above tablet:{' '}
@@ -122,6 +131,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Hidden on print (inline)',
+      showCodeByDefault: true,
       Example: () => (
         <Text>
           The following text node is hidden on print:{' '}

--- a/lib/components/HiddenVisually/HiddenVisually.docs.tsx
+++ b/lib/components/HiddenVisually/HiddenVisually.docs.tsx
@@ -16,6 +16,7 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Inside Text',
+      showCodeByDefault: true,
       Example: () => (
         <Text>
           The next sentence is only available to screen readers.

--- a/lib/components/Inline/Inline.docs.tsx
+++ b/lib/components/Inline/Inline.docs.tsx
@@ -10,9 +10,7 @@ const spaces = Object.keys(padding.top).filter(
 ) as Array<InlineProps['space']>;
 
 const Container = ({ children }: { children: ReactNode }) => (
-  <Box background="neutralLight" style={{ maxWidth: '240px' }}>
-    {children}
-  </Box>
+  <Box style={{ maxWidth: '240px' }}>{children}</Box>
 );
 
 const docs: ComponentDocs = {

--- a/lib/components/Inline/Inline.docs.tsx
+++ b/lib/components/Inline/Inline.docs.tsx
@@ -16,6 +16,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 const docs: ComponentDocs = {
   category: 'Layout',
   screenshotWidths: [320, 768, 1200],
+  screenshotOnlyInWireframe: true,
   description: (
     <Stack space="large">
       <Text>

--- a/lib/components/OverflowMenu/OverflowMenu.docs.tsx
+++ b/lib/components/OverflowMenu/OverflowMenu.docs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { OverflowMenu, MenuItem, Card, Inline } from '../';
+import { Box, OverflowMenu, MenuItem } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -8,15 +8,14 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Default',
+      background: 'card',
       Example: ({ handler }) => (
-        <Card>
-          <Inline space="small" align="right">
-            <OverflowMenu label="Options">
-              <MenuItem onClick={handler}>First</MenuItem>
-              <MenuItem onClick={handler}>Second</MenuItem>
-            </OverflowMenu>
-          </Inline>
-        </Card>
+        <Box style={{ paddingLeft: '100px', maxWidth: '200px' }}>
+          <OverflowMenu label="Options">
+            <MenuItem onClick={handler}>First</MenuItem>
+            <MenuItem onClick={handler}>Second</MenuItem>
+          </OverflowMenu>
+        </Box>
       ),
     },
   ],

--- a/lib/components/OverflowMenu/OverflowMenu.docs.tsx
+++ b/lib/components/OverflowMenu/OverflowMenu.docs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Box, OverflowMenu, MenuItem } from '../';
+import { OverflowMenu, MenuItem, Card, Inline } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -9,12 +9,14 @@ const docs: ComponentDocs = {
     {
       label: 'Default',
       Example: ({ handler }) => (
-        <Box style={{ paddingLeft: '100px', maxWidth: '200px' }}>
-          <OverflowMenu label="Options">
-            <MenuItem onClick={handler}>First</MenuItem>
-            <MenuItem onClick={handler}>Second</MenuItem>
-          </OverflowMenu>
-        </Box>
+        <Card>
+          <Inline space="small" align="right">
+            <OverflowMenu label="Options">
+              <MenuItem onClick={handler}>First</MenuItem>
+              <MenuItem onClick={handler}>Second</MenuItem>
+            </OverflowMenu>
+          </Inline>
+        </Card>
       ),
     },
   ],

--- a/lib/components/PasswordField/PasswordField.docs.tsx
+++ b/lib/components/PasswordField/PasswordField.docs.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useState } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Box, PasswordField, TextLink } from '../';
+import { PasswordField, TextLink } from '../';
 import { PasswordField as PlayroomPasswordField } from '../../playroom/components';
 
 const Container = ({ children }: { children: ReactNode }) => (
@@ -127,18 +127,17 @@ const docs: ComponentDocs = {
     },
     {
       label: 'PasswordField on Brand Background',
+      background: 'brand',
       Container,
       Example: ({ id }) => {
         const [value, setValue] = useState('qwerty');
         return (
-          <Box background="brand" padding="small">
-            <PasswordField
-              label="Password"
-              id={id}
-              onChange={(ev) => setValue(ev.currentTarget.value)}
-              value={value}
-            />
-          </Box>
+          <PasswordField
+            label="Password"
+            id={id}
+            onChange={(ev) => setValue(ev.currentTarget.value)}
+            value={value}
+          />
         );
       },
     },

--- a/lib/components/Radio/Radio.docs.tsx
+++ b/lib/components/Radio/Radio.docs.tsx
@@ -22,6 +22,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Disabled Radio Button',
+      background: 'card',
       Example: ({ id, handler }) => (
         <Radio
           id={id}

--- a/lib/components/Rating/Rating.tsx
+++ b/lib/components/Rating/Rating.tsx
@@ -37,7 +37,7 @@ const RatingStar = ({ percent, ...restProps }: RatingStar) => {
       {...iconProps}
       className={[
         className,
-        { [styles.starColor]: !currentBg || currentBg === 'card' },
+        { [styles.starColor]: currentBg === 'body' || currentBg === 'card' },
       ]}
     />
   );

--- a/lib/components/Stack/Stack.docs.tsx
+++ b/lib/components/Stack/Stack.docs.tsx
@@ -10,9 +10,7 @@ const spaces = Object.keys(padding.top).filter(
 ) as Array<StackProps['space']>;
 
 const Container = ({ children }: { children: ReactNode }) => (
-  <Box background="neutralLight" style={{ maxWidth: '300px' }}>
-    {children}
-  </Box>
+  <Box style={{ maxWidth: '300px' }}>{children}</Box>
 );
 
 const docs: ComponentDocs = {

--- a/lib/components/Stack/Stack.docs.tsx
+++ b/lib/components/Stack/Stack.docs.tsx
@@ -16,6 +16,7 @@ const Container = ({ children }: { children: ReactNode }) => (
 const docs: ComponentDocs = {
   category: 'Layout',
   screenshotWidths: [320, 768, 1200],
+  screenshotOnlyInWireframe: true,
   migrationGuide: true,
   examples: [
     ...spaces.map((space) => ({

--- a/lib/components/Tabs/Tabs.docs.tsx
+++ b/lib/components/Tabs/Tabs.docs.tsx
@@ -91,16 +91,70 @@ const docs: ComponentDocs = {
     {
       label: 'Left aligned',
       Example: ({ id }) => (
+        <Card>
+          <TabsProvider id={id}>
+            <Stack space="medium">
+              <Tabs label="Test tabs">
+                <Tab>The first tab</Tab>
+                <Tab>The second tab</Tab>
+                <Tab>The third tab</Tab>
+                <Tab badge={<Badge tone="positive">New</Badge>}>
+                  The fourth tab
+                </Tab>
+              </Tabs>
+              <TabPanels>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 1" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 2" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 3" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 4" />
+                </TabPanel>
+              </TabPanels>
+            </Stack>
+          </TabsProvider>
+        </Card>
+      ),
+    },
+    {
+      label: 'Center aligned',
+      Example: ({ id }) => (
+        <Card>
+          <TabsProvider id={id}>
+            <Stack space="medium">
+              <Tabs label="Test tabs" align="center">
+                <Tab>The first tab</Tab>
+                <Tab>The second tab</Tab>
+              </Tabs>
+              <TabPanels>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 1" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 2" />
+                </TabPanel>
+              </TabPanels>
+            </Stack>
+          </TabsProvider>
+        </Card>
+      ),
+    },
+    {
+      label: 'With gutter',
+      Example: ({ id }) => (
         <TabsProvider id={id}>
-          <Stack space="medium">
-            <Tabs label="Test tabs">
-              <Tab>The first tab</Tab>
-              <Tab>The second tab</Tab>
-              <Tab>The third tab</Tab>
-              <Tab badge={<Badge tone="positive">New</Badge>}>
-                The fourth tab
-              </Tab>
-            </Tabs>
+          <Tabs label="Test tabs" gutter="gutter">
+            <Tab>The first tab</Tab>
+            <Tab>The second tab</Tab>
+            <Tab>The third tab</Tab>
+            <Tab>The fourth tab</Tab>
+          </Tabs>
+          <Card>
             <TabPanels>
               <TabPanel>
                 <Placeholder height={200} label="Panel 1" />
@@ -115,38 +169,12 @@ const docs: ComponentDocs = {
                 <Placeholder height={200} label="Panel 4" />
               </TabPanel>
             </TabPanels>
-          </Stack>
-        </TabsProvider>
-      ),
-    },
-    {
-      label: 'Center aligned',
-      Example: ({ id }) => (
-        <TabsProvider id={id}>
-          <Stack space="medium">
-            <Tabs label="Test tabs" align="center">
-              <Tab>The first tab</Tab>
-              <Tab>The second tab</Tab>
-            </Tabs>
-            <TabPanels>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 1" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 2" />
-              </TabPanel>
-            </TabPanels>
-          </Stack>
+          </Card>
         </TabsProvider>
       ),
     },
     {
       label: 'With gutter and reserved hit area',
-      Container: ({ children }) => (
-        <Box style={{ background: useBraidTheme().color.background.body }}>
-          {children}
-        </Box>
-      ),
       Example: ({ id }) => (
         <TabsProvider id={id}>
           <Tabs label="Test tabs" gutter="gutter" reserveHitArea>

--- a/lib/components/Tag/Tag.docs.tsx
+++ b/lib/components/Tag/Tag.docs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Tag, Card, Inline } from '../';
+import { Tag, Inline } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -9,49 +9,43 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Standard Tag',
-      Example: () => (
-        <Card>
-          <Tag>Tag</Tag>
-        </Card>
-      ),
+      background: 'card',
+      Example: () => <Tag>Tag</Tag>,
     },
     {
       label: 'Clearable Tag',
+      background: 'card',
       Example: ({ handler }) => (
-        <Card>
-          <Tag onClear={handler} clearLabel="Clear tag">
-            Tag
-          </Tag>
-        </Card>
+        <Tag onClear={handler} clearLabel="Clear tag">
+          Tag
+        </Tag>
       ),
     },
     {
       label: 'Truncated Tag',
       docsSite: false,
+      background: 'card',
       Example: ({ handler }) => (
-        <Card>
-          <Tag onClear={handler} clearLabel="Clear tag">
-            The quick brown fox jumps over the lazy dog. The quick brown fox
-            jumps over the lazy dog. The quick brown fox jumps over the lazy
-            dog. The quick brown fox jumps over the lazy dog. The quick brown
-            fox jumps over the lazy dog. The quick brown fox jumps over the lazy
-            dog. The quick brown fox jumps over the lazy dog.
-          </Tag>
-        </Card>
+        <Tag onClear={handler} clearLabel="Clear tag">
+          The quick brown fox jumps over the lazy dog. The quick brown fox jumps
+          over the lazy dog. The quick brown fox jumps over the lazy dog. The
+          quick brown fox jumps over the lazy dog. The quick brown fox jumps
+          over the lazy dog. The quick brown fox jumps over the lazy dog. The
+          quick brown fox jumps over the lazy dog.
+        </Tag>
       ),
     },
     {
       label: 'Test: Standard and clearable tags should be equal height',
       docsSite: false,
+      background: 'card',
       Example: ({ handler }) => (
-        <Card>
-          <Inline space="small">
-            <Tag>Tag</Tag>
-            <Tag onClear={handler} clearLabel="Clear tag">
-              Tag
-            </Tag>
-          </Inline>
-        </Card>
+        <Inline space="small">
+          <Tag>Tag</Tag>
+          <Tag onClear={handler} clearLabel="Clear tag">
+            Tag
+          </Tag>
+        </Inline>
       ),
     },
   ],

--- a/lib/components/Tag/Tag.docs.tsx
+++ b/lib/components/Tag/Tag.docs.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Tag } from './Tag';
-import { Inline } from '../Inline/Inline';
+import { Tag, Card, Inline } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -10,39 +9,49 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Standard Tag',
-      Example: () => <Tag>Tag</Tag>,
+      Example: () => (
+        <Card>
+          <Tag>Tag</Tag>
+        </Card>
+      ),
     },
     {
       label: 'Clearable Tag',
       Example: ({ handler }) => (
-        <Tag onClear={handler} clearLabel="Clear tag">
-          Tag
-        </Tag>
+        <Card>
+          <Tag onClear={handler} clearLabel="Clear tag">
+            Tag
+          </Tag>
+        </Card>
       ),
     },
     {
       label: 'Truncated Tag',
       docsSite: false,
       Example: ({ handler }) => (
-        <Tag onClear={handler} clearLabel="Clear tag">
-          The quick brown fox jumps over the lazy dog. The quick brown fox jumps
-          over the lazy dog. The quick brown fox jumps over the lazy dog. The
-          quick brown fox jumps over the lazy dog. The quick brown fox jumps
-          over the lazy dog. The quick brown fox jumps over the lazy dog. The
-          quick brown fox jumps over the lazy dog.
-        </Tag>
+        <Card>
+          <Tag onClear={handler} clearLabel="Clear tag">
+            The quick brown fox jumps over the lazy dog. The quick brown fox
+            jumps over the lazy dog. The quick brown fox jumps over the lazy
+            dog. The quick brown fox jumps over the lazy dog. The quick brown
+            fox jumps over the lazy dog. The quick brown fox jumps over the lazy
+            dog. The quick brown fox jumps over the lazy dog.
+          </Tag>
+        </Card>
       ),
     },
     {
       label: 'Test: Standard and clearable tags should be equal height',
       docsSite: false,
       Example: ({ handler }) => (
-        <Inline space="small">
-          <Tag>Tag</Tag>
-          <Tag onClear={handler} clearLabel="Clear tag">
-            Tag
-          </Tag>
-        </Inline>
+        <Card>
+          <Inline space="small">
+            <Tag>Tag</Tag>
+            <Tag onClear={handler} clearLabel="Clear tag">
+              Tag
+            </Tag>
+          </Inline>
+        </Card>
       ),
     },
   ],

--- a/lib/components/Text/Text.docs.tsx
+++ b/lib/components/Text/Text.docs.tsx
@@ -36,14 +36,13 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Text on Brand Background',
+      background: 'brand',
       Container,
       Example: () => (
-        <Box background="brand" padding="medium">
-          <Stack space="small">
-            <Text>Neutral text</Text>
-            <Text tone="secondary">Secondary text</Text>
-          </Stack>
-        </Box>
+        <Stack space="small">
+          <Text>Neutral text</Text>
+          <Text tone="secondary">Secondary text</Text>
+        </Stack>
       ),
     },
     {

--- a/lib/components/Text/Text.docs.tsx
+++ b/lib/components/Text/Text.docs.tsx
@@ -78,6 +78,7 @@ const docs: ComponentDocs = {
     {
       label: 'Text Spacing',
       docsSite: false,
+      background: 'card',
       Container,
       Example: () => {
         const sizes = Object.keys(textSizes) as Array<keyof typeof textSizes>;
@@ -100,6 +101,7 @@ const docs: ComponentDocs = {
     {
       label: 'Text Spacing (Legacy)',
       docsSite: false,
+      background: 'card',
       Container,
       Example: () => {
         const sizes = Object.keys(textSizes) as Array<keyof typeof textSizes>;

--- a/lib/components/TextDropdown/TextDropdown.docs.tsx
+++ b/lib/components/TextDropdown/TextDropdown.docs.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useState } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Box, Heading, Stack, Strong, Text, TextLink, TextDropdown } from '..';
+import { Heading, Stack, Strong, Text, TextLink, TextDropdown } from '..';
 import { TextDropdown as PlayroomTextDropdown } from '../../playroom/components';
 
 const Container = ({ children }: { children: ReactNode }) => (
@@ -118,22 +118,21 @@ const docs: ComponentDocs = {
     },
     {
       label: 'TextDropdown on Brand Background',
+      background: 'brand',
       Container,
       Example: ({ id }) => {
         const [value, setValue] = useState('Designer');
 
         return (
-          <Box background="brand" padding="small">
-            <Text>
-              <TextDropdown
-                label="Job Title"
-                id={id}
-                onChange={setValue}
-                value={value}
-                options={['Developer', 'Designer', 'Product Manager']}
-              />
-            </Text>
-          </Box>
+          <Text>
+            <TextDropdown
+              label="Job Title"
+              id={id}
+              onChange={setValue}
+              value={value}
+              options={['Developer', 'Designer', 'Product Manager']}
+            />
+          </Text>
         );
       },
     },

--- a/lib/components/TextField/TextField.docs.tsx
+++ b/lib/components/TextField/TextField.docs.tsx
@@ -1,6 +1,6 @@
 import React, { useState, ReactNode } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Box, IconSearch, TextField, TextLink } from '../';
+import { IconSearch, TextField, TextLink } from '../';
 import { TextField as PlayroomTextField } from '../../playroom/components';
 
 const Container = ({ children }: { children: ReactNode }) => (
@@ -156,16 +156,15 @@ const docs: ComponentDocs = {
     },
     {
       label: 'TextField on Brand Background',
+      background: 'brand',
       Container,
       Example: ({ id, handler }) => (
-        <Box background="brand" padding="small">
-          <TextField
-            label="Job Title"
-            id={id}
-            onChange={handler}
-            value="Senior Developer"
-          />
-        </Box>
+        <TextField
+          label="Job Title"
+          id={id}
+          onChange={handler}
+          value="Senior Developer"
+        />
       ),
     },
   ],

--- a/lib/components/TextLink/TextLink.docs.tsx
+++ b/lib/components/TextLink/TextLink.docs.tsx
@@ -175,10 +175,10 @@ const docs: ComponentDocs = {
 
         return (
           <Fragment>
-            {[undefined, ...backgrounds.sort()].map((background, i) => (
+            {backgrounds.sort().map((background, i) => (
               <Box key={i} background={background}>
                 <Text baseline={false}>
-                  {background || 'No background'}{' '}
+                  {background}{' '}
                   <TextLink href="#">
                     with link <IconNewWindow />
                   </TextLink>

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
@@ -55,7 +55,9 @@ export const TextLinkRenderer = (props: TextLinkRendererProps) => {
 function useTextLinkTone() {
   const backgroundContext = useBackground();
   const highlightLink =
-    backgroundContext === 'body' || backgroundContext === 'card';
+    backgroundContext === 'body' ||
+    backgroundContext === 'card' ||
+    backgroundContext === 'neutralLight';
   return highlightLink ? 'link' : 'neutral';
 }
 

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
@@ -54,7 +54,8 @@ export const TextLinkRenderer = (props: TextLinkRendererProps) => {
 
 function useTextLinkTone() {
   const backgroundContext = useBackground();
-  const highlightLink = backgroundContext === 'card' || !backgroundContext;
+  const highlightLink =
+    backgroundContext === 'body' || backgroundContext === 'card';
   return highlightLink ? 'link' : 'neutral';
 }
 

--- a/lib/components/Textarea/Textarea.docs.tsx
+++ b/lib/components/Textarea/Textarea.docs.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useState } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { Textarea, TextLink } from '../';
-import { Textarea as PlayroomTextarea, Box } from '../../playroom/components';
+import { Textarea as PlayroomTextarea } from '../../playroom/components';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -169,19 +169,18 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Textarea on Brand Background',
+      background: 'brand',
       Container,
       Example: ({ id }) => {
         const [value, setValue] = useState('');
 
         return (
-          <Box background="brand" padding="small">
-            <Textarea
-              label="Do you like Braid?"
-              id={id}
-              onChange={(e) => setValue(e.currentTarget.value)}
-              value={value}
-            />
-          </Box>
+          <Textarea
+            label="Do you like Braid?"
+            id={id}
+            onChange={(e) => setValue(e.currentTarget.value)}
+            value={value}
+          />
         );
       },
     },

--- a/lib/components/Tiles/Tiles.docs.tsx
+++ b/lib/components/Tiles/Tiles.docs.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Tiles, Box, Card, Text } from '../';
+import { Tiles, Card, Text } from '../';
 import { Placeholder } from '../private/Placeholder/Placeholder';
 
 const exampleRows = 3;
@@ -33,29 +33,25 @@ const docs: ComponentDocs = {
     {
       label: 'Dividers (when in a single column)',
       Example: () => (
-        <Box background="neutralLight" padding="small">
-          <Tiles space={['none', 'small']} columns={[1, 2]} dividers>
-            {[...new Array(2 * exampleRows)].map((_, i) => (
-              <Card key={i}>
-                <Text>Tile</Text>
-              </Card>
-            ))}
-          </Tiles>
-        </Box>
+        <Tiles space={['none', 'small']} columns={[1, 2]} dividers>
+          {[...new Array(2 * exampleRows)].map((_, i) => (
+            <Card key={i}>
+              <Text>Tile</Text>
+            </Card>
+          ))}
+        </Tiles>
       ),
     },
     {
       label: 'Strong dividers (when in a single column)',
       Example: () => (
-        <Box background="neutralLight" padding="small">
-          <Tiles space={['none', 'small']} columns={[1, 2]} dividers="strong">
-            {[...new Array(2 * exampleRows)].map((_, i) => (
-              <Card key={i}>
-                <Text>Tile</Text>
-              </Card>
-            ))}
-          </Tiles>
-        </Box>
+        <Tiles space={['none', 'small']} columns={[1, 2]} dividers="strong">
+          {[...new Array(2 * exampleRows)].map((_, i) => (
+            <Card key={i}>
+              <Text>Tile</Text>
+            </Card>
+          ))}
+        </Tiles>
       ),
     },
     {

--- a/lib/components/Tiles/Tiles.docs.tsx
+++ b/lib/components/Tiles/Tiles.docs.tsx
@@ -8,6 +8,7 @@ const exampleRows = 3;
 const docs: ComponentDocs = {
   category: 'Layout',
   screenshotWidths: [320, 768],
+  screenshotOnlyInWireframe: true,
   examples: [
     ...([1, 2, 3, 4, 5, 6] as const).map((columns) => ({
       label: `${columns} column${columns === 1 ? '' : 's'}`,

--- a/lib/components/iconButtons/IconButton.tsx
+++ b/lib/components/iconButtons/IconButton.tsx
@@ -119,7 +119,9 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
         >
           <Overlay
             background={
-              !background || background === 'card' || background === 'input'
+              background === 'body' ||
+              background === 'card' ||
+              background === 'input'
                 ? 'neutralLight'
                 : 'card'
             }

--- a/lib/components/icons/Icons.docs.tsx
+++ b/lib/components/icons/Icons.docs.tsx
@@ -1,17 +1,12 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Text } from '../Text/Text';
-import { Box } from '../Box/Box';
-import { Heading } from '../Heading/Heading';
-import { Inline } from '../Inline/Inline';
-import { Button } from '../Button/Button';
+import { Text, Heading, Inline, Button, Stack } from '../';
 import { UseIconProps } from '../../hooks/useIcon';
 import {
   heading as headingSizes,
   text as textSizes,
   tone as tones,
 } from '../../hooks/typography/typography.treat';
-import { Stack } from '../Stack/Stack';
 
 import * as icons from './index';
 
@@ -117,19 +112,18 @@ const docs: ComponentDocs = {
     {
       label: 'Auto Tone with Background Contrast (via TextContext)',
       docsSite: false,
+      background: 'brand',
       Example: () => (
-        <Box background="brand" padding="xsmall">
-          <Stack space="medium">
-            <Text>Default:</Text>
-            <Text>
-              <Icons />
-            </Text>
-            <Text>Explicitly positive:</Text>
-            <Text>
-              <Icons tone="positive" />
-            </Text>
-          </Stack>
-        </Box>
+        <Stack space="medium">
+          <Text>Default:</Text>
+          <Text>
+            <Icons />
+          </Text>
+          <Text>Explicitly positive:</Text>
+          <Text>
+            <Icons tone="positive" />
+          </Text>
+        </Stack>
       ),
     },
     {
@@ -163,10 +157,10 @@ const docs: ComponentDocs = {
             return (
               <Inline key={icon} space="small">
                 <Button>
-                  <IconComponent /> Uppercase
+                  <IconComponent /> Upper
                 </Button>
                 <Button>
-                  Lowercase <IconComponent alignY="lowercase" />
+                  Lower <IconComponent alignY="lowercase" />
                 </Button>
               </Inline>
             );

--- a/lib/components/useToast/useToast.docs.tsx
+++ b/lib/components/useToast/useToast.docs.tsx
@@ -10,8 +10,6 @@ import {
   Heading,
   TextLink,
   Strong,
-  Columns,
-  Column,
   IconPromote,
 } from '..';
 import Code from '../../../site/src/App/Code/Code';
@@ -109,27 +107,21 @@ const docs: ComponentDocs = {
         } as const;
 
         return (
-          <Columns space="gutter" alignY="center" collapseBelow="tablet">
-            <Column width="content">
-              <Toast
-                id={id}
-                dedupeKey={id}
-                shouldRemove={false}
-                treatTheme={theme}
-                onClear={handler}
-                {...toastProps}
-              />
-            </Column>
-            <Column width="content">
-              <Box display="flex" justifyContent="center">
-                <Box>
-                  <Button onClick={() => showToast(toastProps)}>
-                    Show animation <IconPromote alignY="lowercase" />
-                  </Button>
-                </Box>
-              </Box>
-            </Column>
-          </Columns>
+          <Stack space="large" align="center">
+            <Toast
+              id={id}
+              dedupeKey={id}
+              shouldRemove={false}
+              treatTheme={theme}
+              onClear={handler}
+              {...toastProps}
+            />
+            <Box display="flex">
+              <Button onClick={() => showToast(toastProps)}>
+                Show animation <IconPromote alignY="lowercase" />
+              </Button>
+            </Box>
+          </Stack>
         );
       },
       code: `
@@ -157,27 +149,21 @@ const docs: ComponentDocs = {
         } as const;
 
         return (
-          <Columns space="gutter" alignY="center" collapseBelow="tablet">
-            <Column width="content">
-              <Toast
-                id={id}
-                dedupeKey={id}
-                shouldRemove={false}
-                treatTheme={theme}
-                onClear={handler}
-                {...toastProps}
-              />
-            </Column>
-            <Column width="content">
-              <Box display="flex" justifyContent="center">
-                <Box>
-                  <Button onClick={() => showToast(toastProps)}>
-                    Show animation <IconPromote alignY="lowercase" />
-                  </Button>
-                </Box>
-              </Box>
-            </Column>
-          </Columns>
+          <Stack space="large" align="center">
+            <Toast
+              id={id}
+              dedupeKey={id}
+              shouldRemove={false}
+              treatTheme={theme}
+              onClear={handler}
+              {...toastProps}
+            />
+            <Box display="flex">
+              <Button onClick={() => showToast(toastProps)}>
+                Show animation <IconPromote alignY="lowercase" />
+              </Button>
+            </Box>
+          </Stack>
         );
       },
       code: `
@@ -207,27 +193,21 @@ const docs: ComponentDocs = {
         } as const;
 
         return (
-          <Columns space="gutter" alignY="center" collapseBelow="tablet">
-            <Column width="content">
-              <Toast
-                id={id}
-                dedupeKey={id}
-                shouldRemove={false}
-                treatTheme={theme}
-                onClear={handler}
-                {...toastProps}
-              />
-            </Column>
-            <Column width="content">
-              <Box display="flex" justifyContent="center">
-                <Box>
-                  <Button onClick={() => showToast(toastProps)}>
-                    Show animation <IconPromote alignY="lowercase" />
-                  </Button>
-                </Box>
-              </Box>
-            </Column>
-          </Columns>
+          <Stack space="large" align="center">
+            <Toast
+              id={id}
+              dedupeKey={id}
+              shouldRemove={false}
+              treatTheme={theme}
+              onClear={handler}
+              {...toastProps}
+            />
+            <Box display="flex">
+              <Button onClick={() => showToast(toastProps)}>
+                Show animation <IconPromote alignY="lowercase" />
+              </Button>
+            </Box>
+          </Stack>
         );
       },
       code: `
@@ -255,27 +235,21 @@ const docs: ComponentDocs = {
         } as const;
 
         return (
-          <Columns space="gutter" alignY="center" collapseBelow="tablet">
-            <Column width="content">
-              <Toast
-                id={id}
-                dedupeKey={id}
-                shouldRemove={false}
-                treatTheme={theme}
-                onClear={handler}
-                {...toastProps}
-              />
-            </Column>
-            <Column width="content">
-              <Box display="flex" justifyContent="center">
-                <Box>
-                  <Button onClick={() => showToast(toastProps)}>
-                    Show animation <IconPromote alignY="lowercase" />
-                  </Button>
-                </Box>
-              </Box>
-            </Column>
-          </Columns>
+          <Stack space="large" align="center">
+            <Toast
+              id={id}
+              dedupeKey={id}
+              shouldRemove={false}
+              treatTheme={theme}
+              onClear={handler}
+              {...toastProps}
+            />
+            <Box display="flex">
+              <Button onClick={() => showToast(toastProps)}>
+                Show animation <IconPromote alignY="lowercase" />
+              </Button>
+            </Box>
+          </Stack>
         );
       },
       code: `
@@ -301,27 +275,21 @@ const docs: ComponentDocs = {
         } as const;
 
         return (
-          <Columns space="gutter" alignY="center" collapseBelow="tablet">
-            <Column width="content">
-              <Toast
-                id={id}
-                dedupeKey={id}
-                shouldRemove={false}
-                treatTheme={theme}
-                onClear={handler}
-                {...toastProps}
-              />
-            </Column>
-            <Column width="content">
-              <Box display="flex" justifyContent="center">
-                <Box>
-                  <Button onClick={() => showToast(toastProps)}>
-                    Show animation <IconPromote alignY="lowercase" />
-                  </Button>
-                </Box>
-              </Box>
-            </Column>
-          </Columns>
+          <Stack space="large" align="center">
+            <Toast
+              id={id}
+              dedupeKey={id}
+              shouldRemove={false}
+              treatTheme={theme}
+              onClear={handler}
+              {...toastProps}
+            />
+            <Box display="flex">
+              <Button onClick={() => showToast(toastProps)}>
+                Show animation <IconPromote alignY="lowercase" />
+              </Button>
+            </Box>
+          </Stack>
         );
       },
       code: `

--- a/lib/stories/all.stories.tsx
+++ b/lib/stories/all.stories.tsx
@@ -4,7 +4,7 @@ import { BrowserRouter } from 'react-router-dom';
 import { uniq, flatten, values } from 'lodash';
 import '../../reset';
 import * as themes from '../themes';
-import { BraidProvider } from '../components';
+import { BraidProvider, Box } from '../components';
 import { ComponentDocs } from '../../site/src/types';
 
 const webFontLinkTags = uniq(
@@ -83,6 +83,7 @@ req.keys().forEach((filename) => {
                   label = componentName,
                   Example,
                   Container = DefaultContainer,
+                  background = 'body',
                 },
                 i,
               ) =>
@@ -107,9 +108,11 @@ req.keys().forEach((filename) => {
                     >
                       {label}
                     </h4>
-                    <Container>
-                      <Example id="id" handler={handler} />
-                    </Container>
+                    <Box background={background}>
+                      <Container>
+                        <Example id="id" handler={handler} />
+                      </Container>
+                    </Box>
                     <div style={{ paddingTop: 18 }}>
                       <hr
                         style={{

--- a/lib/stories/all.stories.tsx
+++ b/lib/stories/all.stories.tsx
@@ -108,7 +108,7 @@ req.keys().forEach((filename) => {
                     >
                       {label}
                     </h4>
-                    <Box background={background}>
+                    <Box background={background} style={{ padding: 12 }}>
                       <Container>
                         <Example id="id" handler={handler} />
                       </Container>

--- a/lib/themes/docs/tokens.ts
+++ b/lib/themes/docs/tokens.ts
@@ -13,8 +13,8 @@ const black = '#333';
 const white = '#fff';
 const link = formAccent;
 const linkVisited = 'DarkViolet';
-const secondary = '#1c1c1ca1';
-const neutral = '#747474';
+const secondary = '#757575';
+const neutral = '#ccc';
 
 const tokens: TreatTokens = {
   name: 'docs',

--- a/lib/themes/docs/tokens.ts
+++ b/lib/themes/docs/tokens.ts
@@ -14,7 +14,7 @@ const white = '#fff';
 const link = formAccent;
 const linkVisited = 'DarkViolet';
 const secondary = '#757575';
-const neutral = '#ccc';
+const neutral = '#c0c0c0';
 
 const tokens: TreatTokens = {
   name: 'docs',
@@ -154,8 +154,8 @@ const tokens: TreatTokens = {
       standard: '6px',
     },
     width: {
-      standard: 2,
-      large: 3,
+      standard: 1.5,
+      large: 2.5,
     },
     color: {
       standard: '#d6d6d6',

--- a/site/src/App/Code/Code.treat.ts
+++ b/site/src/App/Code/Code.treat.ts
@@ -3,13 +3,6 @@ import { style } from 'sku/treat';
 export const code = style({
   background: '#010d19',
   overflowX: 'auto',
-  borderBottomLeftRadius: '0 !important',
-  borderBottomRightRadius: '0 !important',
-});
-
-export const toolbar = style({
-  borderTopLeftRadius: '0 !important',
-  borderTopRightRadius: '0 !important',
 });
 
 export const button = style({});

--- a/site/src/App/Code/Code.tsx
+++ b/site/src/App/Code/Code.tsx
@@ -13,8 +13,6 @@ import {
   Stack,
   Text,
   Inline,
-  Columns,
-  Column,
   IconChevron,
   Hidden,
 } from '../../../../lib/components';
@@ -53,7 +51,6 @@ const CodeButton = ({
     <Box
       component={component}
       cursor="pointer"
-      background="neutralLight"
       borderRadius="standard"
       paddingY="xxsmall"
       paddingX="xsmall"
@@ -67,7 +64,7 @@ const CodeButton = ({
         className={classnames(styles.focusOverlay)}
       />
       <FieldOverlay
-        background="card"
+        background="neutralLight"
         className={classnames(styles.hoverOverlay)}
       />
       <FieldOverlay className={classnames(styles.activeOverlay)} />
@@ -77,7 +74,7 @@ const CodeButton = ({
         pointerEvents="none"
         userSelect="none"
       >
-        <Text size="xsmall" baseline={false}>
+        <Text size="xsmall" baseline={false} tone="secondary">
           {children}
         </Text>
       </Box>
@@ -119,81 +116,56 @@ export default ({
     >
       <Stack space="xsmall">
         {typeof children !== 'string' && (
+          <ThemedExample background="body">{children}</ThemedExample>
+        )}
+        {hideCode ? null : (
           <Box
-            padding="small"
-            background="neutralLight"
+            position="relative"
+            padding="medium"
             borderRadius="standard"
+            className={styles.code}
           >
-            <ThemedExample>{children}</ThemedExample>
+            <Text size="small" component="pre" baseline={false}>
+              <SyntaxHighlighter language="tsx" style={editorTheme}>
+                {snippet}
+              </SyntaxHighlighter>
+            </Text>
           </Box>
         )}
-        <Box>
-          {hideCode ? null : (
-            <Box
-              position="relative"
-              padding="medium"
-              borderRadius="standard"
-              className={styles.code}
-            >
-              <Text size="small" component="pre" baseline={false}>
-                <SyntaxHighlighter language="tsx" style={editorTheme}>
-                  {snippet}
-                </SyntaxHighlighter>
-              </Text>
-            </Box>
-          )}
-          <Box
-            padding="xxsmall"
-            background="neutralLight"
-            borderRadius="standard"
-            className={hideCode ? undefined : styles.toolbar}
+        <Inline space="xxsmall" align="right">
+          {collapsedByDefault ? (
+            <CodeButton onClick={() => setHideCode(!hideCode)}>
+              <IconChevron direction={hideCode ? 'down' : 'up'} />
+              <Hidden inline below="tablet">
+                {hideCode ? ' View code' : ' Hide code'}
+              </Hidden>
+              <Hidden inline above="mobile">
+                {' '}
+                Code
+              </Hidden>
+            </CodeButton>
+          ) : null}
+          <CodeButton
+            onClick={() => copy(snippet)}
+            title="Copy code to clipboard"
           >
-            <Columns space="xxsmall" alignY="center">
-              <Column width="content">
-                {collapsedByDefault ? (
-                  <CodeButton onClick={() => setHideCode(!hideCode)}>
-                    <IconChevron direction={hideCode ? 'down' : 'up'} />
-                    <Hidden inline below="tablet">
-                      {hideCode ? ' Show code' : ' Hide code'}
-                    </Hidden>
-                    <Hidden inline above="mobile">
-                      {' '}
-                      Code
-                    </Hidden>
-                  </CodeButton>
-                ) : null}
-              </Column>
-              <Column>
-                <Inline space="xxsmall" align="right">
-                  <CodeButton
-                    onClick={() => copy(snippet)}
-                    title="Copy to clipboard"
-                  >
-                    <CopyIcon /> Copy
-                  </CodeButton>
-                  {/^import/m.test(snippet) || !playroom ? null : (
-                    <CodeButton
-                      component="a"
-                      target="_blank"
-                      href={createUrl({ baseUrl: playroomUrl, code: snippet })}
-                      className={useBoxStyles({
-                        component: 'a',
-                        display: 'block',
-                      })}
-                      title="Open in Playroom"
-                    >
-                      <PlayIcon />{' '}
-                      <Hidden inline below="tablet">
-                        Open in{' '}
-                      </Hidden>
-                      Playroom
-                    </CodeButton>
-                  )}
-                </Inline>
-              </Column>
-            </Columns>
-          </Box>
-        </Box>
+            <CopyIcon /> Copy
+          </CodeButton>
+          {/^import/m.test(snippet) || !playroom ? null : (
+            <CodeButton
+              component="a"
+              target="_blank"
+              href={createUrl({ baseUrl: playroomUrl, code: snippet })}
+              className={useBoxStyles({
+                component: 'a',
+                display: 'block',
+              })}
+              title="Open in Playroom"
+            >
+              <PlayIcon /> Playroom
+            </CodeButton>
+          )}
+        </Inline>
       </Stack>
     </Box>
   );

--- a/site/src/App/Code/Code.tsx
+++ b/site/src/App/Code/Code.tsx
@@ -6,7 +6,6 @@ import reactElementToJSXString from 'react-element-to-jsx-string';
 import prettier from 'prettier/standalone';
 import typescriptParser from 'prettier/parser-typescript';
 import { createUrl } from 'sku/playroom/utils';
-import classnames from 'classnames';
 import { useConfig } from '../ConfigContext';
 import {
   Box,
@@ -19,6 +18,7 @@ import {
 import { BoxProps } from '../../../../lib/components/Box/Box';
 import { FieldOverlay } from '../../../../lib/components/private/FieldOverlay/FieldOverlay';
 import { useBoxStyles } from '../../../../lib/components/Box/useBoxStyles';
+import { hideFocusRingsClassName } from '../../../../lib/components/private/hideFocusRings/hideFocusRings';
 import { CopyIcon } from './CopyIcon';
 import { PlayIcon } from './PlayIcon';
 import * as styleRefs from './Code.treat';
@@ -61,13 +61,10 @@ const CodeButton = ({
     >
       <FieldOverlay
         variant="focus"
-        className={classnames(styles.focusOverlay)}
+        className={[styles.focusOverlay, hideFocusRingsClassName]}
       />
-      <FieldOverlay
-        background="neutralLight"
-        className={classnames(styles.hoverOverlay)}
-      />
-      <FieldOverlay className={classnames(styles.activeOverlay)} />
+      <FieldOverlay background="neutralLight" className={styles.hoverOverlay} />
+      <FieldOverlay className={styles.activeOverlay} />
       <Box
         component="span"
         position="relative"
@@ -121,15 +118,17 @@ export default ({
         {hideCode ? null : (
           <Box
             position="relative"
-            padding="medium"
+            padding="xxsmall"
             borderRadius="standard"
             className={styles.code}
           >
-            <Text size="small" component="pre" baseline={false}>
-              <SyntaxHighlighter language="tsx" style={editorTheme}>
-                {snippet}
-              </SyntaxHighlighter>
-            </Text>
+            <Box padding={['small', 'medium', 'large']}>
+              <Text size="small" component="pre" baseline={false}>
+                <SyntaxHighlighter language="tsx" style={editorTheme}>
+                  {snippet}
+                </SyntaxHighlighter>
+              </Text>
+            </Box>
           </Box>
         )}
         <Inline space="xxsmall" align="right">
@@ -145,12 +144,14 @@ export default ({
               </Hidden>
             </CodeButton>
           ) : null}
-          <CodeButton
-            onClick={() => copy(snippet)}
-            title="Copy code to clipboard"
-          >
-            <CopyIcon /> Copy
-          </CodeButton>
+          {hideCode ? null : (
+            <CodeButton
+              onClick={() => copy(snippet)}
+              title="Copy code to clipboard"
+            >
+              <CopyIcon /> Copy
+            </CodeButton>
+          )}
           {/^import/m.test(snippet) || !playroom ? null : (
             <CodeButton
               component="a"
@@ -162,7 +163,11 @@ export default ({
               })}
               title="Open in Playroom"
             >
-              <PlayIcon /> Playroom
+              <PlayIcon />{' '}
+              <Hidden inline below="tablet">
+                Open in{' '}
+              </Hidden>
+              Playroom
             </CodeButton>
           )}
         </Inline>

--- a/site/src/App/ComponentDoc/ComponentDoc.tsx
+++ b/site/src/App/ComponentDoc/ComponentDoc.tsx
@@ -72,6 +72,7 @@ export const ComponentDoc = ({
             code,
             Container = DefaultContainer,
             background = 'body',
+            showCodeByDefault = false,
             playroom,
           } = example;
 
@@ -101,7 +102,14 @@ export const ComponentDoc = ({
                     </ThemedExample>
                   ) : null}
                   {codeAsString ? (
-                    <Code collapsedByDefault playroom={playroom}>
+                    <Code
+                      collapsedByDefault={
+                        !showCodeByDefault &&
+                        Example !== undefined &&
+                        docs.category !== 'Logic'
+                      }
+                      playroom={playroom}
+                    >
                       {codeAsString}
                     </Code>
                   ) : null}

--- a/site/src/App/ComponentDoc/ComponentDoc.tsx
+++ b/site/src/App/ComponentDoc/ComponentDoc.tsx
@@ -71,6 +71,7 @@ export const ComponentDoc = ({
             Example,
             code,
             Container = DefaultContainer,
+            background = 'body',
             playroom,
           } = example;
 
@@ -87,20 +88,24 @@ export const ComponentDoc = ({
 
           return (
             <Box key={index}>
-              <Stack space="xlarge">
+              <Stack space="large">
                 {label && filteredExamples.length > 1 ? (
                   <Heading level="3">{label}</Heading>
                 ) : null}
-                {Example ? (
-                  <Container>
-                    <ThemedExample>
-                      <Example id={`${index}`} handler={handler} />
+                <Stack space="xxsmall">
+                  {Example ? (
+                    <ThemedExample background={background}>
+                      <Container>
+                        <Example id={`${index}`} handler={handler} />
+                      </Container>
                     </ThemedExample>
-                  </Container>
-                ) : null}
-                {codeAsString ? (
-                  <Code playroom={playroom}>{codeAsString}</Code>
-                ) : null}
+                  ) : null}
+                  {codeAsString ? (
+                    <Code collapsedByDefault playroom={playroom}>
+                      {codeAsString}
+                    </Code>
+                  ) : null}
+                </Stack>
               </Stack>
             </Box>
           );

--- a/site/src/App/ThemeSetting/ThemedExample.treat.ts
+++ b/site/src/App/ThemeSetting/ThemedExample.treat.ts
@@ -1,0 +1,6 @@
+import { style } from 'sku/treat';
+import tokens from '../../../../lib/themes/docs/tokens';
+
+export const unthemedBorderRadius = style({
+  borderRadius: tokens.border.radius.standard,
+});

--- a/site/src/App/ThemeSetting/ThemedExample.tsx
+++ b/site/src/App/ThemeSetting/ThemedExample.tsx
@@ -1,19 +1,34 @@
 import React, { ReactNode } from 'react';
+import { useStyles } from 'sku/react-treat';
 import { useThemeSettings } from './ThemeSettingContext';
 import { BraidProvider, Box } from '../../../../lib/components';
+import { BoxProps } from '../../../../lib/components/Box/Box';
 import * as themes from '../../../../lib/themes';
+import * as styleRefs from './ThemedExample.treat';
 
 interface ThemedExampleProps {
+  background?: BoxProps['background'];
   children: ReactNode;
 }
 
-export function ThemedExample({ children }: ThemedExampleProps) {
+export function ThemedExample({ background, children }: ThemedExampleProps) {
+  const styles = useStyles(styleRefs);
   const { theme, ready } = useThemeSettings();
 
   return (
     <Box opacity={!ready ? 0 : undefined} transition="fast">
       <BraidProvider styleBody={false} theme={themes[theme]}>
-        {children}
+        {background ? (
+          <Box
+            background={background}
+            padding={['small', 'large']}
+            className={styles.unthemedBorderRadius}
+          >
+            {children}
+          </Box>
+        ) : (
+          children
+        )}
       </BraidProvider>
     </Box>
   );

--- a/site/src/App/ThemeSetting/ThemedExample.tsx
+++ b/site/src/App/ThemeSetting/ThemedExample.tsx
@@ -20,11 +20,21 @@ export function ThemedExample({ background, children }: ThemedExampleProps) {
       <BraidProvider styleBody={false} theme={themes[theme]}>
         {background ? (
           <Box
-            background={background}
-            padding={['small', 'large']}
+            background={theme === 'docs' ? 'neutralLight' : 'body'}
+            padding="xsmall"
             className={styles.unthemedBorderRadius}
           >
-            {children}
+            <Box
+              background={
+                theme === 'docs' && background === 'body'
+                  ? 'neutralLight'
+                  : background
+              }
+              padding={['small', 'medium', 'large']}
+              className={styles.unthemedBorderRadius}
+            >
+              {children}
+            </Box>
           </Box>
         ) : (
           children

--- a/site/src/App/routes/foundations/layout/layout.tsx
+++ b/site/src/App/routes/foundations/layout/layout.tsx
@@ -58,10 +58,6 @@ const LinkableHeading = ({ children, level = '3' }: LinkableHeadingProps) => {
   );
 };
 
-const HeadingLink = ({ children }: { children: string }) => (
-  <TextLink href={`#${slugify(children)}`}>{children}</TextLink>
-);
-
 type Space = 'none' | keyof typeof tokens.space;
 const spaceScale = ['none', ...Object.keys(tokens.space)] as Space[];
 
@@ -76,28 +72,6 @@ const page: Page = {
   component: () => (
     <TextStack>
       <Heading level="2">Layout</Heading>
-
-      <Divider />
-
-      <BulletList>
-        {[
-          'Spacing',
-          'Box',
-          'Card',
-          'Stack',
-          'Inline',
-          'Columns',
-          'Tiles',
-          'ContentBlock',
-        ].map((section) => (
-          <Bullet key={section}>
-            <HeadingLink>{section}</HeadingLink>
-          </Bullet>
-        ))}
-      </BulletList>
-
-      <Divider />
-
       <Text>
         The guiding principle for layout in Braid is that components should not
         provide surrounding white space. Instead, spacing between elements is

--- a/site/src/types.d.ts
+++ b/site/src/types.d.ts
@@ -45,5 +45,6 @@ export interface ComponentExample {
   Example?: (props: { id: string; handler: () => void }) => JSX.Element;
   Container?: (props: { children: ReactNode }) => JSX.Element;
   code?: string;
+  showCodeByDefault?: boolean;
   playroom?: boolean;
 }

--- a/site/src/types.d.ts
+++ b/site/src/types.d.ts
@@ -3,6 +3,7 @@ import { RouteProps } from 'react-router';
 import { Snippets } from 'sku/playroom';
 import { Optional } from 'utility-types';
 import { ReactNodeNoStrings } from './../../lib/components/private/ReactNodeNoStrings';
+import { BoxProps } from '../../lib/components/Box/Box';
 
 export interface AppConfig {
   playroomUrl: string;
@@ -40,6 +41,7 @@ export interface ComponentExample {
   label?: string;
   docsSite?: boolean;
   storybook?: boolean;
+  background?: NonNullable<BoxProps['background']>;
   Example?: (props: { id: string; handler: () => void }) => JSX.Element;
   Container?: (props: { children: ReactNode }) => JSX.Element;
   code?: string;


### PR DESCRIPTION
See changeset for details.

This PR also makes the following improvements to the docs site:
- All examples are now separated from the page background rather than sitting on white. By default they're sitting on the active theme's body background, but this background can also be configured per example, most notably being used for `card` or `brand` backgrounds. Screenshot tests also make use of this background.
- Code snippets are collapsed by default, except for logic components, and in cases where the example has no visual elements. This can also be configured per example, e.g. this PR shows code for all `Hidden` examples.
- Removed the table of contents from the layout guide since we now have a list of layout components in the main navigation.
- Added examples of `Alert` within `Card` since it alters the border treatment.
- Tweaked some docs site theme variables to improve neutral colours and border widths.