### PR TITLE
Playroom: Remove checked prop from Checkbox and Toggle snippets

### DIFF
--- a/lib/components/Checkbox/Checkbox.docs.tsx
+++ b/lib/components/Checkbox/Checkbox.docs.tsx
@@ -166,12 +166,8 @@ const docs: ComponentDocs = {
   ],
   snippets: [
     {
-      name: 'Unchecked',
-      code: <PlayroomCheckbox label="Label" checked={false} />,
-    },
-    {
-      name: 'Checked',
-      code: <PlayroomCheckbox label="Label" checked={true} />,
+      name: 'Standard',
+      code: <PlayroomCheckbox label="Label" />,
     },
     {
       name: 'With description',

--- a/lib/components/Toggle/Toggle.docs.tsx
+++ b/lib/components/Toggle/Toggle.docs.tsx
@@ -77,28 +77,16 @@ const docs: ComponentDocs = {
   ],
   snippets: [
     {
-      name: 'On',
-      code: <PlayroomToggle label="Toggled on" on />,
+      name: 'Standard',
+      code: <PlayroomToggle label="Toggle" />,
     },
     {
-      name: 'Off',
-      code: <PlayroomToggle label="Toggled off" on={false} />,
+      name: 'Aligned right',
+      code: <PlayroomToggle label="Toggled" align="right" />,
     },
     {
-      name: 'On, Aligned right',
-      code: <PlayroomToggle label="Toggled on" align="right" on />,
-    },
-    {
-      name: 'Off, Aligned right',
-      code: <PlayroomToggle label="Toggled off" align="right" on={false} />,
-    },
-    {
-      name: 'On, Justified',
-      code: <PlayroomToggle label="Toggled on" align="justify" on />,
-    },
-    {
-      name: 'Off, Justified',
-      code: <PlayroomToggle label="Toggled off" align="justify" on={false} />,
+      name: 'Justified',
+      code: <PlayroomToggle label="Toggled" align="justify" />,
     },
   ],
 };


### PR DESCRIPTION
Removing this since it's likely to cause confusion when combined with our new prototyping and state binding system.