### PR TITLE
Pagination: Add space between buttons above mobile

### DIFF
--- a/.changeset/six-monkeys-itch.md
+++ b/.changeset/six-monkeys-itch.md
@@ -1,0 +1,10 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Pagination
+---
+
+Add space between page and navigation controls above mobile to improve affordance between the current page and the hover state of surrounding buttons.

--- a/lib/components/Pagination/Pagination.tsx
+++ b/lib/components/Pagination/Pagination.tsx
@@ -72,7 +72,17 @@ const PageNav = ({
   );
 };
 
-const Page = ({ number, current }: { number: number; current: boolean }) => {
+const tabletButtonSpacing = 'xxsmall';
+
+const Page = ({
+  number,
+  current,
+  isLast,
+}: {
+  number: number;
+  current: boolean;
+  isLast: boolean;
+}) => {
   const styles = useStyles(styleRefs);
 
   return (
@@ -84,6 +94,7 @@ const Page = ({ number, current }: { number: number; current: boolean }) => {
       height="touchable"
       width="touchable"
       position="relative"
+      marginRight={['none', isLast ? 'none' : tabletButtonSpacing]}
       className={styles.hover}
     >
       <Overlay
@@ -127,7 +138,7 @@ export const Pagination = ({
     <Box component="nav" aria-label={label}>
       <Box component="ul" display="flex" justifyContent="center">
         {showPrevious ? (
-          <Box component="li" paddingRight={['medium', 'none']}>
+          <Box component="li" paddingRight={['medium', tabletButtonSpacing]}>
             <Link
               {...linkProps({ page: page - 1, type: 'previous' })}
               rel="prev"
@@ -139,7 +150,7 @@ export const Pagination = ({
           </Box>
         ) : null}
 
-        {pages.map((pageNumber) => {
+        {pages.map((pageNumber, index) => {
           const current = page === pageNumber;
 
           return (
@@ -154,14 +165,18 @@ export const Pagination = ({
                 aria-current={current ? 'page' : undefined}
                 title={pageLabel(pageNumber)}
               >
-                <Page number={pageNumber} current={current} />
+                <Page
+                  number={pageNumber}
+                  current={current}
+                  isLast={pages.length - 1 === index}
+                />
               </Link>
             </Hidden>
           );
         })}
 
         {showNext ? (
-          <Box component="li" paddingLeft={['medium', 'none']}>
+          <Box component="li" paddingLeft={['medium', tabletButtonSpacing]}>
             <Link
               {...linkProps({ page: page + 1, type: 'next' })}
               rel="next"

--- a/lib/components/Pagination/Pagination.tsx
+++ b/lib/components/Pagination/Pagination.tsx
@@ -6,7 +6,6 @@ import { IconChevron } from '../icons';
 import { Link, LinkProps } from '../Link/Link';
 import { Overlay } from '../private/Overlay/Overlay';
 import { Text } from '../Text/Text';
-import { Hidden } from '../Hidden/Hidden';
 import { paginate } from './paginate';
 
 import * as styleRefs from './Pagination.treat';
@@ -74,15 +73,7 @@ const PageNav = ({
 
 const tabletButtonSpacing = 'xxsmall';
 
-const Page = ({
-  number,
-  current,
-  isLast,
-}: {
-  number: number;
-  current: boolean;
-  isLast: boolean;
-}) => {
+const Page = ({ number, current }: { number: number; current: boolean }) => {
   const styles = useStyles(styleRefs);
 
   return (
@@ -94,7 +85,6 @@ const Page = ({
       height="touchable"
       width="touchable"
       position="relative"
-      marginRight={['none', isLast ? 'none' : tabletButtonSpacing]}
       className={styles.hover}
     >
       <Overlay
@@ -154,9 +144,13 @@ export const Pagination = ({
           const current = page === pageNumber;
 
           return (
-            <Hidden
+            <Box
               component="li"
-              below={!current ? 'tablet' : undefined}
+              display={!current ? ['none', 'block'] : undefined}
+              paddingRight={[
+                'none',
+                pages.length - 1 === index ? 'none' : tabletButtonSpacing,
+              ]}
               key={pageNumber}
             >
               <Link
@@ -165,13 +159,9 @@ export const Pagination = ({
                 aria-current={current ? 'page' : undefined}
                 title={pageLabel(pageNumber)}
               >
-                <Page
-                  number={pageNumber}
-                  current={current}
-                  isLast={pages.length - 1 === index}
-                />
+                <Page number={pageNumber} current={current} />
               </Link>
-            </Hidden>
+            </Box>
           );
         })}
 


### PR DESCRIPTION
Add space between page and navigation controls above mobile to improve affordance between the current page and the hover state of surrounding buttons.