### PR TITLE
Fix type definitions for Stack and scroll components

### DIFF
--- a/.changeset/nasty-squids-confess.md
+++ b/.changeset/nasty-squids-confess.md
@@ -1,0 +1,5 @@
+---
+'braid-design-system': patch
+---
+
+Fix type definitions for Stack and scroll components

--- a/lib/components/Autosuggest/Autosuggest.test.tsx
+++ b/lib/components/Autosuggest/Autosuggest.test.tsx
@@ -959,7 +959,7 @@ describe('Autosuggest', () => {
       changeHandler.mockClear();
 
       // Simulate suggestions coming back from an API
-      await new Promise((resolve) => {
+      await new Promise<void>((resolve) => {
         setTimeout(() => {
           setSuggestions([
             {

--- a/lib/components/Stack/Stack.tsx
+++ b/lib/components/Stack/Stack.tsx
@@ -35,7 +35,7 @@ const useStackItem = ({ align, space }: UseStackItemProps) => ({
     ? null
     : {
         display: mapResponsiveProp(align, alignToDisplay) || 'flex',
-        flexDirection: 'column',
+        flexDirection: 'column' as const,
         alignItems: alignToFlexAlign(align),
       }),
 });
@@ -75,7 +75,7 @@ const calculateHiddenStackItemProps = (
       hiddenOnMobile ? 'none' : displayMobile,
       hiddenOnTablet ? 'none' : displayTablet,
       hiddenOnDesktop ? 'none' : displayDesktop,
-    ],
+    ] as const,
   };
 };
 
@@ -158,11 +158,13 @@ export const Stack = ({
               <Box
                 width="full"
                 paddingBottom={space}
-                display={[
-                  index === firstItemOnMobile ? 'none' : 'block',
-                  index === firstItemOnTablet ? 'none' : 'block',
-                  index === firstItemOnDesktop ? 'none' : 'block',
-                ]}
+                display={
+                  [
+                    index === firstItemOnMobile ? 'none' : 'block',
+                    index === firstItemOnTablet ? 'none' : 'block',
+                    index === firstItemOnDesktop ? 'none' : 'block',
+                  ] as const
+                }
               >
                 {typeof dividers === 'string' ? (
                   <Divider weight={dividers} />

--- a/lib/components/private/smoothScroll.ts
+++ b/lib/components/private/smoothScroll.ts
@@ -155,7 +155,7 @@ export const smoothScroll = (
     ...scrollOptions
   }: SmoothScrollOptions = {},
 ) =>
-  new Promise((resolve) => {
+  new Promise<void>((resolve) => {
     const scrollOffset = getScrollOffset(scrollContainer, element, direction);
     const scrollPosition =
       position === 'end'


### PR DESCRIPTION
- Sets promise to void when being resolved without a value
- Use const types where possible to add assurance that the correct length of arrays are being used