### PR TITLE
Form field description a11y & improved MonthPicker i18n support

### DIFF
--- a/.changeset/fair-dragons-smoke.md
+++ b/.changeset/fair-dragons-smoke.md
@@ -1,0 +1,16 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - TextField
+  - Dropdown
+  - PasswordField
+  - MonthPicker
+  - Textarea
+---
+
+**TextField,Dropdown,PasswordField,MonthPicker,Textarea:** Apply aria-describedby to form elements only when needed
+
+Only apply `aria-describedby` to form elements when needed, e.g. either a `message`, `description`, or an explicit `aria-describedby` is passed.

--- a/.changeset/tasty-jars-jog.md
+++ b/.changeset/tasty-jars-jog.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - MonthPicker
+---
+
+**MonthPicker:** Announce semantic grouping of fields and improved translation support.
+
+When not on a native device, the MonthPicker uses a `fieldset` containing two dropdowns. This change ensures that the grouping is announced correctly. From a translations perspective the labels for the dropdowns are no longer a concatenation of the `label` and `monthLabel`/`yearLabel`, supporting translation of the entire phrase.

--- a/lib/components/Dropdown/Dropdown.test.tsx
+++ b/lib/components/Dropdown/Dropdown.test.tsx
@@ -1,0 +1,114 @@
+import '@testing-library/jest-dom/extend-expect';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { BraidTestProvider, Dropdown } from '..';
+
+describe('Dropdown', () => {
+  it('associates field with label correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <Dropdown id="field" label="My dropdown" value="" onChange={() => {}}>
+          <option>1</option>
+        </Dropdown>
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My dropdown').tagName).toBe('SELECT');
+  });
+
+  it('associates field with message correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <Dropdown
+          id="field"
+          label="My dropdown"
+          message="Required"
+          value=""
+          onChange={() => {}}
+        >
+          <option>1</option>
+        </Dropdown>
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My dropdown')).toHaveDescription('Required');
+  });
+
+  it('associates field with description correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <Dropdown
+          id="field"
+          label="My dropdown"
+          description="More detail about field"
+          value=""
+          onChange={() => {}}
+        >
+          <option>1</option>
+        </Dropdown>
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My dropdown')).toHaveDescription(
+      'More detail about field',
+    );
+  });
+
+  it('associates field with custom description correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <span id="detail">Custom description</span>
+        <Dropdown
+          id="field"
+          label="My dropdown"
+          aria-describedby="detail"
+          value=""
+          onChange={() => {}}
+        >
+          <option>1</option>
+        </Dropdown>
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My dropdown')).toHaveDescription(
+      'Custom description',
+    );
+  });
+
+  it('associates field with multiple description elements correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <span id="detail">Custom description</span>
+        <Dropdown
+          id="field"
+          label="My dropdown"
+          message="Required"
+          description="More detail about field"
+          aria-describedby="detail"
+          value=""
+          onChange={() => {}}
+        >
+          <option>1</option>
+        </Dropdown>
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My dropdown')).toHaveDescription(
+      'Custom description Required More detail about field',
+    );
+  });
+
+  it('field is not marked as having a description without a message or description', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <Dropdown id="field" label="My dropdown" value="" onChange={() => {}}>
+          <option>1</option>
+        </Dropdown>
+      </BraidTestProvider>,
+    );
+
+    expect(
+      getByLabelText('My dropdown').getAttribute('aria-describedby'),
+    ).toBeNull();
+  });
+});

--- a/lib/components/MonthPicker/MonthPicker.test.tsx
+++ b/lib/components/MonthPicker/MonthPicker.test.tsx
@@ -48,4 +48,199 @@ describe('MonthPicker (Double dropdown)', () => {
     expect(options[1].value).toBe('1999');
     expect(options[27].value).toBe('2025');
   });
+
+  it('associates fieldset with label correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <MonthPicker
+          id="month-picker"
+          label="Start"
+          value={{}}
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('Start').tagName).toBe('FIELDSET');
+  });
+
+  it('associates month field with label correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <MonthPicker
+          id="month-picker"
+          label="Start"
+          monthLabel="Month"
+          value={{}}
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('Start Month').tagName).toBe('SELECT');
+  });
+
+  it('associates year field with label correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <MonthPicker
+          id="month-picker"
+          label="Start"
+          yearLabel="Year"
+          value={{}}
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('Start Year').tagName).toBe('SELECT');
+  });
+
+  it('associates month field with message correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <MonthPicker
+          id="month-picker"
+          label="Start"
+          monthLabel="Month"
+          message="Required"
+          value={{}}
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('Start Month')).toHaveDescription('Required');
+  });
+
+  it('associates year field with message correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <MonthPicker
+          id="month-picker"
+          label="Start"
+          yearLabel="Year"
+          message="Required"
+          value={{}}
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('Start Year')).toHaveDescription('Required');
+  });
+
+  it('associates month field with description correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <MonthPicker
+          id="month-picker"
+          label="Start"
+          monthLabel="Month"
+          description="More detail about field"
+          value={{}}
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('Start Month')).toHaveDescription(
+      'More detail about field',
+    );
+  });
+
+  it('associates year field with description correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <MonthPicker
+          id="month-picker"
+          label="Start"
+          yearLabel="Year"
+          description="More detail about field"
+          value={{}}
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('Start Year')).toHaveDescription(
+      'More detail about field',
+    );
+  });
+
+  it('associates month field with multiple description elements correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <MonthPicker
+          id="month-picker"
+          label="Start"
+          monthLabel="Month"
+          message="Required"
+          description="More detail about field"
+          value={{}}
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('Start Month')).toHaveDescription(
+      'Required More detail about field',
+    );
+  });
+
+  it('associates year field with multiple description elements correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <MonthPicker
+          id="month-picker"
+          label="Start"
+          yearLabel="Year"
+          message="Required"
+          description="More detail about field"
+          value={{}}
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('Start Year')).toHaveDescription(
+      'Required More detail about field',
+    );
+  });
+
+  it('month field is not marked as having a description without a message or description', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <MonthPicker
+          id="month-picker"
+          label="Start"
+          monthLabel="Month"
+          value={{}}
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(
+      getByLabelText('Start Month').getAttribute('aria-describedby'),
+    ).toBeNull();
+  });
+
+  it('year field is not marked as having a description without a message or description', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <MonthPicker
+          id="month-picker"
+          label="Start"
+          yearLabel="Year"
+          value={{}}
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(
+      getByLabelText('Start Year').getAttribute('aria-describedby'),
+    ).toBeNull();
+  });
 });

--- a/lib/components/MonthPicker/MonthPicker.test.tsx
+++ b/lib/components/MonthPicker/MonthPicker.test.tsx
@@ -77,7 +77,7 @@ describe('MonthPicker (Double dropdown)', () => {
       </BraidTestProvider>,
     );
 
-    expect(getByLabelText('Start Month').tagName).toBe('SELECT');
+    expect(getByLabelText('Month').tagName).toBe('SELECT');
   });
 
   it('associates year field with label correctly', () => {
@@ -93,7 +93,7 @@ describe('MonthPicker (Double dropdown)', () => {
       </BraidTestProvider>,
     );
 
-    expect(getByLabelText('Start Year').tagName).toBe('SELECT');
+    expect(getByLabelText('Year').tagName).toBe('SELECT');
   });
 
   it('associates month field with message correctly', () => {
@@ -110,7 +110,7 @@ describe('MonthPicker (Double dropdown)', () => {
       </BraidTestProvider>,
     );
 
-    expect(getByLabelText('Start Month')).toHaveDescription('Required');
+    expect(getByLabelText('Month')).toHaveDescription('Required');
   });
 
   it('associates year field with message correctly', () => {
@@ -127,7 +127,7 @@ describe('MonthPicker (Double dropdown)', () => {
       </BraidTestProvider>,
     );
 
-    expect(getByLabelText('Start Year')).toHaveDescription('Required');
+    expect(getByLabelText('Year')).toHaveDescription('Required');
   });
 
   it('associates month field with description correctly', () => {
@@ -144,7 +144,7 @@ describe('MonthPicker (Double dropdown)', () => {
       </BraidTestProvider>,
     );
 
-    expect(getByLabelText('Start Month')).toHaveDescription(
+    expect(getByLabelText('Month')).toHaveDescription(
       'More detail about field',
     );
   });
@@ -163,9 +163,7 @@ describe('MonthPicker (Double dropdown)', () => {
       </BraidTestProvider>,
     );
 
-    expect(getByLabelText('Start Year')).toHaveDescription(
-      'More detail about field',
-    );
+    expect(getByLabelText('Year')).toHaveDescription('More detail about field');
   });
 
   it('associates month field with multiple description elements correctly', () => {
@@ -183,7 +181,7 @@ describe('MonthPicker (Double dropdown)', () => {
       </BraidTestProvider>,
     );
 
-    expect(getByLabelText('Start Month')).toHaveDescription(
+    expect(getByLabelText('Month')).toHaveDescription(
       'Required More detail about field',
     );
   });
@@ -203,7 +201,7 @@ describe('MonthPicker (Double dropdown)', () => {
       </BraidTestProvider>,
     );
 
-    expect(getByLabelText('Start Year')).toHaveDescription(
+    expect(getByLabelText('Year')).toHaveDescription(
       'Required More detail about field',
     );
   });
@@ -221,9 +219,7 @@ describe('MonthPicker (Double dropdown)', () => {
       </BraidTestProvider>,
     );
 
-    expect(
-      getByLabelText('Start Month').getAttribute('aria-describedby'),
-    ).toBeNull();
+    expect(getByLabelText('Month').getAttribute('aria-describedby')).toBeNull();
   });
 
   it('year field is not marked as having a description without a message or description', () => {
@@ -239,8 +235,6 @@ describe('MonthPicker (Double dropdown)', () => {
       </BraidTestProvider>,
     );
 
-    expect(
-      getByLabelText('Start Year').getAttribute('aria-describedby'),
-    ).toBeNull();
+    expect(getByLabelText('Year').getAttribute('aria-describedby')).toBeNull();
   });
 });

--- a/lib/components/MonthPicker/MonthPicker.tsx
+++ b/lib/components/MonthPicker/MonthPicker.tsx
@@ -234,7 +234,7 @@ const MonthPicker = ({
         <Columns space="medium">
           <Column>
             <HiddenVisually>
-              <label htmlFor={monthId}>{`${label} ${monthLabel}`}</label>
+              <label htmlFor={monthId}>{monthLabel}</label>
             </HiddenVisually>
             <Dropdown
               id={monthId}
@@ -252,7 +252,7 @@ const MonthPicker = ({
           </Column>
           <Column>
             <HiddenVisually>
-              <label htmlFor={yearId}>{`${label} ${yearLabel}`}</label>
+              <label htmlFor={yearId}>{yearLabel}</label>
             </HiddenVisually>
             <Dropdown
               id={yearId}

--- a/lib/components/PasswordField/PasswordField.test.tsx
+++ b/lib/components/PasswordField/PasswordField.test.tsx
@@ -83,4 +83,108 @@ describe('PasswordField', () => {
     const visibilityButton = queryByRole('button');
     expect(visibilityButton).not.toBeInTheDocument();
   });
+
+  it('associates field with label correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <PasswordField
+          id="field"
+          label="My field"
+          value=""
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field').tagName).toBe('INPUT');
+  });
+
+  it('associates field with message correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <PasswordField
+          id="field"
+          label="My field"
+          message="Required"
+          value=""
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field')).toHaveDescription('Required');
+  });
+
+  it('associates field with description correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <PasswordField
+          id="field"
+          label="My field"
+          description="More detail about field"
+          value=""
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field')).toHaveDescription(
+      'More detail about field',
+    );
+  });
+
+  it('associates field with custom description correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <span id="detail">Custom description</span>
+        <PasswordField
+          id="field"
+          label="My field"
+          aria-describedby="detail"
+          value=""
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field')).toHaveDescription('Custom description');
+  });
+
+  it('associates field with multiple description elements correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <span id="detail">Custom description</span>
+        <PasswordField
+          id="field"
+          label="My field"
+          message="Required"
+          description="More detail about field"
+          aria-describedby="detail"
+          value=""
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field')).toHaveDescription(
+      'Custom description Required More detail about field',
+    );
+  });
+
+  it('field is not marked as having a description without a message or description', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <PasswordField
+          id="field"
+          label="My field"
+          value=""
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(
+      getByLabelText('My field').getAttribute('aria-describedby'),
+    ).toBeNull();
+  });
 });

--- a/lib/components/TextField/TextField.test.tsx
+++ b/lib/components/TextField/TextField.test.tsx
@@ -1,0 +1,100 @@
+import '@testing-library/jest-dom/extend-expect';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { BraidTestProvider, TextField } from '..';
+
+describe('TextField', () => {
+  it('associates field with label correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <TextField id="field" label="My field" value="" onChange={() => {}} />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field').tagName).toBe('INPUT');
+  });
+
+  it('associates field with message correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <TextField
+          id="field"
+          label="My field"
+          message="Required"
+          value=""
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field')).toHaveDescription('Required');
+  });
+
+  it('associates field with description correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <TextField
+          id="field"
+          label="My field"
+          description="More detail about field"
+          value=""
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field')).toHaveDescription(
+      'More detail about field',
+    );
+  });
+
+  it('associates field with custom description correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <span id="detail">Custom description</span>
+        <TextField
+          id="field"
+          label="My field"
+          aria-describedby="detail"
+          value=""
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field')).toHaveDescription('Custom description');
+  });
+
+  it('associates field with multiple description elements correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <span id="detail">Custom description</span>
+        <TextField
+          id="field"
+          label="My field"
+          message="Required"
+          description="More detail about field"
+          aria-describedby="detail"
+          value=""
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field')).toHaveDescription(
+      'Custom description Required More detail about field',
+    );
+  });
+
+  it('field is not marked as having a description without a message or description', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <TextField id="field" label="My field" value="" onChange={() => {}} />
+      </BraidTestProvider>,
+    );
+
+    expect(
+      getByLabelText('My field').getAttribute('aria-describedby'),
+    ).toBeNull();
+  });
+});

--- a/lib/components/Textarea/Textarea.test.tsx
+++ b/lib/components/Textarea/Textarea.test.tsx
@@ -1,0 +1,100 @@
+import '@testing-library/jest-dom/extend-expect';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { BraidTestProvider, Textarea } from '..';
+
+describe('Textarea', () => {
+  it('associates field with label correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <Textarea id="field" label="My field" value="" onChange={() => {}} />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field').tagName).toBe('INPUT');
+  });
+
+  it('associates field with message correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <Textarea
+          id="field"
+          label="My field"
+          message="Required"
+          value=""
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field')).toHaveDescription('Required');
+  });
+
+  it('associates field with description correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <Textarea
+          id="field"
+          label="My field"
+          description="More detail about field"
+          value=""
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field')).toHaveDescription(
+      'More detail about field',
+    );
+  });
+
+  it('associates field with custom description correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <span id="detail">Custom description</span>
+        <Textarea
+          id="field"
+          label="My field"
+          aria-describedby="detail"
+          value=""
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field')).toHaveDescription('Custom description');
+  });
+
+  it('associates field with multiple description elements correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <span id="detail">Custom description</span>
+        <Textarea
+          id="field"
+          label="My field"
+          message="Required"
+          description="More detail about field"
+          aria-describedby="detail"
+          value=""
+          onChange={() => {}}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field')).toHaveDescription(
+      'Custom description Required More detail about field',
+    );
+  });
+
+  it('field is not marked as having a description without a message or description', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <Textarea id="field" label="My field" value="" onChange={() => {}} />
+      </BraidTestProvider>,
+    );
+
+    expect(
+      getByLabelText('My field').getAttribute('aria-describedby'),
+    ).toBeNull();
+  });
+});

--- a/lib/components/Textarea/Textarea.test.tsx
+++ b/lib/components/Textarea/Textarea.test.tsx
@@ -11,7 +11,7 @@ describe('Textarea', () => {
       </BraidTestProvider>,
     );
 
-    expect(getByLabelText('My field').tagName).toBe('INPUT');
+    expect(getByLabelText('My field').tagName).toBe('TEXTAREA');
   });
 
   it('associates field with message correctly', () => {

--- a/lib/components/private/Field/Field.tsx
+++ b/lib/components/private/Field/Field.tsx
@@ -148,7 +148,7 @@ export const Field = ({
             outline: 'none',
             'aria-describedby': mergeIds(
               ariaDescribedBy,
-              messageId,
+              message || secondaryMessage ? messageId : undefined,
               descriptionId,
             ),
             'aria-required': required,

--- a/lib/components/private/FieldGroup/FieldGroup.tsx
+++ b/lib/components/private/FieldGroup/FieldGroup.tsx
@@ -45,6 +45,7 @@ export const FieldGroup = ({
   tone,
   required,
 }: InternalFieldGroupProps) => {
+  const labelId = `${id}-label`;
   const messageId = `${id}-message`;
   const descriptionId = description ? `${id}-description` : undefined;
 
@@ -53,11 +54,12 @@ export const FieldGroup = ({
       component="fieldset"
       disabled={disabled}
       id={id}
+      aria-labelledby={label ? labelId : undefined}
       aria-required={required}
     >
       <Stack space="xsmall">
         {label ? (
-          <Box component="legend">
+          <Box component="legend" id={labelId}>
             <FieldLabel
               htmlFor={false}
               label={label}

--- a/lib/components/private/FieldGroup/FieldGroup.tsx
+++ b/lib/components/private/FieldGroup/FieldGroup.tsx
@@ -6,6 +6,7 @@ import {
   FieldMessageProps,
 } from '../../FieldMessage/FieldMessage';
 import { Stack } from '../../Stack/Stack';
+import { mergeIds } from '../mergeIds';
 import { ReactNodeNoStrings } from '../ReactNodeNoStrings';
 
 type FormElementProps = AllHTMLAttributes<HTMLFormElement>;
@@ -70,7 +71,10 @@ export const FieldGroup = ({
 
         {children({
           disabled,
-          ...(message && { 'aria-describedby': messageId }),
+          'aria-describedby': mergeIds(
+            message ? messageId : undefined,
+            descriptionId,
+          ),
         })}
 
         {message || reserveMessageSpace ? (


### PR DESCRIPTION
**TextField,Dropdown,PasswordField,MonthPicker,Textarea:** Apply aria-describedby to form elements only when needed

Only apply `aria-describedby` to form elements when needed, e.g. either a `message`, `description`, or an explicit `aria-describedby` is passed.

**MonthPicker:** Announce semantic grouping of fields and improved translation support.

When not on a native device, the MonthPicker uses a `fieldset` containing two dropdowns. This change ensures that the grouping is announced correctly. From a translations perspective the labels for the dropdowns are no longer a concatenation of the `label` and `monthLabel`/`yearLabel`, supporting translation of the entire phrase.