### PR TITLE
Button: Add `bleedY` prop

### DIFF
--- a/.changeset/olive-turtles-hug.md
+++ b/.changeset/olive-turtles-hug.md
@@ -1,0 +1,27 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Button
+  - ButtonLink
+  - ButtonRenderer
+---
+
+**Button, ButtonLink, ButtonRenderer:** Add `bleedY` prop
+
+You can now choose to allow the button’s background colour to bleed out into the surrounding layout, making it easier to align with other elements.
+
+For example, we can align a button to a Heading element using an Inline, even though the button is actually taller than the heading. If we didn’t use the **bleedY** prop in this case, the button would introduce unwanted space above and below the heading.
+
+**EXAMPLE USAGE:**
+```jsx
+<Inline space="small" alignY="center">
+  <Heading level="4">Heading</Heading>
+  <Button bleedY>Button</Button>
+  <Button bleedY size="small">
+    Button
+  </Button>
+</Inline>
+```

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -1707,6 +1707,7 @@ Object {
         | "true"
         | false
         | true
+    bleedY?: boolean
     children?: ReactNode
     data?: Record<string, string | number>
     id?: string
@@ -1903,6 +1904,7 @@ Object {
     autoCapitalize?: string
     autoCorrect?: string
     autoSave?: string
+    bleedY?: boolean
     children?: ReactNode
     color?: string
     contentEditable?: 
@@ -2172,6 +2174,7 @@ exports[`ButtonRenderer 1`] = `
 Object {
   exportType: component,
   props: {
+    bleedY?: boolean
     children: (ButtonChildren: ComponentType<ButtonChildrenProps>, styleProps: { style: CSSProperties; className: string; }) => ReactNode
     loading?: boolean
     size?: 

--- a/lib/components/Button/Button.docs.tsx
+++ b/lib/components/Button/Button.docs.tsx
@@ -5,6 +5,7 @@ import {
   Card,
   Stack,
   Box,
+  Heading,
   Text,
   TextLink,
   Inline,
@@ -236,6 +237,36 @@ const docs: ComponentDocs = {
               <Button variant="transparent">Transparent</Button>
             </Inline>
           </Box>,
+        ),
+    },
+    {
+      label: 'Vertical bleed',
+      description: (
+        <>
+          <Text>
+            With the <Strong>bleedY</Strong> prop, you can allow the background
+            colour to bleed out into the surrounding layout.
+          </Text>
+          <Text>
+            For example, we can align a button to a{' '}
+            <TextLink href="/components/Heading">Heading</TextLink> element
+            using an <TextLink href="/components/Inline">Inline</TextLink>, even
+            though the button is actually taller than the heading. If we didn’t
+            use the <Strong>bleedY</Strong> prop in this case, the button would
+            introduce unwanted space above and below the heading.
+          </Text>
+        </>
+      ),
+      background: 'card',
+      Example: () =>
+        source(
+          <Inline space="small" alignY="center">
+            <Heading level="4">Heading</Heading>
+            <Button bleedY>Button</Button>
+            <Button bleedY size="small">
+              Button
+            </Button>
+          </Inline>,
         ),
     },
   ],

--- a/lib/components/Button/Button.docs.tsx
+++ b/lib/components/Button/Button.docs.tsx
@@ -260,13 +260,44 @@ const docs: ComponentDocs = {
       background: 'card',
       Example: () =>
         source(
-          <Inline space="small" alignY="center">
-            <Heading level="4">Heading</Heading>
-            <Button bleedY>Button</Button>
-            <Button bleedY size="small">
-              Button
-            </Button>
-          </Inline>,
+          <Stack space="large">
+            <Stack space="small">
+              <Text tone="secondary" weight="strong">
+                Standard size
+              </Text>
+              <Box
+                background="neutralLight"
+                borderRadius="standard"
+                padding="gutter"
+              >
+                <Box background="card">
+                  <Inline space="xsmall" alignY="center">
+                    <Heading level="2">Heading</Heading>
+                    <Button bleedY>Button</Button>
+                  </Inline>
+                </Box>
+              </Box>
+            </Stack>
+            <Stack space="small">
+              <Text tone="secondary" weight="strong">
+                Small size
+              </Text>
+              <Box
+                background="neutralLight"
+                borderRadius="standard"
+                padding="gutter"
+              >
+                <Box background="card">
+                  <Inline space="xsmall" alignY="center">
+                    <Heading level="2">Heading</Heading>
+                    <Button bleedY size="small">
+                      Button
+                    </Button>
+                  </Inline>
+                </Box>
+              </Box>
+            </Stack>
+          </Stack>,
         ),
     },
   ],

--- a/lib/components/Button/Button.gallery.tsx
+++ b/lib/components/Button/Button.gallery.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ComponentExample } from '../../../site/src/types';
 import source from '../../utils/source.macro';
-import { Button, Box, Inline, IconSend } from '../';
+import { Button, Box, Heading, Inline, IconSend } from '../';
 
 export const galleryItems: ComponentExample[] = [
   {
@@ -95,6 +95,19 @@ export const galleryItems: ComponentExample[] = [
       source(
         <Inline space="small">
           <Button size="small">Submit</Button>
+        </Inline>,
+      ),
+  },
+  {
+    label: 'With vertical bleed',
+    Example: () =>
+      source(
+        <Inline space="small" alignY="center">
+          <Heading level="4">Heading</Heading>
+          <Button bleedY>Button</Button>
+          <Button bleedY size="small">
+            Button
+          </Button>
         </Inline>,
       ),
   },

--- a/lib/components/Button/Button.playroom.tsx
+++ b/lib/components/Button/Button.playroom.tsx
@@ -1,0 +1,12 @@
+import React from 'react';
+import { buttonVariants } from '../ButtonRenderer/ButtonRenderer';
+import { Button as BraidButton, ButtonProps } from './Button';
+
+export const Button = ({ variant, ...restProps }: ButtonProps) => (
+  <BraidButton
+    variant={
+      variant && buttonVariants.indexOf(variant) > -1 ? variant : 'solid'
+    }
+    {...restProps}
+  />
+);

--- a/lib/components/Button/Button.screenshots.tsx
+++ b/lib/components/Button/Button.screenshots.tsx
@@ -79,16 +79,33 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'With vertical bleed',
+      label: 'With vertical bleed (standard)',
       background: 'card',
       Example: () => (
-        <Inline space="small" alignY="center">
-          <Heading level="4">Heading</Heading>
-          <Button bleedY>Button</Button>
-          <Button bleedY size="small">
-            Button
-          </Button>
-        </Inline>
+        <Box background="neutralLight" borderRadius="standard" padding="gutter">
+          <Box background="card">
+            <Inline space="xsmall" alignY="center">
+              <Heading level="2">Heading</Heading>
+              <Button bleedY>Button</Button>
+            </Inline>
+          </Box>
+        </Box>
+      ),
+    },
+    {
+      label: 'With vertical bleed (small)',
+      background: 'card',
+      Example: () => (
+        <Box background="neutralLight" borderRadius="standard" padding="gutter">
+          <Box background="card">
+            <Inline space="xsmall" alignY="center">
+              <Heading level="2">Heading</Heading>
+              <Button bleedY size="small">
+                Button
+              </Button>
+            </Inline>
+          </Box>
+        </Box>
       ),
     },
     {

--- a/lib/components/Button/Button.screenshots.tsx
+++ b/lib/components/Button/Button.screenshots.tsx
@@ -3,6 +3,7 @@ import { ComponentScreenshot } from '../../../site/src/types';
 import { background as boxBackgrounds } from '../Box/useBoxStyles.treat';
 import { Box, Button } from '../';
 import { Inline } from '../Inline/Inline';
+import { Heading } from '../Heading/Heading';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -73,6 +74,19 @@ export const screenshots: ComponentScreenshot = {
           </Button>
           <Button size="small" variant="transparent">
             Transparent
+          </Button>
+        </Inline>
+      ),
+    },
+    {
+      label: 'With vertical bleed',
+      background: 'card',
+      Example: () => (
+        <Inline space="small" alignY="center">
+          <Heading level="4">Heading</Heading>
+          <Button bleedY>Button</Button>
+          <Button bleedY size="small">
+            Button
           </Button>
         </Inline>
       ),

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -26,6 +26,7 @@ export const Button = ({
   size,
   tone,
   weight,
+  bleedY,
   variant,
   loading,
   type = 'button',
@@ -41,6 +42,7 @@ export const Button = ({
     weight={weight}
     loading={loading}
     variant={variant}
+    bleedY={bleedY}
   >
     {(ButtonChildren, buttonProps) => (
       <button

--- a/lib/components/ButtonLink/ButtonLink.playroom.tsx
+++ b/lib/components/ButtonLink/ButtonLink.playroom.tsx
@@ -1,14 +1,19 @@
 import React from 'react';
+import { buttonVariants } from '../ButtonRenderer/ButtonRenderer';
 import { ButtonLink as BraidButtonLink, ButtonLinkProps } from './ButtonLink';
 
 export const ButtonLink = ({
   href,
   onClick,
+  variant,
   ...restProps
 }: ButtonLinkProps) => (
   <BraidButtonLink
     href={href ?? ''}
     onClick={onClick ? onClick : (event) => event?.preventDefault()}
+    variant={
+      variant && buttonVariants.indexOf(variant) > -1 ? variant : 'solid'
+    }
     {...restProps}
   />
 );

--- a/lib/components/ButtonLink/ButtonLink.tsx
+++ b/lib/components/ButtonLink/ButtonLink.tsx
@@ -20,6 +20,7 @@ export const ButtonLink = ({
   tone,
   weight,
   variant,
+  bleedY,
   loading,
   ...restProps
 }: ButtonLinkProps) => {
@@ -32,6 +33,7 @@ export const ButtonLink = ({
       weight={weight}
       variant={variant}
       loading={loading}
+      bleedY={bleedY}
     >
       {(ButtonChildren, buttonProps) => (
         <LinkComponent {...restProps} {...buttonProps}>

--- a/lib/components/ButtonRenderer/ButtonRenderer.treat.ts
+++ b/lib/components/ButtonRenderer/ButtonRenderer.treat.ts
@@ -1,5 +1,8 @@
 import { style } from 'sku/treat';
-import buttonSmallPaddingSize from './buttonSmallPaddingSize';
+
+export const constants = {
+  smallButtonPaddingSize: 'small' as const,
+};
 
 export const root = style({
   textDecoration: 'none',
@@ -63,7 +66,7 @@ export const bleedY = style(
       const { capHeight } = typography.text[size][breakpoint];
       const height =
         size === 'small'
-          ? space[buttonSmallPaddingSize] * grid * 2 +
+          ? space[constants.smallButtonPaddingSize] * grid * 2 +
             typography.text.small[breakpoint].rows * grid
           : touchableSize * grid;
 

--- a/lib/components/ButtonRenderer/ButtonRenderer.treat.ts
+++ b/lib/components/ButtonRenderer/ButtonRenderer.treat.ts
@@ -1,4 +1,5 @@
 import { style } from 'sku/treat';
+import buttonSmallPaddingSize from './buttonSmallPaddingSize';
 
 export const root = style({
   textDecoration: 'none',
@@ -48,6 +49,44 @@ export const focusOverlay = style({
     },
   },
 });
+
+export const standard = style({});
+export const small = style({});
+
+export const bleedY = style(
+  ({ utils, touchableSize, space, grid, typography }) => {
+    type TextBreakpoint = keyof typeof typography.text.small;
+    const stylesForBreakpoint = (
+      breakpoint: TextBreakpoint,
+      size: 'standard' | 'small',
+    ) => {
+      const { capHeight } = typography.text[size][breakpoint];
+      const height =
+        size === 'small'
+          ? space[buttonSmallPaddingSize] * grid * 2 +
+            typography.text.small[breakpoint].rows * grid
+          : touchableSize * grid;
+
+      return {
+        marginTop: `-${(height - capHeight) / 2}px`,
+        marginBottom: `-${(height - capHeight) / 2}px`,
+      };
+    };
+
+    return {
+      selectors: {
+        [`${standard}&`]: utils.responsiveStyle({
+          mobile: stylesForBreakpoint('mobile', 'standard'),
+          tablet: stylesForBreakpoint('tablet', 'standard'),
+        }),
+        [`${small}&`]: utils.responsiveStyle({
+          mobile: stylesForBreakpoint('mobile', 'small'),
+          tablet: stylesForBreakpoint('tablet', 'small'),
+        }),
+      },
+    };
+  },
+);
 
 export const loadingDot = style({
   animationDuration: '1s',

--- a/lib/components/ButtonRenderer/ButtonRenderer.treat.ts
+++ b/lib/components/ButtonRenderer/ButtonRenderer.treat.ts
@@ -1,7 +1,7 @@
 import { style } from 'sku/treat';
 
 export const constants = {
-  smallButtonPaddingSize: 'small' as const,
+  smallButtonPaddingSize: 'xsmall' as const,
 };
 
 export const root = style({

--- a/lib/components/ButtonRenderer/ButtonRenderer.tsx
+++ b/lib/components/ButtonRenderer/ButtonRenderer.tsx
@@ -21,7 +21,6 @@ import { FieldOverlay } from '../private/FieldOverlay/FieldOverlay';
 import { useTouchableSpace } from '../../hooks/typography';
 import { useVirtualTouchable } from '../private/touchable/useVirtualTouchable';
 import ActionsContext from '../Actions/ActionsContext';
-import buttonSmallPaddingSize from './buttonSmallPaddingSize';
 import * as styleRefs from './ButtonRenderer.treat';
 
 export const buttonVariants = [
@@ -206,7 +205,9 @@ const ButtonChildren = ({ children }: ButtonChildrenProps) => {
         paddingX={
           size === 'small' || variant === 'transparent' ? 'small' : 'medium'
         }
-        paddingY={size === 'small' ? buttonSmallPaddingSize : undefined}
+        paddingY={
+          size === 'small' ? styles.constants.smallButtonPaddingSize : undefined
+        }
         pointerEvents="none"
         textAlign="center"
         overflow="hidden"

--- a/lib/components/ButtonRenderer/ButtonRenderer.tsx
+++ b/lib/components/ButtonRenderer/ButtonRenderer.tsx
@@ -24,10 +24,17 @@ import ActionsContext from '../Actions/ActionsContext';
 import buttonSmallPaddingSize from './buttonSmallPaddingSize';
 import * as styleRefs from './ButtonRenderer.treat';
 
+export const buttonVariants = [
+  'solid',
+  'ghost',
+  'soft',
+  'transparent',
+] as const;
+
 type ButtonSize = 'standard' | 'small';
 type ButtonTone = 'brandAccent' | 'critical';
 type ButtonWeight = 'weak' | 'regular' | 'strong';
-type ButtonVariant = 'solid' | 'ghost' | 'soft' | 'transparent';
+type ButtonVariant = typeof buttonVariants[number];
 type ButtonStyles = {
   textTone: TextProps['tone'];
   background: UseBoxStylesProps['background'];
@@ -36,7 +43,7 @@ type ButtonStyles = {
   boxShadow: UseBoxStylesProps['boxShadow'];
 };
 
-const buttonVariants: Record<
+const buttonVariantStyles: Record<
   ButtonVariant,
   Record<'default' | ButtonTone, ButtonStyles>
 > = {
@@ -147,8 +154,8 @@ const useButtonVariant = (variant: ButtonVariant, tone?: ButtonTone) => {
   }
 
   return (
-    buttonVariants[variant][tone ?? 'default'] ??
-    buttonVariants[variant].default
+    buttonVariantStyles[variant][tone ?? 'default'] ??
+    buttonVariantStyles[variant].default
   );
 };
 

--- a/lib/components/ButtonRenderer/ButtonRenderer.tsx
+++ b/lib/components/ButtonRenderer/ButtonRenderer.tsx
@@ -21,6 +21,7 @@ import { FieldOverlay } from '../private/FieldOverlay/FieldOverlay';
 import { useTouchableSpace } from '../../hooks/typography';
 import { useVirtualTouchable } from '../private/touchable/useVirtualTouchable';
 import ActionsContext from '../Actions/ActionsContext';
+import buttonSmallPaddingSize from './buttonSmallPaddingSize';
 import * as styleRefs from './ButtonRenderer.treat';
 
 type ButtonSize = 'standard' | 'small';
@@ -198,7 +199,7 @@ const ButtonChildren = ({ children }: ButtonChildrenProps) => {
         paddingX={
           size === 'small' || variant === 'transparent' ? 'small' : 'medium'
         }
-        paddingY={size === 'small' ? 'xsmall' : undefined}
+        paddingY={size === 'small' ? buttonSmallPaddingSize : undefined}
         pointerEvents="none"
         textAlign="center"
         overflow="hidden"
@@ -237,6 +238,7 @@ export interface PrivateButtonRendererProps {
   size?: ButtonSize;
   tone?: ButtonTone;
   variant?: ButtonVariant;
+  bleedY?: boolean;
   /** @deprecated The `weight` prop has been deprecated. Please choose a [variant](https://seek-oss.github.io/braid-design-system/components/Button#variants) instead. */
   weight?: ButtonWeight;
   loading?: boolean;
@@ -289,6 +291,7 @@ export const PrivateButtonRenderer = ({
   size: sizeProp,
   tone: toneProp,
   variant: variantProp,
+  bleedY,
   weight,
   loading = false,
   children,
@@ -359,6 +362,8 @@ export const PrivateButtonRenderer = ({
       variant !== 'solid' ? styles.lightHoverBg : null,
       useBackgroundLightness() === 'dark' ? styles.inverted : null,
       size === 'small' ? virtualTouchableStyles : null,
+      size === 'standard' ? styles.standard : styles.small,
+      bleedY ? styles.bleedY : null,
     ],
   });
 

--- a/lib/components/ButtonRenderer/buttonSmallPaddingSize.ts
+++ b/lib/components/ButtonRenderer/buttonSmallPaddingSize.ts
@@ -1,0 +1,1 @@
+export default 'xsmall';

--- a/lib/components/ButtonRenderer/buttonSmallPaddingSize.ts
+++ b/lib/components/ButtonRenderer/buttonSmallPaddingSize.ts
@@ -1,1 +1,0 @@
-export default 'xsmall';

--- a/lib/playroom/components.ts
+++ b/lib/playroom/components.ts
@@ -3,6 +3,7 @@ export * from '../components';
 
 export { AccordionItem } from '../components/Accordion/AccordionItem.playroom';
 export { Autosuggest } from '../components/Autosuggest/Autosuggest.playroom';
+export { Button } from '../components/Button/Button.playroom';
 export { ButtonLink } from '../components/ButtonLink/ButtonLink.playroom';
 export { Checkbox } from '../components/Checkbox/Checkbox.playroom';
 export { Dialog } from '../components/Dialog/Dialog.playroom';


### PR DESCRIPTION
**Button, ButtonLink, ButtonRenderer:** Add `bleedY` prop

You can now choose to allow the button’s background colour to bleed out into the surrounding layout, making it easier to align with other elements.

For example, we can align a button to a Heading element using an Inline, even though the button is actually taller than the heading. If we didn’t use the **bleedY** prop in this case, the button would introduce unwanted space above and below the heading.

**EXAMPLE USAGE:**
```jsx
<Inline space="small" alignY="center">
  <Heading level="4">Heading</Heading>
  <Button bleedY>Button</Button>
  <Button bleedY size="small">
    Button
  </Button>
</Inline>
```

[Playroom Demo](https://braid-design-system--8c5ab9100e8f713f58fcd50b597a68ffffcddb63.surge.sh/playroom/#?code=N4Igxg9gJgpiBcIA8AhCAPABABwIZSgEsA7AcwF4AdEAG1wCdSZqA%2BS4zTJAYQhoFcAtsQDOmEXjAwqIUvwAu8mPWqZINOthEwUMGhADuM%2BbgBGNGPNbtOnHnyHE2HW3YDKJsAGtxk6dRFBXA1rF1c7ABUYdHlxQgAvfxB0QOCaVXkIYiTtSGIoBgBPUPDwlABRADEAeQAlcvgbUq4AeiiY52aubgYoTq6uNCxTXG9Segh%2BfJkwekJ5QjBggBlCUgALKxB%2Bga4PUZ8JUaS6RmZtpt27IcwRsYmpqBnekqvXJHbYzOyZXKyC%2BjFC5hN62ZYQegwQSYQhaISYKB8CFxWK4QSWAA0aiyuSU8n49Ew%2BFhhBEYBIpEwenmADpLqCkG1ovIdldGUNWbtUBhbgdxpNptQlvQoK9QVwAJLEGgkGC%2BY4yFJBEIgIky0jEACaMxgxCUKmB4veAAkYMSyJgLAA3PQyABMrFN5tIjKdRDInIZKAU3xY3sUWXZPqynq5LSlMuyoea7Iw0dK3OGfIegvAL0NRo%2BzMw3xyMDyAKB8YGAFlcATSZgbetFvw6ES9XLsAT%2BCIsdkwGrCABHfhoy1rOu4NQEkStqvzXAwOkg8UANUIVrR4%2B0gmwyiJ9DA-ARhDRM6NrU%2BxfeLQ59K6jP23mLsfQ0cZPRFnqvni8rMfDmEH94Am-F72N95SkX5lXSDME0%2BOJEkVVIVRzLI8wLIoxWaABBSoInKWpGlnWxGWPAC7CfPoiPwm47i8flHhkbAIBEeZFxgVYNi2E9AIOYCTgYJhUK5CjkwFJ4hXTdj3ig3Nfnzf4UIgo1wUhaFYTHaFEX0QkGNRdF5CxPJcUsAkiSIbBSXJC1qXkA9MyZDoyITM84zs8JE15e4hOeEU%2BLZCNZS42CwNUYI1i1HVGwNMTnLdClLRgG0aHtR0zXdF0Wiij0nMvf1vluCwYCgTU-WDYggwDJwMuc8NpVlCK7xqgS3JokTPLkt4sxiBCfgCaT8lkiLXDLCsxGrWt61wRscBbNtMA7Lte37dUhxHegxyGydp3K0oFyXQQVyhddCQYbdd33Db8JsllTtq8rXwOW8HPvMjH16F8Wmvd96U-P8ypcT7HBEZwruIEAMRAeR1ihGARAQABtEBcEkEAAF0QYMQgoDBqH4GhgB2AA2AAORGAF8gA)