### PR TITLE
Add initial Box docs

### DIFF
--- a/lib/components/Box/Box.docs.tsx
+++ b/lib/components/Box/Box.docs.tsx
@@ -110,7 +110,7 @@ const docs: ComponentDocs = {
         <>
           <Text>
             Box provides a suite of common CSS utility props. Styles that
-            commonly differ across screen sizes can also be expressed as
+            regularly differ across screen sizes can also be expressed as
             responsive props, e.g.{' '}
             <Strong>{"justifyContent={['center', 'flexStart']}"}</Strong>
           </Text>

--- a/lib/components/Box/Box.docs.tsx
+++ b/lib/components/Box/Box.docs.tsx
@@ -9,7 +9,6 @@ import {
   Tiles,
   Columns,
   Column,
-  Divider,
   Strong,
   Alert,
 } from '../';
@@ -108,10 +107,10 @@ const docs: ComponentDocs = {
       description: (
         <>
           <Text>
-            Padding and margins can be applied in all directions using our{' '}
+            Padding can be applied in all directions using our{' '}
             <TextLink href="/foundations/layout#spacing">space scale.</TextLink>{' '}
-            In most cases, padding is recommended over margin to avoid issues
-            with{' '}
+            Margin is also supported with the same syntax, but padding is
+            recommended over margin in most cases to avoid issues with{' '}
             <TextLink href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">
               collapsing margins.
             </TextLink>
@@ -129,235 +128,113 @@ const docs: ComponentDocs = {
       ),
       Example: () =>
         source(
-          <Stack space="large" align="center">
-            <Stack space="gutter" align="center">
+          <Stack space="gutter" align="center">
+            <Inline space="gutter" align="center" alignY="center">
+              <Box
+                background="formAccentHover"
+                borderRadius="standard"
+                padding="medium"
+              >
+                <Box
+                  background="formAccent"
+                  borderRadius="standard"
+                  padding="medium"
+                >
+                  <Text>padding</Text>
+                </Box>
+              </Box>
               <Inline space="gutter" align="center" alignY="center">
                 <Box
                   background="formAccentHover"
                   borderRadius="standard"
-                  padding="medium"
+                  paddingX="medium"
                 >
                   <Box
                     background="formAccent"
                     borderRadius="standard"
                     padding="medium"
                   >
-                    <Text>padding</Text>
+                    <Text>paddingX</Text>
                   </Box>
                 </Box>
-                <Inline space="gutter" align="center" alignY="center">
-                  <Box
-                    background="formAccentHover"
-                    borderRadius="standard"
-                    paddingX="medium"
-                  >
-                    <Box
-                      background="formAccent"
-                      borderRadius="standard"
-                      padding="medium"
-                    >
-                      <Text>paddingX</Text>
-                    </Box>
-                  </Box>
-                  <Box
-                    background="formAccentHover"
-                    borderRadius="standard"
-                    paddingY="medium"
-                  >
-                    <Box
-                      background="formAccent"
-                      borderRadius="standard"
-                      padding="medium"
-                    >
-                      <Text>paddingY</Text>
-                    </Box>
-                  </Box>
-                </Inline>
-              </Inline>
-              <Inline
-                space="gutter"
-                collapseBelow="desktop"
-                align="center"
-                alignY="center"
-              >
-                <Inline space="gutter" align="center" alignY="center">
-                  <Box
-                    background="formAccentHover"
-                    borderRadius="standard"
-                    paddingTop="medium"
-                  >
-                    <Box
-                      background="formAccent"
-                      borderRadius="standard"
-                      padding="medium"
-                    >
-                      <Text>paddingTop</Text>
-                    </Box>
-                  </Box>
-                  <Box
-                    background="formAccentHover"
-                    borderRadius="standard"
-                    paddingRight="medium"
-                  >
-                    <Box
-                      background="formAccent"
-                      borderRadius="standard"
-                      padding="medium"
-                    >
-                      <Text>paddingRight</Text>
-                    </Box>
-                  </Box>
-                </Inline>
-                <Inline space="gutter" align="center" alignY="center">
-                  <Box
-                    background="formAccentHover"
-                    borderRadius="standard"
-                    paddingBottom="medium"
-                  >
-                    <Box
-                      background="formAccent"
-                      borderRadius="standard"
-                      padding="medium"
-                    >
-                      <Text>paddingBottom</Text>
-                    </Box>
-                  </Box>
-                  <Box
-                    background="formAccentHover"
-                    borderRadius="standard"
-                    paddingLeft="medium"
-                  >
-                    <Box
-                      background="formAccent"
-                      borderRadius="standard"
-                      padding="medium"
-                    >
-                      <Text>paddingLeft</Text>
-                    </Box>
-                  </Box>
-                </Inline>
-              </Inline>
-            </Stack>
-
-            <Box width="full">
-              <Divider />
-            </Box>
-
-            <Stack space="gutter" align="center">
-              <Inline space="gutter" align="center" alignY="center">
                 <Box
-                  display="flex"
-                  background="brandAccentHover"
+                  background="formAccentHover"
                   borderRadius="standard"
+                  paddingY="medium"
                 >
                   <Box
-                    background="brandAccent"
+                    background="formAccent"
                     borderRadius="standard"
                     padding="medium"
-                    margin="medium"
                   >
-                    <Text>margin</Text>
+                    <Text>paddingY</Text>
                   </Box>
                 </Box>
-                <Inline space="gutter" align="center" alignY="center">
-                  <Box
-                    display="flex"
-                    background="brandAccentHover"
-                    borderRadius="standard"
-                  >
-                    <Box
-                      background="brandAccent"
-                      borderRadius="standard"
-                      padding="medium"
-                      marginX="medium"
-                    >
-                      <Text>marginX</Text>
-                    </Box>
-                  </Box>
-                  <Box
-                    display="flex"
-                    background="brandAccentHover"
-                    borderRadius="standard"
-                  >
-                    <Box
-                      background="brandAccent"
-                      borderRadius="standard"
-                      padding="medium"
-                      marginY="medium"
-                    >
-                      <Text>marginY</Text>
-                    </Box>
-                  </Box>
-                </Inline>
               </Inline>
-              <Inline
-                space="gutter"
-                collapseBelow="desktop"
-                align="center"
-                alignY="center"
-              >
-                <Inline space="gutter" align="center" alignY="center">
+            </Inline>
+            <Inline
+              space="gutter"
+              collapseBelow="desktop"
+              align="center"
+              alignY="center"
+            >
+              <Inline space="gutter" align="center" alignY="center">
+                <Box
+                  background="formAccentHover"
+                  borderRadius="standard"
+                  paddingTop="medium"
+                >
                   <Box
-                    display="flex"
-                    background="brandAccentHover"
+                    background="formAccent"
                     borderRadius="standard"
+                    padding="medium"
                   >
-                    <Box
-                      background="brandAccent"
-                      borderRadius="standard"
-                      padding="medium"
-                      marginTop="medium"
-                    >
-                      <Text>marginTop</Text>
-                    </Box>
+                    <Text>paddingTop</Text>
                   </Box>
+                </Box>
+                <Box
+                  background="formAccentHover"
+                  borderRadius="standard"
+                  paddingRight="medium"
+                >
                   <Box
-                    display="flex"
-                    background="brandAccentHover"
+                    background="formAccent"
                     borderRadius="standard"
+                    padding="medium"
                   >
-                    <Box
-                      background="brandAccent"
-                      borderRadius="standard"
-                      padding="medium"
-                      marginRight="medium"
-                    >
-                      <Text>marginRight</Text>
-                    </Box>
+                    <Text>paddingRight</Text>
                   </Box>
-                </Inline>
-                <Inline space="gutter" align="center" alignY="center">
-                  <Box
-                    display="flex"
-                    background="brandAccentHover"
-                    borderRadius="standard"
-                  >
-                    <Box
-                      background="brandAccent"
-                      borderRadius="standard"
-                      padding="medium"
-                      marginBottom="medium"
-                    >
-                      <Text>marginBottom</Text>
-                    </Box>
-                  </Box>
-                  <Box
-                    display="flex"
-                    background="brandAccentHover"
-                    borderRadius="standard"
-                  >
-                    <Box
-                      background="brandAccent"
-                      borderRadius="standard"
-                      padding="medium"
-                      marginLeft="medium"
-                    >
-                      <Text>marginLeft</Text>
-                    </Box>
-                  </Box>
-                </Inline>
+                </Box>
               </Inline>
-            </Stack>
+              <Inline space="gutter" align="center" alignY="center">
+                <Box
+                  background="formAccentHover"
+                  borderRadius="standard"
+                  paddingBottom="medium"
+                >
+                  <Box
+                    background="formAccent"
+                    borderRadius="standard"
+                    padding="medium"
+                  >
+                    <Text>paddingBottom</Text>
+                  </Box>
+                </Box>
+                <Box
+                  background="formAccentHover"
+                  borderRadius="standard"
+                  paddingLeft="medium"
+                >
+                  <Box
+                    background="formAccent"
+                    borderRadius="standard"
+                    padding="medium"
+                  >
+                    <Text>paddingLeft</Text>
+                  </Box>
+                </Box>
+              </Inline>
+            </Inline>
           </Stack>,
         ),
     },
@@ -372,7 +249,7 @@ const docs: ComponentDocs = {
       ),
       Example: () =>
         source(
-          <Inline space="gutter" align="center">
+          <Inline space="medium" align="center">
             <Box
               background="formAccentHover"
               borderRadius="standard"
@@ -384,21 +261,6 @@ const docs: ComponentDocs = {
                 padding="medium"
               >
                 <Text>Responsive padding</Text>
-              </Box>
-            </Box>
-
-            <Box
-              display="flex"
-              background="brandAccentHover"
-              borderRadius="standard"
-            >
-              <Box
-                background="brandAccent"
-                borderRadius="standard"
-                padding="medium"
-                margin={['small', 'medium', 'large']}
-              >
-                <Text>Responsive margin</Text>
               </Box>
             </Box>
           </Inline>,
@@ -456,7 +318,7 @@ const docs: ComponentDocs = {
                 critical: 'Used for heavier “critical” elements.',
                 criticalLight: 'Used for lighter “critical” elements.',
                 criticalHover: 'Hover colour for “critical” elements.',
-                criticalActive: 'Hover colour for “critical” elements.',
+                criticalActive: 'Active colour for “critical” elements.',
                 caution: 'Used for heavier “caution” elements.',
                 cautionLight: 'Used for lighter “caution” elements.',
                 info: 'Used for heavier “info” elements.',

--- a/lib/components/Box/Box.docs.tsx
+++ b/lib/components/Box/Box.docs.tsx
@@ -15,6 +15,8 @@ import {
 import source from '../../utils/source.macro';
 import Code from '../../../site/src/App/Code/Code';
 import { BoxProps } from './Box';
+import { UseBoxStylesProps } from './useBoxStyles';
+import * as styleRefs from './useBoxStyles.treat';
 
 type BackgroundDocs = Required<
   Record<NonNullable<BoxProps['background']>, string>
@@ -99,6 +101,112 @@ const docs: ComponentDocs = {
               ).code;
             })()}
           </Code>
+        </>
+      ),
+    },
+    {
+      label: 'CSS utilities',
+      description: (
+        <>
+          <Text>
+            Box provides a suite of common CSS utility props. Styles that
+            commonly differ across screen sizes can also be expressed as
+            responsive props, e.g.{' '}
+            <Strong>{"justifyContent={['center', 'flexStart']}"}</Strong>
+          </Text>
+          <Text>
+            These utilities are recommended where possible to reduce the amount
+            of custom CSS in your application.
+          </Text>
+          <Code playroom={false}>
+            {
+              source(
+                <Box
+                  display="flex"
+                  justifyContent={['center', 'flexStart']}
+                  position="absolute"
+                  top={0}
+                  left={0}
+                  width="full"
+                  height="full"
+                >
+                  ...
+                </Box>,
+              ).code
+            }
+          </Code>
+          <Box paddingBottom="large">
+            <Tiles space="xlarge" columns={[1, 2]}>
+              {(() => {
+                type UtilName = keyof Omit<
+                  UseBoxStylesProps,
+                  | 'background'
+                  | 'boxShadow'
+                  | 'className'
+                  | 'component'
+                  | 'margin'
+                  | 'marginX'
+                  | 'marginY'
+                  | 'marginTop'
+                  | 'marginBottom'
+                  | 'marginLeft'
+                  | 'marginRight'
+                  | 'padding'
+                  | 'paddingX'
+                  | 'paddingY'
+                  | 'paddingTop'
+                  | 'paddingBottom'
+                  | 'paddingLeft'
+                  | 'paddingRight'
+                >;
+
+                const utils: Record<UtilName, true> = {
+                  alignItems: true,
+                  bottom: true,
+                  borderRadius: true,
+                  cursor: true,
+                  display: true,
+                  flexDirection: true,
+                  flexGrow: true,
+                  flexShrink: true,
+                  flexWrap: true,
+                  height: true,
+                  justifyContent: true,
+                  left: true,
+                  maxWidth: true,
+                  minWidth: true,
+                  opacity: true,
+                  outline: true,
+                  overflow: true,
+                  pointerEvents: true,
+                  position: true,
+                  right: true,
+                  textAlign: true,
+                  top: true,
+                  transform: true,
+                  transition: true,
+                  userSelect: true,
+                  width: true,
+                  zIndex: true,
+                };
+
+                return (Object.keys(utils) as Array<UtilName>).map((prop) => (
+                  <Stack key={prop} space="medium">
+                    <Text weight="strong">
+                      {prop}
+                      {`${prop}Desktop` in styleRefs ? ' (Responsive)' : ''}
+                    </Text>
+                    <Text tone="secondary">
+                      {Object.keys(styleRefs[prop])
+                        .sort()
+                        .map((key) => (!/[0-9]/.test(key) ? `"${key}"` : key))
+                        .join(', ')}
+                    </Text>
+                  </Stack>
+                ));
+              })()}
+            </Tiles>
+          </Box>
         </>
       ),
     },

--- a/lib/components/Box/Box.docs.tsx
+++ b/lib/components/Box/Box.docs.tsx
@@ -429,7 +429,6 @@ const docs: ComponentDocs = {
           </Alert>
         </>
       ),
-      background: 'card',
       Example: () => {
         const { code, value } = source(
           <Tiles space="large" columns={[1, 1, 2]}>
@@ -468,14 +467,12 @@ const docs: ComponentDocs = {
                 neutralLight: 'Used for lighter “neutral” elements.',
               }),
             ).map(([background, description]) => (
-              <Columns key={background} space="medium">
+              <Columns key={background} space="medium" alignY="center">
                 <Column width="content">
                   <Box
-                    background={
-                      ['card', 'input'].includes(background) ? 'body' : 'card'
-                    }
+                    background="card"
                     borderRadius="standard"
-                    padding="xsmall"
+                    padding="gutter"
                   >
                     <Box
                       background={background as keyof BackgroundDocs}
@@ -485,9 +482,13 @@ const docs: ComponentDocs = {
                   </Box>
                 </Column>
                 <Column>
-                  <Box paddingTop="medium" paddingRight="medium">
+                  <Box paddingRight="medium">
                     <Stack space="small">
-                      <Text weight="medium">{background}</Text>
+                      <Text weight="medium">
+                        <Box style={{ wordBreak: 'break-all' }}>
+                          {background}
+                        </Box>
+                      </Text>
                       <Text tone="secondary">{description}</Text>
                     </Stack>
                   </Box>
@@ -530,7 +531,6 @@ const docs: ComponentDocs = {
           </Alert>
         </>
       ),
-      background: 'card',
       Example: () => {
         const { code, value } = source(
           <Tiles space="large" columns={[1, 1, 2]}>
@@ -561,14 +561,14 @@ const docs: ComponentDocs = {
                 borderPromote: 'Used for borders around “promote” elements.',
               }),
             ).map(([boxShadow, description]) => (
-              <Columns key={boxShadow} space="medium">
+              <Columns key={boxShadow} space="medium" alignY="center">
                 <Column width="content">
                   <Box
                     background={
                       boxShadow.includes('Inverted') ? 'brand' : 'card'
                     }
                     borderRadius="standard"
-                    padding="small"
+                    padding="gutter"
                   >
                     <Box
                       boxShadow={boxShadow as keyof BoxShadowDocs}
@@ -578,7 +578,7 @@ const docs: ComponentDocs = {
                   </Box>
                 </Column>
                 <Column>
-                  <Box paddingTop="medium" paddingRight="medium">
+                  <Box paddingRight="medium">
                     <Stack space="small">
                       <Text weight="medium">
                         <Box style={{ wordBreak: 'break-all' }}>

--- a/lib/components/Box/Box.docs.tsx
+++ b/lib/components/Box/Box.docs.tsx
@@ -476,6 +476,11 @@ const docs: ComponentDocs = {
                   >
                     <Box
                       background={background as keyof BackgroundDocs}
+                      boxShadow={
+                        ['card', 'input'].includes(background)
+                          ? 'borderStandard'
+                          : undefined
+                      }
                       borderRadius="standard"
                       padding="gutter"
                     />

--- a/lib/components/Box/Box.docs.tsx
+++ b/lib/components/Box/Box.docs.tsx
@@ -429,6 +429,7 @@ const docs: ComponentDocs = {
           </Alert>
         </>
       ),
+      background: 'card',
       Example: () => {
         const { code, value } = source(
           <Tiles space="large" columns={[1, 1, 2]}>
@@ -457,12 +458,12 @@ const docs: ComponentDocs = {
                 criticalLight: 'Used for lighter “critical” elements.',
                 criticalHover: 'Hover colour for “critical” elements.',
                 criticalActive: 'Hover colour for “critical” elements.',
+                caution: 'Used for heavier “caution” elements.',
+                cautionLight: 'Used for lighter “caution” elements.',
                 info: 'Used for heavier “info” elements.',
                 infoLight: 'Used for lighter “info” elements.',
                 promote: 'Used for heavier “promote” elements.',
                 promoteLight: 'Used for lighter “promote” elements.',
-                caution: 'Used for heavier “caution” elements.',
-                cautionLight: 'Used for lighter “caution” elements.',
                 neutral: 'Used for heavier “neutral” elements.',
                 neutralLight: 'Used for lighter “neutral” elements.',
               }),
@@ -470,14 +471,16 @@ const docs: ComponentDocs = {
               <Columns key={background} space="medium">
                 <Column width="content">
                   <Box
-                    background="card"
+                    background={
+                      ['card', 'input'].includes(background) ? 'body' : 'card'
+                    }
                     borderRadius="standard"
-                    padding="xxsmall"
+                    padding="xsmall"
                   >
                     <Box
                       background={background as keyof BackgroundDocs}
                       borderRadius="standard"
-                      padding="large"
+                      padding="gutter"
                     />
                   </Box>
                 </Column>

--- a/lib/components/Box/Box.docs.tsx
+++ b/lib/components/Box/Box.docs.tsx
@@ -1,33 +1,605 @@
-import React, { Fragment } from 'react';
-import { ComponentDocs, ComponentExample } from '../../../site/src/types';
-import { Box } from './Box';
-import { Placeholder } from '../private/Placeholder/Placeholder';
-import tokens from '../../themes/wireframe/tokens';
+import React from 'react';
+import { ComponentDocs } from '../../../site/src/types';
+import {
+  Box,
+  Text,
+  TextLink,
+  Stack,
+  Inline,
+  Tiles,
+  Columns,
+  Column,
+  Divider,
+  Strong,
+  Alert,
+} from '../';
 import source from '../../utils/source.macro';
+import Code from '../../../site/src/App/Code/Code';
+import { BoxProps } from './Box';
 
-type Space = keyof typeof tokens.space;
-const spaceScale = Object.keys(tokens.space) as Space[];
+type BackgroundDocs = Required<
+  Record<NonNullable<BoxProps['background']>, string>
+>;
+const validateBackgrounds = (backgrounds: BackgroundDocs) => backgrounds;
+
+type BoxShadowDocs = Required<
+  Record<NonNullable<BoxProps['boxShadow']>, string>
+>;
+const validateBoxShadows = (boxShadows: BoxShadowDocs) => boxShadows;
 
 const docs: ComponentDocs = {
   category: 'Layout',
+  description: (
+    <>
+      <Text>
+        Box is the lowest-level component for binding theme-based styles to an
+        individual element on the screen. Internally, all Braid components are
+        made up of Boxes.
+      </Text>
+      <Text>
+        All elements rendered via Box are provided with a{' '}
+        <TextLink href="https://github.com/seek-oss/braid-design-system/blob/master/lib/reset/reset.treat.ts">
+          CSS reset
+        </TextLink>{' '}
+        to ensure that elements only have styling rules that have been
+        explicitly specified.
+      </Text>
+    </>
+  ),
   alternatives: [],
-  additional: spaceScale.map(
-    (space): ComponentExample => ({
-      label: `"${space}" space`,
-      Container: ({ children }) => (
-        <Box style={{ overflow: 'auto', maxWidth: '300px' }}>{children}</Box>
+  additional: [
+    {
+      label: 'Semantic elements',
+      description: (
+        <>
+          <Text>
+            By default, Box renders a <Strong>div</Strong> element. You can
+            customise this via the <Strong>component</Strong> prop. Non-Braid
+            props will also be forwarded to the underlying element.
+          </Text>
+          <Code playroom={false}>
+            {
+              source(
+                <Box component="span" aria-hidden>
+                  ...
+                </Box>,
+              ).code
+            }
+          </Code>
+        </>
+      ),
+    },
+    {
+      label: 'Dynamic CSS classes',
+      description: (
+        <>
+          <Text>
+            The <Strong>className</Strong> prop supports the full{' '}
+            <TextLink href="https://github.com/JedWatson/classnames">
+              Classnames API.
+            </TextLink>
+          </Text>
+          <Code playroom={false}>
+            {(() => {
+              const styles = {
+                firstClass: null,
+                secondClass: null,
+                thirdClass: null,
+              };
+
+              return source(
+                <Box
+                  className={[
+                    styles.firstClass,
+                    styles.secondClass,
+                    styles.thirdClass,
+                  ]}
+                >
+                  ...
+                </Box>,
+              ).code;
+            })()}
+          </Code>
+        </>
+      ),
+    },
+    {
+      label: 'Padding and margins',
+      description: (
+        <>
+          <Text>
+            Padding and margins can be applied in all directions using our{' '}
+            <TextLink href="/foundations/layout#spacing">space scale.</TextLink>{' '}
+            In most cases, padding is recommended over margin to avoid issues
+            with{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Web/CSS/CSS_Box_Model/Mastering_margin_collapsing">
+              collapsing margins.
+            </TextLink>
+          </Text>
+          <Code playroom={false}>
+            {
+              source(
+                <Box paddingX="gutter" paddingY="large">
+                  ...
+                </Box>,
+              ).code
+            }
+          </Code>
+        </>
       ),
       Example: () =>
         source(
-          <Fragment>
-            <Box paddingBottom={space}>
-              <Placeholder height={40} />
+          <Stack space="large" align="center">
+            <Stack space="gutter" align="center">
+              <Inline space="gutter" align="center" alignY="center">
+                <Box
+                  background="formAccentHover"
+                  borderRadius="standard"
+                  padding="medium"
+                >
+                  <Box
+                    background="formAccent"
+                    borderRadius="standard"
+                    padding="medium"
+                  >
+                    <Text>padding</Text>
+                  </Box>
+                </Box>
+                <Inline space="gutter" align="center" alignY="center">
+                  <Box
+                    background="formAccentHover"
+                    borderRadius="standard"
+                    paddingX="medium"
+                  >
+                    <Box
+                      background="formAccent"
+                      borderRadius="standard"
+                      padding="medium"
+                    >
+                      <Text>paddingX</Text>
+                    </Box>
+                  </Box>
+                  <Box
+                    background="formAccentHover"
+                    borderRadius="standard"
+                    paddingY="medium"
+                  >
+                    <Box
+                      background="formAccent"
+                      borderRadius="standard"
+                      padding="medium"
+                    >
+                      <Text>paddingY</Text>
+                    </Box>
+                  </Box>
+                </Inline>
+              </Inline>
+              <Inline
+                space="gutter"
+                collapseBelow="desktop"
+                align="center"
+                alignY="center"
+              >
+                <Inline space="gutter" align="center" alignY="center">
+                  <Box
+                    background="formAccentHover"
+                    borderRadius="standard"
+                    paddingTop="medium"
+                  >
+                    <Box
+                      background="formAccent"
+                      borderRadius="standard"
+                      padding="medium"
+                    >
+                      <Text>paddingTop</Text>
+                    </Box>
+                  </Box>
+                  <Box
+                    background="formAccentHover"
+                    borderRadius="standard"
+                    paddingRight="medium"
+                  >
+                    <Box
+                      background="formAccent"
+                      borderRadius="standard"
+                      padding="medium"
+                    >
+                      <Text>paddingRight</Text>
+                    </Box>
+                  </Box>
+                </Inline>
+                <Inline space="gutter" align="center" alignY="center">
+                  <Box
+                    background="formAccentHover"
+                    borderRadius="standard"
+                    paddingBottom="medium"
+                  >
+                    <Box
+                      background="formAccent"
+                      borderRadius="standard"
+                      padding="medium"
+                    >
+                      <Text>paddingBottom</Text>
+                    </Box>
+                  </Box>
+                  <Box
+                    background="formAccentHover"
+                    borderRadius="standard"
+                    paddingLeft="medium"
+                  >
+                    <Box
+                      background="formAccent"
+                      borderRadius="standard"
+                      padding="medium"
+                    >
+                      <Text>paddingLeft</Text>
+                    </Box>
+                  </Box>
+                </Inline>
+              </Inline>
+            </Stack>
+
+            <Box width="full">
+              <Divider />
             </Box>
-            <Placeholder height={40} />
-          </Fragment>,
+
+            <Stack space="gutter" align="center">
+              <Inline space="gutter" align="center" alignY="center">
+                <Box
+                  display="flex"
+                  background="brandAccentHover"
+                  borderRadius="standard"
+                >
+                  <Box
+                    background="brandAccent"
+                    borderRadius="standard"
+                    padding="medium"
+                    margin="medium"
+                  >
+                    <Text>margin</Text>
+                  </Box>
+                </Box>
+                <Inline space="gutter" align="center" alignY="center">
+                  <Box
+                    display="flex"
+                    background="brandAccentHover"
+                    borderRadius="standard"
+                  >
+                    <Box
+                      background="brandAccent"
+                      borderRadius="standard"
+                      padding="medium"
+                      marginX="medium"
+                    >
+                      <Text>marginX</Text>
+                    </Box>
+                  </Box>
+                  <Box
+                    display="flex"
+                    background="brandAccentHover"
+                    borderRadius="standard"
+                  >
+                    <Box
+                      background="brandAccent"
+                      borderRadius="standard"
+                      padding="medium"
+                      marginY="medium"
+                    >
+                      <Text>marginY</Text>
+                    </Box>
+                  </Box>
+                </Inline>
+              </Inline>
+              <Inline
+                space="gutter"
+                collapseBelow="desktop"
+                align="center"
+                alignY="center"
+              >
+                <Inline space="gutter" align="center" alignY="center">
+                  <Box
+                    display="flex"
+                    background="brandAccentHover"
+                    borderRadius="standard"
+                  >
+                    <Box
+                      background="brandAccent"
+                      borderRadius="standard"
+                      padding="medium"
+                      marginTop="medium"
+                    >
+                      <Text>marginTop</Text>
+                    </Box>
+                  </Box>
+                  <Box
+                    display="flex"
+                    background="brandAccentHover"
+                    borderRadius="standard"
+                  >
+                    <Box
+                      background="brandAccent"
+                      borderRadius="standard"
+                      padding="medium"
+                      marginRight="medium"
+                    >
+                      <Text>marginRight</Text>
+                    </Box>
+                  </Box>
+                </Inline>
+                <Inline space="gutter" align="center" alignY="center">
+                  <Box
+                    display="flex"
+                    background="brandAccentHover"
+                    borderRadius="standard"
+                  >
+                    <Box
+                      background="brandAccent"
+                      borderRadius="standard"
+                      padding="medium"
+                      marginBottom="medium"
+                    >
+                      <Text>marginBottom</Text>
+                    </Box>
+                  </Box>
+                  <Box
+                    display="flex"
+                    background="brandAccentHover"
+                    borderRadius="standard"
+                  >
+                    <Box
+                      background="brandAccent"
+                      borderRadius="standard"
+                      padding="medium"
+                      marginLeft="medium"
+                    >
+                      <Text>marginLeft</Text>
+                    </Box>
+                  </Box>
+                </Inline>
+              </Inline>
+            </Stack>
+          </Stack>,
         ),
-    }),
-  ),
+    },
+    {
+      label: 'Responsive padding and margins',
+      description: (
+        <Text>
+          Padding and margins can also differ across screen sizes by providing
+          an array of responsive values, e.g.{' '}
+          <Strong>{"['small', 'medium', 'large']"}</Strong>
+        </Text>
+      ),
+      Example: () =>
+        source(
+          <Inline space="gutter" align="center">
+            <Box
+              background="formAccentHover"
+              borderRadius="standard"
+              padding={['small', 'medium', 'large']}
+            >
+              <Box
+                background="formAccent"
+                borderRadius="standard"
+                padding="medium"
+              >
+                <Text>Responsive padding</Text>
+              </Box>
+            </Box>
+
+            <Box
+              display="flex"
+              background="brandAccentHover"
+              borderRadius="standard"
+            >
+              <Box
+                background="brandAccent"
+                borderRadius="standard"
+                padding="medium"
+                margin={['small', 'medium', 'large']}
+              >
+                <Text>Responsive margin</Text>
+              </Box>
+            </Box>
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Backgrounds',
+      description: (
+        <>
+          <Text>
+            Box provides a series of <Strong>semantic</Strong> backgrounds,
+            meaning that they are named based on their desired usage rather than
+            what they happen to look like. This is what allows us to change
+            colours in radically different ways across our suite of themes.
+          </Text>
+          <Code playroom={false}>
+            {source(<Box background="brand">...</Box>).code}
+          </Code>
+          <Alert tone="caution">
+            <Text>
+              These background colours are likely to change over time, so it’s
+              important that you only use them within the semantic context they
+              were designed for, e.g. only using the “selection” colour for
+              actual user selections. If you choose colours based soley on their
+              appearance, your application’s colours may change in unexpected
+              ways when upgrading Braid.
+            </Text>
+          </Alert>
+        </>
+      ),
+      Example: () => {
+        const { code, value } = source(
+          <Tiles space="large" columns={[1, 1, 2]}>
+            {Object.entries(
+              validateBackgrounds({
+                body:
+                  'Used for elements that need to match the body background.',
+                brand: 'Used for branding larger areas of the screen.',
+                brandAccent: 'Used for branding smaller areas of the screen.',
+                brandAccentHover: 'Hover colour for “brandAccent” elements.',
+                brandAccentActive: 'Hover colour for “brandAccent” elements.',
+                formAccent:
+                  'Used for prominent interactive elements, typically within a form.',
+                formAccentHover: 'Hover colour for “formAccent” elements.',
+                formAccentActive: 'Active colour for “formAccent” elements.',
+                formAccentDisabled:
+                  'Disabled colour for “formAccent” elements.',
+                input: 'Used for input fields.',
+                inputDisabled: 'Used for input fields when disabled.',
+                card: 'Used for card surfaces.',
+                selection:
+                  'Used for user selections, e.g. selected item in an Autosuggest.',
+                positive: 'Used for heavier “positive” elements.',
+                positiveLight: 'Used for lighter “positive” elements.',
+                critical: 'Used for heavier “critical” elements.',
+                criticalLight: 'Used for lighter “critical” elements.',
+                criticalHover: 'Hover colour for “critical” elements.',
+                criticalActive: 'Hover colour for “critical” elements.',
+                info: 'Used for heavier “info” elements.',
+                infoLight: 'Used for lighter “info” elements.',
+                promote: 'Used for heavier “promote” elements.',
+                promoteLight: 'Used for lighter “promote” elements.',
+                caution: 'Used for heavier “caution” elements.',
+                cautionLight: 'Used for lighter “caution” elements.',
+                neutral: 'Used for heavier “neutral” elements.',
+                neutralLight: 'Used for lighter “neutral” elements.',
+              }),
+            ).map(([background, description]) => (
+              <Columns key={background} space="medium">
+                <Column width="content">
+                  <Box
+                    background="card"
+                    borderRadius="standard"
+                    padding="xxsmall"
+                  >
+                    <Box
+                      background={background as keyof BackgroundDocs}
+                      borderRadius="standard"
+                      padding="large"
+                    />
+                  </Box>
+                </Column>
+                <Column>
+                  <Box paddingTop="medium" paddingRight="medium">
+                    <Stack space="small">
+                      <Text weight="medium">{background}</Text>
+                      <Text tone="secondary">{description}</Text>
+                    </Stack>
+                  </Box>
+                </Column>
+              </Columns>
+            ))}
+          </Tiles>,
+        );
+
+        return {
+          code: code
+            .replace('validateBackgrounds', '')
+            .replace(' as keyof BackgroundDocs', ''),
+          value,
+        };
+      },
+    },
+    {
+      label: 'Shadows, borders and outlines',
+      description: (
+        <>
+          <Text>
+            Box provides a series of <Strong>boxShadow</Strong> values that
+            handle a wide variety of use cases. Note that box shadows are also
+            used for outlines and borders so that their presence doesn’t alter
+            the dimensions of the element.
+          </Text>
+          <Code playroom={false}>
+            {source(<Box boxShadow="large">...</Box>).code}
+          </Code>
+          <Alert tone="caution">
+            <Text>
+              These box shadows are likely to change over time, so it’s
+              important that you only use them within the semantic context they
+              were designed for, e.g. only using “borderField” for actual field
+              borders. If you choose semantic box shadows based soley on their
+              appearance, your application’s colours may change in unexpected
+              ways when upgrading Braid.
+            </Text>
+          </Alert>
+        </>
+      ),
+      background: 'card',
+      Example: () => {
+        const { code, value } = source(
+          <Tiles space="large" columns={[1, 1, 2]}>
+            {Object.entries(
+              validateBoxShadows({
+                small: 'Used for small shadows.',
+                medium: 'Used for medium shadows.',
+                large: 'Used for large shadows.',
+                borderStandard: 'Used for neutral element borders.',
+                borderStandardInverted:
+                  'Used for standard borders on dark backgrounds.',
+                borderStandardInvertedLarge:
+                  'Used for large standard borders on dark backgrounds.',
+                borderField: 'Used for borders around form fields.',
+                borderFormHover:
+                  'Used for borders around form fields on hover.',
+                outlineFocus: 'Used for focus states of interactive elements.',
+                borderFormAccent:
+                  'Used for borders around prominent interactive elements.',
+                borderFormAccentLarge:
+                  'Used for large borders around prominent interactive elements.',
+                borderPositive: 'Used for borders around “positive” elements.',
+                borderCritical: 'Used for borders around “critical” elements.',
+                borderCriticalLarge:
+                  'Used for large borders around “critical” elements.',
+                borderCaution: 'Used for borders around “caution” elements.',
+                borderInfo: 'Used for borders around “info” elements.',
+                borderPromote: 'Used for borders around “promote” elements.',
+              }),
+            ).map(([boxShadow, description]) => (
+              <Columns key={boxShadow} space="medium">
+                <Column width="content">
+                  <Box
+                    background={
+                      boxShadow.includes('Inverted') ? 'brand' : 'card'
+                    }
+                    borderRadius="standard"
+                    padding="small"
+                  >
+                    <Box
+                      boxShadow={boxShadow as keyof BoxShadowDocs}
+                      borderRadius="standard"
+                      padding="gutter"
+                    />
+                  </Box>
+                </Column>
+                <Column>
+                  <Box paddingTop="medium" paddingRight="medium">
+                    <Stack space="small">
+                      <Text weight="medium">
+                        <Box style={{ wordBreak: 'break-all' }}>
+                          {boxShadow}
+                        </Box>
+                      </Text>
+                      <Text tone="secondary">{description}</Text>
+                    </Stack>
+                  </Box>
+                </Column>
+              </Columns>
+            ))}
+          </Tiles>,
+        );
+
+        return {
+          code: code
+            .replace('validateBoxShadows', '')
+            .replace(' as keyof BoxShadowDocs', ''),
+          value,
+        };
+      },
+    },
+  ],
 };
 
 export default docs;

--- a/lib/components/Box/useBoxStyles.treat.ts
+++ b/lib/components/Box/useBoxStyles.treat.ts
@@ -363,22 +363,19 @@ export const maxWidth = styleMap(({ contentWidth }) =>
 const relativePositionRules = {
   0: 0,
 };
-// Remove this when 'styleMap' supports numbers as keys and it's been released to sku consumers,
 type PositionRulesType = Record<keyof typeof relativePositionRules, string>;
-export const relativePosition = {
-  top: styleMap(
-    mapToStyleProperty(relativePositionRules, 'top'),
-  ) as PositionRulesType,
-  bottom: styleMap(
-    mapToStyleProperty(relativePositionRules, 'bottom'),
-  ) as PositionRulesType,
-  left: styleMap(
-    mapToStyleProperty(relativePositionRules, 'left'),
-  ) as PositionRulesType,
-  right: styleMap(
-    mapToStyleProperty(relativePositionRules, 'right'),
-  ) as PositionRulesType,
-};
+export const top = styleMap(
+  mapToStyleProperty(relativePositionRules, 'top'),
+) as PositionRulesType;
+export const bottom = styleMap(
+  mapToStyleProperty(relativePositionRules, 'bottom'),
+) as PositionRulesType;
+export const left = styleMap(
+  mapToStyleProperty(relativePositionRules, 'left'),
+) as PositionRulesType;
+export const right = styleMap(
+  mapToStyleProperty(relativePositionRules, 'right'),
+) as PositionRulesType;
 
 export const userSelect = styleMap({
   none: { userSelect: 'none' },

--- a/lib/components/Box/useBoxStyles.treat.ts
+++ b/lib/components/Box/useBoxStyles.treat.ts
@@ -363,6 +363,7 @@ export const maxWidth = styleMap(({ contentWidth }) =>
 const relativePositionRules = {
   0: 0,
 };
+// Remove this when 'styleMap' supports numbers as keys and it's been released to sku consumers,
 type PositionRulesType = Record<keyof typeof relativePositionRules, string>;
 export const top = styleMap(
   mapToStyleProperty(relativePositionRules, 'top'),

--- a/lib/components/Box/useBoxStyles.ts
+++ b/lib/components/Box/useBoxStyles.ts
@@ -49,10 +49,10 @@ export interface UseBoxStylesProps {
   overflow?: keyof typeof styleRefs.overflow;
   minWidth?: keyof typeof styleRefs.minWidth;
   maxWidth?: keyof typeof styleRefs.maxWidth;
-  top?: keyof typeof styleRefs.relativePosition.top;
-  bottom?: keyof typeof styleRefs.relativePosition.bottom;
-  left?: keyof typeof styleRefs.relativePosition.left;
-  right?: keyof typeof styleRefs.relativePosition.right;
+  top?: keyof typeof styleRefs.top;
+  bottom?: keyof typeof styleRefs.bottom;
+  left?: keyof typeof styleRefs.left;
+  right?: keyof typeof styleRefs.right;
   userSelect?: keyof typeof styleRefs.userSelect;
   outline?: keyof typeof styleRefs.outline;
   opacity?: keyof typeof styleRefs.opacity;
@@ -137,10 +137,10 @@ export const useBoxStyles = ({
     styles.overflow[overflow!],
     styles.minWidth[minWidth!],
     styles.maxWidth[maxWidth!],
-    styles.relativePosition.top[top!],
-    styles.relativePosition.bottom[bottom!],
-    styles.relativePosition.right[right!],
-    styles.relativePosition.left[left!],
+    styles.top[top!],
+    styles.bottom[bottom!],
+    styles.right[right!],
+    styles.left[left!],
     resolvedMarginTop !== undefined &&
       resolveResponsiveProp(
         resolvedMarginTop,

--- a/lib/themes/docs/tokens.ts
+++ b/lib/themes/docs/tokens.ts
@@ -129,7 +129,7 @@ const tokens: TreatTokens = {
   breakpoint: {
     mobile: 0,
     tablet: 768,
-    desktop: 992,
+    desktop: 1136,
   },
   contentWidth: {
     xsmall: 400,

--- a/site/src/App/ComponentDoc/ComponentProps.tsx
+++ b/site/src/App/ComponentDoc/ComponentProps.tsx
@@ -1,5 +1,5 @@
 import React, { Fragment } from 'react';
-import sortBy from 'lodash/sortBy';
+import partition from 'lodash/partition';
 import { Box, Text, Stack } from '../../../../lib/components';
 import componentDocs from '../../../../generate-component-docs/componentDocs.json';
 import type {
@@ -91,27 +91,29 @@ export const ComponentProps = ({ componentName }: Props) => {
     return null;
   }
 
-  const propList = sortBy(
+  const [requiredProps, optionalProps] = partition(
     doc.props.props,
     ({ required }) => required,
-  ).reverse();
+  );
 
   return Object.keys(doc.props).length === 0 ? null : (
     <Stack space="xlarge">
-      {propList.map(({ propName, type, required, description }) => (
-        <Stack space="medium" key={propName}>
-          <Stack space="small">
-            <Text weight="strong">
-              {propName}
-              {required ? ' (Required)' : null}
+      {[...requiredProps, ...optionalProps].map(
+        ({ propName, type, required, description }) => (
+          <Stack space="medium" key={propName}>
+            <Stack space="small">
+              <Text weight="strong">
+                {propName}
+                {required ? ' (Required)' : null}
+              </Text>
+              {description ? <Text size="small">{description}</Text> : null}
+            </Stack>
+            <Text size="small" tone="secondary">
+              <PropType type={type} />
             </Text>
-            {description ? <Text size="small">{description}</Text> : null}
           </Stack>
-          <Text size="small" tone="secondary">
-            <PropType type={type} />
-          </Text>
-        </Stack>
-      ))}
+        ),
+      )}
     </Stack>
   );
 };

--- a/site/src/App/Navigation/Navigation.tsx
+++ b/site/src/App/Navigation/Navigation.tsx
@@ -107,7 +107,12 @@ export const Navigation = ({ children }: NavigationProps) => {
           paddingX={gutterSize}
           paddingBottom="xxlarge"
           width="full"
-          display={[isMenuOpen ? 'block' : 'none', 'block']}
+          display={[
+            ...(isMenuOpen
+              ? (['block', 'block'] as const)
+              : (['none', 'none'] as const)),
+            'block',
+          ]}
           zIndex="sticky"
           background="body"
           className={[


### PR DESCRIPTION
This obvously isn't complete, but it's an improvement over the current docs, documenting the following Box features:
- `component` prop and forwarding native props to the underlying element.
- `className` prop supporting the full Classnames API.
- Padding and margin props, including responsive values.
- Backgrounds.
- Box shadows.
- General CSS utils.

To ensure the docs stay up to date, I've also made sure that the background and box shadow docs will break the build if they don't have a description provided for every possible value.

This PR also increases the "desktop" breakpoint in the docs theme, adjusts the sorting of component props so that third-party props are at the bottom, and fixes a bug with the navigation on tablet.