### PR TITLE
Button: Remove all interactive styles when loading

### DIFF
--- a/.changeset/red-readers-crash.md
+++ b/.changeset/red-readers-crash.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Button
+  - ButtonLink
+---
+
+**Button, ButtonLink:** Remove all interactive styles when loading
+
+No longer applies hover and cursor pointer styles when a `Button` is set to `loading`.

--- a/lib/components/ButtonRenderer/ButtonRenderer.treat.ts
+++ b/lib/components/ButtonRenderer/ButtonRenderer.treat.ts
@@ -29,13 +29,13 @@ export const activeOverlay = style({
 
 export const hoverOverlay = style({
   selectors: {
-    [`${root}:hover:not(:active) &`]: {
+    [`${root}:hover:not(:disabled):not(:active) &`]: {
       opacity: 1,
     },
-    [`${lightHoverBg}:hover:not(:active) &`]: {
+    [`${lightHoverBg}:hover:not(:disabled):not(:active) &`]: {
       opacity: 0.075,
     },
-    [`${lightHoverBg}${inverted}:hover:not(:active) &`]: {
+    [`${lightHoverBg}${inverted}:hover:not(:disabled):not(:active) &`]: {
       opacity: 0.15,
     },
   },

--- a/lib/components/ButtonRenderer/ButtonRenderer.tsx
+++ b/lib/components/ButtonRenderer/ButtonRenderer.tsx
@@ -344,7 +344,7 @@ export const PrivateButtonRenderer = ({
 
   const buttonStyles = useBoxStyles({
     component: 'button',
-    cursor: 'pointer',
+    cursor: !loading ? 'pointer' : undefined,
     width: 'full',
     position: 'relative',
     display: 'block',


### PR DESCRIPTION
**Button, ButtonLink:** Remove all interactive styles when loading

No longer applies hover and cursor pointer styles when a `Button` is set to `loading`.