### PR TITLE
Toggle: Ensure space between label and toggle when justified

### DIFF
--- a/.changeset/strong-spoons-promise.md
+++ b/.changeset/strong-spoons-promise.md
@@ -1,0 +1,10 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Toggle
+---
+
+**Toggle:** Ensure there is a minimum amount of space between the label and the toggle when using justified alignment

--- a/lib/components/Toggle/Toggle.docs.tsx
+++ b/lib/components/Toggle/Toggle.docs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Toggle } from '../';
+import { Toggle, Box } from '../';
 import { Toggle as PlayroomToggle } from '../../playroom/components';
 
 const handler = () => {
@@ -52,6 +52,26 @@ const docs: ComponentDocs = {
           id={id}
           onChange={handler}
         />
+      ),
+    },
+    {
+      label:
+        'Test: Should have space between the label and the toggle when justified in a flex container',
+      docsSite: false,
+      gallery: false,
+      Container: ({ children }) => (
+        <div style={{ maxWidth: '300px' }}>{children}</div>
+      ),
+      Example: ({ id }) => (
+        <Box display="flex">
+          <Toggle
+            on={true}
+            align="justify"
+            label="Justified"
+            id={id}
+            onChange={handler}
+          />
+        </Box>
       ),
     },
   ],

--- a/lib/components/Toggle/Toggle.tsx
+++ b/lib/components/Toggle/Toggle.tsx
@@ -107,7 +107,9 @@ export const Toggle = ({
         component="label"
         htmlFor={id}
         paddingLeft={align === 'left' ? 'xsmall' : undefined}
-        paddingRight={align === 'right' ? 'xsmall' : undefined}
+        paddingRight={
+          align === 'right' || align === 'justify' ? 'xsmall' : undefined
+        }
         flexGrow={align === 'justify' ? 1 : undefined}
         userSelect="none"
         cursor="pointer"


### PR DESCRIPTION
This fixes an issue where a justified Toggle inside a flex container (e.g. Column with a width of "content") would have no space between the label and the toggle.