### PR TITLE
Fix element type passed to onChange event

### DIFF
--- a/.changeset/curvy-boxes-grin.md
+++ b/.changeset/curvy-boxes-grin.md
@@ -1,0 +1,14 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Checkbox
+  - RadioGroup
+  - Radio
+---
+
+**Checkbox,RadioGroup,Radio:** Fix element type passed to onChange event
+
+Fixes a bug where the `onChange` event previously received the change event for a `form` element rather than an `input` element.

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -2148,7 +2148,7 @@ Object {
     label: ReactNode
     message?: ReactNode
     name?: string
-    onChange: (event: FormEvent<HTMLFormElement>) => void
+    onChange: (event: FormEvent<HTMLInputElement>) => void
     ref?: 
         | (instance: HTMLInputElement | null) => void
         | RefObject<HTMLInputElement>
@@ -5377,7 +5377,7 @@ Object {
     id: string
     label: ReactNode
     name?: string
-    onChange: (event: FormEvent<HTMLFormElement>) => void
+    onChange: (event: FormEvent<HTMLInputElement>) => void
     ref?: 
         | (instance: HTMLInputElement | null) => void
         | RefObject<HTMLInputElement>
@@ -5403,7 +5403,7 @@ Object {
     label?: ReactNode
     message?: ReactNode
     name?: string
-    onChange: (event: FormEvent<HTMLFormElement>) => void
+    onChange: (event: FormEvent<HTMLInputElement>) => void
     required?: boolean
     reserveMessageSpace?: boolean
     secondaryLabel?: ReactNode

--- a/lib/components/RadioGroup/RadioGroup.tsx
+++ b/lib/components/RadioGroup/RadioGroup.tsx
@@ -11,7 +11,7 @@ export interface RadioGroupProps<Value = NonNullable<string | number>>
   extends FieldGroupProps {
   children: ReactElement<RadioItemProps>[];
   value: Value;
-  onChange: (event: FormEvent<HTMLFormElement>) => void;
+  onChange: (event: FormEvent<HTMLInputElement>) => void;
   name?: string;
 }
 

--- a/lib/components/private/InlineField/InlineField.tsx
+++ b/lib/components/private/InlineField/InlineField.tsx
@@ -25,7 +25,7 @@ import * as styleRefs from './InlineField.treat';
 const tones = ['neutral', 'critical'] as const;
 type InlineFieldTone = typeof tones[number];
 
-type FormElementProps = AllHTMLAttributes<HTMLFormElement>;
+type FormElementProps = AllHTMLAttributes<HTMLInputElement>;
 export interface InlineFieldProps {
   id: NonNullable<FormElementProps['id']>;
   label: NonNullable<FieldLabelProps['label']>;


### PR DESCRIPTION
**Checkbox,RadioGroup,Radio:** Fix element type passed to onChange event

Fixes a bug where the `onChange` event previously received the change event for a `form` element rather than an `input` element.