### PR TITLE
Apply aria-describedby only when needed

### DIFF
--- a/.changeset/afraid-coins-talk.md
+++ b/.changeset/afraid-coins-talk.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Radio
+  - Checkbox
+---
+
+**Radio,Checkbox:** Apply aria-describedby only when needed
+
+Only apply aria-describedby when needed, e.g. either a message or description is passed.

--- a/lib/components/BulletList/BulletList.docs.tsx
+++ b/lib/components/BulletList/BulletList.docs.tsx
@@ -10,7 +10,7 @@ const docs: ComponentDocs = {
       <TextLink href="/components/List">List</TextLink> instead.
     </Text>
   ),
-  migrationGuide: true,
+  migrationGuide: false,
   screenshotWidths: [320],
   examples: [
     {

--- a/lib/components/Checkbox/Checkbox.test.tsx
+++ b/lib/components/Checkbox/Checkbox.test.tsx
@@ -1,0 +1,96 @@
+import '@testing-library/jest-dom/extend-expect';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { BraidTestProvider, Checkbox } from '..';
+
+describe('Checkbox', () => {
+  it('associates field with label correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <Checkbox
+          id="field"
+          label="My field"
+          value=""
+          onChange={() => {}}
+          checked={false}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field').tagName).toBe('INPUT');
+  });
+
+  it('associates field with message correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <Checkbox
+          id="field"
+          label="My field"
+          message="Required"
+          value=""
+          onChange={() => {}}
+          checked={false}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field')).toHaveDescription('Required');
+  });
+
+  it('associates field with description correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <Checkbox
+          id="field"
+          label="My field"
+          description="More detail about field"
+          value=""
+          onChange={() => {}}
+          checked={false}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field')).toHaveDescription(
+      'More detail about field',
+    );
+  });
+
+  it('associates field with multiple description elements correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <Checkbox
+          id="field"
+          label="My field"
+          message="Required"
+          description="More detail about field"
+          value=""
+          onChange={() => {}}
+          checked={false}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field')).toHaveDescription(
+      'Required More detail about field',
+    );
+  });
+
+  it('field is not marked as having a description without a message or description', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <Checkbox
+          id="field"
+          label="My field"
+          value=""
+          onChange={() => {}}
+          checked={false}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(
+      getByLabelText('My field').getAttribute('aria-describedby'),
+    ).toBeNull();
+  });
+});

--- a/lib/components/Radio/Radio.test.tsx
+++ b/lib/components/Radio/Radio.test.tsx
@@ -1,0 +1,59 @@
+import '@testing-library/jest-dom/extend-expect';
+import React from 'react';
+import { render } from '@testing-library/react';
+import { BraidTestProvider, Radio } from '..';
+
+describe('Radio', () => {
+  it('associates field with label correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <Radio
+          id="field"
+          label="My field"
+          value=""
+          onChange={() => {}}
+          checked={false}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field').tagName).toBe('INPUT');
+  });
+
+  it('associates field with description correctly', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <Radio
+          id="field"
+          label="My field"
+          description="More detail about field"
+          value=""
+          onChange={() => {}}
+          checked={false}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field')).toHaveDescription(
+      'More detail about field',
+    );
+  });
+
+  it('field is not marked as having a description without a message or description', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <Radio
+          id="field"
+          label="My field"
+          value=""
+          onChange={() => {}}
+          checked={false}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(
+      getByLabelText('My field').getAttribute('aria-describedby'),
+    ).toBeNull();
+  });
+});

--- a/lib/components/private/InlineField/InlineField.tsx
+++ b/lib/components/private/InlineField/InlineField.tsx
@@ -144,7 +144,10 @@ export const InlineField = forwardRef<HTMLElement, InternalInlineFieldProps>(
             className={styles.realField}
             cursor={!disabled ? 'pointer' : undefined}
             opacity={0}
-            aria-describedby={mergeIds(messageId, descriptionId)}
+            aria-describedby={mergeIds(
+              message ? messageId : undefined,
+              description ? descriptionId : undefined,
+            )}
             aria-required={required}
             disabled={disabled}
             ref={ref}


### PR DESCRIPTION
**Radio,Checkbox:** Apply aria-describedby only when needed

Only apply aria-describedby when needed, e.g. either a message or description is passed.