### PR TITLE
PasswordField: Ensure disabled is handled correctly

### DIFF
--- a/.changeset/weak-paws-help.md
+++ b/.changeset/weak-paws-help.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - PasswordField
+---
+
+**PasswordField:** Ensure disabled is handled correctly
+
+Fixes a bug where the **disabled** prop was not being honoured, it was hiding the visibility toggle but leaving the field enabled.

--- a/.changeset/weak-paws-help.md
+++ b/.changeset/weak-paws-help.md
@@ -9,4 +9,4 @@ updated:
 
 **PasswordField:** Ensure disabled is handled correctly
 
-Fixes a bug where the **disabled** prop was not being honoured, it was hiding the visibility toggle but leaving the field enabled.
+Fixes a bug where the **disabled** prop was hiding the visibility toggle but leaving the field enabled.

--- a/lib/components/PasswordField/PasswordField.screenshots.tsx
+++ b/lib/components/PasswordField/PasswordField.screenshots.tsx
@@ -123,6 +123,22 @@ export const screenshots: ComponentScreenshot = {
       },
     },
     {
+      label: 'PasswordField disabled',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('qwerty');
+        return (
+          <PasswordField
+            label="Password"
+            id={id}
+            value={value}
+            onChange={(ev) => setValue(ev.currentTarget.value)}
+            disabled={true}
+          />
+        );
+      },
+    },
+    {
       label: 'PasswordField on Brand Background',
       background: 'brand',
       Container,

--- a/lib/components/PasswordField/PasswordField.test.tsx
+++ b/lib/components/PasswordField/PasswordField.test.tsx
@@ -187,4 +187,20 @@ describe('PasswordField', () => {
       getByLabelText('My field').getAttribute('aria-describedby'),
     ).toBeNull();
   });
+
+  it('field should be marked as disabled when disabled', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <PasswordField
+          id="field"
+          label="My field"
+          value=""
+          onChange={() => {}}
+          disabled={true}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('My field')).toHaveAttribute('disabled');
+  });
 });

--- a/lib/components/PasswordField/PasswordField.tsx
+++ b/lib/components/PasswordField/PasswordField.tsx
@@ -70,6 +70,7 @@ const NamedPasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
         value={value}
         icon={undefined}
         labelId={undefined}
+        disabled={disabled}
         secondaryMessage={null}
         secondaryIcon={
           disabled ? null : (


### PR DESCRIPTION
**PasswordField:** Ensure disabled is handled correctly

Fixes a bug where the **disabled** prop was not being honoured, it was hiding the visibility toggle but leaving the field enabled.