### PR TITLE
Add variant to Button and deprecate weight

### DIFF
--- a/.changeset/early-zebras-unite.md
+++ b/.changeset/early-zebras-unite.md
@@ -1,0 +1,10 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Box
+---
+
+**Box:** Add `borderBrandAccentLarge` to `boxShadow` prop

--- a/.changeset/light-oranges-call.md
+++ b/.changeset/light-oranges-call.md
@@ -1,0 +1,90 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Text
+  - IconAdd
+  - IconBookmark
+  - IconCaution
+  - IconChevron
+  - IconClear
+  - IconCompany
+  - IconCompose
+  - IconCopy
+  - IconCreditCard
+  - IconCritical
+  - IconDate
+  - IconDelete
+  - IconDesktop
+  - IconDocument
+  - IconDocumentBroken
+  - IconDownload
+  - IconEdit
+  - IconEducation
+  - IconFilter
+  - IconGrid
+  - IconHeart
+  - IconHelp
+  - IconHistory
+  - IconHome
+  - IconImage
+  - IconInfo
+  - IconInvoice
+  - IconLanguage
+  - IconLink
+  - IconLinkBroken
+  - IconList
+  - IconLocation
+  - IconMail
+  - IconMinus
+  - IconMobile
+  - IconMoney
+  - IconNewWindow
+  - IconNote
+  - IconNotification
+  - IconOverflow
+  - IconPeople
+  - IconPersonAdd
+  - IconPersonVerified
+  - IconPhone
+  - IconPositive
+  - IconPrint
+  - IconProfile
+  - IconPromote
+  - IconRecommended
+  - IconRefresh
+  - IconResume
+  - IconSearch
+  - IconSecurity
+  - IconSend
+  - IconSent
+  - IconSettings
+  - IconShare
+  - IconSocialFacebook
+  - IconSocialGitHub
+  - IconSocialInstagram
+  - IconSocialLinkedIn
+  - IconSocialMedium
+  - IconSocialTwitter
+  - IconStar
+  - IconStatistics
+  - IconSubCategory
+  - IconTag
+  - IconTick
+  - IconTime
+  - IconUpload
+  - IconVideo
+  - IconVisibility
+  - IconWorkExperience
+---
+
+**Text:** Add brandAccent tone to Text and Icons
+
+**EXAMPLE USAGE:**
+```jsx
+<Text tone="brandAccent">...</Text>
+```
+
+

--- a/.changeset/many-keys-sort.md
+++ b/.changeset/many-keys-sort.md
@@ -15,10 +15,9 @@ Usage of `TextLink` or `TextLinkButton` inside of an `Actions` container should 
 Previously when a `TextLink` or `TextLinkButton` was placed inside of an `Actions` container, it would be given a custom layout to align with the `Button` elements. We are deprecating this behaviour.
 
 **MIGRATION GUIDE:**
-Going forward `Actions` should only contain `Button` elements. To migrate towards this, both `TextLink` and `TextLinkButton` should now use either a `ButtonLink` or `Button` respectively, with a `variant` of `transparent`.
+Going forward `Actions` should only contain `Button` elements. To migrate towards this, both `TextLink` and `TextLinkButton` should now use either a `ButtonLink` or `Button` respectively, with a `variant` or `transparent`.
 
 #### TextLink
-Can be replicated with a `variant` of `standard` (default).
 ```diff
 <Actions>
   <Button>...</Button>

--- a/.changeset/many-keys-sort.md
+++ b/.changeset/many-keys-sort.md
@@ -1,0 +1,37 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - TextLink
+  - TextLinkButton
+---
+
+**TextLink,TextLinkButton:** Deprecate inside of Actions in favour of transparent Button
+
+Usage of `TextLink` or `TextLinkButton` inside of an `Actions` container should now use a `Button` with a `variant` of `transparent`.
+
+Previously when a `TextLink` or `TextLinkButton` was placed inside of an `Actions` container, it would be given a custom layout to align with the `Button` elements. We are deprecating this behaviour.
+
+**MIGRATION GUIDE:**
+Going forward `Actions` should only contain `Button` elements. To migrate towards this, both `TextLink` and `TextLinkButton` should now use either a `ButtonLink` or `Button` respectively, with a `variant` or `transparent`.
+
+#### TextLink
+Can be replicated with a `variant` of `standard` (default).
+```diff
+<Actions>
+  <Button>...</Button>
+- <TextLink href="...">...</TextLink>
++ <ButtonLink href="..." variant="transparent">...</ButtonLink>
+</Actions>
+```
+
+#### TextLinkButton
+```diff
+<Actions>
+  <Button>...</Button>
+- <TextLinkButton onClick={...}>...</TextLinkButton>
++ <Button onClick={...} variant="transparent">...</Button>
+</Actions>
+```

--- a/.changeset/pretty-beers-reply.md
+++ b/.changeset/pretty-beers-reply.md
@@ -10,14 +10,14 @@ updated:
 
 **Button,ButtonLink:** Add variant to Button and deprecate weight
 
-Introduces a new `variant` prop to `Button`/`ButtonLink` giving consumers a single prop to use for selecting the visual style of the button. Choose from `standard`, `ghost`, `soft` or `transparent`. The colour of the button is now consistently controlled via the `tone` prop, with supported values being `brandAccent`, `critical` or `undefined`.
+Introduces a new `variant` prop to `Button`/`ButtonLink` giving consumers a single prop to use for selecting the visual style of the button. Choose from `solid` (default), `ghost`, `soft` or `transparent`. The colour of the button is now consistently controlled via the `tone` prop, with supported values being `brandAccent`, `critical` or `undefined`.
 
 As a result the `weight` prop is now deprecated. See the migration guide below.
 
 **EXAMPLE USAGE:**
 ```jsx
 <Inline space="small" collapseBelow="desktop">
-  <Button>Standard</Button>
+  <Button>Solid</Button>
   <Button variant="ghost">Ghost</Button>
   <Button variant="soft">Soft</Button>
   <Button variant="transparent">Transparent</Button>
@@ -30,10 +30,10 @@ The `weight` prop is now deprecated. If you are not specifying a `weight` there 
 If you are, each weight can be migrated as follows:
 
 #### Regular
-Can be replicated with a `variant` of `standard` (default).
+Can be replicated with a `variant` of `solid` (default).
 ```diff
 -<Button weight="regular">...</Button>
-+<Button variant="standard">...</Button>
++<Button variant="solid">...</Button>
 ```
 
 Given it is the default `variant`, you could also choose to simply remove the `weight` prop.
@@ -43,7 +43,7 @@ Given it is the default `variant`, you could also choose to simply remove the `w
 ```
 
 #### Strong
-Can be replicated with a `variant` of `standard` (default), with a `tone` of `brandAccent`.
+Can be replicated with a `variant` of `solid` (default), with a `tone` of `brandAccent`.
 ```diff
 -<Button weight="strong">...</Button>
 +<Button tone="brandAccent">...</Button>

--- a/.changeset/pretty-beers-reply.md
+++ b/.changeset/pretty-beers-reply.md
@@ -1,0 +1,59 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Button
+  - ButtonLink
+---
+
+**Button,ButtonLink:** Add variant to Button and deprecate weight
+
+Introduces a new `variant` prop to `Button`/`ButtonLink` giving consumers a single prop to use for selecting the visual style of the button. Choose from `standard`, `ghost`, `soft` or `transparent`. The colour of the button is now consistently controlled via the `tone` prop, with supported values being `brandAccent`, `critical` or `undefined`.
+
+As a result the `weight` prop is now deprecated. See the migration guide below.
+
+**EXAMPLE USAGE:**
+```jsx
+<Inline space="small" collapseBelow="desktop">
+  <Button>Standard</Button>
+  <Button variant="ghost">Ghost</Button>
+  <Button variant="soft">Soft</Button>
+  <Button variant="transparent">Transparent</Button>
+</Inline>
+```
+
+**MIGRATION GUIDE:**
+The `weight` prop is now deprecated. If you are not specifying a `weight` there is no change required.
+
+If you are, each weight can be migrated as follows:
+
+#### Regular
+Can be replicated with a `variant` of `standard` (default).
+```diff
+-<Button weight="regular">...</Button>
++<Button variant="standard">...</Button>
+```
+
+Given it is the default `variant`, you could also choose to simply remove the `weight` prop.
+```diff
+-<Button weight="regular">...</Button>
++<Button>...</Button>
+```
+
+#### Strong
+Can be replicated with a `variant` of `standard` (default), with a `tone` of `brandAccent`.
+```diff
+-<Button weight="strong">...</Button>
++<Button tone="brandAccent">...</Button>
+```
+
+#### Weak
+Can be replicated with a `variant` of `ghost`.
+```diff
+-<Button weight="weak">...</Button>
++<Button variant="ghost">...</Button>
+```
+
+

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -1725,7 +1725,7 @@ Object {
     variant?: 
         | "ghost"
         | "soft"
-        | "standard"
+        | "solid"
         | "transparent"
     weight?: 
         | "regular"
@@ -2157,7 +2157,7 @@ Object {
     variant?: 
         | "ghost"
         | "soft"
-        | "standard"
+        | "solid"
         | "transparent"
     vocab?: string
     weight?: 
@@ -2183,7 +2183,7 @@ Object {
     variant?: 
         | "ghost"
         | "soft"
-        | "standard"
+        | "solid"
         | "transparent"
     weight?: 
         | "regular"

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -357,6 +357,7 @@ Object {
         | "standard"
     bottom?: 0
     boxShadow?: 
+        | "borderBrandAccentLarge"
         | "borderCaution"
         | "borderCritical"
         | "borderCriticalLarge"
@@ -1168,6 +1169,7 @@ Object {
         | "standard"
     bottom?: 0
     boxShadow?: 
+        | "borderBrandAccentLarge"
         | "borderCaution"
         | "borderCritical"
         | "borderCriticalLarge"
@@ -1713,11 +1715,18 @@ Object {
     size?: 
         | "small"
         | "standard"
-    tone?: "critical"
+    tone?: 
+        | "brandAccent"
+        | "critical"
     type?: 
         | "button"
         | "reset"
         | "submit"
+    variant?: 
+        | "ghost"
+        | "soft"
+        | "standard"
+        | "transparent"
     weight?: 
         | "regular"
         | "strong"
@@ -2134,7 +2143,9 @@ Object {
     tabIndex?: number
     target?: string
     title?: string
-    tone?: "critical"
+    tone?: 
+        | "brandAccent"
+        | "critical"
     translate?: 
         | "no"
         | "yes"
@@ -2143,6 +2154,11 @@ Object {
     unselectable?: 
         | "off"
         | "on"
+    variant?: 
+        | "ghost"
+        | "soft"
+        | "standard"
+        | "transparent"
     vocab?: string
     weight?: 
         | "regular"
@@ -2161,7 +2177,14 @@ Object {
     size?: 
         | "small"
         | "standard"
-    tone?: "critical"
+    tone?: 
+        | "brandAccent"
+        | "critical"
+    variant?: 
+        | "ghost"
+        | "soft"
+        | "standard"
+        | "transparent"
     weight?: 
         | "regular"
         | "strong"
@@ -2862,6 +2885,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -2892,6 +2916,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -2921,6 +2946,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -2955,6 +2981,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -2984,6 +3011,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3013,6 +3041,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3042,6 +3071,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3071,6 +3101,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3100,6 +3131,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3129,6 +3161,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3158,6 +3191,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3187,6 +3221,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3216,6 +3251,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3245,6 +3281,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3274,6 +3311,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3303,6 +3341,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3332,6 +3371,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3361,6 +3401,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3390,6 +3431,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3419,6 +3461,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3449,6 +3492,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3478,6 +3522,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3507,6 +3552,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3536,6 +3582,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3565,6 +3612,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3594,6 +3642,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3623,6 +3672,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3652,6 +3702,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3681,6 +3732,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3710,6 +3762,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3739,6 +3792,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3768,6 +3822,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3797,6 +3852,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3826,6 +3882,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3855,6 +3912,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3884,6 +3942,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3913,6 +3972,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3942,6 +4002,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -3971,6 +4032,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4000,6 +4062,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4029,6 +4092,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4058,6 +4122,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4087,6 +4152,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4116,6 +4182,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4145,6 +4212,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4174,6 +4242,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4203,6 +4272,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4232,6 +4302,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4261,6 +4332,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4290,6 +4362,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4319,6 +4392,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4348,6 +4422,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4377,6 +4452,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4406,6 +4482,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4435,6 +4512,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4464,6 +4542,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4493,6 +4572,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4522,6 +4602,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4551,6 +4632,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4580,6 +4662,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4609,6 +4692,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4638,6 +4722,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4667,6 +4752,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4697,6 +4783,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4726,6 +4813,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4755,6 +4843,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4784,6 +4873,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4813,6 +4903,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4842,6 +4933,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4871,6 +4963,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4900,6 +4993,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4930,6 +5024,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -4959,6 +5054,7 @@ Object {
     title?: string
     titleId?: string
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -5460,6 +5556,7 @@ Object {
     >
     start?: number
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"
@@ -6110,6 +6207,7 @@ Object {
         | "standard"
         | "xsmall"
     tone?: 
+        | "brandAccent"
         | "caution"
         | "critical"
         | "formAccent"

--- a/lib/components/Actions/Actions.docs.tsx
+++ b/lib/components/Actions/Actions.docs.tsx
@@ -20,9 +20,9 @@ const docs: ComponentDocs = {
     source(
       <Card>
         <Actions>
-          <Button>Regular Button</Button>
-          <Button weight="weak">Weak Button</Button>
-          <TextLink href="#">TextLink</TextLink>
+          <Button>Button 1</Button>
+          <Button>Button 2</Button>
+          <Button variant="transparent">Button 3</Button>
         </Actions>
       </Card>,
     ),
@@ -54,9 +54,8 @@ const docs: ComponentDocs = {
                 Standard size
               </Text>
               <Actions>
-                <Button>Regular Button</Button>
-                <Button weight="weak">Weak Button</Button>
-                <TextLink href="#">TextLink</TextLink>
+                <Button>Button 1</Button>
+                <Button variant="transparent">Button 2</Button>
               </Actions>
             </Stack>
             <Stack space="small">
@@ -64,9 +63,8 @@ const docs: ComponentDocs = {
                 Small size
               </Text>
               <Actions size="small">
-                <Button>Regular Button</Button>
-                <Button weight="weak">Weak Button</Button>
-                <TextLink href="#">TextLink</TextLink>
+                <Button>Button 1</Button>
+                <Button variant="transparent">Button 2</Button>
               </Actions>
             </Stack>
           </Stack>,
@@ -77,10 +75,9 @@ const docs: ComponentDocs = {
       description: (
         <Text>
           You can add icons to{' '}
-          <TextLink href="/components/Button">Button</TextLink> and{' '}
-          <TextLink href="/components/TextLink">TextLink</TextLink> elements by
-          nesting icon elements inside. The size of the icon will adjust
-          automatically based on its surrounding context.
+          <TextLink href="/components/Button">Button</TextLink> elements by
+          nesting icons inside. The size of the icon will adjust automatically
+          based on its surrounding context.
         </Text>
       ),
       Example: () =>
@@ -94,7 +91,7 @@ const docs: ComponentDocs = {
                 <Button>
                   <IconSend /> Send
                 </Button>
-                <TextLink href="#">Cancel</TextLink>
+                <Button variant="transparent">Cancel</Button>
               </Actions>
             </Stack>
             <Stack space="small">
@@ -105,7 +102,7 @@ const docs: ComponentDocs = {
                 <Button>
                   <IconSend /> Send
                 </Button>
-                <TextLink href="#">Cancel</TextLink>
+                <Button variant="transparent">Cancel</Button>
               </Actions>
             </Stack>
           </Stack>,
@@ -126,20 +123,9 @@ const docs: ComponentDocs = {
             <Button tone="critical">
               <IconDelete /> Delete
             </Button>
-            <TextLink href="#">Cancel</TextLink>
+            <Button variant="transparent">Cancel</Button>
           </Actions>,
         ),
-    },
-    {
-      label: 'Contextual design',
-      description: (
-        <Text>
-          When nested inside Actions,{' '}
-          <TextLink href="/components/TextLink">TextLink</TextLink> is given a
-          more prominent treatment to visually align with{' '}
-          <TextLink href="/components/Button">Button</TextLink>.
-        </Text>
-      ),
     },
   ],
 };

--- a/lib/components/Actions/Actions.gallery.tsx
+++ b/lib/components/Actions/Actions.gallery.tsx
@@ -1,39 +1,39 @@
 import React from 'react';
 import source from '../../utils/source.macro';
 import { ComponentExample } from '../../../site/src/types';
-import { Actions, Button, TextLink, IconDelete } from '../';
+import { Actions, Button, IconDelete } from '../';
 
 export const galleryItems: ComponentExample[] = [
   {
-    label: 'With strong Button and TextLink',
+    label: 'With multiple buttons',
     Example: () =>
       source(
         <Actions>
-          <Button weight="strong">Strong Button</Button>
-          <TextLink href="#">TextLink</TextLink>
+          <Button>Button 1</Button>
+          <Button>Button 2</Button>
+          <Button variant="transparent">Button 3</Button>
         </Actions>,
       ),
   },
   {
-    label: 'With multiple buttons and a TextLink',
+    label: 'With a branded action',
     Example: () =>
       source(
         <Actions>
-          <Button>Regular Button</Button>
-          <Button weight="weak">Weak Button</Button>
-          <TextLink href="#">TextLink</TextLink>
+          <Button tone="brandAccent">Button 1</Button>
+          <Button variant="transparent">Button 2</Button>
         </Actions>,
       ),
   },
   {
-    label: 'With destructive action',
+    label: 'With a destructive action',
     Example: () =>
       source(
         <Actions>
           <Button tone="critical">
             <IconDelete /> Delete
           </Button>
-          <TextLink href="#">Cancel</TextLink>
+          <Button variant="transparent">Cancel</Button>
         </Actions>,
       ),
   },
@@ -42,9 +42,9 @@ export const galleryItems: ComponentExample[] = [
     Example: () =>
       source(
         <Actions size="small">
-          <Button>Regular Button</Button>
-          <Button weight="weak">Weak Button</Button>
-          <TextLink href="#">TextLink</TextLink>
+          <Button>Button 1</Button>
+          <Button>Button 2</Button>
+          <Button variant="transparent">Button 3</Button>
         </Actions>,
       ),
   },

--- a/lib/components/Actions/Actions.migration.md
+++ b/lib/components/Actions/Actions.migration.md
@@ -3,7 +3,6 @@
 ## API Changes
 
 - Renamed from `ButtonGroup` to `Actions`.
-- Accepts `TextLink` components as children, not just `Button` components.
 - No longer accepts arbitrary DOM properties, e.g. `className`. Please check that everything you need is exposed via the [public API.](https://seek-oss.github.io/braid-design-system/components/Actions)
 
 ## SEEK Style Guide
@@ -21,8 +20,8 @@
 
 ```jsx
 <Actions>
-  <Button weight="strong">Create a Profile</Button>
-  <TextLink href="...">Cancel</TextLink>
+  <Button tone="brandAccent">Create a Profile</Button>
+  <Button variant="transparent">Cancel</Button>
 </Actions>
 ```
 
@@ -41,8 +40,8 @@
 
 ```jsx
 <Actions>
-  <Button weight="strong">Create a Profile</Button>
-  <TextLink href="...">Cancel</TextLink>
+  <Button tone="brandAccent">Create a Profile</Button>
+  <Button variant="transparent">Cancel</Button>
 </Actions>
 ```
 

--- a/lib/components/Actions/Actions.screenshots.tsx
+++ b/lib/components/Actions/Actions.screenshots.tsx
@@ -1,13 +1,6 @@
 import React, { Fragment } from 'react';
 import { ComponentScreenshot } from '../../../site/src/types';
-import {
-  Box,
-  Button,
-  IconNewWindow,
-  Stack,
-  TextLink,
-  Text,
-} from '../../components';
+import { Box, Button, IconNewWindow, Stack, Text } from '../../components';
 import { Actions } from './Actions';
 import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
 
@@ -18,9 +11,9 @@ export const screenshots: ComponentScreenshot = {
       label: 'Standard Actions',
       Example: () => (
         <Actions>
-          <Button weight="regular">Regular</Button>
-          <Button weight="weak">Weak</Button>
-          <TextLink href="#">TextLink</TextLink>
+          <Button>Button 1</Button>
+          <Button>Button 2</Button>
+          <Button variant="transparent">Button 3</Button>
         </Actions>
       ),
     },
@@ -28,9 +21,9 @@ export const screenshots: ComponentScreenshot = {
       label: 'Small Actions',
       Example: () => (
         <Actions size="small">
-          <Button weight="regular">Regular</Button>
-          <Button weight="weak">Weak</Button>
-          <TextLink href="#">TextLink</TextLink>
+          <Button>Button 1</Button>
+          <Button>Button 2</Button>
+          <Button variant="transparent">Button 3</Button>
         </Actions>
       ),
     },
@@ -48,10 +41,10 @@ export const screenshots: ComponentScreenshot = {
                 <Stack space="xsmall">
                   <Text size="small">{background}</Text>
                   <Actions>
-                    <Button weight="strong">Strong</Button>
-                    <TextLink href="#">
-                      TextLink <IconNewWindow />
-                    </TextLink>
+                    <Button tone="brandAccent">Standard</Button>
+                    <Button variant="transparent">
+                      Transparent <IconNewWindow />
+                    </Button>
                   </Actions>
                 </Stack>
               </Box>

--- a/lib/components/Actions/Actions.screenshots.tsx
+++ b/lib/components/Actions/Actions.screenshots.tsx
@@ -3,6 +3,7 @@ import { ComponentScreenshot } from '../../../site/src/types';
 import { Box, Button, IconNewWindow, Stack, Text } from '../../components';
 import { Actions } from './Actions';
 import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
+import { TextLink } from '../TextLink/TextLink';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320, 768],
@@ -28,7 +29,27 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Actions Contrast',
+      label: 'Standard with TextLink (Deprecated)',
+      Example: () => (
+        <Actions size="small">
+          <Button>Button 1</Button>
+          <Button>Button 2</Button>
+          <TextLink href="#">TextLink</TextLink>
+        </Actions>
+      ),
+    },
+    {
+      label: 'Small with TextLink (Deprecated)',
+      Example: () => (
+        <Actions size="small">
+          <Button>Button 1</Button>
+          <Button>Button 2</Button>
+          <TextLink href="#">TextLink</TextLink>
+        </Actions>
+      ),
+    },
+    {
+      label: 'Actions Contrast (Deprecated)',
       Example: () => {
         const backgrounds = Object.keys(boxBackgrounds) as Array<
           keyof typeof boxBackgrounds
@@ -41,10 +62,10 @@ export const screenshots: ComponentScreenshot = {
                 <Stack space="xsmall">
                   <Text size="small">{background}</Text>
                   <Actions>
-                    <Button tone="brandAccent">Standard</Button>
-                    <Button variant="transparent">
+                    <Button tone="brandAccent">Solid</Button>
+                    <TextLink href="#">
                       Transparent <IconNewWindow />
-                    </Button>
+                    </TextLink>
                   </Actions>
                 </Stack>
               </Box>

--- a/lib/components/Actions/Actions.snippets.tsx
+++ b/lib/components/Actions/Actions.snippets.tsx
@@ -1,33 +1,45 @@
 import React from 'react';
-import { Actions, Button, TextLink } from '../../playroom/components';
+import { Actions, Button, IconDelete } from '../../playroom/components';
 import source from '../../utils/source.macro';
 import { Snippets } from '../private/Snippets';
 
 export const snippets: Snippets = [
   {
-    name: 'Regular Button, TextLink',
+    name: 'With multiple buttons',
     code: source(
       <Actions>
         <Button>Submit</Button>
-        <TextLink href="#">Cancel</TextLink>
+        <Button variant="transparent">Cancel</Button>
       </Actions>,
     ),
   },
   {
-    name: 'Strong Button, TextLink',
+    name: 'With a branded action',
     code: source(
       <Actions>
-        <Button weight="strong">Submit</Button>
-        <TextLink href="#">Cancel</TextLink>
+        <Button tone="brandAccent">Submit</Button>
+        <Button variant="transparent">Cancel</Button>
       </Actions>,
     ),
   },
   {
-    name: 'Weak Button, TextLink',
+    name: 'With a destructive action',
     code: source(
       <Actions>
-        <Button weight="weak">Submit</Button>
-        <TextLink href="#">Cancel</TextLink>
+        <Button tone="critical">
+          <IconDelete /> Delete
+        </Button>
+        <Button variant="transparent">Cancel</Button>
+      </Actions>,
+    ),
+  },
+  {
+    name: 'Small size',
+    code: source(
+      <Actions size="small">
+        <Button>Button 1</Button>
+        <Button>Button 2</Button>
+        <Button variant="transparent">Button 3</Button>
       </Actions>,
     ),
   },

--- a/lib/components/Box/Box.docs.tsx
+++ b/lib/components/Box/Box.docs.tsx
@@ -407,7 +407,7 @@ const docs: ComponentDocs = {
                 body:
                   'Used for elements that need to match the body background.',
                 brand: 'Used for branding larger areas of the screen.',
-                brandAccent: 'Used for branding smaller areas of the screen.',
+                brandAccent: 'Used for hero elements on the screen.',
                 brandAccentHover: 'Hover colour for “brandAccent” elements.',
                 brandAccentActive: 'Hover colour for “brandAccent” elements.',
                 formAccent:
@@ -527,6 +527,8 @@ const docs: ComponentDocs = {
                   'Used for borders around prominent interactive elements.',
                 borderFormAccentLarge:
                   'Used for large borders around prominent interactive elements.',
+                borderBrandAccentLarge:
+                  'Used for large borders around branded elements.',
                 borderPositive: 'Used for borders around “positive” elements.',
                 borderCritical: 'Used for borders around “critical” elements.',
                 borderCriticalLarge:

--- a/lib/components/Box/useBoxStyles.treat.ts
+++ b/lib/components/Box/useBoxStyles.treat.ts
@@ -303,6 +303,9 @@ export const boxShadow = styleMap(
     borderFormAccentLarge: {
       boxShadow: `inset 0 0 0 ${borderWidth.large}px ${color.formAccent}`,
     },
+    borderBrandAccentLarge: {
+      boxShadow: `inset 0 0 0 ${borderWidth.large}px ${color.brandAccent}`,
+    },
     borderStandardInvertedLarge: {
       boxShadow: `inset 0 0 0 ${borderWidth.large}px ${color.standardInverted}`,
     },

--- a/lib/components/Button/Button.docs.tsx
+++ b/lib/components/Button/Button.docs.tsx
@@ -21,7 +21,7 @@ const docs: ComponentDocs = {
     source(
       <Card>
         <Inline space="small" collapseBelow="desktop">
-          <Button>Standard</Button>
+          <Button>Solid</Button>
           <Button variant="ghost">Ghost</Button>
           <Button variant="soft">Soft</Button>
           <Button variant="transparent">Transparent</Button>
@@ -46,14 +46,14 @@ const docs: ComponentDocs = {
         <Text>
           You can customise the appearance of the button via the{' '}
           <Strong>variant</Strong> prop, which accepts either{' '}
-          <Strong>standard</Strong>, <Strong>ghost</Strong>,{' '}
-          <Strong>soft</Strong> or <Strong>transparent</Strong>.
+          <Strong>solid</Strong>, <Strong>ghost</Strong>, <Strong>soft</Strong>{' '}
+          or <Strong>transparent</Strong>.
         </Text>
       ),
       Example: () =>
         source(
           <Inline space="small" collapseBelow="desktop">
-            <Button>Standard</Button>
+            <Button variant="solid">Solid</Button>
             <Button variant="ghost">Ghost</Button>
             <Button variant="soft">Soft</Button>
             <Button variant="transparent">Transparent</Button>
@@ -78,7 +78,7 @@ const docs: ComponentDocs = {
                 Standard size
               </Text>
               <Inline space="small" collapseBelow="desktop">
-                <Button>Standard</Button>
+                <Button>Solid</Button>
                 <Button variant="ghost">Ghost</Button>
                 <Button variant="soft">Soft</Button>
                 <Button variant="transparent">Transparent</Button>
@@ -89,7 +89,7 @@ const docs: ComponentDocs = {
                 Small size
               </Text>
               <Inline space="small" collapseBelow="desktop">
-                <Button size="small">Standard</Button>
+                <Button size="small">Solid</Button>
                 <Button variant="ghost" size="small">
                   Ghost
                 </Button>

--- a/lib/components/Button/Button.docs.tsx
+++ b/lib/components/Button/Button.docs.tsx
@@ -20,22 +20,12 @@ const docs: ComponentDocs = {
   Example: () =>
     source(
       <Card>
-        <Stack space="medium">
-          <Inline space="small" collapseBelow="desktop">
-            <Button weight="strong">Strong</Button>
-            <Button>Regular</Button>
-            <Button weight="weak">Weak</Button>
-          </Inline>
-          <Inline space="small" collapseBelow="desktop">
-            <Button weight="strong" size="small">
-              Strong
-            </Button>
-            <Button size="small">Regular</Button>
-            <Button weight="weak" size="small">
-              Weak
-            </Button>
-          </Inline>
-        </Stack>
+        <Inline space="small" collapseBelow="desktop">
+          <Button>Standard</Button>
+          <Button variant="ghost">Ghost</Button>
+          <Button variant="soft">Soft</Button>
+          <Button variant="transparent">Transparent</Button>
+        </Inline>
       </Card>,
     ),
   alternatives: [
@@ -50,7 +40,29 @@ const docs: ComponentDocs = {
   ],
   additional: [
     {
+      label: 'Variants',
+      background: 'card',
+      description: (
+        <Text>
+          You can customise the appearance of the button via the{' '}
+          <Strong>variant</Strong> prop, which accepts either{' '}
+          <Strong>standard</Strong>, <Strong>ghost</Strong>,{' '}
+          <Strong>soft</Strong> or <Strong>transparent</Strong>.
+        </Text>
+      ),
+      Example: () =>
+        source(
+          <Inline space="small" collapseBelow="desktop">
+            <Button>Standard</Button>
+            <Button variant="ghost">Ghost</Button>
+            <Button variant="soft">Soft</Button>
+            <Button variant="transparent">Transparent</Button>
+          </Inline>,
+        ),
+    },
+    {
       label: 'Sizes',
+      background: 'card',
       description: (
         <Text>
           You can customise the size of the button via the <Strong>size</Strong>{' '}
@@ -66,9 +78,10 @@ const docs: ComponentDocs = {
                 Standard size
               </Text>
               <Inline space="small" collapseBelow="desktop">
-                <Button weight="strong">Strong</Button>
-                <Button>Regular</Button>
-                <Button weight="weak">Weak</Button>
+                <Button>Standard</Button>
+                <Button variant="ghost">Ghost</Button>
+                <Button variant="soft">Soft</Button>
+                <Button variant="transparent">Transparent</Button>
               </Inline>
             </Stack>
             <Stack space="small">
@@ -76,12 +89,15 @@ const docs: ComponentDocs = {
                 Small size
               </Text>
               <Inline space="small" collapseBelow="desktop">
-                <Button weight="strong" size="small">
-                  Strong
+                <Button size="small">Standard</Button>
+                <Button variant="ghost" size="small">
+                  Ghost
                 </Button>
-                <Button size="small">Regular</Button>
-                <Button weight="weak" size="small">
-                  Weak
+                <Button variant="soft" size="small">
+                  Soft
+                </Button>
+                <Button variant="transparent" size="small">
+                  Transparent
                 </Button>
               </Inline>
             </Stack>
@@ -90,6 +106,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Icons',
+      background: 'card',
       description: (
         <Text>
           You can add an icon to the button by nesting an icon element inside.
@@ -99,7 +116,7 @@ const docs: ComponentDocs = {
       ),
       Example: () =>
         source(
-          <Inline space="small" alignY="center">
+          <Inline space="gutter" alignY="center">
             <Stack space="small" align="center">
               <Text tone="secondary" weight="strong">
                 Standard size
@@ -121,6 +138,7 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Loading Button',
+      background: 'card',
       description: (
         <>
           <Text>
@@ -138,7 +156,33 @@ const docs: ComponentDocs = {
         ),
     },
     {
+      label: 'Branding',
+      background: 'card',
+      description: (
+        <Text>
+          For hero actions that want to leverage the brand colour, you can set
+          the button’s <Strong>tone</Strong> to <Strong>brandAccent.</Strong>
+        </Text>
+      ),
+      Example: () =>
+        source(
+          <Inline space="small">
+            <Button tone="brandAccent">Search</Button>
+            <Button tone="brandAccent" variant="ghost">
+              Search
+            </Button>
+            <Button tone="brandAccent" variant="soft">
+              Search
+            </Button>
+            <Button tone="brandAccent" variant="transparent">
+              Search
+            </Button>
+          </Inline>,
+        ),
+    },
+    {
       label: 'Destructive actions',
+      background: 'card',
       description: (
         <Text>
           For destructive actions like “Delete” you can set the button’s{' '}
@@ -151,7 +195,13 @@ const docs: ComponentDocs = {
             <Button tone="critical">
               <IconDelete /> Delete
             </Button>
-            <Button tone="critical" weight="weak">
+            <Button tone="critical" variant="ghost">
+              <IconDelete /> Delete
+            </Button>
+            <Button tone="critical" variant="soft">
+              <IconDelete /> Delete
+            </Button>
+            <Button tone="critical" variant="transparent">
               <IconDelete /> Delete
             </Button>
           </Inline>,
@@ -162,8 +212,9 @@ const docs: ComponentDocs = {
       description: (
         <>
           <Text>
-            Weak Button elements are inverted when rendered on a dark
-            background.
+            The <Strong>ghost</Strong>, <Strong>soft</Strong>, and{' '}
+            <Strong>transparent</Strong> variants are inverted when rendered on
+            a dark background.
           </Text>
           <Text>
             When using custom backgrounds or images, this behaviour can be
@@ -180,7 +231,9 @@ const docs: ComponentDocs = {
         source(
           <Box background="brand">
             <Inline space="small">
-              <Button weight="weak">Weak Button</Button>
+              <Button variant="ghost">Ghost</Button>
+              <Button variant="soft">Soft</Button>
+              <Button variant="transparent">Transparent</Button>
             </Inline>
           </Box>,
         ),

--- a/lib/components/Button/Button.gallery.tsx
+++ b/lib/components/Button/Button.gallery.tsx
@@ -60,7 +60,7 @@ export const galleryItems: ComponentExample[] = [
     background: 'brand',
     Example: () =>
       source(
-        <Box background="brand" padding="small" borderRadius="standard">
+        <Box background="brand" padding="small">
           <Inline space="small">
             <Button variant="ghost">Ghost</Button>
             <Button variant="soft">Soft</Button>

--- a/lib/components/Button/Button.gallery.tsx
+++ b/lib/components/Button/Button.gallery.tsx
@@ -5,59 +5,66 @@ import { Button, Box, Inline, IconSend } from '../';
 
 export const galleryItems: ComponentExample[] = [
   {
-    label: 'Regular weight',
+    label: 'Default',
+    background: 'card',
     Example: () =>
       source(
         <Inline space="small">
           <Button>Submit</Button>
+          <Button variant="ghost">Submit</Button>
+          <Button variant="soft">Submit</Button>
+          <Button variant="transparent">Submit</Button>
         </Inline>,
       ),
   },
   {
-    label: 'Strong weight',
-    Example: () =>
-      source(
-        <Inline space="small">
-          <Button weight="strong">Submit</Button>
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Weak weight',
-    Example: () =>
-      source(
-        <Inline space="small">
-          <Button weight="weak">Submit</Button>
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Critical Button',
+    label: 'Critical',
+    background: 'card',
     Example: () =>
       source(
         <Inline space="small">
           <Button tone="critical">Delete</Button>
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Weak Critical Button',
-    Example: () =>
-      source(
-        <Inline space="small">
-          <Button weight="weak" tone="critical">
+          <Button tone="critical" variant="ghost">
+            Delete
+          </Button>
+          <Button tone="critical" variant="soft">
+            Delete
+          </Button>
+          <Button tone="critical" variant="transparent">
             Delete
           </Button>
         </Inline>,
       ),
   },
   {
-    label: 'Weak weight on dark background',
+    label: 'BrandAccent',
+    background: 'card',
     Example: () =>
       source(
-        <Box background="brand" padding="large" borderRadius="standard">
+        <Inline space="small">
+          <Button tone="brandAccent">Search</Button>
+          <Button tone="brandAccent" variant="ghost">
+            Search
+          </Button>
+          <Button tone="brandAccent" variant="soft">
+            Search
+          </Button>
+          <Button tone="brandAccent" variant="transparent">
+            Search
+          </Button>
+        </Inline>,
+      ),
+  },
+  {
+    label: 'Inverted on dark backgrounds',
+    background: 'brand',
+    Example: () =>
+      source(
+        <Box background="brand" padding="small" borderRadius="standard">
           <Inline space="small">
-            <Button weight="weak">Weak Button</Button>
+            <Button variant="ghost">Ghost</Button>
+            <Button variant="soft">Soft</Button>
+            <Button variant="transparent">Transparent</Button>
           </Inline>
         </Box>,
       ),
@@ -83,7 +90,7 @@ export const galleryItems: ComponentExample[] = [
       ),
   },
   {
-    label: 'Small Button',
+    label: 'Small size',
     Example: () =>
       source(
         <Inline space="small">

--- a/lib/components/Button/Button.migration.md
+++ b/lib/components/Button/Button.migration.md
@@ -2,7 +2,7 @@
 
 ## API Changes
 
-- The `color`, `ghost` and `transparent`/`hyperlink` props have been removed in favour of `variant={'standard' | 'ghost' | 'soft' | 'transparent'}` and `tone={'brandAccent' | 'critical'}`.
+- The `color`, `ghost` and `transparent`/`hyperlink` props have been removed in favour of `variant={'solid' | 'ghost' | 'soft' | 'transparent'}` and `tone={'brandAccent' | 'critical'}`.
 - The `compact` prop has been removed in favour of `size="small"`.
 - No longer accepts arbitrary DOM properties, e.g. `className`. Please check that everything you need is exposed via the [public API.](https://seek-oss.github.io/braid-design-system/components/Button)
 

--- a/lib/components/Button/Button.migration.md
+++ b/lib/components/Button/Button.migration.md
@@ -2,14 +2,9 @@
 
 ## API Changes
 
-- The `color` and `ghost` props have been removed in favour of `weight={'strong' | 'regular' | 'weak'}`.
-- The `transparent`/`hyperlink` color has been removed. Use [`TextLink`](https://seek-oss.github.io/braid-design-system/components/TextLink)/[`TextLinkRenderer`](https://seek-oss.github.io/braid-design-system/components/TextLinkRenderer) instead.
+- The `color`, `ghost` and `transparent`/`hyperlink` props have been removed in favour of `variant={'standard' | 'ghost' | 'soft' | 'transparent'}` and `tone={'brandAccent' | 'critical'}`.
+- The `compact` prop has been removed in favour of `size="small"`.
 - No longer accepts arbitrary DOM properties, e.g. `className`. Please check that everything you need is exposed via the [public API.](https://seek-oss.github.io/braid-design-system/components/Button)
-
-## TBD
-
-- `ButtonRenderer` or similar, like [TextLinkRenderer](https://seek-oss.github.io/braid-design-system/components/TextLinkRenderer).
-- `compact={boolean}`
 
 ## Diff
 
@@ -17,26 +12,29 @@
 
 ```diff
 -<Button color="pink">Primary</Button>
-+<Button weight="strong">Primary</Button>
++<Button tone="brandAccent">Primary</Button>
 
 -<Button color="blue">Secondary</Button>
 +<Button>Secondary</Button>
 
 -<Button color="blue" ghost>Tertiary</Button>
-+<Button weight="weak">Tertiary</Button>
++<Button variant="ghost">Tertiary</Button>
 ```
 
 ### SEEK Asia Style Guide
 
 ```diff
 -<Button color="callToAction">Primary</Button>
-+<Button weight="strong">Primary</Button>
++<Button tone="brandAccent">Primary</Button>
 
 -<Button color="primary">Secondary</Button>
 +<Button>Secondary</Button>
 
 -<Button color="tertiary">Tertiary</Button>
-+<Button weight="weak">Tertiary</Button>
++<Button variant="ghost">Tertiary</Button>
+
+-<Button compact>Small</Button>
++<Button size="small">Small</Button>
 ```
 
 ## Previous Implementations

--- a/lib/components/Button/Button.screenshots.tsx
+++ b/lib/components/Button/Button.screenshots.tsx
@@ -16,7 +16,7 @@ export const screenshots: ComponentScreenshot = {
       Container,
       Example: () => (
         <Inline space="small" collapseBelow="desktop">
-          <Button>Standard</Button>
+          <Button>Solid</Button>
           <Button variant="ghost">Ghost</Button>
           <Button variant="soft">Soft</Button>
           <Button variant="transparent">Transparent</Button>
@@ -28,7 +28,7 @@ export const screenshots: ComponentScreenshot = {
       Container,
       Example: () => (
         <Inline space="small" collapseBelow="desktop">
-          <Button tone="critical">Standard</Button>
+          <Button tone="critical">Solid</Button>
           <Button tone="critical" variant="ghost">
             Ghost
           </Button>
@@ -46,7 +46,7 @@ export const screenshots: ComponentScreenshot = {
       Container,
       Example: () => (
         <Inline space="small" collapseBelow="desktop">
-          <Button tone="brandAccent">Standard</Button>
+          <Button tone="brandAccent">Solid</Button>
           <Button tone="brandAccent" variant="ghost">
             Ghost
           </Button>
@@ -64,7 +64,7 @@ export const screenshots: ComponentScreenshot = {
       Container,
       Example: () => (
         <Inline space="small" collapseBelow="desktop">
-          <Button size="small">Standard</Button>
+          <Button size="small">Solid</Button>
           <Button size="small" variant="ghost">
             Ghost
           </Button>
@@ -101,7 +101,7 @@ export const screenshots: ComponentScreenshot = {
             {backgrounds.sort().map((background) => (
               <Box key={background} background={background} padding="medium">
                 <Inline space="small" collapseBelow="desktop">
-                  <Button>Standard</Button>
+                  <Button>Solid</Button>
                   <Button variant="ghost">Ghost</Button>
                   <Button variant="soft">Soft</Button>
                   <Button variant="transparent">Transparent</Button>
@@ -125,7 +125,7 @@ export const screenshots: ComponentScreenshot = {
             {backgrounds.sort().map((background) => (
               <Box key={background} background={background} padding="medium">
                 <Inline space="small" collapseBelow="desktop">
-                  <Button tone="critical">Standard</Button>
+                  <Button tone="critical">Solid</Button>
                   <Button tone="critical" variant="ghost">
                     Ghost
                   </Button>
@@ -155,7 +155,7 @@ export const screenshots: ComponentScreenshot = {
             {backgrounds.sort().map((background) => (
               <Box key={background} background={background} padding="medium">
                 <Inline space="small" collapseBelow="desktop">
-                  <Button tone="brandAccent">Standard</Button>
+                  <Button tone="brandAccent">Solid</Button>
                   <Button tone="brandAccent" variant="ghost">
                     Ghost
                   </Button>

--- a/lib/components/Button/Button.screenshots.tsx
+++ b/lib/components/Button/Button.screenshots.tsx
@@ -2,6 +2,7 @@ import React, { Fragment, ReactNode } from 'react';
 import { ComponentScreenshot } from '../../../site/src/types';
 import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
 import { Box, Button } from '../';
+import { Inline } from '../Inline/Inline';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -11,68 +12,84 @@ export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],
   examples: [
     {
-      label: 'Standard Button',
-      Container,
-      Example: () => <Button>Submit</Button>,
-    },
-    {
-      label: 'Strong Button',
-      Container,
-      Example: () => <Button weight="strong">Submit</Button>,
-    },
-    {
-      label: 'Weak Button',
-      Container,
-      Example: () => <Button weight="weak">Submit</Button>,
-    },
-    {
-      label: 'Standard Critical Button',
-      Container,
-      Example: () => <Button tone="critical">Delete</Button>,
-    },
-    {
-      label: 'Strong Critical Button',
+      label: 'Default',
       Container,
       Example: () => (
-        <Button weight="strong" tone="critical">
-          Delete
-        </Button>
+        <Inline space="small" collapseBelow="desktop">
+          <Button>Standard</Button>
+          <Button variant="ghost">Ghost</Button>
+          <Button variant="soft">Soft</Button>
+          <Button variant="transparent">Transparent</Button>
+        </Inline>
       ),
     },
     {
-      label: 'Weak Critical Button',
+      label: 'Critical',
       Container,
       Example: () => (
-        <Button weight="weak" tone="critical">
-          Delete
-        </Button>
+        <Inline space="small" collapseBelow="desktop">
+          <Button tone="critical">Standard</Button>
+          <Button tone="critical" variant="ghost">
+            Ghost
+          </Button>
+          <Button tone="critical" variant="soft">
+            Soft
+          </Button>
+          <Button tone="critical" variant="transparent">
+            Transparent
+          </Button>
+        </Inline>
       ),
     },
     {
-      label: 'Small Standard Button',
-      Container,
-      Example: () => <Button size="small">Submit</Button>,
-    },
-    {
-      label: 'Small Strong Button',
+      label: 'BrandAccent',
       Container,
       Example: () => (
-        <Button weight="strong" size="small">
-          Submit
-        </Button>
+        <Inline space="small" collapseBelow="desktop">
+          <Button tone="brandAccent">Standard</Button>
+          <Button tone="brandAccent" variant="ghost">
+            Ghost
+          </Button>
+          <Button tone="brandAccent" variant="soft">
+            Soft
+          </Button>
+          <Button tone="brandAccent" variant="transparent">
+            Transparent
+          </Button>
+        </Inline>
       ),
     },
     {
-      label: 'Small Weak Button',
+      label: 'Small size',
       Container,
       Example: () => (
-        <Button weight="weak" size="small">
-          Submit
-        </Button>
+        <Inline space="small" collapseBelow="desktop">
+          <Button size="small">Standard</Button>
+          <Button size="small" variant="ghost">
+            Ghost
+          </Button>
+          <Button size="small" variant="soft">
+            Soft
+          </Button>
+          <Button size="small" variant="transparent">
+            Transparent
+          </Button>
+        </Inline>
       ),
     },
     {
-      label: 'Weak Button Contrast',
+      label: 'Legacy weights',
+      Container,
+      Example: () => (
+        <Inline space="small" collapseBelow="desktop">
+          <Button weight="strong">Strong</Button>
+          <Button weight="regular">Regular</Button>
+          <Button weight="weak">Weak</Button>
+        </Inline>
+      ),
+    },
+    {
+      label: 'Contrast',
       Container,
       Example: () => {
         const backgrounds = Object.keys(boxBackgrounds) as Array<
@@ -83,7 +100,12 @@ export const screenshots: ComponentScreenshot = {
           <Fragment>
             {backgrounds.sort().map((background) => (
               <Box key={background} background={background} padding="medium">
-                <Button weight="weak">{background}</Button>
+                <Inline space="small" collapseBelow="desktop">
+                  <Button>Standard</Button>
+                  <Button variant="ghost">Ghost</Button>
+                  <Button variant="soft">Soft</Button>
+                  <Button variant="transparent">Transparent</Button>
+                </Inline>
               </Box>
             ))}
           </Fragment>
@@ -91,7 +113,7 @@ export const screenshots: ComponentScreenshot = {
       },
     },
     {
-      label: 'Weak Critical Button Contrast',
+      label: 'Contrast - critical',
       Container,
       Example: () => {
         const backgrounds = Object.keys(boxBackgrounds) as Array<
@@ -102,9 +124,48 @@ export const screenshots: ComponentScreenshot = {
           <Fragment>
             {backgrounds.sort().map((background) => (
               <Box key={background} background={background} padding="medium">
-                <Button weight="weak" tone="critical">
-                  {background}
-                </Button>
+                <Inline space="small" collapseBelow="desktop">
+                  <Button tone="critical">Standard</Button>
+                  <Button tone="critical" variant="ghost">
+                    Ghost
+                  </Button>
+                  <Button tone="critical" variant="soft">
+                    Soft
+                  </Button>
+                  <Button tone="critical" variant="transparent">
+                    Transparent
+                  </Button>
+                </Inline>
+              </Box>
+            ))}
+          </Fragment>
+        );
+      },
+    },
+    {
+      label: 'Contrast - brandAccent',
+      Container,
+      Example: () => {
+        const backgrounds = Object.keys(boxBackgrounds) as Array<
+          keyof typeof boxBackgrounds
+        >;
+
+        return (
+          <Fragment>
+            {backgrounds.sort().map((background) => (
+              <Box key={background} background={background} padding="medium">
+                <Inline space="small" collapseBelow="desktop">
+                  <Button tone="brandAccent">Standard</Button>
+                  <Button tone="brandAccent" variant="ghost">
+                    Ghost
+                  </Button>
+                  <Button tone="brandAccent" variant="soft">
+                    Soft
+                  </Button>
+                  <Button tone="brandAccent" variant="transparent">
+                    Transparent
+                  </Button>
+                </Inline>
               </Box>
             ))}
           </Fragment>

--- a/lib/components/Button/Button.snippets.tsx
+++ b/lib/components/Button/Button.snippets.tsx
@@ -5,7 +5,7 @@ import { Button } from '../../playroom/components';
 
 export const snippets: Snippets = [
   {
-    name: 'Standard',
+    name: 'Solid',
     code: source(<Button>Button</Button>),
   },
   {
@@ -21,7 +21,7 @@ export const snippets: Snippets = [
     code: source(<Button variant="transparent">Button</Button>),
   },
   {
-    name: 'Critical Standard',
+    name: 'Critical Solid',
     code: source(<Button tone="critical">Button</Button>),
   },
   {
@@ -49,7 +49,7 @@ export const snippets: Snippets = [
     ),
   },
   {
-    name: 'BrandAccent Standard',
+    name: 'BrandAccent Solid',
     code: source(<Button tone="brandAccent">Button</Button>),
   },
   {
@@ -77,7 +77,7 @@ export const snippets: Snippets = [
     ),
   },
   {
-    name: 'Small Standard',
+    name: 'Small Solid',
     code: source(<Button size="small">Button</Button>),
   },
   {

--- a/lib/components/Button/Button.snippets.tsx
+++ b/lib/components/Button/Button.snippets.tsx
@@ -5,46 +5,102 @@ import { Button } from '../../playroom/components';
 
 export const snippets: Snippets = [
   {
-    name: 'Regular',
-    code: source(<Button>Submit</Button>),
+    name: 'Standard',
+    code: source(<Button>Button</Button>),
   },
   {
-    name: 'Strong',
-    code: source(<Button weight="strong">Submit</Button>),
+    name: 'Ghost',
+    code: source(<Button variant="ghost">Button</Button>),
   },
   {
-    name: 'Weak',
-    code: source(<Button weight="weak">Submit</Button>),
+    name: 'Soft',
+    code: source(<Button variant="soft">Button</Button>),
   },
   {
-    name: 'Critical',
+    name: 'Transparent',
+    code: source(<Button variant="transparent">Button</Button>),
+  },
+  {
+    name: 'Critical Standard',
     code: source(<Button tone="critical">Button</Button>),
   },
   {
-    name: 'Critical Weak',
+    name: 'Critical Ghost',
     code: source(
-      <Button weight="weak" tone="critical">
+      <Button tone="critical" variant="ghost">
         Button
       </Button>,
     ),
   },
   {
-    name: 'Regular (Small)',
-    code: source(<Button size="small">Submit</Button>),
-  },
-  {
-    name: 'Strong (Small)',
+    name: 'Critical Soft',
     code: source(
-      <Button size="small" weight="strong">
-        Submit
+      <Button tone="critical" variant="soft">
+        Button
       </Button>,
     ),
   },
   {
-    name: 'Weak (Small)',
+    name: 'Critical Transparent',
     code: source(
-      <Button size="small" weight="weak">
-        Submit
+      <Button tone="critical" variant="transparent">
+        Button
+      </Button>,
+    ),
+  },
+  {
+    name: 'BrandAccent Standard',
+    code: source(<Button tone="brandAccent">Button</Button>),
+  },
+  {
+    name: 'BrandAccent Ghost',
+    code: source(
+      <Button tone="brandAccent" variant="ghost">
+        Button
+      </Button>,
+    ),
+  },
+  {
+    name: 'BrandAccent Soft',
+    code: source(
+      <Button tone="brandAccent" variant="soft">
+        Button
+      </Button>,
+    ),
+  },
+  {
+    name: 'BrandAccent Transparent',
+    code: source(
+      <Button tone="brandAccent" variant="transparent">
+        Button
+      </Button>,
+    ),
+  },
+  {
+    name: 'Small Standard',
+    code: source(<Button size="small">Button</Button>),
+  },
+  {
+    name: 'Small Ghost',
+    code: source(
+      <Button size="small" variant="ghost">
+        Button
+      </Button>,
+    ),
+  },
+  {
+    name: 'Small Soft',
+    code: source(
+      <Button size="small" variant="soft">
+        Button
+      </Button>,
+    ),
+  },
+  {
+    name: 'Small Transparent',
+    code: source(
+      <Button size="small" variant="transparent">
+        Button
       </Button>,
     ),
   },

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -8,15 +8,12 @@ import buildDataAttributes, {
 } from '../private/buildDataAttributes';
 
 type NativeButtonProps = AllHTMLAttributes<HTMLButtonElement>;
-export interface ButtonProps {
+export interface ButtonProps
+  extends Omit<PrivateButtonRendererProps, 'children'> {
   id?: NativeButtonProps['id'];
   onClick?: NativeButtonProps['onClick'];
   type?: 'button' | 'submit' | 'reset';
   children?: ReactNode;
-  size?: PrivateButtonRendererProps['size'];
-  tone?: PrivateButtonRendererProps['tone'];
-  weight?: PrivateButtonRendererProps['weight'];
-  loading?: PrivateButtonRendererProps['loading'];
   'aria-controls'?: NativeButtonProps['aria-controls'];
   'aria-expanded'?: NativeButtonProps['aria-expanded'];
   'aria-describedby'?: NativeButtonProps['aria-describedby'];
@@ -29,6 +26,7 @@ export const Button = ({
   size,
   tone,
   weight,
+  variant,
   loading,
   type = 'button',
   id,
@@ -42,6 +40,7 @@ export const Button = ({
     tone={tone}
     weight={weight}
     loading={loading}
+    variant={variant}
   >
     {(ButtonChildren, buttonProps) => (
       <button

--- a/lib/components/ButtonLink/ButtonLink.docs.tsx
+++ b/lib/components/ButtonLink/ButtonLink.docs.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import source from '../../utils/source.macro';
 import { ComponentDocs } from '../../../site/src/types';
-import { ButtonLink, Strong, Text, Card, Stack, Inline } from '../';
+import { ButtonLink, Strong, Text, Card, Inline } from '../';
 import { TextLink } from '../TextLink/TextLink';
 
 const docs: ComponentDocs = {
@@ -10,28 +10,18 @@ const docs: ComponentDocs = {
   Example: () =>
     source(
       <Card>
-        <Stack space="medium">
-          <Inline space="small" collapseBelow="desktop">
-            <ButtonLink href="#" weight="strong">
-              Strong
-            </ButtonLink>
-            <ButtonLink href="#">Regular</ButtonLink>
-            <ButtonLink href="#" weight="weak">
-              Weak
-            </ButtonLink>
-          </Inline>
-          <Inline space="small" collapseBelow="desktop">
-            <ButtonLink href="#" weight="strong" size="small">
-              Strong
-            </ButtonLink>
-            <ButtonLink href="#" size="small">
-              Regular
-            </ButtonLink>
-            <ButtonLink href="#" weight="weak" size="small">
-              Weak
-            </ButtonLink>
-          </Inline>
-        </Stack>
+        <Inline space="small" collapseBelow="desktop">
+          <ButtonLink href="#">Standard</ButtonLink>
+          <ButtonLink href="#" variant="ghost">
+            Ghost
+          </ButtonLink>
+          <ButtonLink href="#" variant="soft">
+            Soft
+          </ButtonLink>
+          <ButtonLink href="#" variant="transparent">
+            Transparent
+          </ButtonLink>
+        </Inline>
       </Card>,
     ),
   accessibility: (

--- a/lib/components/ButtonLink/ButtonLink.docs.tsx
+++ b/lib/components/ButtonLink/ButtonLink.docs.tsx
@@ -11,7 +11,7 @@ const docs: ComponentDocs = {
     source(
       <Card>
         <Inline space="small" collapseBelow="desktop">
-          <ButtonLink href="#">Standard</ButtonLink>
+          <ButtonLink href="#">Solid</ButtonLink>
           <ButtonLink href="#" variant="ghost">
             Ghost
           </ButtonLink>

--- a/lib/components/ButtonLink/ButtonLink.screenshots.tsx
+++ b/lib/components/ButtonLink/ButtonLink.screenshots.tsx
@@ -15,7 +15,7 @@ export const screenshots: ComponentScreenshot = {
       Container,
       Example: () => (
         <Inline space="small" collapseBelow="desktop">
-          <ButtonLink href="#">Standard</ButtonLink>
+          <ButtonLink href="#">Solid</ButtonLink>
           <ButtonLink href="#" variant="ghost">
             Ghost
           </ButtonLink>
@@ -34,7 +34,7 @@ export const screenshots: ComponentScreenshot = {
       Example: () => (
         <Inline space="small" collapseBelow="desktop">
           <ButtonLink href="#" tone="critical">
-            Standard
+            Solid
           </ButtonLink>
           <ButtonLink href="#" tone="critical" variant="ghost">
             Ghost
@@ -54,7 +54,7 @@ export const screenshots: ComponentScreenshot = {
       Example: () => (
         <Inline space="small" collapseBelow="desktop">
           <ButtonLink href="#" tone="brandAccent">
-            Standard
+            Solid
           </ButtonLink>
           <ButtonLink href="#" tone="brandAccent" variant="ghost">
             Ghost

--- a/lib/components/ButtonLink/ButtonLink.screenshots.tsx
+++ b/lib/components/ButtonLink/ButtonLink.screenshots.tsx
@@ -1,6 +1,7 @@
 import React, { ReactNode } from 'react';
 import { ComponentScreenshot } from '../../../site/src/types';
 import { ButtonLink } from '../';
+import { Inline } from '../Inline/Inline';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -10,53 +11,61 @@ export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],
   examples: [
     {
-      label: 'Default Button Link',
-      Container,
-      Example: () => <ButtonLink href="#">Submit</ButtonLink>,
-    },
-    {
-      label: 'Strong Button Link',
+      label: 'Default',
       Container,
       Example: () => (
-        <ButtonLink href="#" weight="strong">
-          Submit
-        </ButtonLink>
+        <Inline space="small" collapseBelow="desktop">
+          <ButtonLink href="#">Standard</ButtonLink>
+          <ButtonLink href="#" variant="ghost">
+            Ghost
+          </ButtonLink>
+          <ButtonLink href="#" variant="soft">
+            Soft
+          </ButtonLink>
+          <ButtonLink href="#" variant="transparent">
+            Transparent
+          </ButtonLink>
+        </Inline>
       ),
     },
     {
-      label: 'Weak Button Link',
+      label: 'Critical',
       Container,
       Example: () => (
-        <ButtonLink href="#" weight="weak">
-          Submit
-        </ButtonLink>
+        <Inline space="small" collapseBelow="desktop">
+          <ButtonLink href="#" tone="critical">
+            Standard
+          </ButtonLink>
+          <ButtonLink href="#" tone="critical" variant="ghost">
+            Ghost
+          </ButtonLink>
+          <ButtonLink href="#" tone="critical" variant="soft">
+            Soft
+          </ButtonLink>
+          <ButtonLink href="#" tone="critical" variant="transparent">
+            Transparent
+          </ButtonLink>
+        </Inline>
       ),
     },
     {
-      label: 'Default Critical Button Link',
+      label: 'BrandAccent',
       Container,
       Example: () => (
-        <ButtonLink href="#" tone="critical">
-          Delete
-        </ButtonLink>
-      ),
-    },
-    {
-      label: 'Strong Critical Button Link',
-      Container,
-      Example: () => (
-        <ButtonLink href="#" weight="strong" tone="critical">
-          Delete
-        </ButtonLink>
-      ),
-    },
-    {
-      label: 'Weak Critical Button Link',
-      Container,
-      Example: () => (
-        <ButtonLink href="#" weight="weak" tone="critical">
-          Delete
-        </ButtonLink>
+        <Inline space="small" collapseBelow="desktop">
+          <ButtonLink href="#" tone="brandAccent">
+            Standard
+          </ButtonLink>
+          <ButtonLink href="#" tone="brandAccent" variant="ghost">
+            Ghost
+          </ButtonLink>
+          <ButtonLink href="#" tone="brandAccent" variant="soft">
+            Soft
+          </ButtonLink>
+          <ButtonLink href="#" tone="brandAccent" variant="transparent">
+            Transparent
+          </ButtonLink>
+        </Inline>
       ),
     },
   ],

--- a/lib/components/ButtonLink/ButtonLink.tsx
+++ b/lib/components/ButtonLink/ButtonLink.tsx
@@ -19,6 +19,7 @@ export const ButtonLink = ({
   size,
   tone,
   weight,
+  variant,
   loading,
   ...restProps
 }: ButtonLinkProps) => {
@@ -29,6 +30,7 @@ export const ButtonLink = ({
       size={size}
       tone={tone}
       weight={weight}
+      variant={variant}
       loading={loading}
     >
       {(ButtonChildren, buttonProps) => (

--- a/lib/components/ButtonRenderer/ButtonRenderer.treat.ts
+++ b/lib/components/ButtonRenderer/ButtonRenderer.treat.ts
@@ -4,18 +4,24 @@ export const root = style({
   textDecoration: 'none',
 });
 
-export const weak = style({
-  backgroundColor: 'transparent',
-});
-
 export const inverted = style({});
+export const lightBg = style({});
+export const lightHoverBg = style({});
+
+export const backgroundOverlay = style({
+  selectors: {
+    [`${lightBg} &`]: {
+      opacity: 0.075,
+    },
+  },
+});
 
 export const activeOverlay = style({
   selectors: {
     [`${root}:active &`]: {
       opacity: 1,
     },
-    [`${weak}:active &`]: {
+    [`${lightHoverBg}:active &`]: {
       opacity: 0.1,
     },
   },
@@ -26,10 +32,10 @@ export const hoverOverlay = style({
     [`${root}:hover:not(:active) &`]: {
       opacity: 1,
     },
-    [`${weak}:hover:not(:active) &`]: {
+    [`${lightHoverBg}:hover:not(:active) &`]: {
       opacity: 0.075,
     },
-    [`${weak}${inverted}:hover:not(:active) &`]: {
+    [`${lightHoverBg}${inverted}:hover:not(:active) &`]: {
       opacity: 0.15,
     },
   },

--- a/lib/components/ButtonRenderer/ButtonRenderer.tsx
+++ b/lib/components/ButtonRenderer/ButtonRenderer.tsx
@@ -236,7 +236,7 @@ export interface PrivateButtonRendererProps {
   size?: ButtonSize;
   tone?: ButtonTone;
   variant?: ButtonVariant;
-  /** @deprecated `weight` has been deprecated. Please choose a [variant](https://seek-oss.github.io/braid-design-system/components/Button) instead. */
+  /** @deprecated `weight` has been deprecated. Please choose a [variant](https://seek-oss.github.io/braid-design-system/components/Button#variants) instead. */
   weight?: ButtonWeight;
   loading?: boolean;
   children: (

--- a/lib/components/ButtonRenderer/ButtonRenderer.tsx
+++ b/lib/components/ButtonRenderer/ButtonRenderer.tsx
@@ -23,24 +23,30 @@ import ActionsContext from '../Actions/ActionsContext';
 import * as styleRefs from './ButtonRenderer.treat';
 
 type ButtonSize = 'standard' | 'small';
-type ButtonTone = 'critical';
+type ButtonTone = 'brandAccent' | 'critical';
 type ButtonWeight = 'weak' | 'regular' | 'strong';
-type ButtonVariant = 'strong' | 'regular' | 'weak' | 'weakInverted';
+type ButtonVariant = 'standard' | 'ghost' | 'soft' | 'transparent';
+type ButtonStyles = {
+  textTone: TextProps['tone'];
+  background: UseBoxStylesProps['background'];
+  backgroundHover: UseBoxStylesProps['background'];
+  backgroundActive: UseBoxStylesProps['background'];
+  boxShadow: UseBoxStylesProps['boxShadow'];
+};
+
 const buttonVariants: Record<
   ButtonVariant,
-  Record<
-    'default' | ButtonTone,
-    {
-      textTone: TextProps['tone'];
-      background: UseBoxStylesProps['background'];
-      backgroundHover: UseBoxStylesProps['background'];
-      backgroundActive: UseBoxStylesProps['background'];
-      boxShadow: UseBoxStylesProps['boxShadow'];
-    }
-  >
+  Record<'default' | ButtonTone, ButtonStyles>
 > = {
-  strong: {
+  standard: {
     default: {
+      textTone: undefined,
+      background: 'formAccent',
+      backgroundHover: 'formAccentHover',
+      backgroundActive: 'formAccentActive',
+      boxShadow: undefined,
+    },
+    brandAccent: {
       textTone: undefined,
       background: 'brandAccent',
       backgroundHover: 'brandAccentHover',
@@ -55,29 +61,20 @@ const buttonVariants: Record<
       boxShadow: undefined,
     },
   },
-  regular: {
-    default: {
-      textTone: undefined,
-      background: 'formAccent',
-      backgroundHover: 'formAccentHover',
-      backgroundActive: 'formAccentActive',
-      boxShadow: undefined,
-    },
-    critical: {
-      textTone: undefined,
-      background: 'critical',
-      backgroundHover: 'criticalHover',
-      backgroundActive: 'criticalActive',
-      boxShadow: undefined,
-    },
-  },
-  weak: {
+  ghost: {
     default: {
       textTone: 'formAccent',
       background: undefined,
       backgroundHover: 'formAccentHover',
       backgroundActive: 'formAccentActive',
       boxShadow: 'borderFormAccentLarge',
+    },
+    brandAccent: {
+      textTone: 'brandAccent',
+      background: undefined,
+      backgroundHover: 'brandAccentHover',
+      backgroundActive: 'brandAccentActive',
+      boxShadow: 'borderBrandAccentLarge',
     },
     critical: {
       textTone: 'critical',
@@ -87,44 +84,80 @@ const buttonVariants: Record<
       boxShadow: 'borderCriticalLarge',
     },
   },
-  weakInverted: {
+  soft: {
     default: {
-      textTone: undefined,
-      background: undefined,
-      backgroundHover: 'card',
-      backgroundActive: 'card',
-      boxShadow: 'borderStandardInvertedLarge',
+      textTone: 'formAccent',
+      background: 'formAccent',
+      backgroundHover: 'formAccentHover',
+      backgroundActive: 'formAccentActive',
+      boxShadow: undefined,
+    },
+    brandAccent: {
+      textTone: 'brandAccent',
+      background: 'brandAccent',
+      backgroundHover: 'brandAccentHover',
+      backgroundActive: 'brandAccentActive',
+      boxShadow: undefined,
     },
     critical: {
-      textTone: undefined,
+      textTone: 'critical',
+      background: 'critical',
+      backgroundHover: 'criticalHover',
+      backgroundActive: 'criticalActive',
+      boxShadow: undefined,
+    },
+  },
+  transparent: {
+    default: {
+      textTone: 'formAccent',
       background: undefined,
-      backgroundHover: 'card',
-      backgroundActive: 'card',
-      boxShadow: 'borderStandardInvertedLarge',
+      backgroundHover: 'formAccentHover',
+      backgroundActive: 'formAccentActive',
+      boxShadow: undefined,
+    },
+    brandAccent: {
+      textTone: 'brandAccent',
+      background: undefined,
+      backgroundHover: 'brandAccentHover',
+      backgroundActive: 'brandAccentActive',
+      boxShadow: undefined,
+    },
+    critical: {
+      textTone: 'critical',
+      background: undefined,
+      backgroundHover: 'criticalHover',
+      backgroundActive: 'criticalActive',
+      boxShadow: undefined,
     },
   },
 };
 
-const useButtonVariant = (weight: ButtonWeight, tone?: ButtonTone) => {
-  const variantName =
-    useBackgroundLightness() === 'dark' && weight === 'weak'
-      ? 'weakInverted'
-      : weight;
+const useButtonVariant = (variant: ButtonVariant, tone?: ButtonTone) => {
+  if (useBackgroundLightness() === 'dark' && !tone && variant !== 'standard') {
+    return {
+      textTone: undefined,
+      background: variant === 'soft' ? 'card' : undefined,
+      backgroundHover: 'card',
+      backgroundActive: 'card',
+      boxShadow:
+        variant === 'ghost' ? 'borderStandardInvertedLarge' : undefined,
+    } as ButtonStyles;
+  }
 
   return (
-    buttonVariants[variantName][tone ?? 'default'] ??
-    buttonVariants[variantName].default
+    buttonVariants[variant][tone ?? 'default'] ??
+    buttonVariants[variant].default
   );
 };
 
 const ButtonChildrenContext = createContext<{
   size: ButtonSize;
   tone: ButtonTone | undefined;
-  weight: ButtonWeight;
+  variant: ButtonVariant;
   loading: boolean;
 }>({
   size: 'standard',
-  weight: 'regular',
+  variant: 'standard',
   tone: undefined,
   loading: false,
 });
@@ -135,12 +168,17 @@ interface ButtonChildrenProps {
 
 const ButtonChildren = ({ children }: ButtonChildrenProps) => {
   const styles = useStyles(styleRefs);
-  const { size, weight, tone, loading } = useContext(ButtonChildrenContext);
-  const buttonVariant = useButtonVariant(weight, tone);
+  const { size, variant, tone, loading } = useContext(ButtonChildrenContext);
+  const buttonVariant = useButtonVariant(variant, tone);
   const standardTouchableSpaceStyles = useTouchableSpace('standard');
 
   return (
     <Fragment>
+      <FieldOverlay
+        background={buttonVariant.background}
+        className={styles.backgroundOverlay}
+        visible={Boolean(buttonVariant.background)}
+      />
       <FieldOverlay
         variant="focus"
         onlyVisibleForKeyboardNavigation
@@ -156,7 +194,9 @@ const ButtonChildren = ({ children }: ButtonChildrenProps) => {
       />
       <Box
         position="relative"
-        paddingX={size === 'small' ? 'small' : 'medium'}
+        paddingX={
+          size === 'small' || variant === 'transparent' ? 'small' : 'medium'
+        }
         paddingY={size === 'small' ? 'xsmall' : undefined}
         pointerEvents="none"
         textAlign="center"
@@ -195,6 +235,8 @@ const ButtonChildren = ({ children }: ButtonChildrenProps) => {
 export interface PrivateButtonRendererProps {
   size?: ButtonSize;
   tone?: ButtonTone;
+  variant?: ButtonVariant;
+  /** @deprecated `weight` has been deprecated. Please choose a [variant](https://seek-oss.github.io/braid-design-system/components/Button) instead. */
   weight?: ButtonWeight;
   loading?: boolean;
   children: (
@@ -206,10 +248,48 @@ export interface PrivateButtonRendererProps {
   ) => ReactNode;
 }
 
+type PropMapper = {
+  weight?: ButtonWeight;
+  tone?: ButtonTone;
+  variant?: ButtonVariant;
+};
+const resolveToneAndVariant = ({
+  weight,
+  tone,
+  variant = 'standard',
+}: PropMapper): { variant: ButtonVariant; tone?: ButtonTone } => {
+  if (weight === 'strong') {
+    return {
+      tone: tone || 'brandAccent',
+      variant: 'standard',
+    };
+  }
+
+  if (weight === 'regular') {
+    return {
+      tone,
+      variant: 'standard',
+    };
+  }
+
+  if (weight === 'weak') {
+    return {
+      tone,
+      variant: 'ghost',
+    };
+  }
+
+  return {
+    tone,
+    variant,
+  };
+};
+
 export const PrivateButtonRenderer = ({
   size: sizeProp,
-  tone,
-  weight = 'regular',
+  tone: toneProp,
+  variant: variantProp,
+  weight,
   loading = false,
   children,
 }: PrivateButtonRendererProps) => {
@@ -220,9 +300,20 @@ export const PrivateButtonRenderer = ({
     'You shouldn\'t set a "size" prop on Button elements nested inside Actions. Instead, set the size on the Actions element, e.g. <Actions size="small"><Button>...</Button></Actions>',
   );
 
+  assert(
+    !(weight && variantProp),
+    'You shouldn\'t set a "weight" and "variant" prop together. Please migrate from "weight" to "variant".',
+  );
+
+  const { tone, variant } = resolveToneAndVariant({
+    weight,
+    tone: toneProp,
+    variant: variantProp,
+  });
+
   const styles = useStyles(styleRefs);
   const size = sizeProp ?? actionsContext?.size ?? 'standard';
-  const { background, boxShadow } = useButtonVariant(weight, tone);
+  const { background, boxShadow } = useButtonVariant(variant, tone);
   const virtualTouchableStyles = useVirtualTouchable({ xAxis: false });
 
   const buttonStyles = useBoxStyles({
@@ -233,21 +324,21 @@ export const PrivateButtonRenderer = ({
     display: 'block',
     borderRadius: 'standard',
     boxShadow,
-    background,
     transform: 'touchable',
     transition: 'touchable',
     outline: 'none',
     className: [
       styles.root,
-      weight === 'weak' ? styles.weak : null,
+      variant === 'soft' ? styles.lightBg : null,
+      variant !== 'standard' ? styles.lightHoverBg : null,
       useBackgroundLightness() === 'dark' ? styles.inverted : null,
       size === 'small' ? virtualTouchableStyles : null,
     ],
   });
 
   const buttonChildrenContextValue = useMemo(
-    () => ({ size, tone, weight, loading }),
-    [size, tone, weight, loading],
+    () => ({ size, tone, variant, loading }),
+    [size, tone, variant, loading],
   );
 
   const buttonProps = {
@@ -261,7 +352,7 @@ export const PrivateButtonRenderer = ({
     </ButtonChildrenContext.Provider>
   );
 
-  return background ? (
+  return background && variant !== 'soft' ? (
     <BackgroundProvider value={background}>{button}</BackgroundProvider>
   ) : (
     button

--- a/lib/components/ButtonRenderer/ButtonRenderer.tsx
+++ b/lib/components/ButtonRenderer/ButtonRenderer.tsx
@@ -25,7 +25,7 @@ import * as styleRefs from './ButtonRenderer.treat';
 type ButtonSize = 'standard' | 'small';
 type ButtonTone = 'brandAccent' | 'critical';
 type ButtonWeight = 'weak' | 'regular' | 'strong';
-type ButtonVariant = 'standard' | 'ghost' | 'soft' | 'transparent';
+type ButtonVariant = 'solid' | 'ghost' | 'soft' | 'transparent';
 type ButtonStyles = {
   textTone: TextProps['tone'];
   background: UseBoxStylesProps['background'];
@@ -38,7 +38,7 @@ const buttonVariants: Record<
   ButtonVariant,
   Record<'default' | ButtonTone, ButtonStyles>
 > = {
-  standard: {
+  solid: {
     default: {
       textTone: undefined,
       background: 'formAccent',
@@ -133,7 +133,7 @@ const buttonVariants: Record<
 };
 
 const useButtonVariant = (variant: ButtonVariant, tone?: ButtonTone) => {
-  if (useBackgroundLightness() === 'dark' && !tone && variant !== 'standard') {
+  if (useBackgroundLightness() === 'dark' && !tone && variant !== 'solid') {
     return {
       textTone: undefined,
       background: variant === 'soft' ? 'card' : undefined,
@@ -157,7 +157,7 @@ const ButtonChildrenContext = createContext<{
   loading: boolean;
 }>({
   size: 'standard',
-  variant: 'standard',
+  variant: 'solid',
   tone: undefined,
   loading: false,
 });
@@ -256,19 +256,19 @@ type PropMapper = {
 const resolveToneAndVariant = ({
   weight,
   tone,
-  variant = 'standard',
+  variant = 'solid',
 }: PropMapper): { variant: ButtonVariant; tone?: ButtonTone } => {
   if (weight === 'strong') {
     return {
       tone: tone || 'brandAccent',
-      variant: 'standard',
+      variant: 'solid',
     };
   }
 
   if (weight === 'regular') {
     return {
       tone,
-      variant: 'standard',
+      variant: 'solid',
     };
   }
 
@@ -330,7 +330,7 @@ export const PrivateButtonRenderer = ({
     className: [
       styles.root,
       variant === 'soft' ? styles.lightBg : null,
-      variant !== 'standard' ? styles.lightHoverBg : null,
+      variant !== 'solid' ? styles.lightHoverBg : null,
       useBackgroundLightness() === 'dark' ? styles.inverted : null,
       size === 'small' ? virtualTouchableStyles : null,
     ],

--- a/lib/components/ButtonRenderer/ButtonRenderer.tsx
+++ b/lib/components/ButtonRenderer/ButtonRenderer.tsx
@@ -1,4 +1,5 @@
 import assert from 'assert';
+import dedent from 'dedent';
 import React, {
   createContext,
   useContext,
@@ -236,7 +237,7 @@ export interface PrivateButtonRendererProps {
   size?: ButtonSize;
   tone?: ButtonTone;
   variant?: ButtonVariant;
-  /** @deprecated `weight` has been deprecated. Please choose a [variant](https://seek-oss.github.io/braid-design-system/components/Button#variants) instead. */
+  /** @deprecated The `weight` prop has been deprecated. Please choose a [variant](https://seek-oss.github.io/braid-design-system/components/Button#variants) instead. */
   weight?: ButtonWeight;
   loading?: boolean;
   children: (
@@ -248,16 +249,15 @@ export interface PrivateButtonRendererProps {
   ) => ReactNode;
 }
 
-type PropMapper = {
-  weight?: ButtonWeight;
-  tone?: ButtonTone;
-  variant?: ButtonVariant;
-};
 const resolveToneAndVariant = ({
   weight,
   tone,
   variant = 'solid',
-}: PropMapper): { variant: ButtonVariant; tone?: ButtonTone } => {
+}: {
+  weight?: ButtonWeight;
+  tone?: ButtonTone;
+  variant?: ButtonVariant;
+}): { variant: ButtonVariant; tone?: ButtonTone } => {
   if (weight === 'strong') {
     return {
       tone: tone || 'brandAccent',
@@ -310,6 +310,32 @@ export const PrivateButtonRenderer = ({
     tone: toneProp,
     variant: variantProp,
   });
+
+  if (process.env.NODE_ENV !== 'production') {
+    if (weight && /^(strong|regular|weak)$/.test(weight)) {
+      const needsTone = Boolean(tone);
+      const needsVariant = variant && variant !== 'solid';
+
+      // eslint-disable-next-line no-console
+      console.warn(
+        dedent`
+          The \`weight\` prop has been deprecated.${
+            needsVariant || needsTone
+              ? ` Please migrate to${needsVariant ? ` \`variant\`` : ''}${
+                  needsTone ? `${needsVariant ? ' and' : ''} \`tone\`` : ''
+                }.`
+              : ` You can migrate by removing the \`weight="${weight}"\` prop.`
+          }
+          %c  -<Button weight="${weight}">...</Button>
+          %c  +<Button${needsTone ? ` tone="${tone}"` : ''}${
+          needsVariant ? ` variant="${variant}"` : ''
+        }>...</Button>
+        `,
+        'color: red',
+        'color: green',
+      );
+    }
+  }
 
   const styles = useStyles(styleRefs);
   const size = sizeProp ?? actionsContext?.size ?? 'standard';

--- a/lib/components/Dialog/Dialog.docs.tsx
+++ b/lib/components/Dialog/Dialog.docs.tsx
@@ -169,7 +169,10 @@ const docs: ComponentDocs = {
                     <Button onClick={() => toggleState('dialog')}>
                       Got it
                     </Button>
-                    <Button weight="weak" onClick={() => toggleState('dialog')}>
+                    <Button
+                      variant="transparent"
+                      onClick={() => toggleState('dialog')}
+                    >
                       Cancel
                     </Button>
                   </Inline>

--- a/lib/components/Dialog/Dialog.snippets.tsx
+++ b/lib/components/Dialog/Dialog.snippets.tsx
@@ -36,7 +36,7 @@ export const snippets: Snippets = [
           <Placeholder width="100%" height={100} />
           <Inline space="small">
             <Button>Got it</Button>
-            <Button weight="weak">Cancel</Button>
+            <Button variant="transparent">Cancel</Button>
           </Inline>
         </Stack>
       </Dialog>,

--- a/lib/components/MenuItem/MenuItem.docs.tsx
+++ b/lib/components/MenuItem/MenuItem.docs.tsx
@@ -7,7 +7,6 @@ import {
   MenuItemLink,
   Text,
   TextLink,
-  TextLinkButton,
   Strong,
   List,
   Box,
@@ -125,9 +124,12 @@ const docs: ComponentDocs = {
                   >
                     <IconDelete /> Delete
                   </Button>
-                  <TextLinkButton onClick={() => toggleState('confirm')}>
+                  <Button
+                    variant="transparent"
+                    onClick={() => toggleState('confirm')}
+                  >
                     Cancel
-                  </TextLinkButton>
+                  </Button>
                 </Actions>
               </Stack>
             </Dialog>

--- a/lib/components/MenuRenderer/MenuRenderer.docs.tsx
+++ b/lib/components/MenuRenderer/MenuRenderer.docs.tsx
@@ -13,7 +13,6 @@ import {
   Strong,
   Actions,
   Button,
-  TextLinkButton,
   Dialog,
   IconDelete,
 } from '..';
@@ -184,9 +183,12 @@ const docs: ComponentDocs = {
                   >
                     <IconDelete /> Delete
                   </Button>
-                  <TextLinkButton onClick={() => toggleState('confirm')}>
+                  <Button
+                    variant="transparent"
+                    onClick={() => toggleState('confirm')}
+                  >
                     Cancel
-                  </TextLinkButton>
+                  </Button>
                 </Actions>
               </Stack>
             </Dialog>

--- a/lib/components/OverflowMenu/OverflowMenu.docs.tsx
+++ b/lib/components/OverflowMenu/OverflowMenu.docs.tsx
@@ -7,7 +7,6 @@ import {
   MenuItemLink,
   Text,
   TextLink,
-  TextLinkButton,
   Strong,
   Box,
   Dialog,
@@ -90,9 +89,12 @@ const docs: ComponentDocs = {
                   >
                     <IconDelete /> Delete
                   </Button>
-                  <TextLinkButton onClick={() => toggleState('confirm')}>
+                  <Button
+                    variant="transparent"
+                    onClick={() => toggleState('confirm')}
+                  >
                     Cancel
-                  </TextLinkButton>
+                  </Button>
                 </Actions>
               </Stack>
             </Dialog>

--- a/lib/components/TextLink/TextLink.docs.tsx
+++ b/lib/components/TextLink/TextLink.docs.tsx
@@ -1,15 +1,6 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import {
-  Actions,
-  Box,
-  Button,
-  Inline,
-  Stack,
-  Strong,
-  Text,
-  TextLink,
-} from '../';
+import { Box, Inline, Stack, Strong, Text, TextLink } from '../';
 import source from '../../utils/source.macro';
 
 const docs: ComponentDocs = {
@@ -40,8 +31,7 @@ const docs: ComponentDocs = {
         <Text>
           This component must be nested within a{' '}
           <TextLink href="/components/Text">Text</TextLink> or{' '}
-          <TextLink href="/components/Heading">Heading</TextLink> or{' '}
-          <TextLink href="/components/Actions">Actions</TextLink> component.
+          <TextLink href="/components/Heading">Heading</TextLink> component.
         </Text>
       ),
     },
@@ -84,31 +74,15 @@ const docs: ComponentDocs = {
         ),
     },
     {
-      label: 'Development considerations',
+      label: 'Custom link rendering',
       description: (
-        <>
-          <Text>
-            By default renders a native <Strong>a</Strong> element, but this can
-            be customised via the <Strong>linkComponent</Strong> prop on{' '}
-            <TextLink href="/components/BraidProvider">BraidProvider</TextLink>.
-          </Text>
-          <Text>
-            In addition, when inside of an{' '}
-            <TextLink href="/components/Actions">Actions</TextLink> component a
-            TextLink uses a different layout and focus style to better align
-            with the other <TextLink href="/components/Button">Button</TextLink>{' '}
-            and <TextLink href="/components/TextLink">TextLink</TextLink>{' '}
-            elements in the container.
-          </Text>
-        </>
+        <Text>
+          This component renders a native <Strong>a</Strong> element by default,
+          but this can be customised via the <Strong>linkComponent</Strong> prop
+          on <TextLink href="/components/BraidProvider">BraidProvider</TextLink>
+          .
+        </Text>
       ),
-      Example: () =>
-        source(
-          <Actions>
-            <Button>Button</Button>
-            <TextLink href="#">TextLink</TextLink>
-          </Actions>,
-        ),
     },
     {
       label: 'Contextual design',

--- a/lib/components/TextLink/TextLink.screenshots.tsx
+++ b/lib/components/TextLink/TextLink.screenshots.tsx
@@ -75,7 +75,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'TextLink inside Actions',
+      label: 'TextLink inside Actions (Deprecated)',
       Example: () => (
         <Actions>
           <Button>Button</Button>
@@ -143,7 +143,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'TextLink inside Actions with icon',
+      label: 'TextLink inside Actions with icon (Deprecated)',
       Example: () => (
         <Actions>
           <Button>Button</Button>

--- a/lib/components/TextLinkButton/TextLinkButton.docs.tsx
+++ b/lib/components/TextLinkButton/TextLinkButton.docs.tsx
@@ -44,9 +44,8 @@ const docs: ComponentDocs = {
       description: (
         <Text>
           This component must be nested within a{' '}
-          <TextLink href="/components/Text">Text</TextLink>,{' '}
-          <TextLink href="/components/Heading">Heading</TextLink> or{' '}
-          <TextLink href="/components/Actions">Actions</TextLink> component.
+          <TextLink href="/components/Text">Text</TextLink> or{' '}
+          <TextLink href="/components/Heading">Heading</TextLink> component.
         </Text>
       ),
     },

--- a/lib/components/TextLinkButton/TextLinkButton.screenshots.tsx
+++ b/lib/components/TextLinkButton/TextLinkButton.screenshots.tsx
@@ -28,7 +28,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'TextLinkButton inside Actions',
+      label: 'TextLinkButton inside Actions (Deprecated)',
       Example: ({ handler }) => (
         <Actions>
           <Button>Button</Button>

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
@@ -1,5 +1,6 @@
 import React, { CSSProperties, useContext, ReactElement } from 'react';
 import { useStyles } from 'sku/react-treat';
+import dedent from 'dedent';
 import assert from 'assert';
 import classnames from 'classnames';
 import TextLinkRendererContext from './TextLinkRendererContext';
@@ -37,6 +38,23 @@ export const PrivateTextLinkRenderer = (
   props: PrivateTextLinkRendererProps,
 ) => {
   const actionsContext = useContext(ActionsContext);
+
+  if (process.env.NODE_ENV !== 'production') {
+    // eslint-disable-next-line no-console
+    console.warn(
+      dedent`
+      The "TextLink" and "TextLinkButton" components have been deprecated inside of "Actions". Use "ButtonLink" or "Button" with a "variant" of "transparent" instead.
+        <Actions>
+          <Button>...</Button>
+      %c-   <TextLink href="...">...</TextLink>
+      %c+   <ButtonLink href="..." variant="transparent">...</ButtonLink>
+      %c  </Actions>
+    `,
+      'color: red',
+      'color: green',
+      'color: inherit',
+    );
+  }
 
   assert(
     (() => {

--- a/lib/themes/baseTokens/apac.ts
+++ b/lib/themes/baseTokens/apac.ts
@@ -204,6 +204,7 @@ export const makeTokens = ({
         positive,
         caution,
         formAccent,
+        brandAccent,
       },
     },
     shadows: {
@@ -231,6 +232,7 @@ export const makeTokens = ({
         neutral: black,
         neutralInverted: white,
         formAccent,
+        brandAccent,
         critical,
         caution,
         positive,

--- a/lib/themes/baseTokens/seekAsia.ts
+++ b/lib/themes/baseTokens/seekAsia.ts
@@ -203,6 +203,7 @@ export const makeTokens = ({
         caution,
         formHover: formAccent,
         formAccent,
+        brandAccent,
       },
     },
     shadows: {
@@ -221,6 +222,7 @@ export const makeTokens = ({
         neutral: grey1,
         neutralInverted: white,
         formAccent,
+        brandAccent,
         critical,
         caution,
         positive,

--- a/lib/themes/catho/tokens.ts
+++ b/lib/themes/catho/tokens.ts
@@ -175,6 +175,7 @@ const tokens: TreatTokens = {
       caution,
       formHover: formAccent,
       formAccent,
+      brandAccent,
     },
   },
   shadows: {
@@ -193,6 +194,7 @@ const tokens: TreatTokens = {
       neutral,
       neutralInverted: white,
       formAccent,
+      brandAccent,
       critical,
       info,
       promote,

--- a/lib/themes/docs/tokens.ts
+++ b/lib/themes/docs/tokens.ts
@@ -176,6 +176,7 @@ const tokens: TreatTokens = {
       caution,
       formHover: formAccent,
       formAccent,
+      brandAccent,
     },
   },
   shadows: {
@@ -194,6 +195,7 @@ const tokens: TreatTokens = {
       neutral: black,
       neutralInverted: white,
       formAccent,
+      brandAccent,
       critical,
       caution,
       positive,

--- a/lib/themes/makeBraidTheme.ts
+++ b/lib/themes/makeBraidTheme.ts
@@ -101,6 +101,7 @@ export interface TreatTokens {
       caution: string;
       formHover: string;
       formAccent: string;
+      brandAccent: string;
     };
   };
   shadows: {
@@ -116,6 +117,7 @@ export interface TreatTokens {
       neutral: string;
       neutralInverted: string;
       formAccent: string;
+      brandAccent: string;
       critical: string;
       info: string;
       promote: string;

--- a/lib/themes/occ/tokens.ts
+++ b/lib/themes/occ/tokens.ts
@@ -176,6 +176,7 @@ const tokens: TreatTokens = {
       caution,
       formHover: formAccent,
       formAccent,
+      brandAccent,
     },
   },
   shadows: {
@@ -194,6 +195,7 @@ const tokens: TreatTokens = {
       neutral: black,
       neutralInverted: white,
       formAccent,
+      brandAccent,
       critical,
       info,
       promote,

--- a/lib/themes/seekAnz/tokens.ts
+++ b/lib/themes/seekAnz/tokens.ts
@@ -177,6 +177,7 @@ const tokens: TreatTokens = {
       positive,
       caution,
       formAccent,
+      brandAccent,
     },
   },
   shadows: {
@@ -195,6 +196,7 @@ const tokens: TreatTokens = {
       neutral: black,
       neutralInverted: white,
       formAccent,
+      brandAccent,
       critical,
       caution,
       positive,

--- a/lib/themes/seekUnifiedBeta/tokens.ts
+++ b/lib/themes/seekUnifiedBeta/tokens.ts
@@ -176,6 +176,7 @@ const tokens: TreatTokens = {
       positive,
       caution,
       formAccent,
+      brandAccent,
     },
   },
   shadows: {
@@ -194,6 +195,7 @@ const tokens: TreatTokens = {
       neutral: black,
       neutralInverted: white,
       formAccent,
+      brandAccent,
       critical,
       caution,
       positive,

--- a/lib/themes/wireframe/tokens.ts
+++ b/lib/themes/wireframe/tokens.ts
@@ -174,6 +174,7 @@ const tokens: TreatTokens = {
       caution,
       formHover: formAccent,
       formAccent,
+      brandAccent,
     },
   },
   shadows: {
@@ -192,6 +193,7 @@ const tokens: TreatTokens = {
       neutral: black,
       neutralInverted: white,
       formAccent,
+      brandAccent,
       critical,
       caution,
       positive,

--- a/site/src/App/routes/examples/marketing-banner/marketing-banner.tsx
+++ b/site/src/App/routes/examples/marketing-banner/marketing-banner.tsx
@@ -65,7 +65,7 @@ const page: Page = {
                     Heard about our latest marketing campaign?
                   </Heading>
                   <Inline space="none" align={['center', 'left']}>
-                    <Button weight="weak">Show me</Button>
+                    <Button variant="ghost">Show me</Button>
                   </Inline>
                 </Stack>
               </Column>
@@ -260,7 +260,7 @@ const page: Page = {
                   <Heading level="1">
                     Heard about our latest marketing campaign?
                   </Heading>
-                  <Button weight="weak">Show me</Button>
+                  <Button variant="ghost">Show me</Button>
                 </Stack>
               </Column>
               <Column>
@@ -294,7 +294,7 @@ const page: Page = {
                     Heard about our latest marketing campaign?
                   </Heading>
                   <Inline space="none">
-                    <Button weight="weak">Show me</Button>
+                    <Button variant="ghost">Show me</Button>
                   </Inline>
                 </Stack>
               </Column>
@@ -324,7 +324,7 @@ const page: Page = {
                     Heard about our latest marketing campaign?
                   </Heading>
                   <Inline space="none">
-                    <Button weight="weak">Show me</Button>
+                    <Button variant="ghost">Show me</Button>
                   </Inline>
                 </Stack>
               </Column>
@@ -381,7 +381,7 @@ const page: Page = {
                     Heard about our latest marketing campaign?
                   </Heading>
                   <Inline space="none">
-                    <Button weight="weak">Show me</Button>
+                    <Button variant="ghost">Show me</Button>
                   </Inline>
                 </Stack>
               </Column>
@@ -425,7 +425,7 @@ const page: Page = {
                     Heard about our latest marketing campaign?
                   </Heading>
                   <Inline space="none">
-                    <Button weight="weak">Show me</Button>
+                    <Button variant="ghost">Show me</Button>
                   </Inline>
                 </Stack>
               </Column>
@@ -480,7 +480,7 @@ const page: Page = {
                     Heard about our latest marketing campaign?
                   </Heading>
                   <Inline space="none" align={['center', 'left']}>
-                    <Button weight="weak">Show me</Button>
+                    <Button variant="ghost">Show me</Button>
                   </Inline>
                 </Stack>
               </Column>
@@ -528,7 +528,7 @@ const page: Page = {
                       Heard about our latest marketing campaign?
                     </Heading>
                     <Inline space="none">
-                      <Button weight="weak">Show me</Button>
+                      <Button variant="ghost">Show me</Button>
                     </Inline>
                   </Stack>
                 </Column>
@@ -569,7 +569,7 @@ const page: Page = {
                       Heard about our latest marketing campaign?
                     </Heading>
                     <Inline space="none" align={['center', 'left']}>
-                      <Button weight="weak">Show me</Button>
+                      <Button variant="ghost">Show me</Button>
                     </Inline>
                   </Stack>
                 </Column>
@@ -610,7 +610,7 @@ const page: Page = {
                       Heard about our latest marketing campaign?
                     </Heading>
                     <Inline space="none" align={['center', 'left']}>
-                      <Button weight="weak">Show me</Button>
+                      <Button variant="ghost">Show me</Button>
                     </Inline>
                   </Stack>
                 </Column>

--- a/site/src/App/routes/foundations/layout/layout.tsx
+++ b/site/src/App/routes/foundations/layout/layout.tsx
@@ -373,7 +373,7 @@ const page: Page = {
         <Card>
           <Inline space="small" collapseBelow="tablet">
             <Button>Submit</Button>
-            <Button weight="weak">Cancel</Button>
+            <Button variant="ghost">Cancel</Button>
           </Inline>
         </Card>
       </Code>


### PR DESCRIPTION
Introduces a new `variant` prop to `Button`/`ButtonLink` giving consumers a single prop to use for selecting the visual style of the button. Choose from `solid` (default), `ghost`, `soft` or `transparent`. The colour of the button is now consistently controlled via the `tone` prop, with supported values being `brandAccent`, `critical` or `undefined`.

As a result the `weight` prop is now deprecated. See the migration guide below.

**EXAMPLE USAGE:**
```jsx
<Inline space="small" collapseBelow="desktop">
  <Button>Solid</Button>
  <Button variant="ghost">Ghost</Button>
  <Button variant="soft">Soft</Button>
  <Button variant="transparent">Transparent</Button>
</Inline>
```

**MIGRATION GUIDE:**
The `weight` prop is now deprecated. If you are not specifying a `weight` there is no change required.

If you are, each weight can be migrated as follows:

#### Regular
Can be replicated with a `variant` of `solid` (default).
```diff
-<Button weight="regular">...</Button>
+<Button variant="solid">...</Button>
```

Given it is the default `variant`, you could also choose to simply remove the `weight` prop.
```diff
-<Button weight="regular">...</Button>
+<Button>...</Button>
```

#### Strong
Can be replicated with a `variant` of `solid` (default), with a `tone` of `brandAccent`.
```diff
-<Button weight="strong">...</Button>
+<Button tone="brandAccent">...</Button>
```

#### Weak
Can be replicated with a `variant` of `ghost`.
```diff
-<Button weight="weak">...</Button>
+<Button variant="ghost">...</Button>
```