### PR TITLE
TextLink: Add weight prop, add weak weight variant

### DIFF
--- a/.changeset/violet-baboons-invite.md
+++ b/.changeset/violet-baboons-invite.md
@@ -1,0 +1,15 @@
+---
+'braid-design-system': minor
+---
+
+**TextLink, TextLinkButton:** Add `weight` prop, add `weak` weight variant
+
+You can now render links that are underlined while inheriting the tone and weight of its surrounding text.
+
+**EXAMPLE USAGE**
+
+```jsx
+<Text>
+  This sentence contains a <TextLink href="..." weight="weak">weak TextLink.</TextLink>
+</Text>
+```

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -6018,6 +6018,9 @@ Object {
         | "off"
         | "on"
     vocab?: string
+    weight?: 
+        | "regular"
+        | "weak"
 },
 }
 `;
@@ -6040,6 +6043,9 @@ Object {
         | "standard"
     id?: string
     onClick?: (event: MouseEvent<HTMLSpanElement, MouseEvent>) => void
+    weight?: 
+        | "regular"
+        | "weak"
 },
 }
 `;
@@ -6053,6 +6059,9 @@ Object {
         | "large"
         | "standard"
     showVisited?: boolean
+    weight?: 
+        | "regular"
+        | "weak"
 },
 }
 `;

--- a/lib/components/Notice/Notice.docs.tsx
+++ b/lib/components/Notice/Notice.docs.tsx
@@ -34,7 +34,10 @@ const docs: ComponentDocs = {
       Example: () => (
         <Notice tone="info">
           <Stack space="medium">
-            <Text>This is an important piece of information.</Text>
+            <Text>
+              This is an important piece of information with a{' '}
+              <TextLink href="#">TextLink.</TextLink>
+            </Text>
             <BulletList space="medium">
               <Bullet>Bullet 1</Bullet>
               <Bullet>Bullet 2</Bullet>

--- a/lib/components/Text/Text.tsx
+++ b/lib/components/Text/Text.tsx
@@ -6,6 +6,7 @@ import buildDataAttributes, {
   DataAttributeMap,
 } from '../private/buildDataAttributes';
 import { useText, UseTextProps, useTruncate } from '../../hooks/typography';
+import { DefaultTextToneContext } from '../private/DefaultTextToneContext';
 
 export interface TextProps extends Pick<BoxProps, 'component'> {
   id?: string;
@@ -24,7 +25,7 @@ export const Text = ({
   id,
   component = 'span',
   size,
-  tone,
+  tone: toneProp,
   align,
   weight,
   baseline = true,
@@ -38,6 +39,8 @@ export const Text = ({
     'Text components should not be nested within each other',
   );
 
+  const defaultTone = useContext(DefaultTextToneContext);
+  const tone = toneProp ?? defaultTone ?? undefined;
   const textStyles = useText({ weight, size, baseline, tone, _LEGACY_SPACE_ });
   const truncateStyles = useTruncate();
 

--- a/lib/components/TextLink/TextLink.docs.tsx
+++ b/lib/components/TextLink/TextLink.docs.tsx
@@ -16,7 +16,7 @@ import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320, 768],
+  screenshotWidths: [320],
   description: (
     <Stack space="large">
       <Text>
@@ -38,111 +38,126 @@ const docs: ComponentDocs = {
   ),
   examples: [
     {
-      label: 'Text Link',
+      label: 'Regular TextLink',
       Example: () => (
         <Text>
           <TextLink href="#" hitArea="large">
-            Text link
+            TextLink
           </TextLink>
         </Text>
       ),
     },
     {
-      label: 'Text Link in a sentence',
+      label: 'Regular TextLink in a sentence',
       Example: () => (
         <Text>
-          The last word of a sentence is a{' '}
-          <TextLink href="#">text link.</TextLink>
+          This sentence contains a <TextLink href="#">TextLink.</TextLink>
         </Text>
       ),
     },
     {
-      label: 'Visited Text Link',
+      label: 'Weak TextLink in a sentence',
       Example: () => (
         <Text>
-          The last word of a sentence is a{' '}
+          This sentence contains a{' '}
+          <TextLink href="#" weight="weak">
+            weak TextLink
+          </TextLink>
+          .
+        </Text>
+      ),
+    },
+    {
+      label: 'TextLink in secondary text',
+      Example: () => (
+        <Text tone="secondary">
+          This sentence contains a <TextLink href="#">TextLink.</TextLink>
+        </Text>
+      ),
+    },
+    {
+      label: 'Visited TextLink',
+      Example: () => (
+        <Text>
+          This sentence contains a{' '}
           <TextLink href="" showVisited>
-            visited link.
+            visited TextLink.
           </TextLink>
         </Text>
       ),
     },
     {
-      label: 'Text Link inside Actions',
+      label: 'TextLink on dark background',
+      background: 'brand',
+      Example: () => (
+        <Text>
+          This sentence contains a <TextLink href="#">TextLink.</TextLink>
+        </Text>
+      ),
+    },
+    {
+      label: 'TextLink inside Actions',
       Example: () => (
         <Actions>
           <Button>Button</Button>
-          <TextLink href="#">Text Link</TextLink>
+          <TextLink href="#">TextLink</TextLink>
         </Actions>
       ),
     },
     {
-      label: 'Large Text Link',
+      label: 'TextLink inside large Text',
       Example: () => (
         <Text size="large">
-          The last word of a sentence is a{' '}
-          <TextLink href="#">text link.</TextLink>
+          This sentence contains a <TextLink href="#">TextLink.</TextLink>
         </Text>
       ),
     },
     {
-      label: 'Small Text Link',
-      Example: () => (
-        <Text size="small">
-          The last word of a sentence is a{' '}
-          <TextLink href="#">text link.</TextLink>
-        </Text>
-      ),
-    },
-    {
-      label: 'Xsmall Text Link',
-      Example: () => (
-        <Text size="xsmall">
-          The last word of a sentence is a{' '}
-          <TextLink href="#">text link.</TextLink>
-        </Text>
-      ),
-    },
-    {
-      label: 'Heading Level 1 Link',
-      Example: () => (
-        <Heading level="1">
-          The last word of this heading is a <TextLink href="#">link.</TextLink>
-        </Heading>
-      ),
-    },
-    {
-      label: 'Heading Level 2 Link',
-      Example: () => (
-        <Heading level="2">
-          The last word of this heading is a <TextLink href="#">link.</TextLink>
-        </Heading>
-      ),
-    },
-    {
-      label: 'Heading Level 3 Link',
+      label: 'TextLink inside Heading',
       Example: () => (
         <Heading level="3">
-          The last word of this heading is a <TextLink href="#">link.</TextLink>
+          This heading contains a <TextLink href="#">TextLink.</TextLink>
         </Heading>
       ),
     },
     {
-      label: 'Heading Level 4 Link',
+      label: 'TextLink inside weak Heading',
       Example: () => (
-        <Heading level="4">
-          The last word of this heading is a <TextLink href="#">link.</TextLink>
+        <Heading level="3" weight="weak">
+          This heading contains a <TextLink href="#">TextLink.</TextLink>
         </Heading>
       ),
     },
     {
-      label: 'Text Link with icon',
+      label: 'Weak TextLink inside Heading',
+      Example: () => (
+        <Heading level="3">
+          This heading contains a{' '}
+          <TextLink href="#" weight="weak">
+            weak TextLink.
+          </TextLink>
+        </Heading>
+      ),
+    },
+    {
+      label: 'Weak TextLink inside weak Heading',
+      Example: () => (
+        <Heading level="3" weight="weak">
+          This heading contains a{' '}
+          <TextLink href="#" weight="weak">
+            weak TextLink.
+          </TextLink>
+        </Heading>
+      ),
+    },
+    {
+      label: 'TextLink with icon',
       docsSite: false,
       Example: () => (
         <Text>
-          The last word of a sentence is a{' '}
+          This sentence contains a{' '}
           <TextLink href="#">
-            text link
+            TextLink
             <IconChevron direction="right" />
           </TextLink>
           .
@@ -150,13 +165,13 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label: 'Text Link inside Actions with icon',
+      label: 'TextLink inside Actions with icon',
       docsSite: false,
       Example: () => (
         <Actions>
           <Button>Button</Button>
           <TextLink href="#">
-            Text Link <IconChevron direction="right" />
+            TextLink <IconChevron direction="right" />
           </TextLink>
         </Actions>
       ),
@@ -173,12 +188,26 @@ const docs: ComponentDocs = {
           <Fragment>
             {backgrounds.sort().map((background, i) => (
               <Box key={i} background={background}>
-                <Text baseline={false}>
-                  {background}{' '}
-                  <TextLink href="#">
-                    with link <IconNewWindow />
-                  </TextLink>
-                </Text>
+                <Stack space="none">
+                  <Text baseline={false}>
+                    {background}{' '}
+                    <TextLink href="#">
+                      with default weight <IconNewWindow />
+                    </TextLink>
+                  </Text>
+                  <Text baseline={false}>
+                    {background}{' '}
+                    <TextLink href="#" weight="regular">
+                      with regular weight <IconNewWindow />
+                    </TextLink>
+                  </Text>
+                  <Text baseline={false}>
+                    {background}{' '}
+                    <TextLink href="#" weight="weak">
+                      with weak weight <IconNewWindow />
+                    </TextLink>
+                  </Text>
+                </Stack>
               </Box>
             ))}
           </Fragment>

--- a/lib/components/TextLink/TextLink.tsx
+++ b/lib/components/TextLink/TextLink.tsx
@@ -12,11 +12,20 @@ export interface TextLinkProps
   extends Omit<TextLinkRendererProps, 'children'>,
     Omit<LinkComponentProps, 'className' | 'style'> {}
 
-export const TextLink = ({ showVisited, hitArea, ...props }: TextLinkProps) => {
+export const TextLink = ({
+  weight,
+  showVisited,
+  hitArea,
+  ...props
+}: TextLinkProps) => {
   const LinkComponent = useLinkComponent();
 
   return (
-    <TextLinkRenderer showVisited={showVisited} hitArea={hitArea}>
+    <TextLinkRenderer
+      weight={weight}
+      showVisited={showVisited}
+      hitArea={hitArea}
+    >
       {(styleProps) => <LinkComponent {...props} {...styleProps} />}
     </TextLinkRenderer>
   );

--- a/lib/components/TextLinkButton/TextLinkButton.docs.tsx
+++ b/lib/components/TextLinkButton/TextLinkButton.docs.tsx
@@ -49,6 +49,18 @@ const docs: ComponentDocs = {
       ),
     },
     {
+      label: 'Weak TextLinkButton inside Text',
+      showCodeByDefault: true,
+      Example: ({ handler }) => (
+        <Text>
+          The link in this sentence{' '}
+          <TextLinkButton weight="weak" onClick={handler}>
+            is actually a span with an ARIA role of button.
+          </TextLinkButton>
+        </Text>
+      ),
+    },
+    {
       label: 'TextLinkButton inside Actions',
       Example: ({ handler }) => (
         <Actions>

--- a/lib/components/TextLinkButton/TextLinkButton.tsx
+++ b/lib/components/TextLinkButton/TextLinkButton.tsx
@@ -28,6 +28,7 @@ export interface TextLinkButtonProps
 
 const noop = () => {};
 export const TextLinkButton = ({
+  weight,
   hitArea,
   id,
   onClick = noop,
@@ -50,7 +51,7 @@ export const TextLinkButton = ({
   );
 
   return (
-    <TextLinkRenderer hitArea={hitArea}>
+    <TextLinkRenderer weight={weight} hitArea={hitArea}>
       {(styleProps) => (
         <Box
           ref={buttonRef}

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.treat.ts
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.treat.ts
@@ -2,7 +2,6 @@ import { style } from 'sku/treat';
 
 export const underlineAlways = style({
   textDecoration: 'underline',
-  textUnderlinePosition: 'under',
 });
 
 export const underlineOnHoverOnly = style({

--- a/lib/components/TextLinkRenderer/TextLinkRendererContext.ts
+++ b/lib/components/TextLinkRenderer/TextLinkRendererContext.ts
@@ -1,3 +1,3 @@
 import { createContext } from 'react';
 
-export default createContext<null | 'link' | 'neutral'>(null);
+export default createContext<null | 'regular' | 'weak'>(null);

--- a/lib/hooks/typography/index.ts
+++ b/lib/hooks/typography/index.ts
@@ -117,7 +117,7 @@ export function useTextTone({
       : styles.tone[tone];
   }
 
-  if (textLinkContext && textLinkContext === 'link') {
+  if (textLinkContext && textLinkContext !== 'weak') {
     return styles.tone.link;
   }
 


### PR DESCRIPTION
See changeset for details.

I've changed the logic of `TextLink` so that its default tone is based on the parent `TextContext` rather than the background colour, which meant that `Text` needed to put the resolved `tone` on context.

I've also removed the redundant 768px screenshots from `TextLink`.