### PR TITLE
Checkbox: Support inferring of tri-state checked value

### DIFF
--- a/.changeset/nervous-papayas-warn.md
+++ b/.changeset/nervous-papayas-warn.md
@@ -9,7 +9,7 @@ updated:
 
 **Checkbox:** Support inferring of tri-state checked value
 
-To simplify the use of tri-state checkboxes, the **checked** prop now supports resolving the tri-state value from a array of checked values.
+To simplify the use of tri-state checkboxes, the **checked** prop now supports resolving the tri-state value from an array of checked values.
 
 **EXAMPLE USAGE:**
 ```jsx

--- a/.changeset/nervous-papayas-warn.md
+++ b/.changeset/nervous-papayas-warn.md
@@ -13,9 +13,8 @@ To simplify the use of tri-state checkboxes, the **checked** prop now supports r
 
 **EXAMPLE USAGE:**
 ```jsx
-// Will resolve to "mixed" based on the array of values provided
  <Checkbox
   label="Select all"
-  checked={[ true, false, false ]}
+  checked={[ true, false, false ]} // Will resolve to "mixed"
 />
 ```

--- a/.changeset/nervous-papayas-warn.md
+++ b/.changeset/nervous-papayas-warn.md
@@ -1,0 +1,25 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Checkbox
+---
+
+**Checkbox:** Support inferring of tri-state checked value
+
+To simplify the use of tri-state checkboxes, the **checked** prop now supports resolving the tri-state value from a array of checked values.
+
+**EXAMPLE USAGE:**
+```jsx
+// Will resolve to "mixed" based on the array of values provided
+ <Checkbox
+  label="Select all"
+  checked={[
+    getState('one'),
+    getState('two'),
+    getState('three')
+  ]}
+/>
+```

--- a/.changeset/nervous-papayas-warn.md
+++ b/.changeset/nervous-papayas-warn.md
@@ -16,10 +16,6 @@ To simplify the use of tri-state checkboxes, the **checked** prop now supports r
 // Will resolve to "mixed" based on the array of values provided
  <Checkbox
   label="Select all"
-  checked={[
-    getState('one'),
-    getState('two'),
-    getState('three')
-  ]}
+  checked={[ true, false, false ]}
 />
 ```

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -2146,6 +2146,7 @@ Object {
     badge?: ReactElement<BadgeProps, string | ((props: any) => ReactElement<any, string | ... | (new (props: any) => Component<any, any, any>)> | null) | (new (props: any) => Component<...>)>
     checked: 
         | "mixed"
+        | boolean[]
         | false
         | true
     children?: ReactNode

--- a/lib/components/Checkbox/Checkbox.test.tsx
+++ b/lib/components/Checkbox/Checkbox.test.tsx
@@ -3,7 +3,6 @@ import React, { ComponentProps, useState } from 'react';
 import { render } from '@testing-library/react';
 import { BraidTestProvider, Checkbox } from '..';
 import userEvent from '@testing-library/user-event';
-import { resolveCheckedGroup } from './Checkbox';
 
 describe('Checkbox', () => {
   it('associates field with label correctly', () => {
@@ -195,26 +194,76 @@ describe('Checkbox', () => {
     expect(checkbox.indeterminate).toBe(true);
     expect(checkbox.checked).toBe(false);
   });
-});
 
-describe('resolveCheckedGroup', () => {
-  it('returns `mixed` when different values are provided and the last is `false`', () => {
-    expect(resolveCheckedGroup([false, true, false])).toEqual('mixed');
+  it('should resolve to `mixed` when mixed checked values are provided and the last is `false`', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <Checkbox
+          id="field"
+          label="My field"
+          onChange={() => {}}
+          checked={[false, true, false]}
+        />
+      </BraidTestProvider>,
+    );
+    const checkbox = getByRole('checkbox') as HTMLInputElement;
+
+    expect(checkbox.getAttribute('aria-checked')).toBe('mixed');
+    expect(checkbox.indeterminate).toBe(true);
+    expect(checkbox.checked).toBe(false);
   });
 
-  it('returns `mixed` when different values are provided and the last is `true`', () => {
-    expect(resolveCheckedGroup([false, true, true])).toEqual('mixed');
+  it('should resolve to `mixed` when mixed checked values are provided and the last is `true`', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <Checkbox
+          id="field"
+          label="My field"
+          onChange={() => {}}
+          checked={[false, true, true]}
+        />
+      </BraidTestProvider>,
+    );
+    const checkbox = getByRole('checkbox') as HTMLInputElement;
+
+    expect(checkbox.getAttribute('aria-checked')).toBe('mixed');
+    expect(checkbox.indeterminate).toBe(true);
+    expect(checkbox.checked).toBe(false);
   });
 
-  it('returns `true` when all values provided are `true`', () => {
-    expect(resolveCheckedGroup([true, true, true])).toEqual(true);
+  it('should resolve to checked when all values provided are `true`', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <Checkbox
+          id="field"
+          label="My field"
+          onChange={() => {}}
+          checked={[true, true, true]}
+        />
+      </BraidTestProvider>,
+    );
+    const checkbox = getByRole('checkbox') as HTMLInputElement;
+
+    expect(checkbox.getAttribute('aria-checked')).toBe('true');
+    expect(checkbox.indeterminate).toBe(false);
+    expect(checkbox.checked).toBe(true);
   });
 
-  it('returns `false` when all values provided are `false`', () => {
-    expect(resolveCheckedGroup([false, false, false])).toEqual(false);
-  });
+  it('should resolve to unchecked when all values provided are `false`', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <Checkbox
+          id="field"
+          label="My field"
+          onChange={() => {}}
+          checked={[false, false, false]}
+        />
+      </BraidTestProvider>,
+    );
+    const checkbox = getByRole('checkbox') as HTMLInputElement;
 
-  it('returns `false` when no values are provided', () => {
-    expect(resolveCheckedGroup([])).toBe(false);
+    expect(checkbox.getAttribute('aria-checked')).toBe('false');
+    expect(checkbox.indeterminate).toBe(false);
+    expect(checkbox.checked).toBe(false);
   });
 });

--- a/lib/components/Checkbox/Checkbox.test.tsx
+++ b/lib/components/Checkbox/Checkbox.test.tsx
@@ -3,6 +3,7 @@ import React, { ComponentProps, useState } from 'react';
 import { render } from '@testing-library/react';
 import { BraidTestProvider, Checkbox } from '..';
 import userEvent from '@testing-library/user-event';
+import { resolveCheckedGroup } from './Checkbox';
 
 describe('Checkbox', () => {
   it('associates field with label correctly', () => {
@@ -193,5 +194,27 @@ describe('Checkbox', () => {
     expect(checkbox.getAttribute('aria-checked')).toBe('mixed');
     expect(checkbox.indeterminate).toBe(true);
     expect(checkbox.checked).toBe(false);
+  });
+});
+
+describe('resolveCheckedGroup', () => {
+  it('returns `mixed` when different values are provided and the last is `false`', () => {
+    expect(resolveCheckedGroup([false, true, false])).toEqual('mixed');
+  });
+
+  it('returns `mixed` when different values are provided and the last is `true`', () => {
+    expect(resolveCheckedGroup([false, true, true])).toEqual('mixed');
+  });
+
+  it('returns `true` when all values provided are `true`', () => {
+    expect(resolveCheckedGroup([true, true, true])).toEqual(true);
+  });
+
+  it('returns `false` when all values provided are `false`', () => {
+    expect(resolveCheckedGroup([false, false, false])).toEqual(false);
+  });
+
+  it('returns `false` when no values are provided', () => {
+    expect(resolveCheckedGroup([])).toBe(false);
   });
 });

--- a/lib/components/Checkbox/Checkbox.test.tsx
+++ b/lib/components/Checkbox/Checkbox.test.tsx
@@ -266,4 +266,22 @@ describe('Checkbox', () => {
     expect(checkbox.indeterminate).toBe(false);
     expect(checkbox.checked).toBe(false);
   });
+
+  it('should resolve to unchecked when an empty array is provided', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <Checkbox
+          id="field"
+          label="My field"
+          onChange={() => {}}
+          checked={[]}
+        />
+      </BraidTestProvider>,
+    );
+    const checkbox = getByRole('checkbox') as HTMLInputElement;
+
+    expect(checkbox.getAttribute('aria-checked')).toBe('false');
+    expect(checkbox.indeterminate).toBe(false);
+    expect(checkbox.checked).toBe(false);
+  });
 });

--- a/lib/components/Checkbox/Checkbox.tsx
+++ b/lib/components/Checkbox/Checkbox.tsx
@@ -6,21 +6,7 @@ import {
 } from '../private/InlineField/InlineField';
 
 const resolveCheckedGroup = (values: Array<CheckboxChecked>) =>
-  values.reduce((acc, val, index) => {
-    if (acc === 'mixed') {
-      return 'mixed';
-    }
-
-    if (acc === true) {
-      return val || 'mixed';
-    }
-
-    if (acc === false && index > 0) {
-      return val ? 'mixed' : false;
-    }
-
-    return val;
-  }, false);
+  values.some((value) => value !== values[0]) ? 'mixed' : values[0] ?? false;
 
 export interface CheckboxProps extends Omit<InlineFieldProps, 'checked'> {
   checked: CheckboxChecked | Array<boolean>;

--- a/lib/components/Checkbox/Checkbox.tsx
+++ b/lib/components/Checkbox/Checkbox.tsx
@@ -5,7 +5,7 @@ import {
   InlineFieldProps,
 } from '../private/InlineField/InlineField';
 
-export const resolveCheckedGroup = (values: Array<CheckboxChecked>) =>
+const resolveCheckedGroup = (values: Array<CheckboxChecked>) =>
   values.reduce((acc, val, index) => {
     if (acc === 'mixed') {
       return 'mixed';

--- a/lib/components/Checkbox/Checkbox.tsx
+++ b/lib/components/Checkbox/Checkbox.tsx
@@ -5,12 +5,42 @@ import {
   InlineFieldProps,
 } from '../private/InlineField/InlineField';
 
+export const resolveCheckedGroup = (values: Array<CheckboxChecked>) =>
+  values.reduce((acc, val, index) => {
+    if (acc === 'mixed') {
+      return 'mixed';
+    }
+
+    if (acc === true) {
+      return val || 'mixed';
+    }
+
+    if (acc === false && index > 0) {
+      return val ? 'mixed' : false;
+    }
+
+    return val;
+  }, false);
+
 export interface CheckboxProps extends Omit<InlineFieldProps, 'checked'> {
-  checked: CheckboxChecked;
+  checked: CheckboxChecked | Array<boolean>;
 }
 
 const NamedCheckbox = forwardRef<HTMLInputElement, CheckboxProps>(
-  (props, ref) => <InlineField {...props} type="checkbox" ref={ref} />,
+  ({ checked, ...restProps }, ref) => {
+    const calculatedChecked = Array.isArray(checked)
+      ? resolveCheckedGroup(checked)
+      : checked;
+
+    return (
+      <InlineField
+        {...restProps}
+        checked={calculatedChecked}
+        type="checkbox"
+        ref={ref}
+      />
+    );
+  },
 );
 
 NamedCheckbox.displayName = 'Checkbox';


### PR DESCRIPTION
**Checkbox:** Support inferring of tri-state checked value

To simplify the use of tri-state checkboxes, the **checked** prop now supports resolving the tri-state value from a array of checked values.

**EXAMPLE USAGE:**
```jsx
 <Checkbox
  label="Select all"
  checked={[ true, false, false ]} // Will resolve to "mixed"
/>
```