### PR TITLE
List: Add support for icons

### DIFF
--- a/.changeset/silly-lies-add.md
+++ b/.changeset/silly-lies-add.md
@@ -1,0 +1,22 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - List
+---
+
+**List:** Add support for icons
+
+Provides a way to use an icon for all the items in a list. When using `type="icon"` you must also provide the `icon` prop. See example below:
+
+**EXAMPLE USAGE:**
+```jsx
+<List type="icon" icon={<IconTick tone="positive" />}>
+  <Text>This is a list item.</Text>
+  <Text>This is a list item.</Text>
+  <Text>This is a list item.</Text>
+</List>
+```
+

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -5172,6 +5172,7 @@ Object {
     type?: 
         | "alpha"
         | "bullet"
+        | "icon"
         | "number"
         | "roman"
 },

--- a/lib/components/List/List.docs.tsx
+++ b/lib/components/List/List.docs.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { List, Text, TextLink, Stack } from '..';
-import { Placeholder } from '../../playroom/components';
+import { IconTick, Placeholder } from '../../playroom/components';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -57,6 +57,16 @@ const docs: ComponentDocs = {
           <Text>This is a Roman list item.</Text>
           <Text>This is a Roman list item.</Text>
           <Text>This is a Roman list item.</Text>
+        </List>
+      ),
+    },
+    {
+      label: 'Icon List',
+      Example: () => (
+        <List type="icon" icon={<IconTick tone="positive" />}>
+          <Text>This is a list item.</Text>
+          <Text>This is a list item.</Text>
+          <Text>This is a list item.</Text>
         </List>
       ),
     },
@@ -279,6 +289,16 @@ const docs: ComponentDocs = {
       name: 'Roman',
       code: (
         <List space="medium" type="roman">
+          <Text>Text</Text>
+          <Text>Text</Text>
+          <Text>Text</Text>
+        </List>
+      ),
+    },
+    {
+      name: 'Icon',
+      code: (
+        <List space="medium" type="icon" icon={<IconTick tone="positive" />}>
           <Text>Text</Text>
           <Text>Text</Text>
           <Text>Text</Text>

--- a/lib/components/List/List.playroom.tsx
+++ b/lib/components/List/List.playroom.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+
+import { IconClear } from '../icons';
+import { List as BraidList, ListProps } from './List';
+
+export const List = (props: ListProps) => {
+  if (props.type === 'icon' && (!('icon' in props) || !props.icon)) {
+    return <BraidList {...props} icon={<IconClear />} />;
+  }
+
+  return <BraidList {...props} />;
+};

--- a/lib/components/List/List.tsx
+++ b/lib/components/List/List.tsx
@@ -1,4 +1,4 @@
-import React, { Children } from 'react';
+import React, { Children, ReactNode } from 'react';
 import { useStyles } from 'sku/react-treat';
 import { Text, TextProps } from '../Text/Text';
 import { Stack, StackProps } from '../Stack/Stack';
@@ -80,14 +80,24 @@ const CharacterBullet = ({ length = 1, children }: CharacterBulletProps) => {
   );
 };
 
-export interface ListProps {
+type ListTypeCharacter = {
+  type?: 'bullet' | 'number' | 'alpha' | 'roman';
+};
+
+type ListTypeIcon = {
+  type: 'icon';
+  icon: ReactNode;
+};
+
+type ListType = ListTypeCharacter | ListTypeIcon;
+
+export type ListProps = ListType & {
   children: StackProps['children'];
   size?: TextProps['size'];
   space?: StackProps['space'];
   tone?: TextProps['tone'];
-  type?: 'bullet' | 'number' | 'alpha' | 'roman';
   start?: number;
-}
+};
 
 export const List = ({
   children,
@@ -96,6 +106,7 @@ export const List = ({
   space = 'medium',
   type = 'bullet',
   start = 1,
+  ...restProps
 }: ListProps) => {
   const styles = useStyles(styleRefs);
   const { size, tone } = useDefaultTextProps({
@@ -109,7 +120,10 @@ export const List = ({
 
   return (
     <DefaultTextPropsProvider size={size} tone={tone}>
-      <Stack component={type === 'bullet' ? 'ul' : 'ol'} space={space}>
+      <Stack
+        component={/^(bullet|icon)$/.test(type) ? 'ul' : 'ol'}
+        space={space}
+      >
         {Children.map(listItems, (listItem, index) => {
           const resolvedIndex = index + (start - 1);
 
@@ -118,7 +132,9 @@ export const List = ({
               <Text component="div" size={size} tone={tone}>
                 <Box
                   display="flex"
-                  alignItems={type === 'bullet' ? 'center' : undefined}
+                  alignItems={
+                    /^(bullet|icon)$/.test(type) ? 'center' : undefined
+                  }
                   className={lineHeightContainerStyles}
                   userSelect="none"
                   aria-hidden
@@ -146,6 +162,10 @@ export const List = ({
                           {numberToRomanNumerals(resolvedIndex + 1)}
                         </CharacterBullet>
                       );
+                    }
+
+                    if (type === 'icon' && 'icon' in restProps) {
+                      return restProps.icon;
                     }
 
                     return (

--- a/lib/playroom/components.ts
+++ b/lib/playroom/components.ts
@@ -12,6 +12,7 @@ export { Dropdown } from '../components/Dropdown/Dropdown.playroom';
 export { FieldLabel } from '../components/FieldLabel/FieldLabel.playroom';
 export { FieldMessage } from '../components/FieldMessage/FieldMessage.playroom';
 export { Link } from '../components/Link/Link.playroom';
+export { List } from '../components/List/List.playroom';
 export { MonthPicker } from '../components/MonthPicker/MonthPicker.playroom';
 export { PasswordField } from '../components/PasswordField/PasswordField.playroom';
 export { Radio } from '../components/Radio/Radio.playroom';


### PR DESCRIPTION
**List:** Add support for icons

Provides a way to use an icon for all the items in a list. When using `type="icon"` you must also provide the `icon` prop. See example below:

**EXAMPLE USAGE:**
```jsx
<List type="icon" icon={<IconTick tone="positive" />}>
  <Text>This is a list item.</Text>
  <Text>This is a list item.</Text>
  <Text>This is a list item.</Text>
</List>
```