### PR TITLE
Add `aria-label` support to Loader

### DIFF
--- a/.changeset/sharp-pianos-share.md
+++ b/.changeset/sharp-pianos-share.md
@@ -1,0 +1,17 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated
+  - Loader
+---
+
+**Loader:** Add support for `aria-label`
+
+Provides a mechanism for consumers to better communicate to assistive technologies what is happening.
+
+**EXAMPLE USAGE:**
+```jsx
+<Loader aria-label="Loading search results" />
+```

--- a/.changeset/sharp-pianos-share.md
+++ b/.changeset/sharp-pianos-share.md
@@ -1,5 +1,5 @@
 ---
-'braid-design-system': patch
+'braid-design-system': minor
 ---
 
 ---

--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@ package-lock.json
 *.log
 .cache/
 .DS_Store
-.vscode/
+.vscode/*.json
 .idea/
 componentDocs.json
 lib/components/icons/*/*Svg.tsx

--- a/.vscode/Changeset.code-snippets
+++ b/.vscode/Changeset.code-snippets
@@ -1,0 +1,30 @@
+{
+  // Place your braid-design-system workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
+  // description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope
+  // is left empty or omitted, the snippet gets applied to all languages. The prefix is what is
+  // used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
+  // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders.
+  // Placeholders with the same ids are connected.
+  // Example:
+  "Braid changeset": {
+    "scope": "markdown",
+    "prefix": "---",
+    "body": [
+      "---",
+      "${1|new,updated|}",
+      "  - ${2:Scope} ",
+      "---",
+      "",
+      "**${2:Scope}:** ${3:Add support for}",
+      "",
+      "${4:Provides a}",
+      "",
+      "${5:**EXAMPLE USAGE:**",
+      "```jsx",
+      "$0",
+      "```}",
+      ""
+    ],
+    "description": "Standardises the shape of Braid changesets for consistent release notes experience"
+  }
+}

--- a/.vscode/Changeset.code-snippets
+++ b/.vscode/Changeset.code-snippets
@@ -1,11 +1,4 @@
 {
-  // Place your braid-design-system workspace snippets here. Each snippet is defined under a snippet name and has a scope, prefix, body and
-  // description. Add comma separated ids of the languages where the snippet is applicable in the scope field. If scope
-  // is left empty or omitted, the snippet gets applied to all languages. The prefix is what is
-  // used to trigger the snippet and the body will be expanded and inserted. Possible variables are:
-  // $1, $2 for tab stops, $0 for the final cursor position, and ${1:label}, ${2:another} for placeholders.
-  // Placeholders with the same ids are connected.
-  // Example:
   "Braid changeset": {
     "scope": "markdown",
     "prefix": "---",

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -5139,6 +5139,7 @@ exports[`Loader 1`] = `
 Object {
   exportType: component,
   props: {
+    aria-label?: string
     delayVisibility?: boolean
     size?: 
         | "large"

--- a/lib/components/Loader/Loader.tsx
+++ b/lib/components/Loader/Loader.tsx
@@ -8,11 +8,13 @@ const indicators = [...Array(3)];
 
 interface LoaderProps {
   size?: keyof typeof styleRefs.rootSize;
+  'aria-label'?: string;
   delayVisibility?: boolean;
 }
 
 export const Loader = ({
   size = 'standard',
+  'aria-label': ariaLabel = 'Loading',
   delayVisibility = false,
 }: LoaderProps) => {
   const styles = useStyles(styleRefs);
@@ -25,9 +27,11 @@ export const Loader = ({
         styles.rootSize[size],
         delayVisibility ? styles.delay : undefined,
       ]}
+      aria-label={ariaLabel}
     >
       {indicators.map((_, index) => (
         <Box
+          aria-hidden
           key={index}
           borderRadius="full"
           background={parentBackgroundColor === 'dark' ? 'card' : 'neutral'}


### PR DESCRIPTION
**Loader:** Add support for `aria-label`

Provides a mechanism for consumers to better communicate to assistive technologies what is happening.

**EXAMPLE USAGE:**
```jsx
<Loader aria-label="Loading search results" />
```

**Developer Notes**
Also adding vscode snippet to support faster, more consistent release note authoring.