### PR TITLE
Split out screenshot examples from Docs

### DIFF
--- a/lib/components/Accordion/Accordion.docs.tsx
+++ b/lib/components/Accordion/Accordion.docs.tsx
@@ -4,7 +4,6 @@ import { Accordion, AccordionItem, Stack, Text, TextLink } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
-  screenshotWidths: [320],
   subComponents: ['AccordionItem'],
   migrationGuide: true,
   description: (

--- a/lib/components/Accordion/Accordion.screenshots.tsx
+++ b/lib/components/Accordion/Accordion.screenshots.tsx
@@ -1,0 +1,70 @@
+import React, { useState } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { AccordionItem, Accordion, Text } from '../../components';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Collapsed Accordion',
+      Example: ({ id }) => (
+        <Accordion>
+          <AccordionItem label="Accordion item 1" id={`${id}_1`}>
+            <Text>Accordion item content</Text>
+          </AccordionItem>
+          <AccordionItem label="Accordion item 2" id={`${id}_2`}>
+            <Text>Accordion item content</Text>
+          </AccordionItem>
+          <AccordionItem label="Accordion item 3" id={`${id}_3`}>
+            <Text>Accordion item content</Text>
+          </AccordionItem>
+        </Accordion>
+      ),
+    },
+    {
+      label: 'Expanded Accordion',
+      Example: ({ id }) => {
+        const [expanded1, setExpanded1] = useState(true);
+        const [expanded2, setExpanded2] = useState(true);
+        const [expanded3, setExpanded3] = useState(true);
+
+        return (
+          <Accordion>
+            <AccordionItem
+              label="Accordion item 1"
+              id={`${id}_1`}
+              expanded={expanded1}
+              onToggle={setExpanded1}
+            >
+              <Text>Accordion item content</Text>
+            </AccordionItem>
+            <AccordionItem
+              label="Accordion item 2"
+              id={`${id}_2`}
+              expanded={expanded2}
+              onToggle={setExpanded2}
+            >
+              <Text>Accordion item content</Text>
+            </AccordionItem>
+            <AccordionItem
+              label="Accordion item 3"
+              id={`${id}_3`}
+              expanded={expanded3}
+              onToggle={setExpanded3}
+            >
+              <Text>Accordion item content</Text>
+            </AccordionItem>
+          </Accordion>
+        );
+      },
+    },
+    {
+      label: 'Standalone AccordionItem',
+      Example: ({ id }) => (
+        <AccordionItem label="Label" id={id}>
+          <Text>Content</Text>
+        </AccordionItem>
+      ),
+    },
+  ],
+};

--- a/lib/components/Actions/Actions.docs.tsx
+++ b/lib/components/Actions/Actions.docs.tsx
@@ -1,20 +1,10 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import {
-  Actions,
-  Button,
-  TextLink,
-  Box,
-  Stack,
-  Text,
-  IconNewWindow,
-} from '../';
-import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
+import { Actions, Button, TextLink, Stack, Text } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320, 768],
   description: (
     <Stack space="large">
       <Text>Typically used for actions at the end of forms.</Text>
@@ -56,33 +46,6 @@ const docs: ComponentDocs = {
           <Button weight="regular">Regular</Button>
         </Actions>
       ),
-    },
-    {
-      label: 'Actions Contrast',
-      docsSite: false,
-      Example: () => {
-        const backgrounds = Object.keys(boxBackgrounds) as Array<
-          keyof typeof boxBackgrounds
-        >;
-
-        return (
-          <Fragment>
-            {backgrounds.sort().map((background, i) => (
-              <Box key={i} background={background} padding="xsmall">
-                <Stack space="xsmall">
-                  <Text size="small">{background}</Text>
-                  <Actions>
-                    <Button weight="strong">Strong</Button>
-                    <TextLink href="#">
-                      TextLink <IconNewWindow />
-                    </TextLink>
-                  </Actions>
-                </Stack>
-              </Box>
-            ))}
-          </Fragment>
-        );
-      },
     },
   ],
 };

--- a/lib/components/Actions/Actions.screenshots.tsx
+++ b/lib/components/Actions/Actions.screenshots.tsx
@@ -1,0 +1,72 @@
+import React, { Fragment } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import {
+  Box,
+  Button,
+  IconNewWindow,
+  Stack,
+  TextLink,
+  Text,
+} from '../../components';
+import { Actions } from './Actions';
+import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320, 768],
+  examples: [
+    {
+      label: 'Actions with Strong Button and TextLink',
+      Example: () => (
+        <Actions>
+          <Button weight="strong">Strong</Button>
+          <TextLink href="#">TextLink</TextLink>
+        </Actions>
+      ),
+    },
+    {
+      label: 'Actions with Regular Button and Weak Button',
+      Example: () => (
+        <Actions>
+          <Button weight="regular">Regular</Button>
+          <Button weight="weak">Weak</Button>
+        </Actions>
+      ),
+    },
+    {
+      label: 'Actions with Weak Buttons and Regular Button',
+      Example: () => (
+        <Actions>
+          <Button weight="weak">Weak</Button>
+          <Button weight="weak">Weak</Button>
+          <Button weight="regular">Regular</Button>
+        </Actions>
+      ),
+    },
+    {
+      label: 'Actions Contrast',
+      Example: () => {
+        const backgrounds = Object.keys(boxBackgrounds) as Array<
+          keyof typeof boxBackgrounds
+        >;
+
+        return (
+          <Fragment>
+            {backgrounds.sort().map((background, i) => (
+              <Box key={i} background={background} padding="xsmall">
+                <Stack space="xsmall">
+                  <Text size="small">{background}</Text>
+                  <Actions>
+                    <Button weight="strong">Strong</Button>
+                    <TextLink href="#">
+                      TextLink <IconNewWindow />
+                    </TextLink>
+                  </Actions>
+                </Stack>
+              </Box>
+            ))}
+          </Fragment>
+        );
+      },
+    },
+  ],
+};

--- a/lib/components/Alert/Alert.docs.tsx
+++ b/lib/components/Alert/Alert.docs.tsx
@@ -19,7 +19,6 @@ const docs: ComponentDocs = {
     </Stack>
   ),
   migrationGuide: true,
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Info Alert',

--- a/lib/components/Alert/Alert.screenshots.tsx
+++ b/lib/components/Alert/Alert.screenshots.tsx
@@ -1,0 +1,120 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Alert, Text, Stack, TextLink, List } from '../';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Info Alert',
+      Example: () => (
+        <Alert tone="info">
+          <Text>This is an important piece of information.</Text>
+        </Alert>
+      ),
+    },
+    {
+      label: 'Info Alert Inside Card',
+      background: 'card',
+      Example: () => (
+        <Alert tone="info">
+          <Text>This is an important piece of information.</Text>
+        </Alert>
+      ),
+    },
+    {
+      label: 'Dismissible alert',
+      Example: () => (
+        <Alert tone="info" onClose={() => {}} closeLabel="Close info alert">
+          <Text>This is an important piece of information.</Text>
+        </Alert>
+      ),
+    },
+    {
+      label: 'Alert with rich content',
+      Example: () => (
+        <Alert tone="info">
+          <Stack space="large">
+            <Text>
+              This is an important piece of information with a{' '}
+              <TextLink href="#">TextLink.</TextLink>
+            </Text>
+            <List space="medium">
+              <Text>Bullet 1</Text>
+              <Text>Bullet 2</Text>
+              <Text>Bullet 3</Text>
+            </List>
+          </Stack>
+        </Alert>
+      ),
+    },
+    {
+      label: 'Promote Alert',
+      Example: () => (
+        <Alert tone="promote">
+          <Text>This is a promoted piece of information.</Text>
+        </Alert>
+      ),
+    },
+    {
+      label: 'Promote Alert Inside Card',
+      background: 'card',
+      Example: () => (
+        <Alert tone="promote">
+          <Text>This is a promoted piece of information.</Text>
+        </Alert>
+      ),
+    },
+    {
+      label: 'Caution Alert',
+      Example: () => (
+        <Alert tone="caution">
+          <Text>This is a cautionary piece of information.</Text>
+        </Alert>
+      ),
+    },
+    {
+      label: 'Caution Alert Inside Card',
+      background: 'card',
+      Example: () => (
+        <Alert tone="caution">
+          <Text>This is a cautionary piece of information.</Text>
+        </Alert>
+      ),
+    },
+    {
+      label: 'Critical Alert',
+      Example: () => (
+        <Alert tone="critical">
+          <Text>This is a critical piece of information.</Text>
+        </Alert>
+      ),
+    },
+    {
+      label: 'Critical Alert Inside Card',
+      background: 'card',
+      Example: () => (
+        <Alert tone="critical">
+          <Text>This is a critical piece of information.</Text>
+        </Alert>
+      ),
+    },
+    {
+      label: 'Positive Alert',
+      Example: () => (
+        <Alert tone="positive">
+          <Text>This is a positive piece of information.</Text>
+        </Alert>
+      ),
+    },
+    {
+      label: 'Positive Alert Inside Card',
+      background: 'card',
+      Example: () => (
+        <Alert tone="positive">
+          <Text>This is a positive piece of information.</Text>
+        </Alert>
+      ),
+    },
+  ],
+};

--- a/lib/components/Autosuggest/Autosuggest.docs.tsx
+++ b/lib/components/Autosuggest/Autosuggest.docs.tsx
@@ -30,7 +30,6 @@ interface Value {
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   description: (
     <Text>
       Follows the{' '}
@@ -124,7 +123,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Standard suggestions with descriptions',
-      storybook: false,
       Container,
       Example: ({ id }) => {
         const [value, setValue] = useState<Value>({ text: '' });
@@ -162,7 +160,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Grouped suggestions with descriptions',
-      storybook: false,
       Container,
       Example: ({ id }) => {
         const [value, setValue] = useState<Value>({ text: '' });
@@ -220,7 +217,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Standard suggestions with brand background and mobile backdrop',
-      storybook: false,
       Container,
       background: 'brand',
       Example: ({ id }) => {

--- a/lib/components/Autosuggest/Autosuggest.screenshots.tsx
+++ b/lib/components/Autosuggest/Autosuggest.screenshots.tsx
@@ -1,0 +1,152 @@
+import React, { useState, ReactNode } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Autosuggest, filterSuggestions, IconSearch } from '../';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div style={{ maxWidth: '300px' }}>{children}</div>
+);
+
+export const makeSuggestions = (
+  suggestions: Array<string | { text: string; description?: string }>,
+  initialValue = 0,
+) =>
+  suggestions.map((suggestion, i) => ({
+    ...(typeof suggestion === 'string' ? { text: suggestion } : suggestion),
+    value: i + initialValue,
+  }));
+
+interface Value {
+  text: string;
+  value?: number;
+}
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Standard suggestions',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState<Value>({ text: '' });
+        const [showRecent, setShowRecent] = useState(true);
+
+        return (
+          <Autosuggest
+            label="I like to eat"
+            id={id}
+            value={value}
+            onChange={setValue}
+            onClear={() => setValue({ text: '' })}
+            suggestions={filterSuggestions([
+              ...(showRecent && value.text === ''
+                ? [
+                    {
+                      text: 'Apples',
+                      onClear: () => setShowRecent(false),
+                    },
+                  ]
+                : []),
+              ...makeSuggestions([
+                ...(value.text !== '' ? ['Apples'] : []),
+                'Bananas',
+                'Broccoli',
+                'Carrots',
+              ]),
+            ])}
+          />
+        );
+      },
+    },
+    {
+      label: 'Standard suggestions with automatic selection',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState<Value>({ text: '' });
+
+        return (
+          <Autosuggest
+            automaticSelection
+            label="I like to eat"
+            id={id}
+            value={value}
+            onChange={setValue}
+            onClear={() => setValue({ text: '' })}
+            suggestions={filterSuggestions(
+              makeSuggestions(['Apples', 'Bananas', 'Broccoli', 'Carrots']),
+            )}
+          />
+        );
+      },
+    },
+    {
+      label: 'Grouped suggestions',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState<Value>({ text: '' });
+
+        return (
+          <Autosuggest
+            label="I like to eat"
+            id={id}
+            value={value}
+            onChange={setValue}
+            onClear={() => setValue({ text: '' })}
+            suggestions={filterSuggestions([
+              {
+                label: 'Fruit',
+                suggestions: makeSuggestions(['Apples', 'Bananas']),
+              },
+              {
+                label: 'Vegetables',
+                suggestions: makeSuggestions(['Broccoli', 'Carrots'], 2),
+              },
+            ])}
+          />
+        );
+      },
+    },
+    {
+      label: 'Standard suggestions with an icon',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState<Value>({ text: '' });
+
+        return (
+          <Autosuggest
+            label="I like to eat"
+            id={id}
+            value={value}
+            icon={<IconSearch />}
+            onChange={setValue}
+            onClear={() => setValue({ text: '' })}
+            suggestions={filterSuggestions(
+              makeSuggestions(['Apples', 'Bananas', 'Broccoli', 'Carrots']),
+            )}
+          />
+        );
+      },
+    },
+    {
+      label: 'Autosuggest with error',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState<Value>({ text: '' });
+
+        return (
+          <Autosuggest
+            label="I like to eat"
+            id={id}
+            value={value}
+            onChange={setValue}
+            onClear={() => setValue({ text: '' })}
+            tone="critical"
+            message="You must make a selection"
+            suggestions={filterSuggestions(
+              makeSuggestions(['Apples', 'Bananas', 'Broccoli', 'Carrots']),
+            )}
+          />
+        );
+      },
+    },
+  ],
+};

--- a/lib/components/BackgroundProvider/BackgroundProvider.docs.tsx
+++ b/lib/components/BackgroundProvider/BackgroundProvider.docs.tsx
@@ -6,7 +6,6 @@ import { Box } from '../Box/Box';
 
 const docs: ComponentDocs = {
   category: 'Logic',
-  screenshotWidths: [],
   examples: [
     {
       label: 'Custom dark background',

--- a/lib/components/Badge/Badge.docs.tsx
+++ b/lib/components/Badge/Badge.docs.tsx
@@ -5,7 +5,6 @@ import { Badge, Inline, Heading, Text, TextLink, Strong } from '../';
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Regular Badge',

--- a/lib/components/Badge/Badge.screenshots.tsx
+++ b/lib/components/Badge/Badge.screenshots.tsx
@@ -1,0 +1,112 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Badge, Inline, Heading } from '../';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Regular Badge',
+      background: 'card',
+      Example: () => <Badge tone="positive">Regular</Badge>,
+    },
+    {
+      label: 'Strong Badge',
+      Example: () => (
+        <Badge tone="positive" weight="strong">
+          Strong
+        </Badge>
+      ),
+    },
+    {
+      label: 'Badge with Vertical Bleed',
+      background: 'card',
+      Example: () => (
+        <Inline space="xsmall" alignY="center">
+          <Heading level="4">Heading</Heading>
+          <Badge tone="positive" bleedY>
+            New
+          </Badge>
+        </Inline>
+      ),
+    },
+    {
+      label: 'Positive Badge',
+      background: 'card',
+      Example: () => <Badge tone="positive">Positive</Badge>,
+    },
+    {
+      label: 'Strong Positive Badge',
+      Example: () => (
+        <Badge tone="positive" weight="strong">
+          Positive
+        </Badge>
+      ),
+    },
+    {
+      label: 'Critical Badge',
+      background: 'card',
+      Example: () => <Badge tone="critical">Critical</Badge>,
+    },
+    {
+      label: 'Strong Critical Badge',
+      Example: () => (
+        <Badge tone="critical" weight="strong">
+          Critical
+        </Badge>
+      ),
+    },
+    {
+      label: 'Caution Badge',
+      background: 'card',
+      Example: () => <Badge tone="caution">Caution</Badge>,
+    },
+    {
+      label: 'Strong Caution Badge',
+      Example: () => (
+        <Badge tone="caution" weight="strong">
+          Caution
+        </Badge>
+      ),
+    },
+    {
+      label: 'Info Badge',
+      background: 'card',
+      Example: () => <Badge tone="info">Info</Badge>,
+    },
+    {
+      label: 'Strong Info Badge',
+      Example: () => (
+        <Badge tone="info" weight="strong">
+          Info
+        </Badge>
+      ),
+    },
+    {
+      label: 'Promote Badge',
+      background: 'card',
+      Example: () => <Badge tone="promote">Promote</Badge>,
+    },
+    {
+      label: 'Strong Promote Badge',
+      Example: () => (
+        <Badge tone="promote" weight="strong">
+          Promote
+        </Badge>
+      ),
+    },
+    {
+      label: 'Neutral Badge',
+      background: 'card',
+      Example: () => <Badge tone="neutral">Neutral</Badge>,
+    },
+    {
+      label: 'Strong Neutral Badge',
+      Example: () => (
+        <Badge tone="neutral" weight="strong">
+          Neutral
+        </Badge>
+      ),
+    },
+  ],
+};

--- a/lib/components/Box/Box.docs.tsx
+++ b/lib/components/Box/Box.docs.tsx
@@ -9,7 +9,6 @@ const spaceScale = Object.keys(tokens.space) as Space[];
 
 const docs: ComponentDocs = {
   category: 'Layout',
-  screenshotWidths: [],
   examples: spaceScale.map(
     (space): ComponentExample => ({
       label: `"${space}" space`,

--- a/lib/components/Box/BoxRenderer.docs.tsx
+++ b/lib/components/Box/BoxRenderer.docs.tsx
@@ -5,7 +5,6 @@ import { Text } from '../Text/Text';
 
 const docs: ComponentDocs = {
   category: 'Layout',
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Standard BoxRenderer',

--- a/lib/components/Box/BoxRenderer.screenshots.tsx
+++ b/lib/components/Box/BoxRenderer.screenshots.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { BoxRenderer } from './BoxRenderer';
+import { Text } from '../Text/Text';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Standard BoxRenderer',
+      Example: () => (
+        <BoxRenderer component="ul" background="brand" padding="medium">
+          {(className) => (
+            <ul className={className}>
+              <li>
+                <Text baseline={false}>
+                  This text should be white, and it shouldn&apos;t have a
+                  visible bullet.
+                </Text>
+              </li>
+            </ul>
+          )}
+        </BoxRenderer>
+      ),
+    },
+  ],
+};

--- a/lib/components/BraidLoadableProvider/BraidLoadableProvider.docs.tsx
+++ b/lib/components/BraidLoadableProvider/BraidLoadableProvider.docs.tsx
@@ -2,7 +2,6 @@ import { ComponentDocs } from '../../../site/src/types';
 
 const docs: ComponentDocs = {
   category: 'Logic',
-  screenshotWidths: [],
   examples: [
     {
       code: `

--- a/lib/components/BraidProvider/BraidProvider.docs.tsx
+++ b/lib/components/BraidProvider/BraidProvider.docs.tsx
@@ -5,7 +5,6 @@ import { ComponentDocs } from '../../../site/src/types';
 const docs: ComponentDocs = {
   category: 'Logic',
   migrationGuide: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Selecting a theme',

--- a/lib/components/BraidTestProvider/BraidTestProvider.docs.tsx
+++ b/lib/components/BraidTestProvider/BraidTestProvider.docs.tsx
@@ -14,7 +14,6 @@ const docs: ComponentDocs = {
       </Text>
     </Stack>
   ),
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default usage',

--- a/lib/components/BulletList/BulletList.docs.tsx
+++ b/lib/components/BulletList/BulletList.docs.tsx
@@ -11,7 +11,6 @@ const docs: ComponentDocs = {
     </Text>
   ),
   migrationGuide: false,
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Standard Bullets',
@@ -80,17 +79,6 @@ const docs: ComponentDocs = {
           <Bullet>This is a secondary bullet.</Bullet>
           <Bullet>This is a secondary bullet.</Bullet>
           <Bullet>This is a secondary bullet.</Bullet>
-        </BulletList>
-      ),
-    },
-    {
-      label: 'With TextLink',
-      docsSite: false,
-      Example: () => (
-        <BulletList>
-          <Bullet>
-            This is a text <TextLink href="#">link</TextLink>.
-          </Bullet>
         </BulletList>
       ),
     },

--- a/lib/components/BulletList/BulletList.screenshots.tsx
+++ b/lib/components/BulletList/BulletList.screenshots.tsx
@@ -1,0 +1,89 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Bullet, BulletList, TextLink } from '..';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Standard Bullets',
+      Example: () => (
+        <BulletList>
+          <Bullet>This is a bullet.</Bullet>
+          <Bullet>This is a bullet.</Bullet>
+          <Bullet>This is a bullet.</Bullet>
+        </BulletList>
+      ),
+    },
+    {
+      label: 'Small Bullets',
+      Example: () => (
+        <BulletList size="small">
+          <Bullet>This is a small bullet.</Bullet>
+          <Bullet>This is a small bullet.</Bullet>
+          <Bullet>This is a small bullet.</Bullet>
+        </BulletList>
+      ),
+    },
+    {
+      label: 'Xsmall Bullets',
+      Example: () => (
+        <BulletList size="xsmall">
+          <Bullet>This is an xsmall bullet.</Bullet>
+          <Bullet>This is an xsmall bullet.</Bullet>
+          <Bullet>This is an xsmall bullet.</Bullet>
+        </BulletList>
+      ),
+    },
+    {
+      label: 'Large Bullets',
+      Example: () => (
+        <BulletList size="large">
+          <Bullet>This is a large bullet.</Bullet>
+          <Bullet>This is a large bullet.</Bullet>
+          <Bullet>This is a large bullet.</Bullet>
+        </BulletList>
+      ),
+    },
+    {
+      label: 'Decreased space between Bullets',
+      Example: () => (
+        <BulletList space="xsmall">
+          <Bullet>Decreased space below bullet.</Bullet>
+          <Bullet>Decreased space below bullet.</Bullet>
+          <Bullet>Decreased space below bullet.</Bullet>
+        </BulletList>
+      ),
+    },
+    {
+      label: 'Increased space between Bullets',
+      Example: () => (
+        <BulletList space="xlarge">
+          <Bullet>Increased space below bullet.</Bullet>
+          <Bullet>Increased space below bullet.</Bullet>
+          <Bullet>Increased space below bullet.</Bullet>
+        </BulletList>
+      ),
+    },
+    {
+      label: 'Secondary Tone',
+      Example: () => (
+        <BulletList tone="secondary">
+          <Bullet>This is a secondary bullet.</Bullet>
+          <Bullet>This is a secondary bullet.</Bullet>
+          <Bullet>This is a secondary bullet.</Bullet>
+        </BulletList>
+      ),
+    },
+    {
+      label: 'With TextLink',
+      Example: () => (
+        <BulletList>
+          <Bullet>
+            This is a text <TextLink href="#">link</TextLink>.
+          </Bullet>
+        </BulletList>
+      ),
+    },
+  ],
+};

--- a/lib/components/Button/Button.docs.tsx
+++ b/lib/components/Button/Button.docs.tsx
@@ -1,7 +1,6 @@
-import React, { Fragment, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
-import { Box, Button, Stack, Text, TextLink } from '../';
+import { Button, Stack, Text, TextLink } from '../';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -10,7 +9,6 @@ const Container = ({ children }: { children: ReactNode }) => (
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   description: (
     <Stack space="large">
       <Text>Renders a standard button element.</Text>
@@ -46,27 +44,6 @@ const docs: ComponentDocs = {
       label: 'Loading Button',
       Container,
       Example: () => <Button loading>Loading</Button>,
-      storybook: false,
-    },
-    {
-      label: 'Weak Button Contrast',
-      docsSite: false,
-      Container,
-      Example: () => {
-        const backgrounds = Object.keys(boxBackgrounds) as Array<
-          keyof typeof boxBackgrounds
-        >;
-
-        return (
-          <Fragment>
-            {backgrounds.sort().map((background) => (
-              <Box key={background} background={background} padding="medium">
-                <Button weight="weak">{background}</Button>
-              </Box>
-            ))}
-          </Fragment>
-        );
-      },
     },
   ],
 };

--- a/lib/components/Button/Button.screenshots.tsx
+++ b/lib/components/Button/Button.screenshots.tsx
@@ -1,0 +1,54 @@
+import React, { Fragment, ReactNode } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
+import { Box, Button } from '../';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div style={{ maxWidth: '300px' }}>{children}</div>
+);
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Default Button',
+      Container,
+      Example: () => <Button>Submit</Button>,
+    },
+    {
+      label: 'Strong Button',
+      Container,
+      Example: () => <Button weight="strong">Submit</Button>,
+    },
+    {
+      label: 'Weak Button',
+      Container,
+      Example: () => <Button weight="weak">Submit</Button>,
+    },
+    {
+      label: 'Weak Button on Brand Background',
+      background: 'brand',
+      Container,
+      Example: () => <Button weight="weak">Submit</Button>,
+    },
+    {
+      label: 'Weak Button Contrast',
+      Container,
+      Example: () => {
+        const backgrounds = Object.keys(boxBackgrounds) as Array<
+          keyof typeof boxBackgrounds
+        >;
+
+        return (
+          <Fragment>
+            {backgrounds.sort().map((background) => (
+              <Box key={background} background={background} padding="medium">
+                <Button weight="weak">{background}</Button>
+              </Box>
+            ))}
+          </Fragment>
+        );
+      },
+    },
+  ],
+};

--- a/lib/components/ButtonLink/ButtonLink.docs.tsx
+++ b/lib/components/ButtonLink/ButtonLink.docs.tsx
@@ -10,7 +10,6 @@ const Container = ({ children }: { children: ReactNode }) => (
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   description: (
     <Stack space="large">
       <Text>
@@ -65,7 +64,6 @@ const docs: ComponentDocs = {
           Loading
         </ButtonLink>
       ),
-      storybook: false,
     },
   ],
 };

--- a/lib/components/ButtonLink/ButtonLink.screenshots.tsx
+++ b/lib/components/ButtonLink/ButtonLink.screenshots.tsx
@@ -1,0 +1,36 @@
+import React, { ReactNode } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { ButtonLink } from '../';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div style={{ maxWidth: '300px' }}>{children}</div>
+);
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Default Button Link',
+      Container,
+      Example: () => <ButtonLink href="#">Submit</ButtonLink>,
+    },
+    {
+      label: 'Strong Button Link',
+      Container,
+      Example: () => (
+        <ButtonLink href="#" weight="strong">
+          Submit
+        </ButtonLink>
+      ),
+    },
+    {
+      label: 'Weak Button Link',
+      Container,
+      Example: () => (
+        <ButtonLink href="#" weight="weak">
+          Submit
+        </ButtonLink>
+      ),
+    },
+  ],
+};

--- a/lib/components/ButtonRenderer/ButtonRenderer.docs.tsx
+++ b/lib/components/ButtonRenderer/ButtonRenderer.docs.tsx
@@ -9,7 +9,6 @@ const Container = ({ children }: { children: ReactNode }) => (
 
 const docs: ComponentDocs = {
   category: 'Content',
-  screenshotWidths: [320],
   description: (
     <Stack space="large">
       <Text>

--- a/lib/components/ButtonRenderer/ButtonRenderer.screenshots.tsx
+++ b/lib/components/ButtonRenderer/ButtonRenderer.screenshots.tsx
@@ -1,0 +1,27 @@
+import React, { ReactNode } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Link } from 'react-router-dom';
+import { ButtonRenderer } from '../';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div style={{ maxWidth: '300px' }}>{children}</div>
+);
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Button with Custom Renderer',
+      Container,
+      Example: () => (
+        <ButtonRenderer>
+          {(ButtonChildren, buttonProps) => (
+            <Link to="#" {...buttonProps}>
+              <ButtonChildren>Link button</ButtonChildren>
+            </Link>
+          )}
+        </ButtonRenderer>
+      ),
+    },
+  ],
+};

--- a/lib/components/Card/Card.docs.tsx
+++ b/lib/components/Card/Card.docs.tsx
@@ -5,7 +5,6 @@ import { Card, Text } from '../';
 const docs: ComponentDocs = {
   category: 'Layout',
   migrationGuide: true,
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Default',

--- a/lib/components/Card/Card.screenshots.tsx
+++ b/lib/components/Card/Card.screenshots.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Card, Text } from '../';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Default',
+      Example: () => (
+        <Card>
+          <Text>This text is inside a card.</Text>
+        </Card>
+      ),
+    },
+  ],
+};

--- a/lib/components/Checkbox/Checkbox.docs.tsx
+++ b/lib/components/Checkbox/Checkbox.docs.tsx
@@ -5,7 +5,6 @@ import { Badge, Checkbox, Text } from '../';
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Standard Checkbox',
@@ -88,24 +87,6 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label: 'Checkbox with a Badge and description',
-      docsSite: false,
-      Example: ({ id, handler }) => (
-        <Checkbox
-          id={id}
-          checked={false}
-          onChange={handler}
-          label="Label"
-          badge={
-            <Badge tone="positive" weight="strong">
-              New
-            </Badge>
-          }
-          description="Extra information about the field"
-        />
-      ),
-    },
-    {
       label: 'Checkbox with nested content visible only when checked',
       Example: ({ id }) => {
         const [state, setState] = useState(true);
@@ -120,53 +101,6 @@ const docs: ComponentDocs = {
           </Checkbox>
         );
       },
-    },
-    {
-      label: 'Checkbox with nested content and description',
-      docsSite: false,
-      Example: ({ id, handler }) => (
-        <Checkbox
-          id={id}
-          checked={true}
-          onChange={handler}
-          label="Label"
-          description="Extra information about the field"
-        >
-          <Text>This text is visible when the button is checked.</Text>
-        </Checkbox>
-      ),
-    },
-    {
-      label: 'Checkbox with a message and description',
-      docsSite: false,
-      Example: ({ id, handler }) => (
-        <Checkbox
-          id={id}
-          checked={false}
-          onChange={handler}
-          label="Label"
-          tone="critical"
-          message="This is a critical message"
-          description="Extra information about the field"
-        />
-      ),
-    },
-    {
-      label: 'Checkbox with nested content, a message and description',
-      docsSite: false,
-      Example: ({ id, handler }) => (
-        <Checkbox
-          id={id}
-          checked={true}
-          onChange={handler}
-          label="Label"
-          tone="critical"
-          message="This is a critical message"
-          description="Extra information about the field"
-        >
-          <Text>This text is visible when the button is checked.</Text>
-        </Checkbox>
-      ),
     },
   ],
 };

--- a/lib/components/Checkbox/Checkbox.screenshots.tsx
+++ b/lib/components/Checkbox/Checkbox.screenshots.tsx
@@ -1,0 +1,166 @@
+import React, { useState } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Badge, Checkbox, Text } from '../';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Standard Checkbox',
+      Example: ({ id }) => {
+        const [state, setState] = useState(false);
+        return (
+          <Checkbox
+            id={id}
+            checked={state}
+            onChange={() => setState(!state)}
+            label="Label"
+          />
+        );
+      },
+    },
+    {
+      label: 'Checked Checkbox',
+      Example: ({ id, handler }) => (
+        <Checkbox id={id} checked={true} onChange={handler} label="Label" />
+      ),
+    },
+    {
+      label: 'Mixed state Checkbox',
+      Example: ({ id, handler }) => (
+        <Checkbox id={id} checked="mixed" onChange={handler} label="Label" />
+      ),
+    },
+    {
+      label: 'Disabled Checkbox',
+      background: 'card',
+      Example: ({ id, handler }) => (
+        <Checkbox
+          id={id}
+          disabled={true}
+          checked={false}
+          onChange={handler}
+          label="Label"
+        />
+      ),
+    },
+    {
+      label: 'Critical Checkbox',
+      Example: ({ id, handler }) => (
+        <Checkbox
+          id={id}
+          checked={false}
+          onChange={handler}
+          label="Label"
+          message="This is a critical message"
+          tone="critical"
+        />
+      ),
+    },
+    {
+      label: 'Checkbox with description',
+      Example: ({ id, handler }) => (
+        <Checkbox
+          id={id}
+          checked={false}
+          onChange={handler}
+          label="Label"
+          description="Extra information about the field"
+        />
+      ),
+    },
+    {
+      label: 'Checkbox with a Badge',
+      Example: ({ id, handler }) => (
+        <Checkbox
+          id={id}
+          checked={false}
+          onChange={handler}
+          label="Label"
+          badge={
+            <Badge tone="positive" weight="strong">
+              New
+            </Badge>
+          }
+        />
+      ),
+    },
+    {
+      label: 'Checkbox with a Badge and description',
+      Example: ({ id, handler }) => (
+        <Checkbox
+          id={id}
+          checked={false}
+          onChange={handler}
+          label="Label"
+          badge={
+            <Badge tone="positive" weight="strong">
+              New
+            </Badge>
+          }
+          description="Extra information about the field"
+        />
+      ),
+    },
+    {
+      label: 'Checkbox with nested content visible only when checked',
+      Example: ({ id }) => {
+        const [state, setState] = useState(true);
+        return (
+          <Checkbox
+            id={id}
+            checked={state}
+            onChange={() => setState(!state)}
+            label="Label"
+          >
+            <Text>This text is visible when the checkbox is checked.</Text>
+          </Checkbox>
+        );
+      },
+    },
+    {
+      label: 'Checkbox with nested content and description',
+      Example: ({ id, handler }) => (
+        <Checkbox
+          id={id}
+          checked={true}
+          onChange={handler}
+          label="Label"
+          description="Extra information about the field"
+        >
+          <Text>This text is visible when the button is checked.</Text>
+        </Checkbox>
+      ),
+    },
+    {
+      label: 'Checkbox with a message and description',
+      Example: ({ id, handler }) => (
+        <Checkbox
+          id={id}
+          checked={false}
+          onChange={handler}
+          label="Label"
+          tone="critical"
+          message="This is a critical message"
+          description="Extra information about the field"
+        />
+      ),
+    },
+    {
+      label: 'Checkbox with nested content, a message and description',
+      Example: ({ id, handler }) => (
+        <Checkbox
+          id={id}
+          checked={true}
+          onChange={handler}
+          label="Label"
+          tone="critical"
+          message="This is a critical message"
+          description="Extra information about the field"
+        >
+          <Text>This text is visible when the button is checked.</Text>
+        </Checkbox>
+      ),
+    },
+  ],
+};

--- a/lib/components/Column/Column.docs.tsx
+++ b/lib/components/Column/Column.docs.tsx
@@ -1,6 +1,6 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Columns, Column, Box, Stack } from '../';
+import { Columns, Column, Stack } from '../';
 import { Placeholder } from '../private/Placeholder/Placeholder';
 import { width as columnWidths } from '../Column/Column.treat';
 
@@ -11,8 +11,6 @@ const widths = [
 
 const docs: ComponentDocs = {
   category: 'Layout',
-  screenshotWidths: [320],
-  screenshotOnlyInWireframe: true,
   examples: [
     {
       label: 'Standard Columns',
@@ -45,83 +43,6 @@ const docs: ComponentDocs = {
             </Columns>
           ))}
         </Stack>
-      ),
-    },
-    {
-      label: 'Gutter align',
-      docsSite: false,
-      Example: () => (
-        <Fragment>
-          <Box marginBottom="medium">
-            <Columns space="small">
-              <Column>
-                <Placeholder height={60} label="Fluid" />
-              </Column>
-              <Column>
-                <Placeholder height={60} label="Fluid" />
-              </Column>
-            </Columns>
-          </Box>
-          <Box marginBottom="medium">
-            <Columns space="small">
-              <Column width="1/2">
-                <Placeholder height={60} label="&#189;" />
-              </Column>
-              <Column>
-                <Placeholder height={60} label="Fluid" />
-              </Column>
-            </Columns>
-          </Box>
-          <Box marginBottom="medium">
-            <Columns space="small">
-              <Column width="1/2">
-                <Placeholder height={60} label="&#189;" />
-              </Column>
-              <Column width="1/2">
-                <Placeholder height={60} label="&#189;" />
-              </Column>
-            </Columns>
-          </Box>
-          <Box marginBottom="medium">
-            <Columns space="small">
-              <Column width="1/4">
-                <Placeholder height={60} label="&#188;" />
-              </Column>
-              <Column width="1/4">
-                <Placeholder height={60} label="&#188;" />
-              </Column>
-              <Column>
-                <Placeholder height={60} label="Fluid" />
-              </Column>
-            </Columns>
-          </Box>
-          <Box marginBottom="medium">
-            <Columns space="small">
-              <Column width="1/3">
-                <Placeholder height={60} label="&#8531;" />
-              </Column>
-              <Column width="1/4">
-                <Placeholder height={60} label="&#188;" />
-              </Column>
-              <Column width="content">
-                <Placeholder height={60} label="Content" />
-              </Column>
-            </Columns>
-          </Box>
-          <Box marginBottom="medium">
-            <Columns space="small" reverse>
-              <Column width="1/3">
-                <Placeholder height={60} label="&#8531;" />
-              </Column>
-              <Column width="1/4">
-                <Placeholder height={60} label="&#188;" />
-              </Column>
-              <Column width="content">
-                <Placeholder height={60} label="Content" />
-              </Column>
-            </Columns>
-          </Box>
-        </Fragment>
       ),
     },
   ],

--- a/lib/components/Column/Column.screenshots.tsx
+++ b/lib/components/Column/Column.screenshots.tsx
@@ -1,0 +1,126 @@
+import React, { Fragment } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Columns, Column, Box, Stack } from '../';
+import { Placeholder } from '../private/Placeholder/Placeholder';
+import { width as columnWidths } from '../Column/Column.treat';
+
+const widths = [
+  'content',
+  ...(Object.keys(columnWidths) as Array<keyof typeof columnWidths>),
+] as const;
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  screenshotOnlyInWireframe: true,
+  examples: [
+    {
+      label: 'Standard Columns',
+      Example: () => (
+        <Columns space="small">
+          <Column>
+            <Placeholder height={60} />
+          </Column>
+          <Column>
+            <Placeholder height={60} />
+          </Column>
+          <Column>
+            <Placeholder height={60} />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label: 'Available widths',
+      Example: () => (
+        <Stack space="medium">
+          {widths.map((width) => (
+            <Columns space="small" key={width}>
+              <Column width={width}>
+                <Placeholder height={60} label={width} />
+              </Column>
+              <Column>
+                <Placeholder height={60} label="Fluid" />
+              </Column>
+            </Columns>
+          ))}
+        </Stack>
+      ),
+    },
+    {
+      label: 'Gutter align',
+      Example: () => (
+        <Fragment>
+          <Box marginBottom="medium">
+            <Columns space="small">
+              <Column>
+                <Placeholder height={60} label="Fluid" />
+              </Column>
+              <Column>
+                <Placeholder height={60} label="Fluid" />
+              </Column>
+            </Columns>
+          </Box>
+          <Box marginBottom="medium">
+            <Columns space="small">
+              <Column width="1/2">
+                <Placeholder height={60} label="&#189;" />
+              </Column>
+              <Column>
+                <Placeholder height={60} label="Fluid" />
+              </Column>
+            </Columns>
+          </Box>
+          <Box marginBottom="medium">
+            <Columns space="small">
+              <Column width="1/2">
+                <Placeholder height={60} label="&#189;" />
+              </Column>
+              <Column width="1/2">
+                <Placeholder height={60} label="&#189;" />
+              </Column>
+            </Columns>
+          </Box>
+          <Box marginBottom="medium">
+            <Columns space="small">
+              <Column width="1/4">
+                <Placeholder height={60} label="&#188;" />
+              </Column>
+              <Column width="1/4">
+                <Placeholder height={60} label="&#188;" />
+              </Column>
+              <Column>
+                <Placeholder height={60} label="Fluid" />
+              </Column>
+            </Columns>
+          </Box>
+          <Box marginBottom="medium">
+            <Columns space="small">
+              <Column width="1/3">
+                <Placeholder height={60} label="&#8531;" />
+              </Column>
+              <Column width="1/4">
+                <Placeholder height={60} label="&#188;" />
+              </Column>
+              <Column width="content">
+                <Placeholder height={60} label="Content" />
+              </Column>
+            </Columns>
+          </Box>
+          <Box marginBottom="medium">
+            <Columns space="small" reverse>
+              <Column width="1/3">
+                <Placeholder height={60} label="&#8531;" />
+              </Column>
+              <Column width="1/4">
+                <Placeholder height={60} label="&#188;" />
+              </Column>
+              <Column width="content">
+                <Placeholder height={60} label="Content" />
+              </Column>
+            </Columns>
+          </Box>
+        </Fragment>
+      ),
+    },
+  ],
+};

--- a/lib/components/Columns/Columns.docs.tsx
+++ b/lib/components/Columns/Columns.docs.tsx
@@ -6,8 +6,6 @@ import { Columns, Column } from '../';
 const docs: ComponentDocs = {
   category: 'Layout',
   migrationGuide: true,
-  screenshotWidths: [320, 768, 1200],
-  screenshotOnlyInWireframe: true,
   examples: [
     {
       label: 'No space',
@@ -49,36 +47,6 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label:
-        'Responsive space with `none` below tablet, e.g. ["none", "gutter"]',
-      docsSite: false,
-      Example: () => (
-        <Columns space={['none', 'gutter']}>
-          <Column>
-            <Placeholder height={60} />
-          </Column>
-          <Column>
-            <Placeholder height={60} />
-          </Column>
-        </Columns>
-      ),
-    },
-    {
-      label:
-        'Responsive space with `none` above mobile, e.g. ["small", "none"]',
-      docsSite: false,
-      Example: () => (
-        <Columns space={['small', 'none']}>
-          <Column>
-            <Placeholder height={60} />
-          </Column>
-          <Column>
-            <Placeholder height={60} />
-          </Column>
-        </Columns>
-      ),
-    },
-    {
       label: 'Vertically align to center',
       Example: () => (
         <Columns space="small" alignY="center">
@@ -109,20 +77,6 @@ const docs: ComponentDocs = {
         'Responsive alignment (e.g. top on mobile, center on tablet upwards)',
       Example: () => (
         <Columns space="small" alignY={['top', 'center']}>
-          <Column>
-            <Placeholder height={60} />
-          </Column>
-          <Column>
-            <Placeholder height={100} />
-          </Column>
-        </Columns>
-      ),
-    },
-    {
-      label: 'Alignment + collapse',
-      docsSite: false,
-      Example: () => (
-        <Columns space="small" collapseBelow="tablet" alignY="center">
           <Column>
             <Placeholder height={60} />
           </Column>
@@ -213,66 +167,6 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label:
-        'Collapse below tablet with responsive space and `none` below tablet, e.g. ["none", "gutter"]',
-      docsSite: false,
-      Example: () => (
-        <Columns space={['none', 'gutter']} collapseBelow="tablet">
-          <Column>
-            <Placeholder height={60} label="First" />
-          </Column>
-          <Column>
-            <Placeholder height={60} label="Second" />
-          </Column>
-        </Columns>
-      ),
-    },
-    {
-      label:
-        'Collapse below desktop with responsive space and `none` below desktop, e.g. ["none", "xsmall", gutter"]',
-      docsSite: false,
-      Example: () => (
-        <Columns space={['none', 'xsmall', 'gutter']} collapseBelow="desktop">
-          <Column>
-            <Placeholder height={60} label="First" />
-          </Column>
-          <Column>
-            <Placeholder height={60} label="Second" />
-          </Column>
-        </Columns>
-      ),
-    },
-    {
-      label:
-        'Collapse below tablet with responsive space and `none` above mobile, e.g. ["small", "none"]',
-      docsSite: false,
-      Example: () => (
-        <Columns space={['small', 'none']} collapseBelow="tablet">
-          <Column>
-            <Placeholder height={60} label="First" />
-          </Column>
-          <Column>
-            <Placeholder height={60} label="Second" />
-          </Column>
-        </Columns>
-      ),
-    },
-    {
-      label:
-        'Collapse below desktop with responsive space and `none` above tablet, e.g. ["small", "medium, "none"]',
-      docsSite: false,
-      Example: () => (
-        <Columns space={['small', 'medium', 'none']} collapseBelow="desktop">
-          <Column>
-            <Placeholder height={60} label="First" />
-          </Column>
-          <Column>
-            <Placeholder height={60} label="Second" />
-          </Column>
-        </Columns>
-      ),
-    },
-    {
       label: 'Reverse',
       Example: () => (
         <Columns space="small" reverse>
@@ -280,102 +174,6 @@ const docs: ComponentDocs = {
             <Placeholder height={60} label="First" />
           </Column>
           <Column>
-            <Placeholder height={60} label="Second" />
-          </Column>
-        </Columns>
-      ),
-    },
-    {
-      label:
-        'Test: Collapsed "content" columns should be full width when setting "alignY"',
-      docsSite: false,
-      Example: () => (
-        <Columns space="small" alignY="bottom" collapseBelow="tablet">
-          <Column>
-            <Placeholder height={60} label="No width" />
-          </Column>
-          <Column width="1/2">
-            <Placeholder height={100} label="1/2 width" />
-          </Column>
-          <Column width="content">
-            <Placeholder height={140} label="Content width" />
-          </Column>
-        </Columns>
-      ),
-    },
-    {
-      label:
-        'Test - collapseBelow + align: On mobile should be vertical and left aligned, on tablet should be horizontal and centre aligned, on desktop should be horizontal and right aligned',
-      docsSite: false,
-      Example: () => (
-        <Columns
-          space="small"
-          collapseBelow="tablet"
-          align={['left', 'center', 'right']}
-        >
-          <Column width="1/3">
-            <Placeholder height={60} label="First" />
-          </Column>
-          <Column width="1/3">
-            <Placeholder height={60} label="Second" />
-          </Column>
-        </Columns>
-      ),
-    },
-    {
-      label:
-        'Test - collapseBelow + align: On mobile should be vertical and left aligned, on tablet should be horizontal and centre aligned, on desktop should be horizontal and right aligned',
-      docsSite: false,
-      Example: () => (
-        <Columns
-          space="small"
-          collapseBelow="desktop"
-          align={['left', 'center', 'right']}
-        >
-          <Column width="1/3">
-            <Placeholder height={60} label="First" />
-          </Column>
-          <Column width="1/3">
-            <Placeholder height={60} label="Second" />
-          </Column>
-        </Columns>
-      ),
-    },
-    {
-      label:
-        'Test - collapseBelow + align + reverse: On mobile should be vertical and left aligned, on tablet should be reversed horizontally and centre aligned, on desktop should be reversed horizontally and right aligned',
-      docsSite: false,
-      Example: () => (
-        <Columns
-          space="small"
-          collapseBelow="tablet"
-          align={['left', 'center', 'right']}
-          reverse
-        >
-          <Column width="1/3">
-            <Placeholder height={60} label="First" />
-          </Column>
-          <Column width="1/3">
-            <Placeholder height={60} label="Second" />
-          </Column>
-        </Columns>
-      ),
-    },
-    {
-      label:
-        'Test - collapseBelow + align + reverse: On mobile should be vertical and left aligned, on tablet should be vertical and centre aligned, on desktop should be reversed horizontally and right aligned',
-      docsSite: false,
-      Example: () => (
-        <Columns
-          space="small"
-          collapseBelow="desktop"
-          align={['left', 'center', 'right']}
-          reverse
-        >
-          <Column width="1/3">
-            <Placeholder height={60} label="First" />
-          </Column>
-          <Column width="1/3">
             <Placeholder height={60} label="Second" />
           </Column>
         </Columns>

--- a/lib/components/Columns/Columns.screenshots.tsx
+++ b/lib/components/Columns/Columns.screenshots.tsx
@@ -1,0 +1,371 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Placeholder } from '../private/Placeholder/Placeholder';
+import { Columns, Column } from '../';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320, 768, 1200],
+  screenshotOnlyInWireframe: true,
+  examples: [
+    {
+      label: 'No space',
+      Example: () => (
+        <Columns space="none">
+          <Column>
+            <Placeholder height={60} />
+          </Column>
+          <Column>
+            <Placeholder height={60} />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label: 'Custom space, e.g. small',
+      Example: () => (
+        <Columns space="small">
+          <Column>
+            <Placeholder height={60} />
+          </Column>
+          <Column>
+            <Placeholder height={60} />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label: 'Responsive space, e.g. ["small", "large"]',
+      Example: () => (
+        <Columns space={['small', 'large']}>
+          <Column>
+            <Placeholder height={60} />
+          </Column>
+          <Column>
+            <Placeholder height={60} />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label:
+        'Responsive space with `none` below tablet, e.g. ["none", "gutter"]',
+      Example: () => (
+        <Columns space={['none', 'gutter']}>
+          <Column>
+            <Placeholder height={60} />
+          </Column>
+          <Column>
+            <Placeholder height={60} />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label:
+        'Responsive space with `none` above mobile, e.g. ["small", "none"]',
+      Example: () => (
+        <Columns space={['small', 'none']}>
+          <Column>
+            <Placeholder height={60} />
+          </Column>
+          <Column>
+            <Placeholder height={60} />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label: 'Vertically align to center',
+      Example: () => (
+        <Columns space="small" alignY="center">
+          <Column>
+            <Placeholder height={60} />
+          </Column>
+          <Column>
+            <Placeholder height={100} />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label: 'Vertically align to bottom',
+      Example: () => (
+        <Columns space="small" alignY="bottom">
+          <Column>
+            <Placeholder height={60} />
+          </Column>
+          <Column>
+            <Placeholder height={100} />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label:
+        'Responsive alignment (e.g. top on mobile, center on tablet upwards)',
+      Example: () => (
+        <Columns space="small" alignY={['top', 'center']}>
+          <Column>
+            <Placeholder height={60} />
+          </Column>
+          <Column>
+            <Placeholder height={100} />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label: 'Alignment + collapse',
+      Example: () => (
+        <Columns space="small" collapseBelow="tablet" alignY="center">
+          <Column>
+            <Placeholder height={60} />
+          </Column>
+          <Column>
+            <Placeholder height={100} />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label: 'Collapse below tablet',
+      Example: () => (
+        <Columns space="small" collapseBelow="tablet">
+          <Column>
+            <Placeholder height={60} label="First" />
+          </Column>
+          <Column>
+            <Placeholder height={60} label="Second" />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label: 'Collapse below desktop',
+      Example: () => (
+        <Columns space="small" collapseBelow="desktop">
+          <Column>
+            <Placeholder height={60} label="First" />
+          </Column>
+          <Column>
+            <Placeholder height={60} label="Second" />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label: 'Collapse below tablet with custom space, e.g. "small"',
+      Example: () => (
+        <Columns space="small" collapseBelow="tablet">
+          <Column>
+            <Placeholder height={60} label="First" />
+          </Column>
+          <Column>
+            <Placeholder height={60} label="Second" />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label: 'Collapse below desktop with custom space, e.g. "small"',
+      Example: () => (
+        <Columns space="small" collapseBelow="desktop">
+          <Column>
+            <Placeholder height={60} label="First" />
+          </Column>
+          <Column>
+            <Placeholder height={60} label="Second" />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label:
+        'Collapse below tablet with responsive space, e.g. ["small", "large"]',
+      Example: () => (
+        <Columns space={['small', 'large']} collapseBelow="tablet">
+          <Column>
+            <Placeholder height={60} label="First" />
+          </Column>
+          <Column>
+            <Placeholder height={60} label="Second" />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label:
+        'Collapse below desktop with responsive space, e.g. ["small", "medium", "xlarge"]',
+      Example: () => (
+        <Columns space={['small', 'medium', 'xlarge']} collapseBelow="desktop">
+          <Column>
+            <Placeholder height={60} label="First" />
+          </Column>
+          <Column>
+            <Placeholder height={60} label="Second" />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label:
+        'Collapse below tablet with responsive space and `none` below tablet, e.g. ["none", "gutter"]',
+      Example: () => (
+        <Columns space={['none', 'gutter']} collapseBelow="tablet">
+          <Column>
+            <Placeholder height={60} label="First" />
+          </Column>
+          <Column>
+            <Placeholder height={60} label="Second" />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label:
+        'Collapse below desktop with responsive space and `none` below desktop, e.g. ["none", "xsmall", gutter"]',
+      Example: () => (
+        <Columns space={['none', 'xsmall', 'gutter']} collapseBelow="desktop">
+          <Column>
+            <Placeholder height={60} label="First" />
+          </Column>
+          <Column>
+            <Placeholder height={60} label="Second" />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label:
+        'Collapse below tablet with responsive space and `none` above mobile, e.g. ["small", "none"]',
+      Example: () => (
+        <Columns space={['small', 'none']} collapseBelow="tablet">
+          <Column>
+            <Placeholder height={60} label="First" />
+          </Column>
+          <Column>
+            <Placeholder height={60} label="Second" />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label:
+        'Collapse below desktop with responsive space and `none` above tablet, e.g. ["small", "medium, "none"]',
+      Example: () => (
+        <Columns space={['small', 'medium', 'none']} collapseBelow="desktop">
+          <Column>
+            <Placeholder height={60} label="First" />
+          </Column>
+          <Column>
+            <Placeholder height={60} label="Second" />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label: 'Reverse',
+      Example: () => (
+        <Columns space="small" reverse>
+          <Column>
+            <Placeholder height={60} label="First" />
+          </Column>
+          <Column>
+            <Placeholder height={60} label="Second" />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label:
+        'Test: Collapsed "content" columns should be full width when setting "alignY"',
+      Example: () => (
+        <Columns space="small" alignY="bottom" collapseBelow="tablet">
+          <Column>
+            <Placeholder height={60} label="No width" />
+          </Column>
+          <Column width="1/2">
+            <Placeholder height={100} label="1/2 width" />
+          </Column>
+          <Column width="content">
+            <Placeholder height={140} label="Content width" />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label:
+        'Test - collapseBelow + align: On mobile should be vertical and left aligned, on tablet should be horizontal and centre aligned, on desktop should be horizontal and right aligned',
+      Example: () => (
+        <Columns
+          space="small"
+          collapseBelow="tablet"
+          align={['left', 'center', 'right']}
+        >
+          <Column width="1/3">
+            <Placeholder height={60} label="First" />
+          </Column>
+          <Column width="1/3">
+            <Placeholder height={60} label="Second" />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label:
+        'Test - collapseBelow + align: On mobile should be vertical and left aligned, on tablet should be horizontal and centre aligned, on desktop should be horizontal and right aligned',
+      Example: () => (
+        <Columns
+          space="small"
+          collapseBelow="desktop"
+          align={['left', 'center', 'right']}
+        >
+          <Column width="1/3">
+            <Placeholder height={60} label="First" />
+          </Column>
+          <Column width="1/3">
+            <Placeholder height={60} label="Second" />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label:
+        'Test - collapseBelow + align + reverse: On mobile should be vertical and left aligned, on tablet should be reversed horizontally and centre aligned, on desktop should be reversed horizontally and right aligned',
+      Example: () => (
+        <Columns
+          space="small"
+          collapseBelow="tablet"
+          align={['left', 'center', 'right']}
+          reverse
+        >
+          <Column width="1/3">
+            <Placeholder height={60} label="First" />
+          </Column>
+          <Column width="1/3">
+            <Placeholder height={60} label="Second" />
+          </Column>
+        </Columns>
+      ),
+    },
+    {
+      label:
+        'Test - collapseBelow + align + reverse: On mobile should be vertical and left aligned, on tablet should be vertical and centre aligned, on desktop should be reversed horizontally and right aligned',
+      Example: () => (
+        <Columns
+          space="small"
+          collapseBelow="desktop"
+          align={['left', 'center', 'right']}
+          reverse
+        >
+          <Column width="1/3">
+            <Placeholder height={60} label="First" />
+          </Column>
+          <Column width="1/3">
+            <Placeholder height={60} label="Second" />
+          </Column>
+        </Columns>
+      ),
+    },
+  ],
+};

--- a/lib/components/ContentBlock/ContentBlock.docs.tsx
+++ b/lib/components/ContentBlock/ContentBlock.docs.tsx
@@ -5,7 +5,6 @@ import { ContentBlock } from '../';
 
 const docs: ComponentDocs = {
   category: 'Layout',
-  screenshotWidths: [320, 1200],
   examples: [
     {
       label: 'Default Content Block',

--- a/lib/components/ContentBlock/ContentBlock.screenshots.tsx
+++ b/lib/components/ContentBlock/ContentBlock.screenshots.tsx
@@ -1,0 +1,50 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Placeholder } from '../private/Placeholder/Placeholder';
+import { ContentBlock } from '../';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320, 1200],
+  examples: [
+    {
+      label: 'Default Content Block',
+      Example: () => (
+        <ContentBlock>
+          <Placeholder height={100} />
+        </ContentBlock>
+      ),
+    },
+    {
+      label: 'Xsmall Content Block',
+      Example: () => (
+        <ContentBlock width="xsmall">
+          <Placeholder height={100} />
+        </ContentBlock>
+      ),
+    },
+    {
+      label: 'Small Content Block',
+      Example: () => (
+        <ContentBlock width="small">
+          <Placeholder height={100} />
+        </ContentBlock>
+      ),
+    },
+    {
+      label: 'Medium Content Block',
+      Example: () => (
+        <ContentBlock width="medium">
+          <Placeholder height={100} />
+        </ContentBlock>
+      ),
+    },
+    {
+      label: 'Large Content Block',
+      Example: () => (
+        <ContentBlock width="large">
+          <Placeholder height={100} />
+        </ContentBlock>
+      ),
+    },
+  ],
+};

--- a/lib/components/Dialog/Dialog.docs.tsx
+++ b/lib/components/Dialog/Dialog.docs.tsx
@@ -14,11 +14,9 @@ import {
   Strong,
 } from '../';
 import { Placeholder } from '../../playroom/components';
-import { DialogContent } from './Dialog';
 
 const docs: ComponentDocs = {
   category: 'Content',
-  screenshotWidths: [320, 1200],
   description: (
     <Stack space="large">
       <Text>
@@ -51,7 +49,6 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Default',
-      storybook: false,
       Example: ({ id, getState, toggleState }) =>
         source(
           <>
@@ -74,7 +71,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'With illustration/logo',
-      storybook: false,
       Example: ({ id, getState, toggleState }) =>
         source(
           <>
@@ -110,7 +106,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'With additional description',
-      storybook: false,
       Example: ({ id, getState, toggleState }) =>
         source(
           <>
@@ -138,7 +133,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'With scrolling content',
-      storybook: false,
       Example: ({ id, getState, toggleState }) =>
         source(
           <>
@@ -165,7 +159,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Sized to content',
-      storybook: false,
       Example: ({ id, getState, toggleState }) =>
         source(
           <>
@@ -189,7 +182,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Xsmall width',
-      storybook: false,
       Example: ({ id, getState, toggleState }) =>
         source(
           <>
@@ -224,7 +216,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Small width',
-      storybook: false,
       Example: ({ id, getState, toggleState }) =>
         source(
           <>
@@ -259,7 +250,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Medium width',
-      storybook: false,
       Example: ({ id, getState, toggleState }) =>
         source(
           <>
@@ -294,7 +284,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Large width',
-      storybook: false,
       Example: ({ id, getState, toggleState }) =>
         source(
           <>
@@ -323,178 +312,6 @@ const docs: ComponentDocs = {
                   </>
                 }
               />
-            </Dialog>
-          </>,
-        ),
-    },
-
-    // Layout examples
-    {
-      label: 'Default layout',
-      docsSite: false,
-      Example: ({ id }) => (
-        <DialogContent
-          id={id}
-          title="Default test"
-          onClose={() => {}}
-          scrollLock={false}
-        >
-          <Placeholder height={100} width="100%" />
-        </DialogContent>
-      ),
-    },
-    {
-      label: 'Illustration layout',
-      docsSite: false,
-      Example: ({ id }) => (
-        <DialogContent
-          id={id}
-          title="Illustration test"
-          illustration={
-            <Placeholder
-              height={150}
-              width={150}
-              shape="round"
-              label="Illustration"
-            />
-          }
-          onClose={() => {}}
-          scrollLock={false}
-        >
-          <Stack space="xlarge" align="center">
-            <Placeholder width="100%" height={100} />
-            <Inline space="small">
-              <Placeholder height={44} width={80} label="OK" />
-              <Placeholder height={44} width={80} label="Cancel" />
-            </Inline>
-          </Stack>
-        </DialogContent>
-      ),
-    },
-    {
-      label: 'Layout with a description',
-      docsSite: false,
-      Example: ({ id }) => (
-        <DialogContent
-          id={id}
-          title="Description test"
-          description={
-            <Placeholder height="auto" width="100%" label="Description" />
-          }
-          onClose={() => {}}
-          scrollLock={false}
-        >
-          <Placeholder height={100} width="100%" />
-        </DialogContent>
-      ),
-    },
-    {
-      label: 'Layout: Content width',
-      docsSite: false,
-      Example: ({ id }) => (
-        <Box display="flex" alignItems="center" justifyContent="center">
-          <DialogContent
-            id={id}
-            title="Content-sized"
-            width="content"
-            onClose={() => {}}
-            scrollLock={false}
-          >
-            <Placeholder height={100} width={200} label="200px wide" />
-          </DialogContent>
-        </Box>
-      ),
-    },
-    {
-      label: 'Layout: Xsmall width',
-      docsSite: false,
-      Example: ({ id }) => (
-        <DialogContent
-          id={id}
-          title="Xsmall"
-          width="xsmall"
-          onClose={() => {}}
-          scrollLock={false}
-        >
-          <Placeholder height={100} width="100%" label="Xsmall Dialog" />
-        </DialogContent>
-      ),
-    },
-    {
-      label: 'Layout: Small width',
-      docsSite: false,
-      Example: ({ id }) => (
-        <DialogContent
-          id={id}
-          title="Small"
-          width="small"
-          onClose={() => {}}
-          scrollLock={false}
-        >
-          <Placeholder height={100} width="100%" label="Small Dialog" />
-        </DialogContent>
-      ),
-    },
-    {
-      label: 'Layout: Medium width',
-      docsSite: false,
-      Example: ({ id }) => (
-        <DialogContent
-          id={id}
-          title="Medium"
-          width="medium"
-          onClose={() => {}}
-          scrollLock={false}
-        >
-          <Placeholder height={100} width="100%" label="Medium Dialog" />
-        </DialogContent>
-      ),
-    },
-    {
-      label: 'Layout:: Large width',
-      docsSite: false,
-      Example: ({ id }) => (
-        <DialogContent
-          id={id}
-          title="Large"
-          width="large"
-          onClose={() => {}}
-          scrollLock={false}
-        >
-          <Placeholder height={100} width="100%" label="Large Dialog" />
-        </DialogContent>
-      ),
-    },
-    {
-      label: 'Preview animation',
-      storybook: false,
-      docsSite: false,
-      Example: ({ getState, setState, resetState }) =>
-        source(
-          <>
-            <Inline space="small" align="center">
-              <Button onClick={() => setState('width', 'xsmall')}>
-                Open xsmall
-              </Button>
-              <Button onClick={() => setState('width', 'small')}>
-                Open small
-              </Button>
-              <Button onClick={() => setState('width', 'medium')}>
-                Open medium
-              </Button>
-              <Button onClick={() => setState('width', 'large')}>
-                Open large
-              </Button>
-            </Inline>
-
-            <Dialog
-              id="dialog-animation-example"
-              title={`A \"${getState('width')}\" dialog`}
-              width={getState('width')}
-              open={getState('width')}
-              onClose={() => resetState('width')}
-            >
-              <Placeholder height={200} width="100%" />
             </Dialog>
           </>,
         ),

--- a/lib/components/Dialog/Dialog.screenshots.tsx
+++ b/lib/components/Dialog/Dialog.screenshots.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Inline, Stack, Box } from '../';
+import { Placeholder } from '../../playroom/components';
+import { DialogContent } from './Dialog';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320, 1200],
+  examples: [
+    {
+      label: 'Default layout',
+      Example: ({ id }) => (
+        <DialogContent
+          id={id}
+          title="Default test"
+          onClose={() => {}}
+          scrollLock={false}
+        >
+          <Placeholder height={100} width="100%" />
+        </DialogContent>
+      ),
+    },
+    {
+      label: 'Illustration layout',
+      Example: ({ id }) => (
+        <DialogContent
+          id={id}
+          title="Illustration test"
+          illustration={
+            <Placeholder
+              height={150}
+              width={150}
+              shape="round"
+              label="Illustration"
+            />
+          }
+          onClose={() => {}}
+          scrollLock={false}
+        >
+          <Stack space="xlarge" align="center">
+            <Placeholder width="100%" height={100} />
+            <Inline space="small">
+              <Placeholder height={44} width={80} label="OK" />
+              <Placeholder height={44} width={80} label="Cancel" />
+            </Inline>
+          </Stack>
+        </DialogContent>
+      ),
+    },
+    {
+      label: 'Layout with a description',
+      Example: ({ id }) => (
+        <DialogContent
+          id={id}
+          title="Description test"
+          description={
+            <Placeholder height="auto" width="100%" label="Description" />
+          }
+          onClose={() => {}}
+          scrollLock={false}
+        >
+          <Placeholder height={100} width="100%" />
+        </DialogContent>
+      ),
+    },
+    {
+      label: 'Layout: Content width',
+      Example: ({ id }) => (
+        <Box display="flex" alignItems="center" justifyContent="center">
+          <DialogContent
+            id={id}
+            title="Content-sized"
+            width="content"
+            onClose={() => {}}
+            scrollLock={false}
+          >
+            <Placeholder height={100} width={200} label="200px wide" />
+          </DialogContent>
+        </Box>
+      ),
+    },
+    {
+      label: 'Layout: Xsmall width',
+      Example: ({ id }) => (
+        <DialogContent
+          id={id}
+          title="Xsmall"
+          width="xsmall"
+          onClose={() => {}}
+          scrollLock={false}
+        >
+          <Placeholder height={100} width="100%" label="Xsmall Dialog" />
+        </DialogContent>
+      ),
+    },
+    {
+      label: 'Layout: Small width',
+      Example: ({ id }) => (
+        <DialogContent
+          id={id}
+          title="Small"
+          width="small"
+          onClose={() => {}}
+          scrollLock={false}
+        >
+          <Placeholder height={100} width="100%" label="Small Dialog" />
+        </DialogContent>
+      ),
+    },
+    {
+      label: 'Layout: Medium width',
+      Example: ({ id }) => (
+        <DialogContent
+          id={id}
+          title="Medium"
+          width="medium"
+          onClose={() => {}}
+          scrollLock={false}
+        >
+          <Placeholder height={100} width="100%" label="Medium Dialog" />
+        </DialogContent>
+      ),
+    },
+    {
+      label: 'Layout:: Large width',
+      Example: ({ id }) => (
+        <DialogContent
+          id={id}
+          title="Large"
+          width="large"
+          onClose={() => {}}
+          scrollLock={false}
+        >
+          <Placeholder height={100} width="100%" label="Large Dialog" />
+        </DialogContent>
+      ),
+    },
+  ],
+};

--- a/lib/components/Disclosure/Disclosure.docs.tsx
+++ b/lib/components/Disclosure/Disclosure.docs.tsx
@@ -5,7 +5,6 @@ import { Disclosure, Stack, Text, TextLink } from '..';
 
 const docs: ComponentDocs = {
   category: 'Content',
-  screenshotWidths: [320],
   migrationGuide: true,
   description: (
     <Stack space="large">
@@ -78,7 +77,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Disclosure with controlled state',
-      storybook: false,
       playroom: false,
       Example: ({ id }) => {
         const [expanded, setExpanded] = React.useState(false);

--- a/lib/components/Disclosure/Disclosure.screenshots.tsx
+++ b/lib/components/Disclosure/Disclosure.screenshots.tsx
@@ -1,0 +1,58 @@
+import React, { useState } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Disclosure, Text } from '..';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Collapsed Disclosure',
+      Example: ({ id }) => (
+        <Disclosure
+          id={id}
+          expandLabel="Show content"
+          collapseLabel="Hide content"
+        >
+          <Text>Content</Text>
+        </Disclosure>
+      ),
+    },
+    {
+      label: 'Expanded Disclosure',
+      Example: ({ id }) => {
+        const [expanded, setExpanded] = useState(true);
+
+        return (
+          <Disclosure
+            id={id}
+            expandLabel="Show content"
+            collapseLabel="Hide content"
+            expanded={expanded}
+            onToggle={setExpanded}
+          >
+            <Text>Content</Text>
+          </Disclosure>
+        );
+      },
+    },
+    {
+      label: 'Expanded Disclosure with custom space',
+      Example: ({ id }) => {
+        const [expanded, setExpanded] = useState(true);
+
+        return (
+          <Disclosure
+            id={id}
+            expandLabel="Show content"
+            collapseLabel="Hide content"
+            space="small"
+            expanded={expanded}
+            onToggle={setExpanded}
+          >
+            <Text>Content</Text>
+          </Disclosure>
+        );
+      },
+    },
+  ],
+};

--- a/lib/components/Divider/Divider.docs.tsx
+++ b/lib/components/Divider/Divider.docs.tsx
@@ -4,7 +4,6 @@ import { Divider } from '../';
 
 const docs: ComponentDocs = {
   category: 'Layout',
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Divider',

--- a/lib/components/Divider/Divider.screenshots.tsx
+++ b/lib/components/Divider/Divider.screenshots.tsx
@@ -1,0 +1,17 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Divider } from '../';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Divider',
+      Example: () => <Divider />,
+    },
+    {
+      label: 'Strong Divider',
+      Example: () => <Divider weight="strong" />,
+    },
+  ],
+};

--- a/lib/components/Drawer/Drawer.docs.tsx
+++ b/lib/components/Drawer/Drawer.docs.tsx
@@ -1,22 +1,11 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import source from '../../utils/source.macro';
-import {
-  Actions,
-  Drawer,
-  Button,
-  Inline,
-  Text,
-  Stack,
-  TextLink,
-  Strong,
-} from '..';
+import { Actions, Drawer, Button, Text, Stack, TextLink, Strong } from '..';
 import { Placeholder } from '../../playroom/components';
-import { DrawerContent } from './Drawer';
 
 const docs: ComponentDocs = {
   category: 'Content',
-  screenshotWidths: [320, 1200],
   description: (
     <Stack space="large">
       <Text>
@@ -48,7 +37,6 @@ const docs: ComponentDocs = {
   examples: [
     {
       label: 'Default',
-      storybook: false,
       Example: ({ getState, toggleState }) =>
         source(
           <>
@@ -85,7 +73,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'With additional description',
-      storybook: false,
       Example: ({ getState, toggleState }) =>
         source(
           <>
@@ -127,7 +114,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Small width',
-      storybook: false,
       Example: ({ getState, toggleState }) =>
         source(
           <>
@@ -173,7 +159,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Medium width',
-      storybook: false,
       Example: ({ getState, toggleState }) =>
         source(
           <>
@@ -219,7 +204,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Large width',
-      storybook: false,
       Example: ({ getState, toggleState }) =>
         source(
           <>
@@ -243,138 +227,6 @@ const docs: ComponentDocs = {
               width="large"
               open={getState('drawer')}
               onClose={() => toggleState('drawer')}
-            >
-              <Placeholder height={100} width="100%" />
-              <Placeholder height={100} width="100%" />
-              <Placeholder height={100} width="100%" />
-              <Placeholder height={100} width="100%" />
-              <Placeholder height={100} width="100%" />
-              <Placeholder height={100} width="100%" />
-              <Placeholder height={100} width="100%" />
-              <Placeholder height={100} width="100%" />
-              <Placeholder height={100} width="100%" />
-              <Placeholder height={100} width="100%" />
-              <Placeholder height={100} width="100%" />
-              <Placeholder height={100} width="100%" />
-              <Placeholder height={100} width="100%" />
-              <Placeholder height={100} width="100%" />
-              <Placeholder height={100} width="100%" />
-            </Drawer>
-          </>,
-        ),
-    },
-
-    // Layout examples
-    {
-      label: 'Default layout',
-      docsSite: false,
-      Example: ({ id }) => (
-        <DrawerContent
-          id={id}
-          title="Default test"
-          onClose={() => {}}
-          width="medium"
-          scrollLock={false}
-        >
-          <Placeholder height={100} width="100%" />
-        </DrawerContent>
-      ),
-    },
-    {
-      label: 'Layout with a description',
-      docsSite: false,
-      Example: ({ id }) => (
-        <DrawerContent
-          id={id}
-          title="Description test"
-          description={
-            <Placeholder height="auto" width="100%" label="Description" />
-          }
-          onClose={() => {}}
-          scrollLock={false}
-        >
-          <Placeholder height={100} width="100%" />
-        </DrawerContent>
-      ),
-    },
-    {
-      label: 'Layout: Small width',
-      docsSite: false,
-      Example: ({ id }) => (
-        <DrawerContent
-          id={id}
-          title="Small"
-          width="small"
-          onClose={() => {}}
-          scrollLock={false}
-        >
-          <Placeholder height={100} width="100%" label="Small Drawer" />
-        </DrawerContent>
-      ),
-    },
-    {
-      label: 'Layout: Medium width',
-      docsSite: false,
-      Example: ({ id }) => (
-        <DrawerContent
-          id={id}
-          title="Medium"
-          width="medium"
-          onClose={() => {}}
-          scrollLock={false}
-        >
-          <Placeholder height={100} width="100%" label="Medium Drawer" />
-        </DrawerContent>
-      ),
-    },
-    {
-      label: 'Layout: Large width',
-      docsSite: false,
-      Example: ({ id }) => (
-        <DrawerContent
-          id={id}
-          title="Large"
-          width="large"
-          onClose={() => {}}
-          scrollLock={false}
-        >
-          <Placeholder height={100} width="100%" label="Large Drawer" />
-        </DrawerContent>
-      ),
-    },
-    {
-      label: 'Preview animation',
-      storybook: false,
-      docsSite: false,
-      Example: ({ getState, setState, resetState }) =>
-        source(
-          <>
-            <Inline space="small" align="center">
-              <Button onClick={() => setState('width', 'small')}>
-                Open small
-              </Button>
-              <Button onClick={() => setState('width', 'medium')}>
-                Open medium
-              </Button>
-              <Button onClick={() => setState('width', 'large')}>
-                Open large
-              </Button>
-            </Inline>
-
-            <Drawer
-              id="drawer-animation-example"
-              title={`A \"${getState('width')}\" drawer`}
-              description={
-                <Text tone="secondary">
-                  Uses a {getState('width')}{' '}
-                  <TextLink href="/components/ContentBlock">
-                    ContentBlock
-                  </TextLink>
-                </Text>
-              }
-              width={getState('width')}
-              open={getState('width')}
-              onClose={() => resetState('width')}
             >
               <Placeholder height={100} width="100%" />
               <Placeholder height={100} width="100%" />

--- a/lib/components/Drawer/Drawer.screenshots.tsx
+++ b/lib/components/Drawer/Drawer.screenshots.tsx
@@ -1,0 +1,82 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Placeholder } from '../../playroom/components';
+import { DrawerContent } from './Drawer';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320, 1200],
+  examples: [
+    {
+      label: 'Default layout',
+      Example: ({ id }) => (
+        <DrawerContent
+          id={id}
+          title="Default test"
+          onClose={() => {}}
+          width="medium"
+          scrollLock={false}
+        >
+          <Placeholder height={100} width="100%" />
+        </DrawerContent>
+      ),
+    },
+    {
+      label: 'Layout with a description',
+      Example: ({ id }) => (
+        <DrawerContent
+          id={id}
+          title="Description test"
+          description={
+            <Placeholder height="auto" width="100%" label="Description" />
+          }
+          onClose={() => {}}
+          scrollLock={false}
+        >
+          <Placeholder height={100} width="100%" />
+        </DrawerContent>
+      ),
+    },
+    {
+      label: 'Layout: Small width',
+      Example: ({ id }) => (
+        <DrawerContent
+          id={id}
+          title="Small"
+          width="small"
+          onClose={() => {}}
+          scrollLock={false}
+        >
+          <Placeholder height={100} width="100%" label="Small Drawer" />
+        </DrawerContent>
+      ),
+    },
+    {
+      label: 'Layout: Medium width',
+      Example: ({ id }) => (
+        <DrawerContent
+          id={id}
+          title="Medium"
+          width="medium"
+          onClose={() => {}}
+          scrollLock={false}
+        >
+          <Placeholder height={100} width="100%" label="Medium Drawer" />
+        </DrawerContent>
+      ),
+    },
+    {
+      label: 'Layout: Large width',
+      Example: ({ id }) => (
+        <DrawerContent
+          id={id}
+          title="Large"
+          width="large"
+          onClose={() => {}}
+          scrollLock={false}
+        >
+          <Placeholder height={100} width="100%" label="Large Drawer" />
+        </DrawerContent>
+      ),
+    },
+  ],
+};

--- a/lib/components/Dropdown/Dropdown.docs.tsx
+++ b/lib/components/Dropdown/Dropdown.docs.tsx
@@ -9,7 +9,6 @@ const Container = ({ children }: { children: ReactNode }) => (
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Dropdown with placeholder',

--- a/lib/components/Dropdown/Dropdown.screenshots.tsx
+++ b/lib/components/Dropdown/Dropdown.screenshots.tsx
@@ -1,0 +1,109 @@
+import React, { ReactNode } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Dropdown, IconLocation } from '../';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div style={{ maxWidth: '300px' }}>{children}</div>
+);
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Dropdown with placeholder',
+      Container,
+      Example: ({ id, handler }) => (
+        <Dropdown
+          label="Job Title"
+          id={id}
+          onChange={handler}
+          value=""
+          placeholder="Please select a role title"
+        >
+          <option value="1">Developer</option>
+          <option value="2">Designer</option>
+        </Dropdown>
+      ),
+    },
+    {
+      label: 'Dropdown with options group',
+      Container,
+      Example: ({ id, handler }) => (
+        <Dropdown
+          label="Location"
+          id={id}
+          value=""
+          onChange={handler}
+          placeholder="Please select a location"
+        >
+          <optgroup label="Major Cities">
+            <option value="3004">Melbourne</option>
+            <option value="3002">Sydney</option>
+          </optgroup>
+          <option value="3020">Wonthaggi</option>
+        </Dropdown>
+      ),
+    },
+    {
+      label: 'Dropdown with icon',
+      Container,
+      Example: ({ id, handler }) => (
+        <Dropdown
+          label="Location"
+          id={id}
+          icon={<IconLocation />}
+          placeholder="Please select a location"
+          value=""
+          onChange={handler}
+        >
+          <option value="3004">Melbourne</option>
+          <option value="3002">Sydney</option>
+        </Dropdown>
+      ),
+    },
+    {
+      label: 'Dropdown without placeholder',
+      Container,
+      Example: ({ id, handler }) => (
+        <Dropdown label="Job Title" id={id} onChange={handler} value="">
+          <option value="1">Developer</option>
+          <option value="2">Designer</option>
+        </Dropdown>
+      ),
+    },
+    {
+      label: 'Dropdown in invalid state',
+      Container,
+      Example: ({ id, handler }) => (
+        <Dropdown
+          label="Job Title"
+          id={id}
+          onChange={handler}
+          value=""
+          tone="critical"
+          message="Required field"
+        >
+          <option value="1">Developer</option>
+          <option value="2">Designer</option>
+        </Dropdown>
+      ),
+    },
+    {
+      label: 'Dropdown on Brand Background',
+      background: 'brand',
+      Container,
+      Example: ({ id, handler }) => (
+        <Dropdown
+          label="Job Title"
+          id={id}
+          onChange={handler}
+          value=""
+          placeholder="Please select a role title"
+        >
+          <option value="1">Developer</option>
+          <option value="2">Designer</option>
+        </Dropdown>
+      ),
+    },
+  ],
+};

--- a/lib/components/FieldLabel/FieldLabel.docs.tsx
+++ b/lib/components/FieldLabel/FieldLabel.docs.tsx
@@ -8,7 +8,6 @@ const Container = ({ children }: { children: ReactNode }) => (
 
 const docs: ComponentDocs = {
   category: 'Content',
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Standard Field Label',

--- a/lib/components/FieldLabel/FieldLabel.screenshots.tsx
+++ b/lib/components/FieldLabel/FieldLabel.screenshots.tsx
@@ -1,0 +1,54 @@
+import React, { ReactNode } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { FieldLabel, TextLink } from '../';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div style={{ maxWidth: '300px' }}>{children}</div>
+);
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Standard Field Label',
+      Container,
+      Example: ({ id }) => (
+        <FieldLabel htmlFor={id} label="This is a field label" />
+      ),
+    },
+    {
+      label: 'Field Label with secondary',
+      Container,
+      Example: ({ id }) => (
+        <FieldLabel
+          htmlFor={id}
+          label="Username"
+          secondaryLabel="Max 30 characters"
+        />
+      ),
+    },
+    {
+      label: 'Field Label with tertiary label',
+      Container,
+      Example: ({ id }) => (
+        <FieldLabel
+          htmlFor={id}
+          label="Password"
+          tertiaryLabel={<TextLink href="#">Forgot password?</TextLink>}
+        />
+      ),
+    },
+    {
+      label: 'Field Label with all types',
+      Container,
+      Example: ({ id }) => (
+        <FieldLabel
+          htmlFor={id}
+          label="Title"
+          secondaryLabel="Optional"
+          tertiaryLabel={<TextLink href="#">Help?</TextLink>}
+        />
+      ),
+    },
+  ],
+};

--- a/lib/components/FieldMessage/FieldMessage.docs.tsx
+++ b/lib/components/FieldMessage/FieldMessage.docs.tsx
@@ -5,7 +5,6 @@ import { FieldMessage } from '../';
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Critical Field Message',

--- a/lib/components/FieldMessage/FieldMessage.screenshots.tsx
+++ b/lib/components/FieldMessage/FieldMessage.screenshots.tsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { FieldMessage } from '../';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Critical Field Message',
+      Example: ({ id }) => (
+        <FieldMessage
+          id={id}
+          tone="critical"
+          message="This is a critical message."
+        />
+      ),
+    },
+    {
+      label: 'Positive Field Message',
+      Example: ({ id }) => (
+        <FieldMessage
+          id={id}
+          tone="positive"
+          message="This is a positive message."
+        />
+      ),
+    },
+    {
+      label: 'Critical with long (wrapping) message',
+      Container: ({ children }) => (
+        <div style={{ maxWidth: '300px' }}>{children}</div>
+      ),
+      Example: ({ id }) => (
+        <FieldMessage
+          id={id}
+          tone="critical"
+          message="Lorem ipsum dolor sit amet, consectetur adipiscing elit. Pellentesque sodales hendrerit nulla."
+        />
+      ),
+    },
+  ],
+};

--- a/lib/components/Heading/Heading.docs.tsx
+++ b/lib/components/Heading/Heading.docs.tsx
@@ -1,11 +1,6 @@
-import React, { ReactNode, Fragment } from 'react';
+import React, { ReactNode } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import {
-  background as boxBackgrounds,
-  textAlign,
-} from '../Box/useBoxStyles.treat';
-import { heading as headingLevels } from '../../hooks/typography/typography.treat';
-import { Box, Heading, Stack } from '../';
+import { Box, Heading } from '../';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -14,7 +9,6 @@ const Container = ({ children }: { children: ReactNode }) => (
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320, 768],
   examples: [
     {
       label: 'Level 1',
@@ -75,57 +69,12 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label: 'Heading Spacing',
-      docsSite: false,
-      background: 'card',
-      Example: () => {
-        const levels = Object.keys(headingLevels) as Array<
-          keyof typeof headingLevels
-        >;
-
-        return (
-          <Stack space="medium">
-            {levels.sort().map((level) => (
-              <Box key={level} background="neutralLight">
-                <Heading level={level}>
-                  Level {level} Heading (Line 1)
-                  <br />
-                  Level {level} Heading (Line 2)
-                </Heading>
-              </Box>
-            ))}
-          </Stack>
-        );
-      },
-    },
-    {
       label: 'Heading Alignment: "left" | "center" | "right"',
-      storybook: false,
       Example: () => (
         <Heading level="1" align="center">
           Centered heading
         </Heading>
       ),
-    },
-    {
-      label: 'Heading Alignment',
-      docsSite: false,
-      Container,
-      Example: () => {
-        const alignments = Object.keys(textAlign) as Array<
-          keyof typeof textAlign
-        >;
-
-        return (
-          <Stack space="medium">
-            {alignments.map((alignment) => (
-              <Heading level="4" align={alignment} key={alignment}>
-                {alignment}
-              </Heading>
-            ))}
-          </Stack>
-        );
-      },
     },
     {
       label: 'Heading Alignment (responsive)',
@@ -135,26 +84,6 @@ const docs: ComponentDocs = {
           Right aligned mobile, center on tablet, left on desktop
         </Heading>
       ),
-    },
-    {
-      label: 'Heading Contrast',
-      docsSite: false,
-      Container,
-      Example: () => {
-        const backgrounds = Object.keys(boxBackgrounds) as Array<
-          keyof typeof boxBackgrounds
-        >;
-
-        return (
-          <Fragment>
-            {backgrounds.sort().map((background) => (
-              <Box key={background} background={background} paddingY="xsmall">
-                <Heading level="4">{background}</Heading>
-              </Box>
-            ))}
-          </Fragment>
-        );
-      },
     },
   ],
 };

--- a/lib/components/Heading/Heading.gallery.tsx
+++ b/lib/components/Heading/Heading.gallery.tsx
@@ -67,7 +67,6 @@ export const galleryItems: ComponentExample[] = [
   },
   {
     label: 'Heading Alignment: "left" | "center" | "right"',
-    storybook: false,
     Example: () => (
       <Heading level="1" align="center">
         Centered heading

--- a/lib/components/Heading/Heading.screenshots.tsx
+++ b/lib/components/Heading/Heading.screenshots.tsx
@@ -1,0 +1,146 @@
+import React, { ReactNode, Fragment } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import {
+  background as boxBackgrounds,
+  textAlign,
+} from '../Box/useBoxStyles.treat';
+import { heading as headingLevels } from '../../hooks/typography/typography.treat';
+import { Box, Heading, Stack } from '../';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div style={{ maxWidth: '300px' }}>{children}</div>
+);
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320, 768],
+  examples: [
+    {
+      label: 'Level 1',
+      Example: () => <Heading level="1">Heading Level 1</Heading>,
+    },
+    {
+      label: 'Level 1 Weak',
+      Example: () => (
+        <Heading level="1" weight="weak">
+          Heading Level 1 Weak
+        </Heading>
+      ),
+    },
+    {
+      label: 'Level 2',
+      Example: () => <Heading level="2">Heading Level 2</Heading>,
+    },
+    {
+      label: 'Level 2 Weak',
+      Example: () => (
+        <Heading level="2" weight="weak">
+          Heading Level 2 Weak
+        </Heading>
+      ),
+    },
+    {
+      label: 'Level 3',
+      Example: () => <Heading level="3">Heading Level 3</Heading>,
+    },
+    {
+      label: 'Level 3 Weak',
+      Example: () => (
+        <Heading level="3" weight="weak">
+          Heading Level 3 Weak
+        </Heading>
+      ),
+    },
+    {
+      label: 'Level 4',
+      Example: () => <Heading level="4">Heading Level 4</Heading>,
+    },
+    {
+      label: 'Level 4 Weak',
+      Example: () => (
+        <Heading level="4" weight="weak">
+          Heading Level 4 Weak
+        </Heading>
+      ),
+    },
+    {
+      label: 'Truncate a long heading',
+      Example: () => (
+        <Box style={{ width: 160 }}>
+          <Heading level="2" truncate>
+            Really long heading
+          </Heading>
+        </Box>
+      ),
+    },
+    {
+      label: 'Heading Spacing',
+      background: 'card',
+      Example: () => {
+        const levels = Object.keys(headingLevels) as Array<
+          keyof typeof headingLevels
+        >;
+
+        return (
+          <Stack space="medium">
+            {levels.sort().map((level) => (
+              <Box key={level} background="neutralLight">
+                <Heading level={level}>
+                  Level {level} Heading (Line 1)
+                  <br />
+                  Level {level} Heading (Line 2)
+                </Heading>
+              </Box>
+            ))}
+          </Stack>
+        );
+      },
+    },
+    {
+      label: 'Heading Alignment',
+      Container,
+      Example: () => {
+        const alignments = Object.keys(textAlign) as Array<
+          keyof typeof textAlign
+        >;
+
+        return (
+          <Stack space="medium">
+            {alignments.map((alignment) => (
+              <Heading level="4" align={alignment} key={alignment}>
+                {alignment}
+              </Heading>
+            ))}
+          </Stack>
+        );
+      },
+    },
+    {
+      label: 'Heading Alignment (responsive)',
+      Container,
+      Example: () => (
+        <Heading level="4" align={['right', 'center', 'left']}>
+          Right aligned mobile, center on tablet, left on desktop
+        </Heading>
+      ),
+    },
+    {
+      label: 'Heading Contrast',
+      Container,
+      Example: () => {
+        const backgrounds = Object.keys(boxBackgrounds) as Array<
+          keyof typeof boxBackgrounds
+        >;
+
+        return (
+          <Fragment>
+            {backgrounds.sort().map((background) => (
+              <Box key={background} background={background} paddingY="xsmall">
+                <Heading level="4">{background}</Heading>
+              </Box>
+            ))}
+          </Fragment>
+        );
+      },
+    },
+  ],
+};

--- a/lib/components/Hidden/Hidden.docs.tsx
+++ b/lib/components/Hidden/Hidden.docs.tsx
@@ -15,8 +15,6 @@ const docs: ComponentDocs = {
       instead.
     </Text>
   ),
-  screenshotWidths: [320, 768, 1200],
-  screenshotOnlyInWireframe: true,
   examples: [
     {
       label: 'Hidden below tablet',
@@ -79,18 +77,6 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label: 'Hidden on Screen',
-      docsSite: false, // Looking to deprecate this, but we'll leave it in the test suite for now
-      Example: () => (
-        <Stack space="small">
-          <Text>The following line is hidden on screen:</Text>
-          <Hidden screen>
-            <Text>Hidden on screen.</Text>
-          </Hidden>
-        </Stack>
-      ),
-    },
-    {
       label: 'Hidden below tablet (inline)',
       showCodeByDefault: true,
       Example: () => (
@@ -137,16 +123,6 @@ const docs: ComponentDocs = {
         <Text>
           The following text node is hidden on print:{' '}
           <Hidden print>Hidden on print.</Hidden>
-        </Text>
-      ),
-    },
-    {
-      label: 'Hidden on screen (inline)',
-      docsSite: false,
-      Example: () => (
-        <Text>
-          The following text node is hidden on screen:{' '}
-          <Hidden screen>Hidden on screen.</Hidden>
         </Text>
       ),
     },

--- a/lib/components/Hidden/Hidden.screenshots.tsx
+++ b/lib/components/Hidden/Hidden.screenshots.tsx
@@ -1,0 +1,132 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Hidden } from './Hidden';
+import { Text } from '../Text/Text';
+import { Stack } from '../Stack/Stack';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320, 768, 1200],
+  screenshotOnlyInWireframe: true,
+  examples: [
+    {
+      label: 'Hidden below tablet',
+      Example: () => (
+        <Stack space="small">
+          <Text>The following line is hidden below tablet:</Text>
+          <Hidden below="tablet">
+            <Text>Hidden below tablet.</Text>
+          </Hidden>
+        </Stack>
+      ),
+    },
+    {
+      label: 'Hidden below desktop',
+      Example: () => (
+        <Stack space="small">
+          <Text>The following line is hidden below desktop:</Text>
+          <Hidden below="desktop">
+            <Text>Hidden below desktop.</Text>
+          </Hidden>
+        </Stack>
+      ),
+    },
+    {
+      label: 'Hidden above mobile',
+      Example: () => (
+        <Stack space="small">
+          <Text>The following line is hidden above mobile:</Text>
+          <Hidden above="mobile">
+            <Text>Hidden above mobile.</Text>
+          </Hidden>
+        </Stack>
+      ),
+    },
+    {
+      label: 'Hidden above tablet',
+      Example: () => (
+        <Stack space="small">
+          <Text>The following line is hidden above tablet:</Text>
+          <Hidden above="tablet">
+            <Text>Hidden above tablet.</Text>
+          </Hidden>
+        </Stack>
+      ),
+    },
+    {
+      label: 'Hidden on print',
+      Example: () => (
+        <Stack space="small">
+          <Text>The following line is hidden on print:</Text>
+          <Hidden print>
+            <Text>Hidden on print.</Text>
+          </Hidden>
+        </Stack>
+      ),
+    },
+    {
+      label: 'Hidden on Screen',
+      Example: () => (
+        <Stack space="small">
+          <Text>The following line is hidden on screen:</Text>
+          <Hidden screen>
+            <Text>Hidden on screen.</Text>
+          </Hidden>
+        </Stack>
+      ),
+    },
+    {
+      label: 'Hidden below tablet (inline)',
+      Example: () => (
+        <Text>
+          The following text node is hidden below tablet:{' '}
+          <Hidden below="tablet">Hidden below tablet.</Hidden>
+        </Text>
+      ),
+    },
+    {
+      label: 'Hidden below desktop (inline)',
+      Example: () => (
+        <Text>
+          The following text node is hidden below desktop:{' '}
+          <Hidden below="desktop">Hidden below desktop.</Hidden>
+        </Text>
+      ),
+    },
+    {
+      label: 'Hidden above mobile (inline)',
+      Example: () => (
+        <Text>
+          The following text node is hidden above mobile:{' '}
+          <Hidden above="mobile">Hidden above mobile.</Hidden>
+        </Text>
+      ),
+    },
+    {
+      label: 'Hidden above tablet (inline)',
+      Example: () => (
+        <Text>
+          The following text node is hidden above tablet:{' '}
+          <Hidden above="tablet">Hidden above tablet.</Hidden>
+        </Text>
+      ),
+    },
+    {
+      label: 'Hidden on print (inline)',
+      Example: () => (
+        <Text>
+          The following text node is hidden on print:{' '}
+          <Hidden print>Hidden on print.</Hidden>
+        </Text>
+      ),
+    },
+    {
+      label: 'Hidden on screen (inline)',
+      Example: () => (
+        <Text>
+          The following text node is hidden on screen:{' '}
+          <Hidden screen>Hidden on screen.</Hidden>
+        </Text>
+      ),
+    },
+  ],
+};

--- a/lib/components/HiddenVisually/HiddenVisually.docs.tsx
+++ b/lib/components/HiddenVisually/HiddenVisually.docs.tsx
@@ -11,8 +11,6 @@ const docs: ComponentDocs = {
       screen.
     </Text>
   ),
-  screenshotWidths: [320],
-  screenshotOnlyInWireframe: true,
   examples: [
     {
       label: 'Inside Text',

--- a/lib/components/HiddenVisually/HiddenVisually.screenshots.tsx
+++ b/lib/components/HiddenVisually/HiddenVisually.screenshots.tsx
@@ -1,0 +1,20 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { HiddenVisually } from './HiddenVisually';
+import { Text } from '../Text/Text';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  screenshotOnlyInWireframe: true,
+  examples: [
+    {
+      label: 'Inside Text',
+      Example: () => (
+        <Text>
+          The next sentence is only available to screen readers.
+          <HiddenVisually> Hello world.</HiddenVisually>
+        </Text>
+      ),
+    },
+  ],
+};

--- a/lib/components/Inline/Inline.docs.tsx
+++ b/lib/components/Inline/Inline.docs.tsx
@@ -1,13 +1,7 @@
-import React, { Fragment, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { Placeholder } from '../private/Placeholder/Placeholder';
-import { InlineProps } from './Inline';
 import { Box, Inline, Stack, Text, TextLink } from '../';
-import { padding } from '../Box/useBoxStyles.treat';
-
-const spaces = Object.keys(padding.top).filter(
-  (space) => space !== 'none',
-) as Array<InlineProps['space']>;
 
 const Container = ({ children }: { children: ReactNode }) => (
   <Box style={{ maxWidth: '240px' }}>{children}</Box>
@@ -15,8 +9,6 @@ const Container = ({ children }: { children: ReactNode }) => (
 
 const docs: ComponentDocs = {
   category: 'Layout',
-  screenshotWidths: [320, 768, 1200],
-  screenshotOnlyInWireframe: true,
   description: (
     <Stack space="large">
       <Text>
@@ -30,7 +22,6 @@ const docs: ComponentDocs = {
     {
       label: 'Basic example',
       Container,
-      storybook: false,
       Example: () => (
         <Inline space="small">
           <Placeholder width={48} height={48} />
@@ -46,25 +37,6 @@ const docs: ComponentDocs = {
         </Inline>
       ),
     },
-    ...spaces.map((space) => ({
-      label: `Space: ${space}`,
-      Container,
-      docsSite: false,
-      Example: () => (
-        <Inline space={space}>
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-        </Inline>
-      ),
-    })),
     {
       label: "Responsive space, e.g. ['xxsmall', 'medium']",
       Container,
@@ -202,96 +174,6 @@ const docs: ComponentDocs = {
           <Placeholder width={48} height={48} />
           <Placeholder width={48} height={48} />
           <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-        </Inline>
-      ),
-    },
-    {
-      label:
-        'Test - collapseBelow + align: On mobile should be vertical and left aligned, on tablet should be vertical and centre aligned, on desktop should be horizontal and right aligned',
-      docsSite: false,
-      Container,
-      Example: () => (
-        <Inline
-          space="small"
-          collapseBelow="desktop"
-          align={['left', 'center', 'right']}
-        >
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-        </Inline>
-      ),
-    },
-    {
-      label:
-        'Test - collapseBelow + align + reverse: On mobile should be vertical and left aligned, on tablet should be reversed horizontally and centre aligned, on desktop should be reversed horizontally and right aligned',
-      docsSite: false,
-      Container,
-      Example: () => (
-        <Inline
-          space="small"
-          collapseBelow="tablet"
-          align={['left', 'center', 'right']}
-          reverse
-        >
-          <Placeholder width={48} height={48} label="1" />
-          <Placeholder width={48} height={48} label="2" />
-          <Placeholder width={48} height={48} label="3" />
-          <Placeholder width={48} height={48} label="4" />
-          <Placeholder width={48} height={48} label="5" />
-          <Placeholder width={48} height={48} label="6" />
-        </Inline>
-      ),
-    },
-    {
-      label:
-        'Test - collapseBelow + align + reverse: On mobile should be vertical and left aligned, on tablet should be vertical and centre aligned, on desktop should be reversed horizontally and right aligned',
-      docsSite: false,
-      Container,
-      Example: () => (
-        <Inline
-          space="small"
-          collapseBelow="desktop"
-          align={['left', 'center', 'right']}
-          reverse
-        >
-          <Placeholder width={48} height={48} label="1" />
-          <Placeholder width={48} height={48} label="2" />
-          <Placeholder width={48} height={48} label="3" />
-          <Placeholder width={48} height={48} label="4" />
-          <Placeholder width={48} height={48} label="5" />
-          <Placeholder width={48} height={48} label="6" />
-        </Inline>
-      ),
-    },
-    {
-      label:
-        'Test - Should flatten fragments (6 placeholders should be evenly spaced)',
-      docsSite: false,
-      Container,
-      Example: () => (
-        <Inline space="small">
-          <Fragment>
-            <Fragment>
-              <Placeholder width={48} height={48} />
-            </Fragment>
-            <Fragment>
-              <Placeholder width={48} height={48} />
-            </Fragment>
-          </Fragment>
-          <Fragment>
-            <Fragment>
-              <Placeholder width={48} height={48} />
-              <Placeholder width={48} height={48} />
-              <Fragment>
-                <Placeholder width={48} height={48} />
-              </Fragment>
-            </Fragment>
-          </Fragment>
           <Placeholder width={48} height={48} />
         </Inline>
       ),

--- a/lib/components/Inline/Inline.screenshots.tsx
+++ b/lib/components/Inline/Inline.screenshots.tsx
@@ -1,0 +1,266 @@
+import React, { Fragment, ReactNode } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Placeholder } from '../private/Placeholder/Placeholder';
+import { InlineProps } from './Inline';
+import { Box, Inline } from '../';
+import { padding } from '../Box/useBoxStyles.treat';
+
+const spaces = Object.keys(padding.top).filter(
+  (space) => space !== 'none',
+) as Array<InlineProps['space']>;
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <Box style={{ maxWidth: '240px' }}>{children}</Box>
+);
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320, 768, 1200],
+  screenshotOnlyInWireframe: true,
+  examples: [
+    ...spaces.map((space) => ({
+      label: `Space: ${space}`,
+      Container,
+      Example: () => (
+        <Inline space={space}>
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+        </Inline>
+      ),
+    })),
+    {
+      label: "Responsive space, e.g. ['xxsmall', 'medium']",
+      Container,
+      Example: () => (
+        <Inline space={['xxsmall', 'medium']}>
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+        </Inline>
+      ),
+    },
+    {
+      label: 'Align horizontally to center',
+      Container,
+      Example: () => (
+        <Inline space="small" align="center">
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+        </Inline>
+      ),
+    },
+    {
+      label: 'Align horizontally to right',
+      Container,
+      Example: () => (
+        <Inline space="small" align="right">
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+        </Inline>
+      ),
+    },
+    {
+      label:
+        'Responsive alignment (e.g. center on mobile, left from tablet upwards)',
+      Container,
+      Example: () => (
+        <Inline space="small" align={['center', 'left']}>
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+        </Inline>
+      ),
+    },
+    {
+      label: 'Align vertically',
+      Container,
+      Example: () => (
+        <Inline space="small" alignY="center">
+          <Placeholder width={48} height={40} />
+          <Placeholder width={48} height={100} />
+          <Placeholder width={48} height={60} />
+        </Inline>
+      ),
+    },
+    {
+      label: 'Collapse below tablet',
+      Container,
+      Example: () => (
+        <Inline space="small" collapseBelow="tablet">
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+        </Inline>
+      ),
+    },
+    {
+      label: 'Collapse below desktop',
+      Container,
+      Example: () => (
+        <Inline space="small" collapseBelow="desktop">
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+        </Inline>
+      ),
+    },
+    {
+      label:
+        'Collapse below desktop with responsive space (e.g. "xxsmall" on mobile, "small" on tablet, "large" on desktop)',
+      Container,
+      Example: () => (
+        <Inline space={['xxsmall', 'medium', 'large']} collapseBelow="desktop">
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+        </Inline>
+      ),
+    },
+    {
+      label: 'Collapse below desktop with alignment (e.g. "center")',
+      Container,
+      Example: () => (
+        <Inline space="small" collapseBelow="desktop" align="center">
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+        </Inline>
+      ),
+    },
+    {
+      label:
+        'Test - collapseBelow + align: On mobile should be vertical and left aligned, on tablet should be vertical and centre aligned, on desktop should be horizontal and right aligned',
+      Container,
+      Example: () => (
+        <Inline
+          space="small"
+          collapseBelow="desktop"
+          align={['left', 'center', 'right']}
+        >
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+          <Placeholder width={48} height={48} />
+        </Inline>
+      ),
+    },
+    {
+      label:
+        'Test - collapseBelow + align + reverse: On mobile should be vertical and left aligned, on tablet should be reversed horizontally and centre aligned, on desktop should be reversed horizontally and right aligned',
+      Container,
+      Example: () => (
+        <Inline
+          space="small"
+          collapseBelow="tablet"
+          align={['left', 'center', 'right']}
+          reverse
+        >
+          <Placeholder width={48} height={48} label="1" />
+          <Placeholder width={48} height={48} label="2" />
+          <Placeholder width={48} height={48} label="3" />
+          <Placeholder width={48} height={48} label="4" />
+          <Placeholder width={48} height={48} label="5" />
+          <Placeholder width={48} height={48} label="6" />
+        </Inline>
+      ),
+    },
+    {
+      label:
+        'Test - collapseBelow + align + reverse: On mobile should be vertical and left aligned, on tablet should be vertical and centre aligned, on desktop should be reversed horizontally and right aligned',
+      Container,
+      Example: () => (
+        <Inline
+          space="small"
+          collapseBelow="desktop"
+          align={['left', 'center', 'right']}
+          reverse
+        >
+          <Placeholder width={48} height={48} label="1" />
+          <Placeholder width={48} height={48} label="2" />
+          <Placeholder width={48} height={48} label="3" />
+          <Placeholder width={48} height={48} label="4" />
+          <Placeholder width={48} height={48} label="5" />
+          <Placeholder width={48} height={48} label="6" />
+        </Inline>
+      ),
+    },
+    {
+      label:
+        'Test - Should flatten fragments (6 placeholders should be evenly spaced)',
+      Container,
+      Example: () => (
+        <Inline space="small">
+          <Fragment>
+            <Fragment>
+              <Placeholder width={48} height={48} />
+            </Fragment>
+            <Fragment>
+              <Placeholder width={48} height={48} />
+            </Fragment>
+          </Fragment>
+          <Fragment>
+            <Fragment>
+              <Placeholder width={48} height={48} />
+              <Placeholder width={48} height={48} />
+              <Fragment>
+                <Placeholder width={48} height={48} />
+              </Fragment>
+            </Fragment>
+          </Fragment>
+          <Placeholder width={48} height={48} />
+        </Inline>
+      ),
+    },
+  ],
+};

--- a/lib/components/Link/Link.docs.tsx
+++ b/lib/components/Link/Link.docs.tsx
@@ -5,7 +5,6 @@ import { Placeholder } from '../../playroom/components';
 
 const docs: ComponentDocs = {
   category: 'Logic',
-  screenshotWidths: [],
   description: (
     <Stack space="large">
       <Text>

--- a/lib/components/List/List.docs.tsx
+++ b/lib/components/List/List.docs.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { List, Text, TextLink, Stack } from '..';
-import { IconTick, Placeholder } from '../../playroom/components';
+import { IconTick } from '../../playroom/components';
 
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   description: (
     <Stack space="large">
       <Text>
@@ -165,61 +164,6 @@ const docs: ComponentDocs = {
           <Text>This is a Roman list item.</Text>
           <Text>This is a Roman list item.</Text>
           <Text>This is a Roman list item.</Text>
-        </List>
-      ),
-    },
-    {
-      label: 'Test: Size and tone should cascade to nested lists',
-      docsSite: false,
-      Example: () => (
-        <List size="large" tone="critical">
-          <Stack space="medium">
-            <Text>Should be large and critical.</Text>
-            <List>
-              <Text>Should be large and critical.</Text>
-            </List>
-          </Stack>
-        </List>
-      ),
-    },
-    {
-      label: 'Test: Cascading size and tone should be overridable',
-      docsSite: false,
-      Example: () => (
-        <List size="large" tone="critical">
-          <Stack space="medium">
-            <Text>Should be large and critical.</Text>
-            <List size="xsmall" tone="positive">
-              <Text>Should be xsmall and positive.</Text>
-            </List>
-          </Stack>
-        </List>
-      ),
-    },
-    {
-      label: 'Test: Flattens fragments',
-      docsSite: false,
-      Example: () => (
-        <List>
-          <Text>List item.</Text>
-          <>
-            <Text>List item.</Text>
-          </>
-          <>
-            <>
-              <Text>List item.</Text>
-              <Text>List item.</Text>
-            </>
-          </>
-        </List>
-      ),
-    },
-    {
-      label: 'Test: List items should be full width',
-      docsSite: false,
-      Example: () => (
-        <List>
-          <Placeholder height={60} />
         </List>
       ),
     },

--- a/lib/components/List/List.screenshots.tsx
+++ b/lib/components/List/List.screenshots.tsx
@@ -1,0 +1,209 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { List, Text, Stack } from '..';
+import { IconTick, Placeholder } from '../../playroom/components';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Standard List',
+      Example: () => (
+        <List>
+          <Text>This is a list item.</Text>
+          <Text>This is a list item.</Text>
+          <Text>This is a list item.</Text>
+        </List>
+      ),
+    },
+    {
+      label: 'Numbered List',
+      Example: () => (
+        <List type="number">
+          <Text>This is a numbered list item.</Text>
+          <Text>This is a numbered list item.</Text>
+          <Text>This is a numbered list item.</Text>
+        </List>
+      ),
+    },
+    {
+      label: 'Alpha List',
+      Example: () => (
+        <List type="alpha">
+          <Text>This is an alpha list item.</Text>
+          <Text>This is an alpha list item.</Text>
+          <Text>This is an alpha list item.</Text>
+        </List>
+      ),
+    },
+    {
+      label: 'Roman List',
+      Example: () => (
+        <List type="roman">
+          <Text>This is a Roman list item.</Text>
+          <Text>This is a Roman list item.</Text>
+          <Text>This is a Roman list item.</Text>
+        </List>
+      ),
+    },
+    {
+      label: 'Icon List',
+      Example: () => (
+        <List type="icon" icon={<IconTick tone="positive" />}>
+          <Text>This is a list item.</Text>
+          <Text>This is a list item.</Text>
+          <Text>This is a list item.</Text>
+        </List>
+      ),
+    },
+    {
+      label: 'List with paragraphs',
+      Example: () => (
+        <List space="large">
+          <Stack space="medium">
+            <Text>This is a paragraph.</Text>
+            <Text>This is another paragraph.</Text>
+          </Stack>
+          <Stack space="medium">
+            <Text>This is a paragraph.</Text>
+            <Text>This is another paragraph.</Text>
+          </Stack>
+        </List>
+      ),
+    },
+    {
+      label: 'Nested Lists',
+      Example: () => (
+        <List space="large" type="number">
+          <Stack space="medium">
+            <Text>This has a nested list.</Text>
+            <List type="alpha">
+              <Text>This is a nested list item.</Text>
+              <Text>This is a nested list item.</Text>
+              <Text>This is a nested list item.</Text>
+            </List>
+          </Stack>
+          <Stack space="medium">
+            <Text>This has a nested list.</Text>
+            <List type="alpha">
+              <Text>This is a nested list item.</Text>
+              <Text>This is a nested list item.</Text>
+              <Text>This is a nested list item.</Text>
+            </List>
+          </Stack>
+        </List>
+      ),
+    },
+    {
+      label: 'List with custom text size',
+      Example: () => (
+        <List size="large">
+          <Text>This is a large list item.</Text>
+          <Text>This is a large list item.</Text>
+          <Text>This is a large list item.</Text>
+        </List>
+      ),
+    },
+    {
+      label: 'List with custom space between items',
+      Example: () => (
+        <List space="large">
+          <Text>List item with large space.</Text>
+          <Text>List item with large space.</Text>
+          <Text>List item with large space.</Text>
+        </List>
+      ),
+    },
+    {
+      label: 'List with custom tone',
+      Example: () => (
+        <List tone="secondary">
+          <Text>List item with secondary tone.</Text>
+          <Text>List item with secondary tone.</Text>
+          <Text>List item with secondary tone.</Text>
+        </List>
+      ),
+    },
+    {
+      label: 'Numbered List with custom start position',
+      Example: () => (
+        <List type="number" start={9}>
+          <Text>This is a numbered list item.</Text>
+          <Text>This is a numbered list item.</Text>
+          <Text>This is a numbered list item.</Text>
+        </List>
+      ),
+    },
+    {
+      label: 'Alpha List with custom start position',
+      Example: () => (
+        <List type="alpha" start={9}>
+          <Text>This is an alpha list item.</Text>
+          <Text>This is an alpha list item.</Text>
+          <Text>This is an alpha list item.</Text>
+        </List>
+      ),
+    },
+    {
+      label: 'Roman List with custom start position',
+      Example: () => (
+        <List type="roman" start={9}>
+          <Text>This is a Roman list item.</Text>
+          <Text>This is a Roman list item.</Text>
+          <Text>This is a Roman list item.</Text>
+        </List>
+      ),
+    },
+    {
+      label: 'Test: Size and tone should cascade to nested lists',
+      Example: () => (
+        <List size="large" tone="critical">
+          <Stack space="medium">
+            <Text>Should be large and critical.</Text>
+            <List>
+              <Text>Should be large and critical.</Text>
+            </List>
+          </Stack>
+        </List>
+      ),
+    },
+    {
+      label: 'Test: Cascading size and tone should be overridable',
+      Example: () => (
+        <List size="large" tone="critical">
+          <Stack space="medium">
+            <Text>Should be large and critical.</Text>
+            <List size="xsmall" tone="positive">
+              <Text>Should be xsmall and positive.</Text>
+            </List>
+          </Stack>
+        </List>
+      ),
+    },
+    {
+      label: 'Test: Flattens fragments',
+      Example: () => (
+        <List>
+          <Text>List item.</Text>
+          <>
+            <Text>List item.</Text>
+          </>
+          <>
+            <>
+              <Text>List item.</Text>
+              <Text>List item.</Text>
+            </>
+          </>
+        </List>
+      ),
+    },
+    {
+      label: 'Test: List items should be full width',
+      Example: () => (
+        <List>
+          <Placeholder height={60} />
+        </List>
+      ),
+    },
+  ],
+};

--- a/lib/components/Loader/Loader.docs.tsx
+++ b/lib/components/Loader/Loader.docs.tsx
@@ -1,11 +1,9 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
-import { Box, Loader } from '../';
+import { Loader } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Default',
@@ -30,25 +28,6 @@ const docs: ComponentDocs = {
     {
       label: 'large',
       Example: () => <Loader size="large" />,
-    },
-    {
-      label: 'Loader Contrast',
-      docsSite: false,
-      Example: () => {
-        const backgrounds = Object.keys(boxBackgrounds) as Array<
-          keyof typeof boxBackgrounds
-        >;
-
-        return (
-          <Fragment>
-            {backgrounds.sort().map((background) => (
-              <Box key={background} background={background} padding="xsmall">
-                <Loader />
-              </Box>
-            ))}
-          </Fragment>
-        );
-      },
     },
   ],
 };

--- a/lib/components/Loader/Loader.screenshots.tsx
+++ b/lib/components/Loader/Loader.screenshots.tsx
@@ -1,0 +1,52 @@
+import React, { Fragment } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
+import { Box, Loader } from '../';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Default',
+      Example: () => <Loader />,
+    },
+    {
+      label: 'Delay visibility (used to prevent loading flicker)',
+      Example: () => <Loader delayVisibility />,
+    },
+    {
+      label: 'xsmall',
+      Example: () => <Loader size="xsmall" />,
+    },
+    {
+      label: 'small',
+      Example: () => <Loader size="small" />,
+    },
+    {
+      label: 'standard',
+      Example: () => <Loader size="standard" />,
+    },
+    {
+      label: 'large',
+      Example: () => <Loader size="large" />,
+    },
+    {
+      label: 'Loader Contrast',
+      Example: () => {
+        const backgrounds = Object.keys(boxBackgrounds) as Array<
+          keyof typeof boxBackgrounds
+        >;
+
+        return (
+          <Fragment>
+            {backgrounds.sort().map((background) => (
+              <Box key={background} background={background} padding="xsmall">
+                <Loader />
+              </Box>
+            ))}
+          </Fragment>
+        );
+      },
+    },
+  ],
+};

--- a/lib/components/MenuItem/MenuItem.docs.tsx
+++ b/lib/components/MenuItem/MenuItem.docs.tsx
@@ -15,7 +15,6 @@ import {
 const docs: ComponentDocs = {
   category: 'Content',
   subComponents: ['MenuItemLink'],
-  screenshotWidths: [],
   description: (
     <Stack space="large">
       <Text>

--- a/lib/components/MenuItemCheckbox/MenuItemCheckbox.docs.tsx
+++ b/lib/components/MenuItemCheckbox/MenuItemCheckbox.docs.tsx
@@ -4,7 +4,6 @@ import { OverflowMenu, MenuItemCheckbox, Stack, Text, TextLink, Box } from '..';
 
 const docs: ComponentDocs = {
   category: 'Content',
-  screenshotWidths: [],
   description: (
     <Stack space="large">
       <Text>

--- a/lib/components/MenuItemDivider/MenuItemDivider.docs.tsx
+++ b/lib/components/MenuItemDivider/MenuItemDivider.docs.tsx
@@ -13,7 +13,6 @@ import {
 
 const docs: ComponentDocs = {
   category: 'Content',
-  screenshotWidths: [],
   description: (
     <Text>
       Used to separate groups within menu components, e.g.{' '}

--- a/lib/components/MenuRenderer/MenuRenderer.docs.tsx
+++ b/lib/components/MenuRenderer/MenuRenderer.docs.tsx
@@ -15,7 +15,6 @@ import {
 
 const docs: ComponentDocs = {
   category: 'Content',
-  screenshotWidths: [],
   description: (
     <Stack space="large">
       <Text>

--- a/lib/components/MonthPicker/MonthPicker.docs.tsx
+++ b/lib/components/MonthPicker/MonthPicker.docs.tsx
@@ -2,10 +2,6 @@ import React, { ReactNode } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { MonthPicker } from '../';
 
-const handler = () => {
-  /* No-op for docs examples */
-};
-
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
 );
@@ -13,12 +9,11 @@ const Container = ({ children }: { children: ReactNode }) => (
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Default',
       Container,
-      Example: ({ id }) => (
+      Example: ({ id, handler }) => (
         <MonthPicker
           id={id}
           label="Started"
@@ -30,7 +25,7 @@ const docs: ComponentDocs = {
     {
       label: 'Selected values',
       Container,
-      Example: ({ id }) => (
+      Example: ({ id, handler }) => (
         <MonthPicker
           id={id}
           label="Started"
@@ -42,7 +37,7 @@ const docs: ComponentDocs = {
     {
       label: 'Critical message',
       Container,
-      Example: ({ id }) => (
+      Example: ({ id, handler }) => (
         <MonthPicker
           id={id}
           label="Started"
@@ -56,7 +51,7 @@ const docs: ComponentDocs = {
     {
       label: 'Custom month and year labels',
       Container,
-      Example: ({ id }) => (
+      Example: ({ id, handler }) => (
         <MonthPicker
           id={id}
           label="Started"

--- a/lib/components/MonthPicker/MonthPicker.screenshots.tsx
+++ b/lib/components/MonthPicker/MonthPicker.screenshots.tsx
@@ -1,0 +1,79 @@
+import React, { ReactNode } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { MonthPicker } from '../';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div style={{ maxWidth: '300px' }}>{children}</div>
+);
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Default',
+      Container,
+      Example: ({ id, handler }) => (
+        <MonthPicker
+          id={id}
+          label="Started"
+          value={{ month: undefined, year: undefined }}
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'Selected values',
+      Container,
+      Example: ({ id, handler }) => (
+        <MonthPicker
+          id={id}
+          label="Started"
+          value={{ month: 12, year: 2018 }}
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'Critical message',
+      Container,
+      Example: ({ id, handler }) => (
+        <MonthPicker
+          id={id}
+          label="Started"
+          tone="critical"
+          message="This is a critical message."
+          value={{ month: 1, year: 2019 }}
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'Custom month and year labels',
+      Container,
+      Example: ({ id, handler }) => (
+        <MonthPicker
+          id={id}
+          label="Started"
+          value={{ month: 7, year: 2020 }}
+          onChange={handler}
+          monthLabel="MM"
+          yearLabel="YYYY"
+          monthNames={[
+            '01',
+            '02',
+            '03',
+            '04',
+            '05',
+            '06',
+            '07',
+            '08',
+            '09',
+            '10',
+            '11',
+            '12',
+          ]}
+        />
+      ),
+    },
+  ],
+};

--- a/lib/components/Notice/Notice.docs.tsx
+++ b/lib/components/Notice/Notice.docs.tsx
@@ -19,7 +19,6 @@ const docs: ComponentDocs = {
     </Stack>
   ),
   migrationGuide: true,
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Info Notice',

--- a/lib/components/Notice/Notice.screenshots.tsx
+++ b/lib/components/Notice/Notice.screenshots.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Notice, Text, Stack, TextLink, List } from '../';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Info Notice',
+      Example: () => (
+        <Notice tone="info">
+          <Text>This is an important piece of information.</Text>
+        </Notice>
+      ),
+    },
+    {
+      label: 'Notice with rich content',
+      Example: () => (
+        <Notice tone="info">
+          <Stack space="medium">
+            <Text>
+              This is an important piece of information with a{' '}
+              <TextLink href="#">TextLink.</TextLink>
+            </Text>
+            <List space="medium">
+              <Text>Bullet 1</Text>
+              <Text>Bullet 2</Text>
+              <Text>Bullet 3</Text>
+            </List>
+          </Stack>
+        </Notice>
+      ),
+    },
+    {
+      label: 'Promote Notice',
+      Example: () => (
+        <Notice tone="promote">
+          <Text>This is a promoted piece of information.</Text>
+        </Notice>
+      ),
+    },
+    {
+      label: 'Critical Notice',
+      Example: () => (
+        <Notice tone="critical">
+          <Text>This is a critical piece of information.</Text>
+        </Notice>
+      ),
+    },
+    {
+      label: 'Positive Notice',
+      Example: () => (
+        <Notice tone="positive">
+          <Text>This is a positive piece of information.</Text>
+        </Notice>
+      ),
+    },
+  ],
+};

--- a/lib/components/OverflowMenu/OverflowMenu.docs.tsx
+++ b/lib/components/OverflowMenu/OverflowMenu.docs.tsx
@@ -12,7 +12,6 @@ import {
 
 const docs: ComponentDocs = {
   category: 'Content',
-  screenshotWidths: [320],
   description: (
     <Stack space="large">
       <Text>

--- a/lib/components/OverflowMenu/OverflowMenu.screenshots.tsx
+++ b/lib/components/OverflowMenu/OverflowMenu.screenshots.tsx
@@ -1,0 +1,23 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Box, OverflowMenu, MenuItem, MenuItemLink } from '../';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Default',
+      background: 'card',
+      Example: ({ handler }) => (
+        <Box style={{ paddingLeft: '100px', maxWidth: '200px' }}>
+          <OverflowMenu label="Options">
+            <MenuItem onClick={handler}>Button</MenuItem>
+            <MenuItemLink href="#" onClick={handler}>
+              Link
+            </MenuItemLink>
+          </OverflowMenu>
+        </Box>
+      ),
+    },
+  ],
+};

--- a/lib/components/PasswordField/PasswordField.docs.tsx
+++ b/lib/components/PasswordField/PasswordField.docs.tsx
@@ -9,7 +9,6 @@ const Container = ({ children }: { children: ReactNode }) => (
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   examples: [
     {
       label: 'PasswordField',

--- a/lib/components/PasswordField/PasswordField.screenshots.tsx
+++ b/lib/components/PasswordField/PasswordField.screenshots.tsx
@@ -1,0 +1,142 @@
+import React, { ReactNode, useState } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { PasswordField, TextLink } from '../';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div style={{ maxWidth: '300px' }}>{children}</div>
+);
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'PasswordField',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('qwerty');
+        return (
+          <PasswordField
+            label="Password"
+            id={id}
+            value={value}
+            onChange={(ev) => setValue(ev.currentTarget.value)}
+          />
+        );
+      },
+    },
+    {
+      label: 'PasswordField with message',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('qwerty');
+        return (
+          <PasswordField
+            label="Password"
+            id={id}
+            value={value}
+            message={`e.g. Cannot be "password"`}
+            onChange={(ev) => setValue(ev.currentTarget.value)}
+          />
+        );
+      },
+    },
+    {
+      label: 'PasswordField with secondary label',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('qwerty');
+        return (
+          <PasswordField
+            label="Password"
+            secondaryLabel="required"
+            id={id}
+            value={value}
+            onChange={(ev) => setValue(ev.currentTarget.value)}
+          />
+        );
+      },
+    },
+    {
+      label: 'PasswordField with tertiary label',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('qwerty');
+        return (
+          <PasswordField
+            label="Password"
+            tertiaryLabel={<TextLink href="#">Forgot Password?</TextLink>}
+            id={id}
+            value={value}
+            onChange={(ev) => setValue(ev.currentTarget.value)}
+          />
+        );
+      },
+    },
+    {
+      label: 'PasswordField with description',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('qwerty');
+        return (
+          <PasswordField
+            label="Password"
+            id={id}
+            value={value}
+            onChange={(ev) => setValue(ev.currentTarget.value)}
+            description="Must be 8 characters long and include a capital letter, a number and a symbol"
+          />
+        );
+      },
+    },
+    {
+      label: 'PasswordField with critical message',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('qwerty');
+        return (
+          <PasswordField
+            label="Password"
+            tone="critical"
+            id={id}
+            value={value}
+            onChange={(ev) => setValue(ev.currentTarget.value)}
+            message="Not strong enough"
+          />
+        );
+      },
+    },
+    {
+      label: 'PasswordField with positive message',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('qwerty');
+        return (
+          <PasswordField
+            label="Password"
+            id={id}
+            value={value}
+            onChange={(ev) => setValue(ev.currentTarget.value)}
+            message="Strong!"
+            tone="positive"
+          />
+        );
+      },
+    },
+    {
+      label: 'PasswordField on Brand Background',
+      background: 'brand',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('qwerty');
+        return (
+          <PasswordField
+            label="Password"
+            id={id}
+            onChange={(ev) => setValue(ev.currentTarget.value)}
+            value={value}
+          />
+        );
+      },
+    },
+  ],
+};

--- a/lib/components/Radio/Radio.docs.tsx
+++ b/lib/components/Radio/Radio.docs.tsx
@@ -12,7 +12,6 @@ const docs: ComponentDocs = {
       <TextLink href="/components/RadioGroup">RadioGroup</TextLink> instead.
     </Text>
   ),
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Standard Radio Button',
@@ -88,24 +87,6 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label: 'Radio Button with a Badge and description',
-      docsSite: false,
-      Example: ({ id, handler }) => (
-        <Radio
-          id={id}
-          checked={false}
-          onChange={handler}
-          label="Label"
-          badge={
-            <Badge tone="positive" weight="strong">
-              New
-            </Badge>
-          }
-          description="Extra information about the field"
-        />
-      ),
-    },
-    {
       label: 'Radio Button with nested content visible only when checked',
       Example: ({ id }) => {
         const [state, setState] = useState(true);
@@ -121,21 +102,6 @@ const docs: ComponentDocs = {
           </Radio>
         );
       },
-    },
-    {
-      label: 'Radio Button with nested content and description',
-      docsSite: false,
-      Example: ({ id, handler }) => (
-        <Radio
-          id={id}
-          checked={true}
-          onChange={handler}
-          label="Label"
-          description="Extra information about the field"
-        >
-          <Text>This text is visible when the radio button is checked.</Text>
-        </Radio>
-      ),
     },
   ],
 };

--- a/lib/components/Radio/Radio.screenshots.tsx
+++ b/lib/components/Radio/Radio.screenshots.tsx
@@ -1,0 +1,130 @@
+import React, { useState } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Badge, Radio, Text } from '../';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Standard Radio Button',
+      Example: ({ id }) => {
+        const [state, setState] = useState(false);
+        return (
+          <Radio
+            id={id}
+            checked={state}
+            onChange={() => setState(!state)}
+            label="Label"
+          />
+        );
+      },
+    },
+    {
+      label: 'Checked Radio Button',
+      Example: ({ id, handler }) => (
+        <Radio id={id} checked={true} onChange={handler} label="Label" />
+      ),
+    },
+    {
+      label: 'Disabled Radio Button',
+      background: 'card',
+      Example: ({ id, handler }) => (
+        <Radio
+          id={id}
+          disabled={true}
+          checked={false}
+          onChange={handler}
+          label="Label"
+        />
+      ),
+    },
+    {
+      label: 'Critical Radio Button',
+      Example: ({ id, handler }) => (
+        <Radio
+          id={id}
+          checked={false}
+          onChange={handler}
+          label="Label"
+          tone="critical"
+        />
+      ),
+    },
+    {
+      label: 'Radio Button with description',
+      Example: ({ id, handler }) => (
+        <Radio
+          id={id}
+          checked={false}
+          onChange={handler}
+          label="Label"
+          description="Extra information about the field"
+        />
+      ),
+    },
+    {
+      label: 'Radio Button with a Badge',
+      Example: ({ id, handler }) => (
+        <Radio
+          id={id}
+          checked={false}
+          onChange={handler}
+          label="Label"
+          badge={
+            <Badge tone="positive" weight="strong">
+              New
+            </Badge>
+          }
+        />
+      ),
+    },
+    {
+      label: 'Radio Button with a Badge and description',
+      Example: ({ id, handler }) => (
+        <Radio
+          id={id}
+          checked={false}
+          onChange={handler}
+          label="Label"
+          badge={
+            <Badge tone="positive" weight="strong">
+              New
+            </Badge>
+          }
+          description="Extra information about the field"
+        />
+      ),
+    },
+    {
+      label: 'Radio Button with nested content visible only when checked',
+      Example: ({ id }) => {
+        const [state, setState] = useState(true);
+
+        return (
+          <Radio
+            id={id}
+            checked={state}
+            onChange={() => setState(!state)}
+            label="Label"
+          >
+            <Text>This text is visible when the radio button is checked.</Text>
+          </Radio>
+        );
+      },
+    },
+    {
+      label: 'Radio Button with nested content and description',
+      Example: ({ id, handler }) => (
+        <Radio
+          id={id}
+          checked={true}
+          onChange={handler}
+          label="Label"
+          description="Extra information about the field"
+        >
+          <Text>This text is visible when the radio button is checked.</Text>
+        </Radio>
+      ),
+    },
+  ],
+};

--- a/lib/components/RadioGroup/RadioGroup.docs.tsx
+++ b/lib/components/RadioGroup/RadioGroup.docs.tsx
@@ -23,7 +23,6 @@ const docs: ComponentDocs = {
     </Stack>
   ),
   migrationGuide: true,
-  screenshotWidths: [320],
   subComponents: ['RadioItem'],
   examples: [
     {
@@ -112,29 +111,6 @@ const docs: ComponentDocs = {
             value={state}
             onChange={(e) => setState(e.currentTarget.value)}
             label="Experience"
-            disabled
-          >
-            <RadioItem label="Less than one year" value="0" />
-            <RadioItem label="1 year" value="1" />
-            <RadioItem label="2 years" value="2" />
-            <RadioItem label="3+ years " value="3" />
-          </RadioGroup>
-        );
-      },
-    },
-    {
-      label: 'When disabled and critical',
-      docsSite: false,
-      Example: () => {
-        const [state, setState] = useState('');
-        return (
-          <RadioGroup
-            id="radiolist6"
-            value={state}
-            onChange={(e) => setState(e.currentTarget.value)}
-            label="Experience"
-            tone="critical"
-            message="Required field"
             disabled
           >
             <RadioItem label="Less than one year" value="0" />

--- a/lib/components/RadioGroup/RadioGroup.screenshots.tsx
+++ b/lib/components/RadioGroup/RadioGroup.screenshots.tsx
@@ -1,0 +1,150 @@
+import React, { useState } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { RadioGroup, RadioItem } from '..';
+import { Placeholder } from '../../playroom/components';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Default',
+      Example: () => {
+        const [state, setState] = useState('');
+        return (
+          <RadioGroup
+            id="radiolist1"
+            value={state}
+            onChange={(e) => setState(e.currentTarget.value)}
+            label="Experience"
+          >
+            <RadioItem label="Less than one year" value="0" />
+            <RadioItem label="1 year" value="1" />
+            <RadioItem label="2 years" value="2" />
+            <RadioItem label="3+ years " value="3" />
+          </RadioGroup>
+        );
+      },
+    },
+    {
+      label: 'With selected item',
+      Example: ({ handler }) => (
+        <RadioGroup
+          id="radiolist2"
+          value="2"
+          onChange={handler}
+          label="Experience"
+        >
+          <RadioItem label="Less than one year" value="0" />
+          <RadioItem label="1 year" value="1" />
+          <RadioItem label="2 years" value="2" />
+          <RadioItem label="3+ years " value="3" />
+        </RadioGroup>
+      ),
+    },
+    {
+      label: 'With description',
+      Example: () => {
+        const [state, setState] = useState('');
+        return (
+          <RadioGroup
+            id="radiolist3"
+            value={state}
+            onChange={(e) => setState(e.currentTarget.value)}
+            label="Experience"
+            description="How many years have you been in this role?"
+          >
+            <RadioItem label="Less than one year" value="0" />
+            <RadioItem label="1 year" value="1" />
+            <RadioItem label="2 years" value="2" />
+            <RadioItem label="3+ years " value="3" />
+          </RadioGroup>
+        );
+      },
+    },
+    {
+      label: 'With critical message',
+      Example: () => {
+        const [state, setState] = useState('');
+        return (
+          <RadioGroup
+            id="radiolist4"
+            value={state}
+            onChange={(e) => setState(e.currentTarget.value)}
+            label="Experience"
+            tone="critical"
+            message="Required field"
+          >
+            <RadioItem label="Less than one year" value="0" />
+            <RadioItem label="1 year" value="1" />
+            <RadioItem label="2 years" value="2" />
+            <RadioItem label="3+ years " value="3" />
+          </RadioGroup>
+        );
+      },
+    },
+    {
+      label: 'When disabled',
+      Example: () => {
+        const [state, setState] = useState('');
+        return (
+          <RadioGroup
+            id="radiolist5"
+            value={state}
+            onChange={(e) => setState(e.currentTarget.value)}
+            label="Experience"
+            disabled
+          >
+            <RadioItem label="Less than one year" value="0" />
+            <RadioItem label="1 year" value="1" />
+            <RadioItem label="2 years" value="2" />
+            <RadioItem label="3+ years " value="3" />
+          </RadioGroup>
+        );
+      },
+    },
+    {
+      label: 'When disabled and critical',
+      Example: () => {
+        const [state, setState] = useState('');
+        return (
+          <RadioGroup
+            id="radiolist6"
+            value={state}
+            onChange={(e) => setState(e.currentTarget.value)}
+            label="Experience"
+            tone="critical"
+            message="Required field"
+            disabled
+          >
+            <RadioItem label="Less than one year" value="0" />
+            <RadioItem label="1 year" value="1" />
+            <RadioItem label="2 years" value="2" />
+            <RadioItem label="3+ years " value="3" />
+          </RadioGroup>
+        );
+      },
+    },
+    {
+      label: 'With nested content visible only when checked',
+      Example: () => {
+        const [state, setState] = useState('1');
+
+        return (
+          <RadioGroup
+            id="radiolist7"
+            value={state}
+            onChange={(e) => setState(e.currentTarget.value)}
+            label="Experience"
+          >
+            <RadioItem label="Less than one year" value="0" />
+            <RadioItem label="1 year" value="1">
+              <Placeholder height={50} label="Nested content" />
+            </RadioItem>
+            <RadioItem label="2 years" value="2" />
+            <RadioItem label="3+ years " value="3" />
+          </RadioGroup>
+        );
+      },
+    },
+  ],
+};

--- a/lib/components/Rating/Rating.docs.tsx
+++ b/lib/components/Rating/Rating.docs.tsx
@@ -1,12 +1,10 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Box, Rating } from '../';
-import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
+import { Rating } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Default',
@@ -27,25 +25,6 @@ const docs: ComponentDocs = {
     {
       label: 'xsmall',
       Example: () => <Rating rating={1.5} size="xsmall" />,
-    },
-    {
-      label: 'Rating Contrast',
-      docsSite: false,
-      Example: () => {
-        const backgrounds = Object.keys(boxBackgrounds) as Array<
-          keyof typeof boxBackgrounds
-        >;
-
-        return (
-          <Fragment>
-            {backgrounds.sort().map((background) => (
-              <Box key={background} background={background} padding="xsmall">
-                <Rating rating={1.5} size="xsmall" />
-              </Box>
-            ))}
-          </Fragment>
-        );
-      },
     },
   ],
 };

--- a/lib/components/Rating/Rating.screenshots.tsx
+++ b/lib/components/Rating/Rating.screenshots.tsx
@@ -1,0 +1,48 @@
+import React, { Fragment } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Box, Rating } from '../';
+import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Default',
+      Example: () => <Rating rating={3} />,
+    },
+    {
+      label: 'Hide the text rating',
+      Example: () => <Rating rating={4.2} showTextRating={false} />,
+    },
+    {
+      label: 'large',
+      Example: () => <Rating rating={3} size="large" />,
+    },
+    {
+      label: 'small',
+      Example: () => <Rating rating={2} size="small" />,
+    },
+    {
+      label: 'xsmall',
+      Example: () => <Rating rating={1.5} size="xsmall" />,
+    },
+    {
+      label: 'Rating Contrast',
+      Example: () => {
+        const backgrounds = Object.keys(boxBackgrounds) as Array<
+          keyof typeof boxBackgrounds
+        >;
+
+        return (
+          <Fragment>
+            {backgrounds.sort().map((background) => (
+              <Box key={background} background={background} padding="xsmall">
+                <Rating rating={1.5} size="xsmall" />
+              </Box>
+            ))}
+          </Fragment>
+        );
+      },
+    },
+  ],
+};

--- a/lib/components/Secondary/Secondary.docs.tsx
+++ b/lib/components/Secondary/Secondary.docs.tsx
@@ -5,7 +5,6 @@ import { Secondary, Text } from '../';
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   examples: [
     {
       Example: () => (

--- a/lib/components/Secondary/Secondary.screenshots.tsx
+++ b/lib/components/Secondary/Secondary.screenshots.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Secondary, Text } from '../';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      Example: () => (
+        <Text>
+          The word in the <Secondary>middle</Secondary> is secondary text.
+        </Text>
+      ),
+    },
+  ],
+};

--- a/lib/components/Stack/Stack.docs.tsx
+++ b/lib/components/Stack/Stack.docs.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment, ReactNode } from 'react';
+import React, { ReactNode } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { Box, Stack, Hidden } from '../';
 import { StackProps } from './Stack';
@@ -15,8 +15,6 @@ const Container = ({ children }: { children: ReactNode }) => (
 
 const docs: ComponentDocs = {
   category: 'Layout',
-  screenshotWidths: [320, 768, 1200],
-  screenshotOnlyInWireframe: true,
   migrationGuide: true,
   examples: [
     ...spaces.map((space) => ({
@@ -87,28 +85,6 @@ const docs: ComponentDocs = {
       ),
     },
     {
-      label:
-        'Test - Should flatten fragments (6 placeholders should be evenly spaced)',
-      docsSite: false,
-      Container,
-      Example: () => (
-        <Stack space="small">
-          <Fragment>
-            <Placeholder height={40} />
-            <Placeholder height={40} />
-            <Fragment>
-              <Placeholder height={40} />
-              <Fragment>
-                <Placeholder height={40} />
-              </Fragment>
-            </Fragment>
-          </Fragment>
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-        </Stack>
-      ),
-    },
-    {
       label: 'Responsively hiding stack items',
       Container,
       Example: () => (
@@ -121,58 +97,6 @@ const docs: ComponentDocs = {
             <Placeholder height={40} label="3" />
           </Hidden>
           <Placeholder height={40} label="4" />
-        </Stack>
-      ),
-    },
-    {
-      label:
-        'Test - Hidden stack items with responsive alignment (should be center aligned showing 3 + 4 on mobile, right aligned showing 2 + 3 + 4 on tablet, left aligned showing 1 + 2 + 3 on desktop)',
-      Container,
-      docsSite: false,
-      Example: () => (
-        <Stack space="gutter" align={['center', 'right', 'left']}>
-          <Hidden below="desktop">
-            <Placeholder width={40} height={40} label="1" />
-          </Hidden>
-          <Hidden below="tablet">
-            <Placeholder width={40} height={40} label="2" />
-          </Hidden>
-          <Hidden print>
-            <Placeholder width={40} height={40} label="3" />
-          </Hidden>
-          <Hidden above="tablet">
-            <Placeholder width={40} height={40} label="4" />
-          </Hidden>
-          <Hidden screen>
-            <Placeholder
-              width={40}
-              height={40}
-              label="This should not be visible"
-            />
-          </Hidden>
-        </Stack>
-      ),
-    },
-    {
-      label:
-        'Test - Hidden stack items with dividers (should show 3 + 4 on mobile, 2 + 3 + 4 on tablet, and 1 + 2 + 3 on desktop)',
-      Container,
-      docsSite: false,
-      Example: () => (
-        <Stack space="gutter" dividers>
-          <Hidden below="desktop">
-            <Placeholder height={40} label="1" />
-          </Hidden>
-          <Hidden below="tablet">
-            <Placeholder height={40} label="2" />
-          </Hidden>
-          <Placeholder height={40} label="3" />
-          <Hidden above="tablet">
-            <Placeholder height={40} label="4" />
-          </Hidden>
-          <Hidden screen>
-            <Placeholder height={40} label="This should not be visible" />
-          </Hidden>
         </Stack>
       ),
     },

--- a/lib/components/Stack/Stack.screenshots.tsx
+++ b/lib/components/Stack/Stack.screenshots.tsx
@@ -1,0 +1,175 @@
+import React, { Fragment, ReactNode } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Box, Stack, Hidden } from '../';
+import { StackProps } from './Stack';
+import { Placeholder } from '../private/Placeholder/Placeholder';
+import { padding } from '../Box/useBoxStyles.treat';
+
+const spaces = Object.keys(padding.top).filter(
+  (space) => space !== 'none',
+) as Array<StackProps['space']>;
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <Box style={{ maxWidth: '300px' }}>{children}</Box>
+);
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320, 768, 1200],
+  screenshotOnlyInWireframe: true,
+  examples: [
+    ...spaces.map((space) => ({
+      label: `Space: ${space}`,
+      Container,
+      Example: () => (
+        <Stack space={space}>
+          <Placeholder height={40} />
+          <Placeholder height={40} />
+          <Placeholder height={40} />
+        </Stack>
+      ),
+    })),
+    {
+      label: 'Align to center',
+      Container,
+      Example: () => (
+        <Stack space="gutter" align="center">
+          <Placeholder height={40} width={40} />
+          <Placeholder height={40} width={60} />
+          <Placeholder height={40} width={80} />
+        </Stack>
+      ),
+    },
+    {
+      label: 'Align to right',
+      Container,
+      Example: () => (
+        <Stack space="gutter" align="right">
+          <Placeholder height={40} width={40} />
+          <Placeholder height={40} width={60} />
+          <Placeholder height={40} width={80} />
+        </Stack>
+      ),
+    },
+    {
+      label:
+        'Responsive alignment (e.g. center on mobile, left from tablet upwards)',
+      Container,
+      Example: () => (
+        <Stack space="gutter" align={['center', 'left']}>
+          <Placeholder height={40} width={40} />
+          <Placeholder height={40} width={60} />
+          <Placeholder height={40} width={80} />
+        </Stack>
+      ),
+    },
+    {
+      label: 'Dividers',
+      Container,
+      Example: () => (
+        <Stack space="gutter" dividers>
+          <Placeholder height={40} />
+          <Placeholder height={40} />
+          <Placeholder height={40} />
+        </Stack>
+      ),
+    },
+    {
+      label: 'Strong dividers',
+      Container,
+      Example: () => (
+        <Stack space="gutter" dividers="strong">
+          <Placeholder height={40} />
+          <Placeholder height={40} />
+          <Placeholder height={40} />
+        </Stack>
+      ),
+    },
+    {
+      label:
+        'Test - Should flatten fragments (6 placeholders should be evenly spaced)',
+      Container,
+      Example: () => (
+        <Stack space="small">
+          <Fragment>
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Fragment>
+              <Placeholder height={40} />
+              <Fragment>
+                <Placeholder height={40} />
+              </Fragment>
+            </Fragment>
+          </Fragment>
+          <Placeholder height={40} />
+          <Placeholder height={40} />
+        </Stack>
+      ),
+    },
+    {
+      label: 'Responsively hiding stack items',
+      Container,
+      Example: () => (
+        <Stack space="gutter">
+          <Placeholder height={40} label="1" />
+          <Hidden below="tablet">
+            <Placeholder height={40} label="2" />
+          </Hidden>
+          <Hidden above="mobile">
+            <Placeholder height={40} label="3" />
+          </Hidden>
+          <Placeholder height={40} label="4" />
+        </Stack>
+      ),
+    },
+    {
+      label:
+        'Test - Hidden stack items with responsive alignment (should be center aligned showing 3 + 4 on mobile, right aligned showing 2 + 3 + 4 on tablet, left aligned showing 1 + 2 + 3 on desktop)',
+      Container,
+      Example: () => (
+        <Stack space="gutter" align={['center', 'right', 'left']}>
+          <Hidden below="desktop">
+            <Placeholder width={40} height={40} label="1" />
+          </Hidden>
+          <Hidden below="tablet">
+            <Placeholder width={40} height={40} label="2" />
+          </Hidden>
+          <Hidden print>
+            <Placeholder width={40} height={40} label="3" />
+          </Hidden>
+          <Hidden above="tablet">
+            <Placeholder width={40} height={40} label="4" />
+          </Hidden>
+          <Hidden screen>
+            <Placeholder
+              width={40}
+              height={40}
+              label="This should not be visible"
+            />
+          </Hidden>
+        </Stack>
+      ),
+    },
+    {
+      label:
+        'Test - Hidden stack items with dividers (should show 3 + 4 on mobile, 2 + 3 + 4 on tablet, and 1 + 2 + 3 on desktop)',
+      Container,
+      Example: () => (
+        <Stack space="gutter" dividers>
+          <Hidden below="desktop">
+            <Placeholder height={40} label="1" />
+          </Hidden>
+          <Hidden below="tablet">
+            <Placeholder height={40} label="2" />
+          </Hidden>
+          <Placeholder height={40} label="3" />
+          <Hidden above="tablet">
+            <Placeholder height={40} label="4" />
+          </Hidden>
+          <Hidden screen>
+            <Placeholder height={40} label="This should not be visible" />
+          </Hidden>
+        </Stack>
+      ),
+    },
+  ],
+};

--- a/lib/components/Strong/Strong.docs.tsx
+++ b/lib/components/Strong/Strong.docs.tsx
@@ -5,7 +5,6 @@ import { Strong, Text } from '../';
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   examples: [
     {
       Example: () => (

--- a/lib/components/Strong/Strong.screenshots.tsx
+++ b/lib/components/Strong/Strong.screenshots.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Strong, Text } from '../';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      Example: () => (
+        <Text>
+          The last word of this sentence is <Strong>strong.</Strong>
+        </Text>
+      ),
+    },
+  ],
+};

--- a/lib/components/Tabs/Tabs.docs.tsx
+++ b/lib/components/Tabs/Tabs.docs.tsx
@@ -13,14 +13,11 @@ import {
   Strong,
   List,
   Card,
-  Box,
 } from '..';
 import { Placeholder } from '../../playroom/components';
-import { useBraidTheme } from '../BraidProvider/BraidThemeContext';
 
 const docs: ComponentDocs = {
   category: 'Content',
-  screenshotWidths: [320, 1200],
   subComponents: ['TabsProvider', 'Tab', 'TabPanels', 'TabPanel'],
   description: (
     <Stack space="large">
@@ -191,115 +188,6 @@ const docs: ComponentDocs = {
               </TabPanel>
               <TabPanel>
                 <Placeholder height={200} label="Panel 4" />
-              </TabPanel>
-            </TabPanels>
-          </Card>
-        </TabsProvider>
-      ),
-    },
-    {
-      docsSite: false,
-      label:
-        'Test: Center aligned tabs should be left aligned on mobile when content is too wide',
-      Example: ({ id }) => (
-        <TabsProvider id={id}>
-          <Stack space="medium">
-            <Tabs label="Test tabs" align="center">
-              <Tab>The first tab</Tab>
-              <Tab>The second tab</Tab>
-              <Tab>The third tab</Tab>
-              <Tab>The fourth tab</Tab>
-              <Tab>The fifth tab</Tab>
-            </Tabs>
-            <TabPanels>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 1" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 2" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 3" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 4" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 5" />
-              </TabPanel>
-            </TabPanels>
-          </Stack>
-        </TabsProvider>
-      ),
-    },
-    {
-      docsSite: false,
-      label: 'Test: Selected tab should be scrolled into view on load',
-      Example: ({ id }) => (
-        <TabsProvider id={id} selectedItem="4">
-          <Stack space="medium">
-            <Tabs label="Test tabs" align="center">
-              <Tab item="1">The first tab</Tab>
-              <Tab item="2">The second tab</Tab>
-              <Tab item="3">The third tab</Tab>
-              <Tab item="4">The fourth tab</Tab>
-              <Tab item="5">The fifth tab</Tab>
-            </Tabs>
-            <TabPanels>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 1" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 2" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 3" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 4" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 5" />
-              </TabPanel>
-            </TabPanels>
-          </Stack>
-        </TabsProvider>
-      ),
-    },
-    {
-      docsSite: false,
-      label:
-        'Test: Selected tab with gutter should be scrolled into view on load',
-      Container: ({ children }) => (
-        <Box style={{ background: useBraidTheme().color.background.body }}>
-          {children}
-        </Box>
-      ),
-      Example: ({ id }) => (
-        <TabsProvider id={id} selectedItem="3">
-          <Tabs label="Test tabs" align="center" gutter="gutter" reserveHitArea>
-            <Tab item="1">The first tab</Tab>
-            <Tab item="2">The second tab</Tab>
-            <Tab item="3">The third tab</Tab>
-            <Tab item="4">The fourth tab</Tab>
-            <Tab item="5">The fifth tab</Tab>
-          </Tabs>
-          <Card>
-            <TabPanels>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 1" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 2" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 3" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 4" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 5" />
               </TabPanel>
             </TabPanels>
           </Card>

--- a/lib/components/Tabs/Tabs.screenshots.tsx
+++ b/lib/components/Tabs/Tabs.screenshots.tsx
@@ -1,0 +1,241 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import {
+  Stack,
+  Tabs,
+  Tab,
+  TabPanel,
+  TabPanels,
+  TabsProvider,
+  Badge,
+  Card,
+  Box,
+} from '..';
+import { Placeholder } from '../../playroom/components';
+import { useBraidTheme } from '../BraidProvider/BraidThemeContext';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320, 1200],
+  examples: [
+    {
+      label: 'Left aligned',
+      Example: ({ id }) => (
+        <Card>
+          <TabsProvider id={id}>
+            <Stack space="medium">
+              <Tabs label="Test tabs">
+                <Tab>The first tab</Tab>
+                <Tab>The second tab</Tab>
+                <Tab>The third tab</Tab>
+                <Tab badge={<Badge tone="positive">New</Badge>}>
+                  The fourth tab
+                </Tab>
+              </Tabs>
+              <TabPanels>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 1" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 2" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 3" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 4" />
+                </TabPanel>
+              </TabPanels>
+            </Stack>
+          </TabsProvider>
+        </Card>
+      ),
+    },
+    {
+      label: 'Center aligned',
+      Example: ({ id }) => (
+        <Card>
+          <TabsProvider id={id}>
+            <Stack space="medium">
+              <Tabs label="Test tabs" align="center">
+                <Tab>The first tab</Tab>
+                <Tab>The second tab</Tab>
+              </Tabs>
+              <TabPanels>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 1" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 2" />
+                </TabPanel>
+              </TabPanels>
+            </Stack>
+          </TabsProvider>
+        </Card>
+      ),
+    },
+    {
+      label: 'With gutter',
+      Example: ({ id }) => (
+        <TabsProvider id={id}>
+          <Tabs label="Test tabs" gutter="gutter">
+            <Tab>The first tab</Tab>
+            <Tab>The second tab</Tab>
+            <Tab>The third tab</Tab>
+            <Tab>The fourth tab</Tab>
+          </Tabs>
+          <Card>
+            <TabPanels>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 1" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 2" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 3" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 4" />
+              </TabPanel>
+            </TabPanels>
+          </Card>
+        </TabsProvider>
+      ),
+    },
+    {
+      label: 'With gutter and reserved hit area',
+      Example: ({ id }) => (
+        <TabsProvider id={id}>
+          <Tabs label="Test tabs" gutter="gutter" reserveHitArea>
+            <Tab>The first tab</Tab>
+            <Tab>The second tab</Tab>
+            <Tab>The third tab</Tab>
+            <Tab>The fourth tab</Tab>
+          </Tabs>
+          <Card>
+            <TabPanels>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 1" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 2" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 3" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 4" />
+              </TabPanel>
+            </TabPanels>
+          </Card>
+        </TabsProvider>
+      ),
+    },
+    {
+      label:
+        'Test: Center aligned tabs should be left aligned on mobile when content is too wide',
+      Example: ({ id }) => (
+        <TabsProvider id={id}>
+          <Stack space="medium">
+            <Tabs label="Test tabs" align="center">
+              <Tab>The first tab</Tab>
+              <Tab>The second tab</Tab>
+              <Tab>The third tab</Tab>
+              <Tab>The fourth tab</Tab>
+              <Tab>The fifth tab</Tab>
+            </Tabs>
+            <TabPanels>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 1" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 2" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 3" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 4" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 5" />
+              </TabPanel>
+            </TabPanels>
+          </Stack>
+        </TabsProvider>
+      ),
+    },
+    {
+      label: 'Test: Selected tab should be scrolled into view on load',
+      Example: ({ id }) => (
+        <TabsProvider id={id} selectedItem="4">
+          <Stack space="medium">
+            <Tabs label="Test tabs" align="center">
+              <Tab item="1">The first tab</Tab>
+              <Tab item="2">The second tab</Tab>
+              <Tab item="3">The third tab</Tab>
+              <Tab item="4">The fourth tab</Tab>
+              <Tab item="5">The fifth tab</Tab>
+            </Tabs>
+            <TabPanels>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 1" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 2" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 3" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 4" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 5" />
+              </TabPanel>
+            </TabPanels>
+          </Stack>
+        </TabsProvider>
+      ),
+    },
+    {
+      label:
+        'Test: Selected tab with gutter should be scrolled into view on load',
+      Container: ({ children }) => (
+        <Box style={{ background: useBraidTheme().color.background.body }}>
+          {children}
+        </Box>
+      ),
+      Example: ({ id }) => (
+        <TabsProvider id={id} selectedItem="3">
+          <Tabs label="Test tabs" align="center" gutter="gutter" reserveHitArea>
+            <Tab item="1">The first tab</Tab>
+            <Tab item="2">The second tab</Tab>
+            <Tab item="3">The third tab</Tab>
+            <Tab item="4">The fourth tab</Tab>
+            <Tab item="5">The fifth tab</Tab>
+          </Tabs>
+          <Card>
+            <TabPanels>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 1" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 2" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 3" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 4" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 5" />
+              </TabPanel>
+            </TabPanels>
+          </Card>
+        </TabsProvider>
+      ),
+    },
+  ],
+};

--- a/lib/components/Tag/Tag.docs.tsx
+++ b/lib/components/Tag/Tag.docs.tsx
@@ -1,11 +1,10 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Tag, Inline } from '../';
+import { Tag } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Standard Tag',
@@ -19,33 +18,6 @@ const docs: ComponentDocs = {
         <Tag onClear={handler} clearLabel="Clear tag">
           Tag
         </Tag>
-      ),
-    },
-    {
-      label: 'Truncated Tag',
-      docsSite: false,
-      background: 'card',
-      Example: ({ handler }) => (
-        <Tag onClear={handler} clearLabel="Clear tag">
-          The quick brown fox jumps over the lazy dog. The quick brown fox jumps
-          over the lazy dog. The quick brown fox jumps over the lazy dog. The
-          quick brown fox jumps over the lazy dog. The quick brown fox jumps
-          over the lazy dog. The quick brown fox jumps over the lazy dog. The
-          quick brown fox jumps over the lazy dog.
-        </Tag>
-      ),
-    },
-    {
-      label: 'Test: Standard and clearable tags should be equal height',
-      docsSite: false,
-      background: 'card',
-      Example: ({ handler }) => (
-        <Inline space="small">
-          <Tag>Tag</Tag>
-          <Tag onClear={handler} clearLabel="Clear tag">
-            Tag
-          </Tag>
-        </Inline>
       ),
     },
   ],

--- a/lib/components/Tag/Tag.screenshots.tsx
+++ b/lib/components/Tag/Tag.screenshots.tsx
@@ -1,0 +1,48 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Tag, Inline } from '../';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Standard Tag',
+      background: 'card',
+      Example: () => <Tag>Tag</Tag>,
+    },
+    {
+      label: 'Clearable Tag',
+      background: 'card',
+      Example: ({ handler }) => (
+        <Tag onClear={handler} clearLabel="Clear tag">
+          Tag
+        </Tag>
+      ),
+    },
+    {
+      label: 'Truncated Tag',
+      background: 'card',
+      Example: ({ handler }) => (
+        <Tag onClear={handler} clearLabel="Clear tag">
+          The quick brown fox jumps over the lazy dog. The quick brown fox jumps
+          over the lazy dog. The quick brown fox jumps over the lazy dog. The
+          quick brown fox jumps over the lazy dog. The quick brown fox jumps
+          over the lazy dog. The quick brown fox jumps over the lazy dog. The
+          quick brown fox jumps over the lazy dog.
+        </Tag>
+      ),
+    },
+    {
+      label: 'Test: Standard and clearable tags should be equal height',
+      background: 'card',
+      Example: ({ handler }) => (
+        <Inline space="small">
+          <Tag>Tag</Tag>
+          <Tag onClear={handler} clearLabel="Clear tag">
+            Tag
+          </Tag>
+        </Inline>
+      ),
+    },
+  ],
+};

--- a/lib/components/Text/Text.docs.tsx
+++ b/lib/components/Text/Text.docs.tsx
@@ -1,12 +1,6 @@
-import React, { Fragment, ReactNode } from 'react';
-import { titleCase } from 'change-case';
+import React, { ReactNode } from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Box, Text, Stack, Column, Columns, IconPositive } from '../';
-import {
-  background as boxBackgrounds,
-  textAlign,
-} from '../Box/useBoxStyles.treat';
-import { text as textSizes } from '../../hooks/typography/typography.treat';
+import { Box, Text, Stack } from '../';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -15,7 +9,6 @@ const Container = ({ children }: { children: ReactNode }) => (
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320, 768],
   examples: [
     { label: 'Standard Text', Example: () => <Text>Standard text.</Text> },
     {
@@ -44,90 +37,6 @@ const docs: ComponentDocs = {
           <Text tone="secondary">Secondary text</Text>
         </Stack>
       ),
-    },
-    {
-      label: 'Text Alignment',
-      docsSite: false,
-      Container,
-      Example: () => {
-        const alignments = Object.keys(textAlign) as Array<
-          keyof typeof textAlign
-        >;
-
-        return (
-          <Stack space="medium">
-            {alignments.map((alignment) => (
-              <Text align={alignment} key={alignment}>
-                {titleCase(alignment)}
-              </Text>
-            ))}
-          </Stack>
-        );
-      },
-    },
-    {
-      label: 'Text Alignment (responsive)',
-      docsSite: false,
-      Container,
-      Example: () => (
-        <Text align={['right', 'center', 'left']}>
-          Right aligned mobile, center on tablet, left on desktop
-        </Text>
-      ),
-    },
-    {
-      label: 'Text Spacing',
-      docsSite: false,
-      background: 'card',
-      Container,
-      Example: () => {
-        const sizes = Object.keys(textSizes) as Array<keyof typeof textSizes>;
-
-        return (
-          <Stack space="medium">
-            {sizes.sort().map((size) => (
-              <Box key={size} background="neutralLight">
-                <Text size={size}>
-                  {titleCase(size)} Text (Line 1)
-                  <br />
-                  {titleCase(size)} Text (Line 2)
-                </Text>
-              </Box>
-            ))}
-          </Stack>
-        );
-      },
-    },
-    {
-      label: 'Text Contrast',
-      docsSite: false,
-      Container,
-      Example: () => {
-        const backgrounds = Object.keys(boxBackgrounds) as Array<
-          keyof typeof boxBackgrounds
-        >;
-
-        return (
-          <Fragment>
-            {backgrounds.sort().map((background) => (
-              <Box key={background} background={background} padding="xsmall">
-                <Columns space="medium">
-                  <Column>
-                    <Text size="small">
-                      {background} <IconPositive />
-                    </Text>
-                  </Column>
-                  <Column width="content">
-                    <Text size="small" tone="secondary">
-                      Secondary <IconPositive />
-                    </Text>
-                  </Column>
-                </Columns>
-              </Box>
-            ))}
-          </Fragment>
-        );
-      },
     },
   ],
 };

--- a/lib/components/Text/Text.screenshots.tsx
+++ b/lib/components/Text/Text.screenshots.tsx
@@ -1,0 +1,127 @@
+import React, { Fragment, ReactNode } from 'react';
+import { titleCase } from 'change-case';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Box, Text, Stack, Column, Columns, IconPositive } from '../';
+import {
+  background as boxBackgrounds,
+  textAlign,
+} from '../Box/useBoxStyles.treat';
+import { text as textSizes } from '../../hooks/typography/typography.treat';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div style={{ maxWidth: '300px' }}>{children}</div>
+);
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320, 768],
+  examples: [
+    { label: 'Standard Text', Example: () => <Text>Standard text.</Text> },
+    {
+      label: 'Small Text',
+      Example: () => <Text size="small">Small text.</Text>,
+    },
+    {
+      label: 'Large Text',
+      Example: () => <Text size="large">Large text.</Text>,
+    },
+    {
+      label: 'Truncating long text',
+      Example: () => (
+        <Box style={{ width: 90 }}>
+          <Text truncate>Long piece of text</Text>
+        </Box>
+      ),
+    },
+    {
+      label: 'Text on Brand Background',
+      background: 'brand',
+      Container,
+      Example: () => (
+        <Stack space="small">
+          <Text>Neutral text</Text>
+          <Text tone="secondary">Secondary text</Text>
+        </Stack>
+      ),
+    },
+    {
+      label: 'Text Alignment',
+      Container,
+      Example: () => {
+        const alignments = Object.keys(textAlign) as Array<
+          keyof typeof textAlign
+        >;
+
+        return (
+          <Stack space="medium">
+            {alignments.map((alignment) => (
+              <Text align={alignment} key={alignment}>
+                {titleCase(alignment)}
+              </Text>
+            ))}
+          </Stack>
+        );
+      },
+    },
+    {
+      label: 'Text Alignment (responsive)',
+      Container,
+      Example: () => (
+        <Text align={['right', 'center', 'left']}>
+          Right aligned mobile, center on tablet, left on desktop
+        </Text>
+      ),
+    },
+    {
+      label: 'Text Spacing',
+      background: 'card',
+      Container,
+      Example: () => {
+        const sizes = Object.keys(textSizes) as Array<keyof typeof textSizes>;
+
+        return (
+          <Stack space="medium">
+            {sizes.sort().map((size) => (
+              <Box key={size} background="neutralLight">
+                <Text size={size}>
+                  {titleCase(size)} Text (Line 1)
+                  <br />
+                  {titleCase(size)} Text (Line 2)
+                </Text>
+              </Box>
+            ))}
+          </Stack>
+        );
+      },
+    },
+    {
+      label: 'Text Contrast',
+      Container,
+      Example: () => {
+        const backgrounds = Object.keys(boxBackgrounds) as Array<
+          keyof typeof boxBackgrounds
+        >;
+
+        return (
+          <Fragment>
+            {backgrounds.sort().map((background) => (
+              <Box key={background} background={background} padding="xsmall">
+                <Columns space="medium">
+                  <Column>
+                    <Text size="small">
+                      {background} <IconPositive />
+                    </Text>
+                  </Column>
+                  <Column width="content">
+                    <Text size="small" tone="secondary">
+                      Secondary <IconPositive />
+                    </Text>
+                  </Column>
+                </Columns>
+              </Box>
+            ))}
+          </Fragment>
+        );
+      },
+    },
+  ],
+};

--- a/lib/components/TextDropdown/TextDropdown.docs.tsx
+++ b/lib/components/TextDropdown/TextDropdown.docs.tsx
@@ -29,7 +29,6 @@ const docs: ComponentDocs = {
       </Text>
     </Stack>
   ),
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Default',

--- a/lib/components/TextDropdown/TextDropdown.screenshots.tsx
+++ b/lib/components/TextDropdown/TextDropdown.screenshots.tsx
@@ -1,0 +1,117 @@
+import React, { ReactNode, useState } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Heading, Strong, Text, TextDropdown } from '..';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div style={{ maxWidth: '300px' }}>{children}</div>
+);
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Default',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('Developer');
+
+        return (
+          <Text>
+            <TextDropdown
+              label="Job Title"
+              id={id}
+              onChange={setValue}
+              value={value}
+              options={['Developer', 'Designer', 'Product Manager']}
+            />
+          </Text>
+        );
+      },
+    },
+    {
+      label: 'With identifying values',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState(2000);
+
+        return (
+          <Text>
+            <TextDropdown
+              label="Location"
+              id={id}
+              onChange={setValue}
+              value={value}
+              options={[
+                { text: 'Melbourne', value: 3000 },
+                { text: 'Sydney', value: 2000 },
+                { text: 'Brisbane', value: 4000 },
+              ]}
+            />
+          </Text>
+        );
+      },
+    },
+    {
+      label: 'Within strong text',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('Relevance');
+
+        return (
+          <Text>
+            Sort by{' '}
+            <Strong>
+              <TextDropdown
+                label="Sort order"
+                id={id}
+                onChange={setValue}
+                value={value}
+                options={['Relevance', 'Keyword']}
+              />
+            </Strong>
+          </Text>
+        );
+      },
+    },
+    {
+      label: 'Within a heading',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('Sydney');
+
+        return (
+          <Heading level="2">
+            Jobs in{' '}
+            <TextDropdown
+              label="Location"
+              id={id}
+              onChange={setValue}
+              value={value}
+              options={['Melbourne', 'Sydney', 'Brisbane']}
+            />
+          </Heading>
+        );
+      },
+    },
+    {
+      label: 'TextDropdown on Brand Background',
+      background: 'brand',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('Designer');
+
+        return (
+          <Text>
+            <TextDropdown
+              label="Job Title"
+              id={id}
+              onChange={setValue}
+              value={value}
+              options={['Developer', 'Designer', 'Product Manager']}
+            />
+          </Text>
+        );
+      },
+    },
+  ],
+};

--- a/lib/components/TextField/TextField.docs.tsx
+++ b/lib/components/TextField/TextField.docs.tsx
@@ -9,7 +9,6 @@ const Container = ({ children }: { children: ReactNode }) => (
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   examples: [
     {
       label: 'TextField',
@@ -20,19 +19,6 @@ const docs: ComponentDocs = {
           id={id}
           onChange={handler}
           value="Senior Developer"
-        />
-      ),
-    },
-    {
-      docsSite: false,
-      label: 'TextField with default padding',
-      Container,
-      Example: ({ id, handler }) => (
-        <TextField
-          label="Job Title"
-          id={id}
-          onChange={handler}
-          value="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
         />
       ),
     },
@@ -70,20 +56,6 @@ const docs: ComponentDocs = {
           />
         );
       },
-    },
-    {
-      docsSite: false,
-      label: 'TextField with clear button padding',
-      Container,
-      Example: ({ id, handler }) => (
-        <TextField
-          label="Job Title"
-          id={id}
-          onChange={handler}
-          onClear={handler}
-          value="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-        />
-      ),
     },
     {
       label: 'TextField with message',

--- a/lib/components/TextField/TextField.screenshots.tsx
+++ b/lib/components/TextField/TextField.screenshots.tsx
@@ -1,0 +1,180 @@
+import React, { useState, ReactNode } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { IconSearch, TextField, TextLink } from '../';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div style={{ maxWidth: '300px' }}>{children}</div>
+);
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'TextField',
+      Container,
+      Example: ({ id, handler }) => (
+        <TextField
+          label="Job Title"
+          id={id}
+          onChange={handler}
+          value="Senior Developer"
+        />
+      ),
+    },
+    {
+      label: 'TextField with default padding',
+      Container,
+      Example: ({ id, handler }) => (
+        <TextField
+          label="Job Title"
+          id={id}
+          onChange={handler}
+          value="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        />
+      ),
+    },
+    {
+      label: 'TextField with clear button',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('Clear me');
+
+        return (
+          <TextField
+            label="Job Title"
+            id={id}
+            onChange={(e) => setValue(e.currentTarget.value)}
+            onClear={() => setValue('')}
+            value={value}
+          />
+        );
+      },
+    },
+    {
+      label: 'TextField with icon',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('');
+
+        return (
+          <TextField
+            label="Job Title"
+            id={id}
+            icon={<IconSearch />}
+            placeholder="Enter a job title"
+            onChange={(e) => setValue(e.currentTarget.value)}
+            value={value}
+          />
+        );
+      },
+    },
+    {
+      label: 'TextField with clear button padding',
+      Container,
+      Example: ({ id, handler }) => (
+        <TextField
+          label="Job Title"
+          id={id}
+          onChange={handler}
+          onClear={handler}
+          value="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
+        />
+      ),
+    },
+    {
+      label: 'TextField with message',
+      Container,
+      Example: ({ id, handler }) => (
+        <TextField
+          label="Job Title"
+          id={id}
+          value=""
+          message="e.g. Senior Developer"
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'TextField with secondary label',
+      Container,
+      Example: ({ id, handler }) => (
+        <TextField
+          label="Title"
+          secondaryLabel="Optional"
+          id={id}
+          value=""
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'TextField with tertiary label',
+      Container,
+      Example: ({ id, handler }) => (
+        <TextField
+          label="Title"
+          secondaryLabel="Optional"
+          tertiaryLabel={<TextLink href="#">Help?</TextLink>}
+          id={id}
+          value=""
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'TextField with description',
+      Container,
+      Example: ({ id, handler }) => (
+        <TextField
+          label="Title"
+          secondaryLabel="Optional"
+          description="Longer description of this field"
+          id={id}
+          value=""
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'TextField with error',
+      Container,
+      Example: ({ id, handler }) => (
+        <TextField
+          label="Do you like Braid?"
+          tone="critical"
+          id={id}
+          value="No"
+          message="Answer is incorrect"
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'TextField with postive message',
+      Container,
+      Example: ({ id, handler }) => (
+        <TextField
+          label="Do you like Braid?"
+          id={id}
+          value="Yes"
+          message="Nice one!"
+          tone="positive"
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'TextField on Brand Background',
+      background: 'brand',
+      Container,
+      Example: ({ id, handler }) => (
+        <TextField
+          label="Job Title"
+          id={id}
+          onChange={handler}
+          value="Senior Developer"
+        />
+      ),
+    },
+  ],
+};

--- a/lib/components/TextLink/TextLink.docs.tsx
+++ b/lib/components/TextLink/TextLink.docs.tsx
@@ -1,22 +1,10 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import {
-  Actions,
-  Box,
-  Button,
-  Heading,
-  IconNewWindow,
-  IconChevron,
-  Stack,
-  Text,
-  TextLink,
-} from '../';
-import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
+import { Actions, Button, Heading, Stack, Text, TextLink } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   description: (
     <Stack space="large">
       <Text>
@@ -149,70 +137,6 @@ const docs: ComponentDocs = {
           </TextLink>
         </Heading>
       ),
-    },
-    {
-      label: 'TextLink with icon',
-      docsSite: false,
-      Example: () => (
-        <Text>
-          This sentence contains a{' '}
-          <TextLink href="#">
-            TextLink
-            <IconChevron direction="right" />
-          </TextLink>
-          .
-        </Text>
-      ),
-    },
-    {
-      label: 'TextLink inside Actions with icon',
-      docsSite: false,
-      Example: () => (
-        <Actions>
-          <Button>Button</Button>
-          <TextLink href="#">
-            TextLink <IconChevron direction="right" />
-          </TextLink>
-        </Actions>
-      ),
-    },
-    {
-      label: 'TextLink Contrast',
-      docsSite: false,
-      Example: () => {
-        const backgrounds = Object.keys(boxBackgrounds) as Array<
-          keyof typeof boxBackgrounds
-        >;
-
-        return (
-          <Fragment>
-            {backgrounds.sort().map((background, i) => (
-              <Box key={i} background={background}>
-                <Stack space="none">
-                  <Text baseline={false}>
-                    {background}{' '}
-                    <TextLink href="#">
-                      with default weight <IconNewWindow />
-                    </TextLink>
-                  </Text>
-                  <Text baseline={false}>
-                    {background}{' '}
-                    <TextLink href="#" weight="regular">
-                      with regular weight <IconNewWindow />
-                    </TextLink>
-                  </Text>
-                  <Text baseline={false}>
-                    {background}{' '}
-                    <TextLink href="#" weight="weak">
-                      with weak weight <IconNewWindow />
-                    </TextLink>
-                  </Text>
-                </Stack>
-              </Box>
-            ))}
-          </Fragment>
-        );
-      },
     },
   ],
 };

--- a/lib/components/TextLink/TextLink.screenshots.tsx
+++ b/lib/components/TextLink/TextLink.screenshots.tsx
@@ -1,0 +1,194 @@
+import React, { Fragment } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import {
+  Actions,
+  Box,
+  Button,
+  Heading,
+  IconNewWindow,
+  IconChevron,
+  Stack,
+  Text,
+  TextLink,
+} from '../';
+import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Regular TextLink',
+      Example: () => (
+        <Text>
+          <TextLink href="#" hitArea="large">
+            TextLink
+          </TextLink>
+        </Text>
+      ),
+    },
+    {
+      label: 'Regular TextLink in a sentence',
+      Example: () => (
+        <Text>
+          This sentence contains a <TextLink href="#">TextLink.</TextLink>
+        </Text>
+      ),
+    },
+    {
+      label: 'Weak TextLink in a sentence',
+      Example: () => (
+        <Text>
+          This sentence contains a{' '}
+          <TextLink href="#" weight="weak">
+            weak TextLink
+          </TextLink>
+          .
+        </Text>
+      ),
+    },
+    {
+      label: 'TextLink in secondary text',
+      Example: () => (
+        <Text tone="secondary">
+          This sentence contains a <TextLink href="#">TextLink.</TextLink>
+        </Text>
+      ),
+    },
+    {
+      label: 'Visited TextLink',
+      Example: () => (
+        <Text>
+          This sentence contains a{' '}
+          <TextLink href="" showVisited>
+            visited TextLink.
+          </TextLink>
+        </Text>
+      ),
+    },
+    {
+      label: 'TextLink on dark background',
+      background: 'brand',
+      Example: () => (
+        <Text>
+          This sentence contains a <TextLink href="#">TextLink.</TextLink>
+        </Text>
+      ),
+    },
+    {
+      label: 'TextLink inside Actions',
+      Example: () => (
+        <Actions>
+          <Button>Button</Button>
+          <TextLink href="#">TextLink</TextLink>
+        </Actions>
+      ),
+    },
+    {
+      label: 'TextLink inside large Text',
+      Example: () => (
+        <Text size="large">
+          This sentence contains a <TextLink href="#">TextLink.</TextLink>
+        </Text>
+      ),
+    },
+    {
+      label: 'TextLink inside Heading',
+      Example: () => (
+        <Heading level="3">
+          This heading contains a <TextLink href="#">TextLink.</TextLink>
+        </Heading>
+      ),
+    },
+    {
+      label: 'TextLink inside weak Heading',
+      Example: () => (
+        <Heading level="3" weight="weak">
+          This heading contains a <TextLink href="#">TextLink.</TextLink>
+        </Heading>
+      ),
+    },
+    {
+      label: 'Weak TextLink inside Heading',
+      Example: () => (
+        <Heading level="3">
+          This heading contains a{' '}
+          <TextLink href="#" weight="weak">
+            weak TextLink.
+          </TextLink>
+        </Heading>
+      ),
+    },
+    {
+      label: 'Weak TextLink inside weak Heading',
+      Example: () => (
+        <Heading level="3" weight="weak">
+          This heading contains a{' '}
+          <TextLink href="#" weight="weak">
+            weak TextLink.
+          </TextLink>
+        </Heading>
+      ),
+    },
+    {
+      label: 'TextLink with icon',
+      Example: () => (
+        <Text>
+          This sentence contains a{' '}
+          <TextLink href="#">
+            TextLink
+            <IconChevron direction="right" />
+          </TextLink>
+          .
+        </Text>
+      ),
+    },
+    {
+      label: 'TextLink inside Actions with icon',
+      Example: () => (
+        <Actions>
+          <Button>Button</Button>
+          <TextLink href="#">
+            TextLink <IconChevron direction="right" />
+          </TextLink>
+        </Actions>
+      ),
+    },
+    {
+      label: 'TextLink Contrast',
+      Example: () => {
+        const backgrounds = Object.keys(boxBackgrounds) as Array<
+          keyof typeof boxBackgrounds
+        >;
+
+        return (
+          <Fragment>
+            {backgrounds.sort().map((background, i) => (
+              <Box key={i} background={background}>
+                <Stack space="none">
+                  <Text baseline={false}>
+                    {background}{' '}
+                    <TextLink href="#">
+                      with default weight <IconNewWindow />
+                    </TextLink>
+                  </Text>
+                  <Text baseline={false}>
+                    {background}{' '}
+                    <TextLink href="#" weight="regular">
+                      with regular weight <IconNewWindow />
+                    </TextLink>
+                  </Text>
+                  <Text baseline={false}>
+                    {background}{' '}
+                    <TextLink href="#" weight="weak">
+                      with weak weight <IconNewWindow />
+                    </TextLink>
+                  </Text>
+                </Stack>
+              </Box>
+            ))}
+          </Fragment>
+        );
+      },
+    },
+  ],
+};

--- a/lib/components/TextLinkButton/TextLinkButton.docs.tsx
+++ b/lib/components/TextLinkButton/TextLinkButton.docs.tsx
@@ -4,7 +4,6 @@ import { Stack, Text, TextLink, TextLinkButton, Actions, Button } from '..';
 
 const docs: ComponentDocs = {
   category: 'Content',
-  screenshotWidths: [320],
   description: (
     <Stack space="large">
       <Text>

--- a/lib/components/TextLinkButton/TextLinkButton.screenshots.tsx
+++ b/lib/components/TextLinkButton/TextLinkButton.screenshots.tsx
@@ -1,0 +1,40 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Text, TextLinkButton, Actions, Button } from '..';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'TextLinkButton inside Text',
+      Example: ({ handler }) => (
+        <Text>
+          The link in this sentence{' '}
+          <TextLinkButton onClick={handler}>
+            is actually a span with an ARIA role of button.
+          </TextLinkButton>
+        </Text>
+      ),
+    },
+    {
+      label: 'Weak TextLinkButton inside Text',
+      Example: ({ handler }) => (
+        <Text>
+          The link in this sentence{' '}
+          <TextLinkButton weight="weak" onClick={handler}>
+            is actually a span with an ARIA role of button.
+          </TextLinkButton>
+        </Text>
+      ),
+    },
+    {
+      label: 'TextLinkButton inside Actions',
+      Example: ({ handler }) => (
+        <Actions>
+          <Button>Button</Button>
+          <TextLinkButton onClick={handler}>TextLinkButton</TextLinkButton>
+        </Actions>
+      ),
+    },
+  ],
+};

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.docs.tsx
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.docs.tsx
@@ -4,7 +4,6 @@ import { TextLinkRenderer, Stack, Text, TextLink, Box } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
-  screenshotWidths: [320],
   description: (
     <Stack space="large">
       <Text>

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.screenshots.tsx
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.screenshots.tsx
@@ -1,0 +1,25 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { TextLinkRenderer, Text, Box } from '../';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'TextLink with Custom Renderer',
+      Example: () => (
+        <Text>
+          Even though it looks like a link, the last word of this sentence is
+          actually a{' '}
+          <TextLinkRenderer>
+            {(textLinkProps) => (
+              <Box component="button" {...textLinkProps}>
+                button.
+              </Box>
+            )}
+          </TextLinkRenderer>
+        </Text>
+      ),
+    },
+  ],
+};

--- a/lib/components/Textarea/Textarea.docs.tsx
+++ b/lib/components/Textarea/Textarea.docs.tsx
@@ -9,7 +9,6 @@ const Container = ({ children }: { children: ReactNode }) => (
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Textarea',

--- a/lib/components/Textarea/Textarea.screenshots.tsx
+++ b/lib/components/Textarea/Textarea.screenshots.tsx
@@ -1,0 +1,185 @@
+import React, { ReactNode, useState } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Textarea, TextLink } from '../';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <div style={{ maxWidth: '300px' }}>{children}</div>
+);
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Textarea',
+      Container,
+      Example: ({ id, handler }) => (
+        <Textarea
+          id={id}
+          value="Senior Developer"
+          onChange={handler}
+          label="Job Title"
+        />
+      ),
+    },
+    {
+      label: 'Textarea with message',
+      Container,
+      Example: ({ id, handler }) => (
+        <Textarea
+          id={id}
+          value=""
+          onChange={handler}
+          label="Job Title"
+          message="e.g. Senior Developer"
+        />
+      ),
+    },
+    {
+      label: 'Textarea with secondary label',
+      Container,
+      Example: ({ id, handler }) => (
+        <Textarea
+          id={id}
+          value=""
+          onChange={handler}
+          label="Title"
+          secondaryLabel="Optional"
+        />
+      ),
+    },
+    {
+      label: 'Textarea with tertiary label',
+      Container,
+      Example: ({ id, handler }) => (
+        <Textarea
+          id={id}
+          value=""
+          onChange={handler}
+          label="Title"
+          secondaryLabel="Optional"
+          tertiaryLabel={<TextLink href="#">Help?</TextLink>}
+        />
+      ),
+    },
+    {
+      label: 'Textarea with error',
+      Container,
+      Example: ({ id, handler }) => (
+        <Textarea
+          id={id}
+          value="No"
+          onChange={handler}
+          label="Do you like Braid?"
+          message="Answer is incorrect"
+          tone="critical"
+        />
+      ),
+    },
+    {
+      label: 'Textarea with positive message',
+      Container,
+      Example: ({ id, handler }) => (
+        <Textarea
+          id={id}
+          value="Yes"
+          onChange={handler}
+          label="Do you like Braid?"
+          message="Nice one!"
+          tone="positive"
+        />
+      ),
+    },
+    {
+      label: 'Textarea grow field with typing, limited to 6 lines',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('');
+
+        return (
+          <Textarea
+            id={id}
+            value={value}
+            onChange={(e) => setValue(e.currentTarget.value)}
+            label="Do you like Braid?"
+            lineLimit={6}
+          />
+        );
+      },
+    },
+    {
+      label: 'Textarea nearing character limit, eg. 50 characters',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState(
+          'The text is nearing the 50 character limit',
+        );
+
+        return (
+          <Textarea
+            id={id}
+            value={value}
+            onChange={(e) => setValue(e.currentTarget.value)}
+            label="Do you like Braid?"
+            characterLimit={50}
+          />
+        );
+      },
+    },
+    {
+      label: 'Textarea exceeding character limit, eg. > 50 characters',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState(
+          'The long piece of text exceeding the specified 50 character limit',
+        );
+
+        return (
+          <Textarea
+            id={id}
+            value={value}
+            onChange={(e) => setValue(e.currentTarget.value)}
+            label="Do you like Braid?"
+            characterLimit={50}
+          />
+        );
+      },
+    },
+    {
+      label: 'Textarea highlighting a range',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState(
+          'The long piece of text highlighting a range',
+        );
+
+        return (
+          <Textarea
+            id={id}
+            value={value}
+            onChange={(e) => setValue(e.currentTarget.value)}
+            label="Do you like Braid?"
+            description="Characters 9-22 are invalid"
+            highlightRanges={[{ start: 9, end: 22 }]}
+          />
+        );
+      },
+    },
+    {
+      label: 'Textarea on Brand Background',
+      background: 'brand',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('');
+
+        return (
+          <Textarea
+            label="Do you like Braid?"
+            id={id}
+            onChange={(e) => setValue(e.currentTarget.value)}
+            value={value}
+          />
+        );
+      },
+    },
+  ],
+};

--- a/lib/components/ThemeNameConsumer/ThemeNameConsumer.docs.tsx
+++ b/lib/components/ThemeNameConsumer/ThemeNameConsumer.docs.tsx
@@ -4,7 +4,6 @@ import { ThemeNameConsumer } from './ThemeNameConsumer';
 
 const docs: ComponentDocs = {
   category: 'Logic',
-  screenshotWidths: [],
   examples: [
     {
       Example: () => (

--- a/lib/components/Tiles/Tiles.docs.tsx
+++ b/lib/components/Tiles/Tiles.docs.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
 import { Tiles, Card, Text } from '../';
 import { Placeholder } from '../private/Placeholder/Placeholder';
@@ -7,20 +7,17 @@ const exampleRows = 3;
 
 const docs: ComponentDocs = {
   category: 'Layout',
-  screenshotWidths: [320, 768],
-  screenshotOnlyInWireframe: true,
   examples: [
-    ...([1, 2, 3, 4, 5, 6] as const).map((columns) => ({
-      label: `${columns} column${columns === 1 ? '' : 's'}`,
-      docsSite: columns === 3,
+    {
+      label: '3 columns',
       Example: () => (
-        <Tiles space="small" columns={columns}>
-          {[...new Array(columns * exampleRows)].map((_, i) => (
+        <Tiles space="small" columns={3}>
+          {[...new Array(3 * exampleRows)].map((_, i) => (
             <Placeholder key={i} height={40} />
           ))}
         </Tiles>
       ),
-    })),
+    },
     {
       label: 'Responsive columns (e.g. 1 on mobile, 4 from tablet upwards',
       Example: () => (
@@ -52,29 +49,6 @@ const docs: ComponentDocs = {
               <Text>Tile</Text>
             </Card>
           ))}
-        </Tiles>
-      ),
-    },
-    {
-      label:
-        'Test - Should flatten fragments (6 tiles should be evenly spaced)',
-      docsSite: false,
-      Example: () => (
-        <Tiles space="small" columns={3}>
-          <Fragment>
-            <Placeholder height={40} />
-          </Fragment>
-          <Fragment>
-            <Placeholder height={40} />
-            <Placeholder height={40} />
-          </Fragment>
-          <Fragment>
-            <Fragment>
-              <Placeholder height={40} />
-            </Fragment>
-            <Placeholder height={40} />
-          </Fragment>
-          <Placeholder height={40} />
         </Tiles>
       ),
     },

--- a/lib/components/Tiles/Tiles.screenshots.tsx
+++ b/lib/components/Tiles/Tiles.screenshots.tsx
@@ -1,0 +1,79 @@
+import React, { Fragment } from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Tiles, Card, Text } from '../';
+import { Placeholder } from '../private/Placeholder/Placeholder';
+
+const exampleRows = 3;
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320, 768],
+  screenshotOnlyInWireframe: true,
+  examples: [
+    ...([1, 2, 3, 4, 5, 6] as const).map((columns) => ({
+      label: `${columns} column${columns === 1 ? '' : 's'}`,
+      Example: () => (
+        <Tiles space="small" columns={columns}>
+          {[...new Array(columns * exampleRows)].map((_, i) => (
+            <Placeholder key={i} height={40} />
+          ))}
+        </Tiles>
+      ),
+    })),
+    {
+      label: 'Responsive columns (e.g. 1 on mobile, 4 from tablet upwards',
+      Example: () => (
+        <Tiles space="xsmall" columns={[1, 4]}>
+          {[...new Array(4 * exampleRows)].map((_, i) => (
+            <Placeholder key={i} height={40} />
+          ))}
+        </Tiles>
+      ),
+    },
+    {
+      label: 'Dividers (when in a single column)',
+      Example: () => (
+        <Tiles space={['none', 'small']} columns={[1, 2]} dividers>
+          {[...new Array(2 * exampleRows)].map((_, i) => (
+            <Card key={i}>
+              <Text>Tile</Text>
+            </Card>
+          ))}
+        </Tiles>
+      ),
+    },
+    {
+      label: 'Strong dividers (when in a single column)',
+      Example: () => (
+        <Tiles space={['none', 'small']} columns={[1, 2]} dividers="strong">
+          {[...new Array(2 * exampleRows)].map((_, i) => (
+            <Card key={i}>
+              <Text>Tile</Text>
+            </Card>
+          ))}
+        </Tiles>
+      ),
+    },
+    {
+      label:
+        'Test - Should flatten fragments (6 tiles should be evenly spaced)',
+      Example: () => (
+        <Tiles space="small" columns={3}>
+          <Fragment>
+            <Placeholder height={40} />
+          </Fragment>
+          <Fragment>
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+          </Fragment>
+          <Fragment>
+            <Fragment>
+              <Placeholder height={40} />
+            </Fragment>
+            <Placeholder height={40} />
+          </Fragment>
+          <Placeholder height={40} />
+        </Tiles>
+      ),
+    },
+  ],
+};

--- a/lib/components/Toggle/Toggle.docs.tsx
+++ b/lib/components/Toggle/Toggle.docs.tsx
@@ -1,25 +1,20 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Toggle, Box } from '../';
-
-const handler = () => {
-  /* no op for docs examples */
-};
+import { Toggle } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
   migrationGuide: true,
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Toggle off',
-      Example: ({ id }) => (
+      Example: ({ id, handler }) => (
         <Toggle on={false} label="Toggled off" id={id} onChange={handler} />
       ),
     },
     {
       label: 'Toggle on',
-      Example: ({ id }) => (
+      Example: ({ id, handler }) => (
         <Toggle on={true} label="Toggled on" id={id} onChange={handler} />
       ),
     },
@@ -28,7 +23,7 @@ const docs: ComponentDocs = {
       Container: ({ children }) => (
         <div style={{ maxWidth: '300px' }}>{children}</div>
       ),
-      Example: ({ id }) => (
+      Example: ({ id, handler }) => (
         <Toggle
           on={true}
           align="right"
@@ -43,7 +38,7 @@ const docs: ComponentDocs = {
       Container: ({ children }) => (
         <div style={{ maxWidth: '300px' }}>{children}</div>
       ),
-      Example: ({ id }) => (
+      Example: ({ id, handler }) => (
         <Toggle
           on={true}
           align="justify"
@@ -51,25 +46,6 @@ const docs: ComponentDocs = {
           id={id}
           onChange={handler}
         />
-      ),
-    },
-    {
-      label:
-        'Test: Should have space between the label and the toggle when justified in a flex container',
-      docsSite: false,
-      Container: ({ children }) => (
-        <div style={{ maxWidth: '300px' }}>{children}</div>
-      ),
-      Example: ({ id }) => (
-        <Box display="flex">
-          <Toggle
-            on={true}
-            align="justify"
-            label="Justified"
-            id={id}
-            onChange={handler}
-          />
-        </Box>
       ),
     },
   ],

--- a/lib/components/Toggle/Toggle.screenshots.tsx
+++ b/lib/components/Toggle/Toggle.screenshots.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Toggle, Box } from '../';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Toggle off',
+      Example: ({ id, handler }) => (
+        <Toggle on={false} label="Toggled off" id={id} onChange={handler} />
+      ),
+    },
+    {
+      label: 'Toggle on',
+      Example: ({ id, handler }) => (
+        <Toggle on={true} label="Toggled on" id={id} onChange={handler} />
+      ),
+    },
+    {
+      label: 'Right aligned',
+      Container: ({ children }) => (
+        <div style={{ maxWidth: '300px' }}>{children}</div>
+      ),
+      Example: ({ id, handler }) => (
+        <Toggle
+          on={true}
+          align="right"
+          label="Aligned right"
+          id={id}
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'Justified',
+      Container: ({ children }) => (
+        <div style={{ maxWidth: '300px' }}>{children}</div>
+      ),
+      Example: ({ id, handler }) => (
+        <Toggle
+          on={true}
+          align="justify"
+          label="Justified"
+          id={id}
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label:
+        'Test: Should have space between the label and the toggle when justified in a flex container',
+      Container: ({ children }) => (
+        <div style={{ maxWidth: '300px' }}>{children}</div>
+      ),
+      Example: ({ id, handler }) => (
+        <Box display="flex">
+          <Toggle
+            on={true}
+            align="justify"
+            label="Justified"
+            id={id}
+            onChange={handler}
+          />
+        </Box>
+      ),
+    },
+  ],
+};

--- a/lib/components/icons/IconAdd/IconAdd.docs.tsx
+++ b/lib/components/icons/IconAdd/IconAdd.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconBookmark/IconBookmark.docs.tsx
+++ b/lib/components/icons/IconBookmark/IconBookmark.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconCaution/IconCaution.docs.tsx
+++ b/lib/components/icons/IconCaution/IconCaution.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconChevron/IconChevron.docs.tsx
+++ b/lib/components/icons/IconChevron/IconChevron.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconClear/IconClear.docs.tsx
+++ b/lib/components/icons/IconClear/IconClear.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconCompany/IconCompany.docs.tsx
+++ b/lib/components/icons/IconCompany/IconCompany.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconCompose/IconCompose.docs.tsx
+++ b/lib/components/icons/IconCompose/IconCompose.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconCopy/IconCopy.docs.tsx
+++ b/lib/components/icons/IconCopy/IconCopy.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconCreditCard/IconCreditCard.docs.tsx
+++ b/lib/components/icons/IconCreditCard/IconCreditCard.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconCritical/IconCritical.docs.tsx
+++ b/lib/components/icons/IconCritical/IconCritical.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconDate/IconDate.docs.tsx
+++ b/lib/components/icons/IconDate/IconDate.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconDelete/IconDelete.docs.tsx
+++ b/lib/components/icons/IconDelete/IconDelete.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconDocument/IconDocument.docs.tsx
+++ b/lib/components/icons/IconDocument/IconDocument.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconDocumentBroken/IconDocumentBroken.docs.tsx
+++ b/lib/components/icons/IconDocumentBroken/IconDocumentBroken.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconDownload/IconDownload.docs.tsx
+++ b/lib/components/icons/IconDownload/IconDownload.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconEdit/IconEdit.docs.tsx
+++ b/lib/components/icons/IconEdit/IconEdit.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconEducation/IconEducation.docs.tsx
+++ b/lib/components/icons/IconEducation/IconEducation.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconFilter/IconFilter.docs.tsx
+++ b/lib/components/icons/IconFilter/IconFilter.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconGrid/IconGrid.docs.tsx
+++ b/lib/components/icons/IconGrid/IconGrid.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconHeart/IconHeart.docs.tsx
+++ b/lib/components/icons/IconHeart/IconHeart.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconHelp/IconHelp.docs.tsx
+++ b/lib/components/icons/IconHelp/IconHelp.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconHistory/IconHistory.docs.tsx
+++ b/lib/components/icons/IconHistory/IconHistory.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconHome/IconHome.docs.tsx
+++ b/lib/components/icons/IconHome/IconHome.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconImage/IconImage.docs.tsx
+++ b/lib/components/icons/IconImage/IconImage.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconInfo/IconInfo.docs.tsx
+++ b/lib/components/icons/IconInfo/IconInfo.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconInvoice/IconInvoice.docs.tsx
+++ b/lib/components/icons/IconInvoice/IconInvoice.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconLanguage/IconLanguage.docs.tsx
+++ b/lib/components/icons/IconLanguage/IconLanguage.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconLink/IconLink.docs.tsx
+++ b/lib/components/icons/IconLink/IconLink.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconLinkBroken/IconLinkBroken.docs.tsx
+++ b/lib/components/icons/IconLinkBroken/IconLinkBroken.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconList/IconList.docs.tsx
+++ b/lib/components/icons/IconList/IconList.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconLocation/IconLocation.docs.tsx
+++ b/lib/components/icons/IconLocation/IconLocation.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconMail/IconMail.docs.tsx
+++ b/lib/components/icons/IconMail/IconMail.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconMinus/IconMinus.docs.tsx
+++ b/lib/components/icons/IconMinus/IconMinus.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconMoney/IconMoney.docs.tsx
+++ b/lib/components/icons/IconMoney/IconMoney.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconNewWindow/IconNewWindow.docs.tsx
+++ b/lib/components/icons/IconNewWindow/IconNewWindow.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconNote/IconNote.docs.tsx
+++ b/lib/components/icons/IconNote/IconNote.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconNotification/IconNotification.docs.tsx
+++ b/lib/components/icons/IconNotification/IconNotification.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconOverflow/IconOverflow.docs.tsx
+++ b/lib/components/icons/IconOverflow/IconOverflow.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconPeople/IconPeople.docs.tsx
+++ b/lib/components/icons/IconPeople/IconPeople.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconPersonAdd/IconPersonAdd.docs.tsx
+++ b/lib/components/icons/IconPersonAdd/IconPersonAdd.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconPersonVerified/IconPersonVerified.docs.tsx
+++ b/lib/components/icons/IconPersonVerified/IconPersonVerified.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconPhone/IconPhone.docs.tsx
+++ b/lib/components/icons/IconPhone/IconPhone.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconPositive/IconPositive.docs.tsx
+++ b/lib/components/icons/IconPositive/IconPositive.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconPrint/IconPrint.docs.tsx
+++ b/lib/components/icons/IconPrint/IconPrint.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconProfile/IconProfile.docs.tsx
+++ b/lib/components/icons/IconProfile/IconProfile.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconPromote/IconPromote.docs.tsx
+++ b/lib/components/icons/IconPromote/IconPromote.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconRecommended/IconRecommended.docs.tsx
+++ b/lib/components/icons/IconRecommended/IconRecommended.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconRefresh/IconRefresh.docs.tsx
+++ b/lib/components/icons/IconRefresh/IconRefresh.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconResume/IconResume.docs.tsx
+++ b/lib/components/icons/IconResume/IconResume.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconSearch/IconSearch.docs.tsx
+++ b/lib/components/icons/IconSearch/IconSearch.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconSecurity/IconSecurity.docs.tsx
+++ b/lib/components/icons/IconSecurity/IconSecurity.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconSend/IconSend.docs.tsx
+++ b/lib/components/icons/IconSend/IconSend.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconSent/IconSent.docs.tsx
+++ b/lib/components/icons/IconSent/IconSent.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconSettings/IconSettings.docs.tsx
+++ b/lib/components/icons/IconSettings/IconSettings.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconShare/IconShare.docs.tsx
+++ b/lib/components/icons/IconShare/IconShare.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconSocialFacebook/IconSocialFacebook.docs.tsx
+++ b/lib/components/icons/IconSocialFacebook/IconSocialFacebook.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconSocialGitHub/IconSocialGitHub.docs.tsx
+++ b/lib/components/icons/IconSocialGitHub/IconSocialGitHub.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconSocialInstagram/IconSocialInstagram.docs.tsx
+++ b/lib/components/icons/IconSocialInstagram/IconSocialInstagram.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconSocialLinkedIn/IconSocialLinkedIn.docs.tsx
+++ b/lib/components/icons/IconSocialLinkedIn/IconSocialLinkedIn.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconSocialMedium/IconSocialMedium.docs.tsx
+++ b/lib/components/icons/IconSocialMedium/IconSocialMedium.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconSocialTwitter/IconSocialTwitter.docs.tsx
+++ b/lib/components/icons/IconSocialTwitter/IconSocialTwitter.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconStar/IconStar.docs.tsx
+++ b/lib/components/icons/IconStar/IconStar.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconStatistics/IconStatistics.docs.tsx
+++ b/lib/components/icons/IconStatistics/IconStatistics.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconSubCategory/IconSubCategory.docs.tsx
+++ b/lib/components/icons/IconSubCategory/IconSubCategory.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconTag/IconTag.docs.tsx
+++ b/lib/components/icons/IconTag/IconTag.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconTick/IconTick.docs.tsx
+++ b/lib/components/icons/IconTick/IconTick.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconTime/IconTime.docs.tsx
+++ b/lib/components/icons/IconTime/IconTime.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconUpload/IconUpload.docs.tsx
+++ b/lib/components/icons/IconUpload/IconUpload.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconVideo/IconVideo.docs.tsx
+++ b/lib/components/icons/IconVideo/IconVideo.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconVisibility/IconVisibility.docs.tsx
+++ b/lib/components/icons/IconVisibility/IconVisibility.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/IconWorkExperience/IconWorkExperience.docs.tsx
+++ b/lib/components/icons/IconWorkExperience/IconWorkExperience.docs.tsx
@@ -6,7 +6,6 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [],
   examples: [
     {
       label: 'Default',

--- a/lib/components/icons/Icons.docs.tsx
+++ b/lib/components/icons/Icons.docs.tsx
@@ -1,12 +1,7 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Text, Heading, Inline, Button, Stack } from '../';
+import { Inline } from '../';
 import { UseIconProps } from '../../hooks/useIcon';
-import {
-  heading as headingSizes,
-  text as textSizes,
-  tone as tones,
-} from '../../hooks/typography/typography.treat';
 
 import * as icons from './index';
 
@@ -26,147 +21,10 @@ const docs: ComponentDocs = {
   category: 'Icon',
   migrationGuide: true,
   foundation: true,
-  screenshotWidths: [320],
   examples: [
     {
       label: 'Default',
       Example: () => <Icons />,
-    },
-    {
-      label: 'Auto size (via TextContext)',
-      docsSite: false,
-      Example: () => {
-        const sizes = Object.keys(textSizes) as Array<keyof typeof textSizes>;
-
-        return (
-          <Stack space="large">
-            {sizes.map((size) => (
-              <Stack key={size} space="medium">
-                <Text size={size}>{size}</Text>
-                <Text size={size}>
-                  <Icons />
-                </Text>
-              </Stack>
-            ))}
-          </Stack>
-        );
-      },
-    },
-    {
-      label: 'Auto Size (via HeadingContext)',
-      docsSite: false,
-      Example: () => {
-        const headings = Object.keys(headingSizes) as Array<
-          keyof typeof headingSizes
-        >;
-
-        return (
-          <Stack space="large">
-            {headings
-              .sort()
-              .reverse()
-              .map((heading) => (
-                <Stack key={heading} space="medium">
-                  <Heading level={heading}>Level {heading}</Heading>
-                  <Heading level={heading}>
-                    <Icons />
-                  </Heading>
-                </Stack>
-              ))}
-          </Stack>
-        );
-      },
-    },
-    {
-      label: 'Auto Tone (via TextContext)',
-      docsSite: false,
-      Example: () => {
-        const iconTones = ['neutral', ...Object.keys(tones)].sort() as Array<
-          keyof typeof tones | 'neutral'
-        >;
-
-        return (
-          <Stack space="large">
-            {iconTones.map((tone) => (
-              <Stack key={tone} space="medium">
-                <Text tone={tone}>{tone}</Text>
-                <Text tone={tone}>
-                  <Icons />
-                </Text>
-              </Stack>
-            ))}
-          </Stack>
-        );
-      },
-    },
-    {
-      label: 'Override auto tone explicitly',
-      docsSite: false,
-      Example: () => (
-        <Text tone="critical">
-          Critical text overridden to positive icons:
-          <Icons tone="positive" />
-        </Text>
-      ),
-    },
-    {
-      label: 'Auto Tone with Background Contrast (via TextContext)',
-      docsSite: false,
-      background: 'brand',
-      Example: () => (
-        <Stack space="medium">
-          <Text>Default:</Text>
-          <Text>
-            <Icons />
-          </Text>
-          <Text>Explicitly positive:</Text>
-          <Text>
-            <Icons tone="positive" />
-          </Text>
-        </Stack>
-      ),
-    },
-    {
-      label: 'Alignment to text',
-      docsSite: false,
-      Example: () => (
-        <Stack space="small">
-          {iconNames.map((icon) => {
-            const IconComponent = icons[icon];
-            return (
-              <Inline key={icon} space="medium">
-                <Text>
-                  <IconComponent /> Uppercase
-                </Text>
-                <Text>
-                  Lowercase <IconComponent alignY="lowercase" />
-                </Text>
-              </Inline>
-            );
-          })}
-        </Stack>
-      ),
-    },
-    {
-      label: 'Alignment to buttons',
-      docsSite: false,
-      Example: () => (
-        <Stack space="small">
-          {iconNames.map((icon) => {
-            const IconComponent = icons[icon];
-            return (
-              <Inline key={icon} space="small">
-                <Button>
-                  <IconComponent /> Upper
-                </Button>
-                <Button>
-                  Lower <IconComponent alignY="lowercase" />
-                </Button>
-              </Inline>
-            );
-          })}
-        </Stack>
-      ),
     },
   ],
 };

--- a/lib/components/icons/Icons.screenshots.tsx
+++ b/lib/components/icons/Icons.screenshots.tsx
@@ -1,0 +1,162 @@
+import React from 'react';
+import { ComponentScreenshot } from '../../../site/src/types';
+import { Text, Heading, Inline, Button, Stack } from '../';
+import { UseIconProps } from '../../hooks/useIcon';
+import {
+  heading as headingSizes,
+  text as textSizes,
+  tone as tones,
+} from '../../hooks/typography/typography.treat';
+
+import * as icons from './index';
+
+type IconName = keyof typeof icons;
+const iconNames = Object.keys(icons).map((icon) => icon as IconName);
+
+const Icons = ({ tone }: { tone?: UseIconProps['tone'] }) => (
+  <Inline space="small">
+    {iconNames.map((icon) => {
+      const IconComponent = icons[icon];
+      return <IconComponent key={icon} tone={tone} />;
+    })}
+  </Inline>
+);
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Default',
+      Example: () => <Icons />,
+    },
+    {
+      label: 'Auto size (via TextContext)',
+      Example: () => {
+        const sizes = Object.keys(textSizes) as Array<keyof typeof textSizes>;
+
+        return (
+          <Stack space="large">
+            {sizes.map((size) => (
+              <Stack key={size} space="medium">
+                <Text size={size}>{size}</Text>
+                <Text size={size}>
+                  <Icons />
+                </Text>
+              </Stack>
+            ))}
+          </Stack>
+        );
+      },
+    },
+    {
+      label: 'Auto Size (via HeadingContext)',
+      Example: () => {
+        const headings = Object.keys(headingSizes) as Array<
+          keyof typeof headingSizes
+        >;
+
+        return (
+          <Stack space="large">
+            {headings
+              .sort()
+              .reverse()
+              .map((heading) => (
+                <Stack key={heading} space="medium">
+                  <Heading level={heading}>Level {heading}</Heading>
+                  <Heading level={heading}>
+                    <Icons />
+                  </Heading>
+                </Stack>
+              ))}
+          </Stack>
+        );
+      },
+    },
+    {
+      label: 'Auto Tone (via TextContext)',
+      Example: () => {
+        const iconTones = ['neutral', ...Object.keys(tones)].sort() as Array<
+          keyof typeof tones | 'neutral'
+        >;
+
+        return (
+          <Stack space="large">
+            {iconTones.map((tone) => (
+              <Stack key={tone} space="medium">
+                <Text tone={tone}>{tone}</Text>
+                <Text tone={tone}>
+                  <Icons />
+                </Text>
+              </Stack>
+            ))}
+          </Stack>
+        );
+      },
+    },
+    {
+      label: 'Override auto tone explicitly',
+      Example: () => (
+        <Text tone="critical">
+          Critical text overridden to positive icons:
+          <Icons tone="positive" />
+        </Text>
+      ),
+    },
+    {
+      label: 'Auto Tone with Background Contrast (via TextContext)',
+      background: 'brand',
+      Example: () => (
+        <Stack space="medium">
+          <Text>Default:</Text>
+          <Text>
+            <Icons />
+          </Text>
+          <Text>Explicitly positive:</Text>
+          <Text>
+            <Icons tone="positive" />
+          </Text>
+        </Stack>
+      ),
+    },
+    {
+      label: 'Alignment to text',
+      Example: () => (
+        <Stack space="small">
+          {iconNames.map((icon) => {
+            const IconComponent = icons[icon];
+            return (
+              <Inline key={icon} space="medium">
+                <Text>
+                  <IconComponent /> Uppercase
+                </Text>
+                <Text>
+                  Lowercase <IconComponent alignY="lowercase" />
+                </Text>
+              </Inline>
+            );
+          })}
+        </Stack>
+      ),
+    },
+    {
+      label: 'Alignment to buttons',
+      Example: () => (
+        <Stack space="small">
+          {iconNames.map((icon) => {
+            const IconComponent = icons[icon];
+            return (
+              <Inline key={icon} space="small">
+                <Button>
+                  <IconComponent /> Upper
+                </Button>
+                <Button>
+                  Lower <IconComponent alignY="lowercase" />
+                </Button>
+              </Inline>
+            );
+          })}
+        </Stack>
+      ),
+    },
+  ],
+};

--- a/lib/components/useBreakpoint/useBreakpoint.docs.tsx
+++ b/lib/components/useBreakpoint/useBreakpoint.docs.tsx
@@ -25,7 +25,6 @@ const docs: ComponentDocs = {
       </Alert>
     </Stack>
   ),
-  screenshotWidths: [],
   examples: [
     {
       playroom: false,

--- a/lib/components/useColor/useColor.docs.tsx
+++ b/lib/components/useColor/useColor.docs.tsx
@@ -4,7 +4,6 @@ import { useColor } from './useColor';
 
 const docs: ComponentDocs = {
   category: 'Logic',
-  screenshotWidths: [],
   examples: [
     {
       playroom: false,

--- a/lib/components/useSpace/useSpace.docs.tsx
+++ b/lib/components/useSpace/useSpace.docs.tsx
@@ -5,7 +5,6 @@ import { useSpace } from './useSpace';
 
 const docs: ComponentDocs = {
   category: 'Logic',
-  screenshotWidths: [],
   examples: [
     {
       playroom: false,

--- a/lib/components/useThemeName/useThemeName.docs.tsx
+++ b/lib/components/useThemeName/useThemeName.docs.tsx
@@ -6,7 +6,6 @@ import { Strong } from '../Strong/Strong';
 
 const docs: ComponentDocs = {
   category: 'Logic',
-  screenshotWidths: [],
   examples: [
     {
       playroom: false,

--- a/lib/components/useToast/useToast.docs.tsx
+++ b/lib/components/useToast/useToast.docs.tsx
@@ -89,12 +89,10 @@ const description = (
 
 const docs: ComponentDocs = {
   description,
-  screenshotWidths: [320, 768],
   category: 'Content',
   examples: [
     {
       label: 'Positive Toast',
-      storybook: false,
       playroom: false,
       Example: ({ id, handler }) => {
         const showToast = useToast();
@@ -136,7 +134,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Toast with no duplicates',
-      storybook: false,
       playroom: false,
       Example: ({ id, handler }) => {
         const showToast = useToast();
@@ -178,7 +175,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Positive Toast with description',
-      storybook: false,
       playroom: false,
       Example: ({ id, handler }) => {
         const showToast = useToast();
@@ -223,7 +219,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Critical Toast',
-      storybook: false,
       playroom: false,
       Example: ({ id, handler }) => {
         const showToast = useToast();
@@ -260,7 +255,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Critical Toast with description',
-      storybook: false,
       playroom: false,
       Example: ({ id, handler }) => {
         const showToast = useToast();
@@ -302,138 +296,6 @@ const docs: ComponentDocs = {
           action: { label: 'Goto error', onClick: () => {} },
         })
       `,
-    },
-    {
-      label: 'Critical toast',
-      docsSite: false,
-      Example: () => {
-        const treatTheme = useTheme();
-
-        return (
-          <Toast
-            tone="critical"
-            message="Critical toast"
-            treatTheme={treatTheme}
-            onClear={() => {}}
-            id="n/a"
-            dedupeKey="n/a"
-            shouldRemove={false}
-          />
-        );
-      },
-    },
-    {
-      label: 'Critical toast w/actions',
-      docsSite: false,
-      Example: () => {
-        const treatTheme = useTheme();
-
-        return (
-          <Toast
-            tone="critical"
-            message="Critical toast w/action"
-            action={{
-              label: 'Do the action',
-              onClick: () => {},
-            }}
-            treatTheme={treatTheme}
-            onClear={() => {}}
-            id="n/a"
-            dedupeKey="n/a"
-            shouldRemove={false}
-          />
-        );
-      },
-    },
-    {
-      label: 'Critical toast w/descriptions',
-      docsSite: false,
-      Example: () => {
-        const treatTheme = useTheme();
-
-        return (
-          <Toast
-            tone="critical"
-            message="Critical toast"
-            description="A really long description about toast stuff that is quite long and stuff"
-            action={{
-              label: 'Action',
-              onClick: () => {},
-            }}
-            treatTheme={treatTheme}
-            onClear={() => {}}
-            id="n/a"
-            dedupeKey="n/a"
-            shouldRemove={false}
-          />
-        );
-      },
-    },
-    {
-      label: 'Positive toast',
-      docsSite: false,
-      Example: () => {
-        const treatTheme = useTheme();
-
-        return (
-          <Toast
-            tone="positive"
-            message="Positive toast"
-            treatTheme={treatTheme}
-            onClear={() => {}}
-            id="n/a"
-            dedupeKey="n/a"
-            shouldRemove={false}
-          />
-        );
-      },
-    },
-    {
-      label: 'Positive toast w/actions',
-      docsSite: false,
-      Example: () => {
-        const treatTheme = useTheme();
-
-        return (
-          <Toast
-            tone="positive"
-            message="Positive toast w/actions"
-            action={{
-              label: 'Do the action',
-              onClick: () => {},
-            }}
-            treatTheme={treatTheme}
-            onClear={() => {}}
-            id="n/a"
-            dedupeKey="n/a"
-            shouldRemove={false}
-          />
-        );
-      },
-    },
-    {
-      label: 'Positive toast w/descriptions',
-      docsSite: false,
-      Example: () => {
-        const treatTheme = useTheme();
-
-        return (
-          <Toast
-            tone="positive"
-            message="Positive toast"
-            description="A really long description about toast stuff that is quite long and stuff"
-            action={{
-              label: 'Action',
-              onClick: () => {},
-            }}
-            treatTheme={treatTheme}
-            onClear={() => {}}
-            id="n/a"
-            dedupeKey="n/a"
-            shouldRemove={false}
-          />
-        );
-      },
     },
   ],
 };

--- a/lib/components/useToast/useToast.gallery.tsx
+++ b/lib/components/useToast/useToast.gallery.tsx
@@ -7,7 +7,6 @@ import Toast from './Toast';
 export const galleryItems: ComponentExample[] = [
   {
     label: 'Positive Toast',
-    storybook: false,
     playroom: false,
     Example: ({ id, handler }) => {
       const showToast = useToast();
@@ -49,7 +48,6 @@ export const galleryItems: ComponentExample[] = [
   },
   {
     label: 'Positive Toast with description',
-    storybook: false,
     playroom: false,
     Example: ({ id, handler }) => {
       const showToast = useToast();
@@ -93,7 +91,6 @@ export const galleryItems: ComponentExample[] = [
   },
   {
     label: 'Critical Toast',
-    storybook: false,
     playroom: false,
     Example: ({ id, handler }) => {
       const showToast = useToast();
@@ -130,7 +127,6 @@ export const galleryItems: ComponentExample[] = [
   },
   {
     label: 'Critical Toast with description',
-    storybook: false,
     playroom: false,
     Example: ({ id, handler }) => {
       const showToast = useToast();

--- a/lib/components/useToast/useToast.screenshots.tsx
+++ b/lib/components/useToast/useToast.screenshots.tsx
@@ -1,0 +1,136 @@
+import React from 'react';
+import { useTheme } from 'sku/react-treat';
+import { ComponentScreenshot } from '../../../site/src/types';
+import Toast from './Toast';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320, 768],
+  examples: [
+    {
+      label: 'Critical toast',
+      Example: () => {
+        const treatTheme = useTheme();
+
+        return (
+          <Toast
+            tone="critical"
+            message="Critical toast"
+            treatTheme={treatTheme}
+            onClear={() => {}}
+            id="n/a"
+            dedupeKey="n/a"
+            shouldRemove={false}
+          />
+        );
+      },
+    },
+    {
+      label: 'Critical toast w/actions',
+      Example: () => {
+        const treatTheme = useTheme();
+
+        return (
+          <Toast
+            tone="critical"
+            message="Critical toast w/action"
+            action={{
+              label: 'Do the action',
+              onClick: () => {},
+            }}
+            treatTheme={treatTheme}
+            onClear={() => {}}
+            id="n/a"
+            dedupeKey="n/a"
+            shouldRemove={false}
+          />
+        );
+      },
+    },
+    {
+      label: 'Critical toast w/descriptions',
+      Example: () => {
+        const treatTheme = useTheme();
+
+        return (
+          <Toast
+            tone="critical"
+            message="Critical toast"
+            description="A really long description about toast stuff that is quite long and stuff"
+            action={{
+              label: 'Action',
+              onClick: () => {},
+            }}
+            treatTheme={treatTheme}
+            onClear={() => {}}
+            id="n/a"
+            dedupeKey="n/a"
+            shouldRemove={false}
+          />
+        );
+      },
+    },
+    {
+      label: 'Positive toast',
+      Example: () => {
+        const treatTheme = useTheme();
+
+        return (
+          <Toast
+            tone="positive"
+            message="Positive toast"
+            treatTheme={treatTheme}
+            onClear={() => {}}
+            id="n/a"
+            dedupeKey="n/a"
+            shouldRemove={false}
+          />
+        );
+      },
+    },
+    {
+      label: 'Positive toast w/actions',
+      Example: () => {
+        const treatTheme = useTheme();
+
+        return (
+          <Toast
+            tone="positive"
+            message="Positive toast w/actions"
+            action={{
+              label: 'Do the action',
+              onClick: () => {},
+            }}
+            treatTheme={treatTheme}
+            onClear={() => {}}
+            id="n/a"
+            dedupeKey="n/a"
+            shouldRemove={false}
+          />
+        );
+      },
+    },
+    {
+      label: 'Positive toast w/descriptions',
+      Example: () => {
+        const treatTheme = useTheme();
+
+        return (
+          <Toast
+            tone="positive"
+            message="Positive toast"
+            description="A really long description about toast stuff that is quite long and stuff"
+            action={{
+              label: 'Action',
+              onClick: () => {},
+            }}
+            treatTheme={treatTheme}
+            onClear={() => {}}
+            id="n/a"
+            dedupeKey="n/a"
+            shouldRemove={false}
+          />
+        );
+      },
+    },
+  ],
+};

--- a/lib/utils/useSourceFromExample.ts
+++ b/lib/utils/useSourceFromExample.ts
@@ -5,7 +5,7 @@ import { reactElementToJsxString } from './reactElementToJsxString';
 
 export const useSourceFromExample = (
   id: string,
-  { Example, code: codeOverride }: ComponentExample,
+  { Example, code: codeOverride }: Pick<ComponentExample, 'Example' | 'code'>,
 ) => {
   let returnCode, returnValue;
   const playroomScope = useScope();

--- a/scripts/generateIcons.js
+++ b/scripts/generateIcons.js
@@ -168,7 +168,6 @@ const iconComponentsDir = path.join(baseDir, 'lib/components/icons');
             category: 'Icon',
             migrationGuide: true,
             foundation: true,
-            screenshotWidths: [],
             examples: [
               {
                 label: 'Default',

--- a/site/src/App/ComponentDoc/ComponentDoc.tsx
+++ b/site/src/App/ComponentDoc/ComponentDoc.tsx
@@ -85,14 +85,10 @@ export const ComponentDoc = ({
   const componentFolder = `lib/components/${
     subfolder ? `${subfolder}/` : ''
   }${componentName}`;
-  const examples = docs.examples || [];
+  const docsExamples = docs.examples || [];
 
   const sourceUrl = `${sourceUrlPrefix}/${componentFolder}`;
   const migrationGuideUrl = `${sourceUrlPrefix}/${componentFolder}/${componentName}.migration.md`;
-
-  const filteredExamples = examples.filter(
-    (example) => example.docsSite !== false,
-  );
 
   const propsToDocument = docs.subComponents
     ? [componentName, ...docs.subComponents]
@@ -186,9 +182,9 @@ export const ComponentDoc = ({
           <Stack space="xxlarge">
             {docs.description}
 
-            {filteredExamples.map((example, index) => (
+            {docsExamples.map((example, index) => (
               <Stack space="large" key={index}>
-                {example.label && filteredExamples.length > 1 ? (
+                {example.label && docsExamples.length > 1 ? (
                   <Heading level="3">{example.label}</Heading>
                 ) : null}
                 {example.description ?? null}

--- a/site/src/types.d.ts
+++ b/site/src/types.d.ts
@@ -30,8 +30,6 @@ export interface ComponentDocs {
   deprecationWarning?: ReactNodeNoStrings;
   migrationGuide?: boolean;
   foundation?: boolean;
-  screenshotWidths: Array<320 | 768 | 1200>;
-  screenshotOnlyInWireframe?: boolean;
   examples: ComponentExample[];
   description?: ReactNodeNoStrings;
   subComponents?: string[];
@@ -45,12 +43,21 @@ interface ExampleProps extends ReturnType<typeof useScope> {
 export interface ComponentExample {
   label?: string;
   description?: ReactNodeNoStrings;
-  docsSite?: boolean;
-  storybook?: boolean;
   background?: NonNullable<BoxProps['background']>;
   Example?: (props: ExampleProps) => ReactChild | Source<ReactChild>;
   Container?: (props: { children: ReactNode }) => ReactElement;
   code?: string;
   showCodeByDefault?: boolean;
   playroom?: boolean;
+}
+
+export interface ComponentScreenshot {
+  screenshotWidths: Array<320 | 768 | 1200>;
+  screenshotOnlyInWireframe?: boolean;
+  examples: {
+    label?: string;
+    background?: NonNullable<BoxProps['background']>;
+    Example?: (props: ExampleProps) => ReactChild;
+    Container?: (props: { children: ReactNode }) => ReactElement;
+  }[];
 }


### PR DESCRIPTION
The last PR In preparation for a documentation uplift we are changing how we handle component examples on the site. Instead of sharing one set of examples and opting in or out of gallery, docs site, storybook etc we are moving towards custom file extensions for each use case.

This PR breaks out the examples to be used in storybook/chromatic into their own custom file extensions *.screenshots.tsx.

Sorry about the size of this, but success for this PR is quite simple — an unchanged docs site and no diff in chromatic.