### PR TITLE
Minor updates to Gallery

### DIFF
--- a/site/src/App/Code/Code.tsx
+++ b/site/src/App/Code/Code.tsx
@@ -92,7 +92,7 @@ export const CodeButton = ({
       userSelect="none"
       pointerEvents="none"
     >
-      <Text size="small" baseline={false} tone="positive">
+      <Text size="xsmall" baseline={false} tone="positive">
         <IconPositive /> {successLabel}
       </Text>
     </Box>

--- a/site/src/App/Code/Code.tsx
+++ b/site/src/App/Code/Code.tsx
@@ -1,4 +1,10 @@
-import React, { useState, ReactChild } from 'react';
+import React, {
+  useState,
+  ReactChild,
+  useCallback,
+  useEffect,
+  useRef,
+} from 'react';
 import { useStyles } from 'react-treat';
 import copy from 'copy-to-clipboard';
 import memoize from 'lodash/memoize';
@@ -14,6 +20,7 @@ import {
   Inline,
   IconChevron,
   Hidden,
+  IconPositive,
 } from '../../../../lib/components';
 import { BoxProps } from '../../../../lib/components/Box/Box';
 import { FieldOverlay } from '../../../../lib/components/private/FieldOverlay/FieldOverlay';
@@ -39,15 +46,57 @@ const formatSnippet = memoize(
       .replace(/^;/, ''), // Remove leading semicolons from JSX
 );
 
-const CodeButton = ({
+interface CodeButtonProps extends BoxProps {
+  successLabel?: string;
+}
+
+export const CodeButton = ({
   component = 'button',
   children,
   className,
+  onClick,
+  successLabel,
   ...restProps
-}: BoxProps) => {
+}: CodeButtonProps) => {
   const styles = useStyles(styleRefs);
+  const [showSuccess, setShowSuccess] = useState(false);
+  const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  return (
+  const clickHandler = useCallback(
+    (e) => {
+      if (typeof onClick === 'function') {
+        onClick(e);
+
+        if (successLabel) {
+          setShowSuccess(true);
+          timerRef.current = setTimeout(() => setShowSuccess(false), 2000);
+        }
+      }
+    },
+    [onClick, successLabel],
+  );
+
+  useEffect(
+    () => () => {
+      if (timerRef.current) {
+        clearTimeout(timerRef.current);
+      }
+    },
+    [],
+  );
+
+  return showSuccess ? (
+    <Box
+      paddingY="xxsmall"
+      paddingX="xsmall"
+      userSelect="none"
+      pointerEvents="none"
+    >
+      <Text size="small" baseline={false} tone="positive">
+        <IconPositive /> {successLabel}
+      </Text>
+    </Box>
+  ) : (
     <Box
       component={component}
       cursor="pointer"
@@ -57,6 +106,7 @@ const CodeButton = ({
       position="relative"
       outline="none"
       className={[styles.button, className]}
+      onClick={clickHandler}
       {...restProps}
     >
       <FieldOverlay
@@ -159,6 +209,7 @@ export default ({
             <CodeButton
               onClick={() => copy(snippet)}
               title="Copy code to clipboard"
+              successLabel="Copied!"
             >
               <CopyIcon /> Copy
             </CodeButton>

--- a/site/src/App/routes/gallery/Gallery.tsx
+++ b/site/src/App/routes/gallery/Gallery.tsx
@@ -126,7 +126,7 @@ const GalleryItem = ({
   const updateCount = history.filter((item) => item.isRecent).length;
 
   return (
-    <Box padding="xxlarge" data-braid-component-name={component.name}>
+    <Box padding="xxlarge">
       <Stack space="xxlarge">
         <Stack space="large">
           <Inline space="small" alignY="top">

--- a/site/src/App/routes/gallery/Gallery.tsx
+++ b/site/src/App/routes/gallery/Gallery.tsx
@@ -210,7 +210,7 @@ const GalleryItem = ({
                                   onClick={() => copy(codeAsString)}
                                   successLabel="Copied!"
                                 >
-                                  <CopyIcon /> Copy
+                                  <CopyIcon /> Copy code
                                 </CodeButton>
                               </Column>
                             ) : null}

--- a/site/src/App/routes/gallery/Gallery.tsx
+++ b/site/src/App/routes/gallery/Gallery.tsx
@@ -22,13 +22,12 @@ import {
   TextLink,
   Columns,
   Column,
-  TextLinkButton,
-  HiddenVisually,
   Disclosure,
 } from '../../../../../lib/components';
 import { getHistory } from '../../Updates';
 import { CopyIcon } from '../../Code/CopyIcon';
-import { ComponentDocs } from '../../../types';
+import { CodeButton } from '../../Code/Code';
+import { ComponentExample } from '../../../types';
 import { ThemedExample } from '../../ThemeSetting';
 import { documentedComponents } from '../../navigationHelpers';
 import { Overlay } from '../../../../../lib/components/private/Overlay/Overlay';
@@ -68,7 +67,7 @@ const Mask = ({
   background,
 }: {
   children: ReactNode;
-  background: ComponentDocs['examples'][number]['background'];
+  background: ComponentExample['background'];
 }) => {
   const elRef = useRef<HTMLElement | null>(null);
   const [dimensions, setDimensions] = useState<{ w: number; h: number }>({
@@ -127,7 +126,7 @@ const GalleryItem = ({
   const updateCount = history.filter((item) => item.isRecent).length;
 
   return (
-    <Box padding="xxlarge">
+    <Box padding="xxlarge" data-braid-component-name={component.name}>
       <Stack space="xxlarge">
         <Stack space="large">
           <Inline space="small" alignY="top">
@@ -199,27 +198,20 @@ const GalleryItem = ({
 
                     return (
                       <Box style={{ width: '700px' }} key={`${label}_${index}`}>
-                        <Stack space="medium">
-                          <Columns space="medium">
+                        <Stack space="small">
+                          <Columns space="medium" alignY="center">
                             <Column>
                               <Text tone="secondary">{label}</Text>
                             </Column>
                             {codeAsString ? (
                               <Column width="content">
-                                <Text tone="secondary">
-                                  <TextLinkButton
-                                    hitArea="large"
-                                    aria-describedby={`copy-${label}_${index}`}
-                                    onClick={() => copy(codeAsString)}
-                                  >
-                                    <CopyIcon />
-                                    <Box id={`copy-${label}_${index}`}>
-                                      <HiddenVisually>
-                                        Copy to clipboard
-                                      </HiddenVisually>
-                                    </Box>
-                                  </TextLinkButton>
-                                </Text>
+                                <CodeButton
+                                  title="Copy code to clipboard"
+                                  onClick={() => copy(codeAsString)}
+                                  successLabel="Copied!"
+                                >
+                                  <CopyIcon /> Copy
+                                </CodeButton>
                               </Column>
                             ) : null}
                           </Columns>

--- a/site/src/App/routes/gallery/GalleryPanel.tsx
+++ b/site/src/App/routes/gallery/GalleryPanel.tsx
@@ -1,6 +1,10 @@
 import React from 'react';
+import { useStyles } from 'sku/react-treat';
 import { Box, Inline } from '../../../../../lib/components';
+import { InlineProps } from '../../../../../lib/components/Inline/Inline';
+import { Overlay } from '../../../../../lib/components/private/Overlay/Overlay';
 import { ReactNodeNoStrings } from '../../../../../lib/components/private/ReactNodeNoStrings';
+import * as styleRefs from './gallery.treat';
 
 export const GalleryPanel = ({
   children,
@@ -8,33 +12,45 @@ export const GalleryPanel = ({
   left,
   right,
   top,
+  space = 'small',
 }: {
   children: ReactNodeNoStrings;
   bottom?: boolean;
   left?: boolean;
   right?: boolean;
   top?: boolean;
-}) => (
-  <Box
-    position="fixed"
-    margin="small"
-    borderRadius="standard"
-    background="card"
-    bottom={bottom ? 0 : undefined}
-    left={left ? 0 : undefined}
-    right={right ? 0 : undefined}
-    top={top ? 0 : undefined}
-    display="flex"
-    alignItems="center"
-    height="touchable"
-    paddingX={['small', 'gutter']}
-    zIndex="sticky"
-    style={{
-      boxShadow: '0 2px 5px 1px rgba(28,28,28,.2)',
-    }}
-  >
-    <Inline space="small" alignY="center">
-      {children}
-    </Inline>
-  </Box>
-);
+  space?: InlineProps['space'];
+}) => {
+  const styles = useStyles(styleRefs);
+  return (
+    <Box
+      position="fixed"
+      margin="small"
+      borderRadius="standard"
+      bottom={bottom ? 0 : undefined}
+      left={left ? 0 : undefined}
+      right={right ? 0 : undefined}
+      top={top ? 0 : undefined}
+      display="flex"
+      alignItems="center"
+      paddingY="small"
+      paddingX={['small', 'gutter']}
+      zIndex="sticky"
+      className={styles.panel}
+    >
+      <Overlay
+        background="card"
+        borderRadius="standard"
+        transition="fast"
+        className={styles.panelBackground}
+        visible
+      />
+
+      <Box position="relative">
+        <Inline space={space} alignY="center">
+          {children}
+        </Inline>
+      </Box>
+    </Box>
+  );
+};

--- a/site/src/App/routes/gallery/GalleryPanel.tsx
+++ b/site/src/App/routes/gallery/GalleryPanel.tsx
@@ -41,7 +41,6 @@ export const GalleryPanel = ({
       <Overlay
         background="card"
         borderRadius="standard"
-        transition="fast"
         className={styles.panelBackground}
         visible
       />

--- a/site/src/App/routes/gallery/gallery.treat.ts
+++ b/site/src/App/routes/gallery/gallery.treat.ts
@@ -15,3 +15,21 @@ export const moveCursor = style({
 export const delayPanels = style({
   transitionDelay: '1000ms',
 });
+
+const panelShadow = style({
+  boxShadow: '0 2px 5px 1px rgba(28,28,28,.2)',
+});
+
+const panelSize = style(({ touchableSize, grid }) => ({
+  minHeight: touchableSize * grid,
+}));
+
+export const panel = [panelShadow, panelSize];
+
+export const panelBackground = style({
+  selectors: {
+    [`${panelShadow}:not(:hover) &`]: {
+      opacity: 0.8,
+    },
+  },
+});

--- a/site/src/App/routes/gallery/gallery.treat.ts
+++ b/site/src/App/routes/gallery/gallery.treat.ts
@@ -27,9 +27,11 @@ const panelSize = style(({ touchableSize, grid }) => ({
 export const panel = [panelShadow, panelSize];
 
 export const panelBackground = style({
+  backdropFilter: 'blur(4px)',
+  transition: 'opacity .4s ease',
   selectors: {
     [`${panelShadow}:not(:hover) &`]: {
-      opacity: 0.8,
+      opacity: 0.85,
     },
   },
 });


### PR DESCRIPTION
A bunch of improvements following some early stage feedback:

- Added Braid logo in top left to support navigating back to the docs
- Renamed "Reset" to "Fit to Screen", and updated icon
- Zoom buttons now take 20% steps in/out
- Added Copy label to button
- Added `Copied` feedback after copying an example (Note: button is shared with `Code` panels in docs, added success feedback on copy for them too.)
- Added translucency to overlay panels, turning opaque on hover
- Moved theme selector into top left panel alongside logo

