### PR TITLE
Increase timeout for Dialog close assertion

### DIFF
--- a/lib/components/Dialog/Dialog.test.tsx
+++ b/lib/components/Dialog/Dialog.test.tsx
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom/extend-expect';
 import React, { useState } from 'react';
 import {
   render,
+  screen,
   fireEvent,
   waitForElementToBeRemoved,
   waitFor,
@@ -56,6 +57,8 @@ function renderDialog() {
     closeHandler,
   };
 }
+
+const EXIT_TIMEOUT = 1500;
 
 describe('Dialog', () => {
   it('should not focus content when closed', () => {
@@ -144,9 +147,9 @@ describe('Dialog', () => {
     userEvent.click(dialogOpenButton);
     fireEvent.keyDown(getByRole('dialog'), { keyCode: ESCAPE });
 
-    await waitForElementToBeRemoved(() =>
-      queryByRole('dialog'),
-    ).catch(async () => waitForElementToBeRemoved(() => queryByRole('dialog')));
+    await waitForElementToBeRemoved(() => queryByRole('dialog'), {
+      timeout: EXIT_TIMEOUT,
+    });
     expect(queryByRole('dialog')).not.toBeInTheDocument();
   });
 
@@ -178,9 +181,9 @@ describe('Dialog', () => {
     const closeButton = getByLabelText(CLOSE_BUTTON_LABEL);
     userEvent.click(closeButton);
 
-    await waitForElementToBeRemoved(() =>
-      queryByRole('dialog'),
-    ).catch(async () => waitForElementToBeRemoved(() => queryByRole('dialog')));
+    await waitForElementToBeRemoved(() => queryByRole('dialog'), {
+      timeout: EXIT_TIMEOUT,
+    });
     expect(closeHandler).toHaveBeenCalledTimes(1);
     expect(closeHandler).toHaveBeenCalledWith(false);
   });

--- a/lib/components/Dialog/Dialog.test.tsx
+++ b/lib/components/Dialog/Dialog.test.tsx
@@ -2,7 +2,6 @@ import '@testing-library/jest-dom/extend-expect';
 import React, { useState } from 'react';
 import {
   render,
-  screen,
   fireEvent,
   waitForElementToBeRemoved,
   waitFor,

--- a/lib/components/Dialog/Dialog.test.tsx
+++ b/lib/components/Dialog/Dialog.test.tsx
@@ -144,9 +144,9 @@ describe('Dialog', () => {
     userEvent.click(dialogOpenButton);
     fireEvent.keyDown(getByRole('dialog'), { keyCode: ESCAPE });
 
-    await waitForElementToBeRemoved(() => queryByRole('dialog'), {
-      timeout: 3000,
-    });
+    await waitForElementToBeRemoved(() =>
+      queryByRole('dialog'),
+    ).catch(async () => waitForElementToBeRemoved(() => queryByRole('dialog')));
     expect(queryByRole('dialog')).not.toBeInTheDocument();
   });
 
@@ -158,7 +158,7 @@ describe('Dialog', () => {
     const dialogOpenButton = getByTestId('buttonBefore');
     userEvent.click(dialogOpenButton);
 
-    await waitFor(() => queryByRole('dialog'), { timeout: 3000 });
+    await waitFor(() => queryByRole('dialog'));
 
     expect(queryAllByRole('textbox').length).toBe(0);
   });
@@ -178,9 +178,9 @@ describe('Dialog', () => {
     const closeButton = getByLabelText(CLOSE_BUTTON_LABEL);
     userEvent.click(closeButton);
 
-    await waitForElementToBeRemoved(() => queryByRole('dialog'), {
-      timeout: 3000,
-    });
+    await waitForElementToBeRemoved(() =>
+      queryByRole('dialog'),
+    ).catch(async () => waitForElementToBeRemoved(() => queryByRole('dialog')));
     expect(closeHandler).toHaveBeenCalledTimes(1);
     expect(closeHandler).toHaveBeenCalledWith(false);
   });

--- a/lib/components/Dialog/Dialog.test.tsx
+++ b/lib/components/Dialog/Dialog.test.tsx
@@ -144,7 +144,9 @@ describe('Dialog', () => {
     userEvent.click(dialogOpenButton);
     fireEvent.keyDown(getByRole('dialog'), { keyCode: ESCAPE });
 
-    await waitForElementToBeRemoved(() => queryByRole('dialog'));
+    await waitForElementToBeRemoved(() => queryByRole('dialog'), {
+      timeout: 3000,
+    });
     expect(queryByRole('dialog')).not.toBeInTheDocument();
   });
 
@@ -156,7 +158,7 @@ describe('Dialog', () => {
     const dialogOpenButton = getByTestId('buttonBefore');
     userEvent.click(dialogOpenButton);
 
-    await waitFor(() => queryByRole('dialog'));
+    await waitFor(() => queryByRole('dialog'), { timeout: 3000 });
 
     expect(queryAllByRole('textbox').length).toBe(0);
   });
@@ -176,7 +178,9 @@ describe('Dialog', () => {
     const closeButton = getByLabelText(CLOSE_BUTTON_LABEL);
     userEvent.click(closeButton);
 
-    await waitForElementToBeRemoved(() => queryByRole('dialog'));
+    await waitForElementToBeRemoved(() => queryByRole('dialog'), {
+      timeout: 3000,
+    });
     expect(closeHandler).toHaveBeenCalledTimes(1);
     expect(closeHandler).toHaveBeenCalledWith(false);
   });


### PR DESCRIPTION
Increasing the timeout to 1500ms (up from the default 1000ms) for the two tests that assert on the removal of the Dialog from the DOM. Should be more than enough time, and is locally, but seems to struggle in CI.