### PR TITLE
Fix flaky Tabs screenshot test

### DIFF
--- a/lib/components/Tabs/Tabs.docs.tsx
+++ b/lib/components/Tabs/Tabs.docs.tsx
@@ -26,6 +26,7 @@ const docs: ComponentDocs = {
   category: 'Content',
   added: new Date('1 July 2020'),
   screenshotWidths: [320, 1200],
+  screenshotDelay: 300,
   subComponents: ['TabsProvider', 'Tab', 'TabPanels', 'TabPanel'],
   description: (
     <Stack space="large">

--- a/lib/components/Tabs/Tabs.docs.tsx
+++ b/lib/components/Tabs/Tabs.docs.tsx
@@ -26,7 +26,7 @@ const docs: ComponentDocs = {
   category: 'Content',
   added: new Date('1 July 2020'),
   screenshotWidths: [320, 1200],
-  screenshotDelay: 300,
+  screenshotDelay: 1000,
   subComponents: ['TabsProvider', 'Tab', 'TabPanels', 'TabPanel'],
   description: (
     <Stack space="large">

--- a/lib/stories/all.stories.tsx
+++ b/lib/stories/all.stories.tsx
@@ -56,6 +56,7 @@ req.keys().forEach((filename) => {
     const storyConfig = {
       chromatic: {
         viewports: docs.screenshotWidths,
+        delay: docs.screenshotDelay,
       },
     };
 

--- a/site/src/types.d.ts
+++ b/site/src/types.d.ts
@@ -38,6 +38,7 @@ export interface ComponentDocs {
   snippets?: DocsSnippet[];
   description?: ReactNodeNoStrings;
   subComponents?: string[];
+  screenshotDelay?: number;
 }
 
 export interface ComponentExample {


### PR DESCRIPTION
Adds an optional `screenshotDelay` property to the docs. Starting with 300ms to see if that solves the Tabs animation issue. 