### PR TITLE
Highlight new components in Gallery

### DIFF
--- a/site/src/App/routes/gallery/Gallery.tsx
+++ b/site/src/App/routes/gallery/Gallery.tsx
@@ -133,7 +133,7 @@ const GalleryItem = ({
     <Box padding="xxlarge" data-braid-component-name={component.name}>
       <Stack space="xxlarge">
         <Stack space="large">
-          <Inline space="small" alignY="top">
+          <Inline space="small" alignY="center">
             <Heading level="2">
               <TextLink
                 href={`/components/${component.name}`}

--- a/site/src/App/routes/gallery/Gallery.tsx
+++ b/site/src/App/routes/gallery/Gallery.tsx
@@ -24,7 +24,7 @@ import {
   Column,
   Disclosure,
 } from '../../../../../lib/components';
-import { getHistory } from '../../Updates';
+import { getHistory, isNew } from '../../Updates';
 import { CopyIcon } from '../../Code/CopyIcon';
 import { CodeButton } from '../../Code/Code';
 import { ComponentExample } from '../../../types';
@@ -125,7 +125,9 @@ const GalleryItem = ({
     : [component.name];
 
   const history = getHistory(...relevantNames);
-  const updateCount = history.filter((item) => item.isRecent).length;
+  const markAsNew = isNew(component.name);
+  const actualUpdateCount = history.filter((item) => item.isRecent).length;
+  const updateCount = markAsNew ? actualUpdateCount - 1 : actualUpdateCount;
 
   return (
     <Box padding="xxlarge" data-braid-component-name={component.name}>
@@ -140,6 +142,23 @@ const GalleryItem = ({
                 {component.name}
               </TextLink>
             </Heading>
+            {markAsNew ? (
+              <Box
+                component={Link}
+                cursor="pointer"
+                href={`/components/${component.name}/releases`}
+                target="gallery-detail"
+              >
+                <Badge
+                  tone="positive"
+                  weight="strong"
+                  title="Added in the last two months"
+                  bleedY
+                >
+                  New
+                </Badge>
+              </Box>
+            ) : null}
             {updateCount > 0 ? (
               <Box
                 component={Link}
@@ -150,12 +169,12 @@ const GalleryItem = ({
                 <Badge
                   tone="promote"
                   weight="strong"
-                  title={`${updateCount} release${
+                  title={`${updateCount} update${
                     updateCount === 1 ? '' : 's'
                   } in the last two months`}
                   bleedY
                 >
-                  {`${updateCount} new release${updateCount === 1 ? '' : 's'}`}
+                  {`${updateCount} update${updateCount === 1 ? '' : 's'}`}
                 </Badge>
               </Box>
             ) : undefined}


### PR DESCRIPTION
Add badge next to component name in Gallery to highlight when it's 🆕 

![Screen Shot 2020-09-29 at 12 26 28 pm](https://user-images.githubusercontent.com/912060/94505719-0d13b780-024f-11eb-9365-9dd949441a65.png)
