### PR TITLE
Tabs, Tiles: Remove Card from screenshot tests

### DIFF
--- a/lib/components/Tabs/Tabs.screenshots.tsx
+++ b/lib/components/Tabs/Tabs.screenshots.tsx
@@ -1,18 +1,7 @@
 import React from 'react';
 import { ComponentScreenshot } from '../../../site/src/types';
-import {
-  Stack,
-  Tabs,
-  Tab,
-  TabPanel,
-  TabPanels,
-  TabsProvider,
-  Badge,
-  Card,
-  Box,
-} from '..';
+import { Stack, Tabs, Tab, TabPanel, TabPanels, TabsProvider, Badge } from '..';
 import { Placeholder } from '../../playroom/components';
-import { useBraidTheme } from '../BraidProvider/BraidThemeContext';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320, 1200],
@@ -20,70 +9,16 @@ export const screenshots: ComponentScreenshot = {
     {
       label: 'Left aligned',
       Example: ({ id }) => (
-        <Card>
-          <TabsProvider id={id}>
-            <Stack space="medium">
-              <Tabs label="Test tabs">
-                <Tab>The first tab</Tab>
-                <Tab>The second tab</Tab>
-                <Tab>The third tab</Tab>
-                <Tab badge={<Badge tone="positive">New</Badge>}>
-                  The fourth tab
-                </Tab>
-              </Tabs>
-              <TabPanels>
-                <TabPanel>
-                  <Placeholder height={200} label="Panel 1" />
-                </TabPanel>
-                <TabPanel>
-                  <Placeholder height={200} label="Panel 2" />
-                </TabPanel>
-                <TabPanel>
-                  <Placeholder height={200} label="Panel 3" />
-                </TabPanel>
-                <TabPanel>
-                  <Placeholder height={200} label="Panel 4" />
-                </TabPanel>
-              </TabPanels>
-            </Stack>
-          </TabsProvider>
-        </Card>
-      ),
-    },
-    {
-      label: 'Center aligned',
-      Example: ({ id }) => (
-        <Card>
-          <TabsProvider id={id}>
-            <Stack space="medium">
-              <Tabs label="Test tabs" align="center">
-                <Tab>Tab 1</Tab>
-                <Tab>Tab 2</Tab>
-              </Tabs>
-              <TabPanels>
-                <TabPanel>
-                  <Placeholder height={200} label="Panel 1" />
-                </TabPanel>
-                <TabPanel>
-                  <Placeholder height={200} label="Panel 2" />
-                </TabPanel>
-              </TabPanels>
-            </Stack>
-          </TabsProvider>
-        </Card>
-      ),
-    },
-    {
-      label: 'With gutter',
-      Example: ({ id }) => (
         <TabsProvider id={id}>
-          <Tabs label="Test tabs" gutter="gutter">
-            <Tab>The first tab</Tab>
-            <Tab>The second tab</Tab>
-            <Tab>The third tab</Tab>
-            <Tab>The fourth tab</Tab>
-          </Tabs>
-          <Card>
+          <Stack space="medium">
+            <Tabs label="Test tabs">
+              <Tab>The first tab</Tab>
+              <Tab>The second tab</Tab>
+              <Tab>The third tab</Tab>
+              <Tab badge={<Badge tone="positive">New</Badge>}>
+                The fourth tab
+              </Tab>
+            </Tabs>
             <TabPanels>
               <TabPanel>
                 <Placeholder height={200} label="Panel 1" />
@@ -98,7 +33,57 @@ export const screenshots: ComponentScreenshot = {
                 <Placeholder height={200} label="Panel 4" />
               </TabPanel>
             </TabPanels>
-          </Card>
+          </Stack>
+        </TabsProvider>
+      ),
+    },
+    {
+      label: 'Center aligned',
+      Example: ({ id }) => (
+        <TabsProvider id={id}>
+          <Stack space="medium">
+            <Tabs label="Test tabs" align="center">
+              <Tab>Tab 1</Tab>
+              <Tab>Tab 2</Tab>
+            </Tabs>
+            <TabPanels>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 1" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 2" />
+              </TabPanel>
+            </TabPanels>
+          </Stack>
+        </TabsProvider>
+      ),
+    },
+    {
+      label: 'With gutter',
+      Example: ({ id }) => (
+        <TabsProvider id={id}>
+          <Stack space="medium">
+            <Tabs label="Test tabs" gutter="gutter">
+              <Tab>The first tab</Tab>
+              <Tab>The second tab</Tab>
+              <Tab>The third tab</Tab>
+              <Tab>The fourth tab</Tab>
+            </Tabs>
+            <TabPanels>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 1" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 2" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 3" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 4" />
+              </TabPanel>
+            </TabPanels>
+          </Stack>
         </TabsProvider>
       ),
     },
@@ -106,13 +91,13 @@ export const screenshots: ComponentScreenshot = {
       label: 'With gutter and reserved hit area',
       Example: ({ id }) => (
         <TabsProvider id={id}>
-          <Tabs label="Test tabs" gutter="gutter" reserveHitArea>
-            <Tab>The first tab</Tab>
-            <Tab>The second tab</Tab>
-            <Tab>The third tab</Tab>
-            <Tab>The fourth tab</Tab>
-          </Tabs>
-          <Card>
+          <Stack space="medium">
+            <Tabs label="Test tabs" gutter="gutter" reserveHitArea>
+              <Tab>The first tab</Tab>
+              <Tab>The second tab</Tab>
+              <Tab>The third tab</Tab>
+              <Tab>The fourth tab</Tab>
+            </Tabs>
             <TabPanels>
               <TabPanel>
                 <Placeholder height={200} label="Panel 1" />
@@ -127,7 +112,7 @@ export const screenshots: ComponentScreenshot = {
                 <Placeholder height={200} label="Panel 4" />
               </TabPanel>
             </TabPanels>
-          </Card>
+          </Stack>
         </TabsProvider>
       ),
     },
@@ -201,21 +186,22 @@ export const screenshots: ComponentScreenshot = {
     {
       label:
         'Test: Selected tab with gutter should be scrolled into view on load',
-      Container: ({ children }) => (
-        <Box style={{ background: useBraidTheme().color.background.body }}>
-          {children}
-        </Box>
-      ),
       Example: ({ id }) => (
         <TabsProvider id={id} selectedItem="3">
-          <Tabs label="Test tabs" align="center" gutter="gutter" reserveHitArea>
-            <Tab item="1">The first tab</Tab>
-            <Tab item="2">The second tab</Tab>
-            <Tab item="3">The third tab</Tab>
-            <Tab item="4">The fourth tab</Tab>
-            <Tab item="5">The fifth tab</Tab>
-          </Tabs>
-          <Card>
+          <Stack space="medium">
+            <Tabs
+              label="Test tabs"
+              align="center"
+              gutter="gutter"
+              reserveHitArea
+            >
+              <Tab item="1">The first tab</Tab>
+              <Tab item="2">The second tab</Tab>
+              <Tab item="3">The third tab</Tab>
+              <Tab item="4">The fourth tab</Tab>
+              <Tab item="5">The fifth tab</Tab>
+            </Tabs>
+
             <TabPanels>
               <TabPanel>
                 <Placeholder height={200} label="Panel 1" />
@@ -233,65 +219,19 @@ export const screenshots: ComponentScreenshot = {
                 <Placeholder height={200} label="Panel 5" />
               </TabPanel>
             </TabPanels>
-          </Card>
+          </Stack>
         </TabsProvider>
       ),
     },
     {
       label: 'Full width divider',
       Example: ({ id }) => (
-        <Card>
-          <TabsProvider id={id}>
-            <Stack space="medium">
-              <Tabs label="Test tabs" divider="full">
-                <Tab>Tab 1</Tab>
-                <Tab>Tab 2</Tab>
-              </Tabs>
-              <TabPanels>
-                <TabPanel>
-                  <Placeholder height={200} label="Panel 1" />
-                </TabPanel>
-                <TabPanel>
-                  <Placeholder height={200} label="Panel 2" />
-                </TabPanel>
-              </TabPanels>
-            </Stack>
-          </TabsProvider>
-        </Card>
-      ),
-    },
-    {
-      label: 'Full width divider while center aligned',
-      Example: ({ id }) => (
-        <Card>
-          <TabsProvider id={id}>
-            <Stack space="medium">
-              <Tabs label="Test tabs" align="center" divider="full">
-                <Tab>Tab 1</Tab>
-                <Tab>Tab 2</Tab>
-              </Tabs>
-              <TabPanels>
-                <TabPanel>
-                  <Placeholder height={200} label="Panel 1" />
-                </TabPanel>
-                <TabPanel>
-                  <Placeholder height={200} label="Panel 2" />
-                </TabPanel>
-              </TabPanels>
-            </Stack>
-          </TabsProvider>
-        </Card>
-      ),
-    },
-    {
-      label: 'Full width divider with gutter',
-      Example: ({ id }) => (
         <TabsProvider id={id}>
-          <Tabs label="Test tabs" gutter="gutter" reserveHitArea divider="full">
-            <Tab>Tab 1</Tab>
-            <Tab>Tab 2</Tab>
-          </Tabs>
-          <Card>
+          <Stack space="medium">
+            <Tabs label="Test tabs" divider="full">
+              <Tab>Tab 1</Tab>
+              <Tab>Tab 2</Tab>
+            </Tabs>
             <TabPanels>
               <TabPanel>
                 <Placeholder height={200} label="Panel 1" />
@@ -300,7 +240,54 @@ export const screenshots: ComponentScreenshot = {
                 <Placeholder height={200} label="Panel 2" />
               </TabPanel>
             </TabPanels>
-          </Card>
+          </Stack>
+        </TabsProvider>
+      ),
+    },
+    {
+      label: 'Full width divider while center aligned',
+      Example: ({ id }) => (
+        <TabsProvider id={id}>
+          <Stack space="medium">
+            <Tabs label="Test tabs" align="center" divider="full">
+              <Tab>Tab 1</Tab>
+              <Tab>Tab 2</Tab>
+            </Tabs>
+            <TabPanels>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 1" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 2" />
+              </TabPanel>
+            </TabPanels>
+          </Stack>
+        </TabsProvider>
+      ),
+    },
+    {
+      label: 'Full width divider with gutter',
+      Example: ({ id }) => (
+        <TabsProvider id={id}>
+          <Stack space="medium">
+            <Tabs
+              label="Test tabs"
+              gutter="gutter"
+              reserveHitArea
+              divider="full"
+            >
+              <Tab>Tab 1</Tab>
+              <Tab>Tab 2</Tab>
+            </Tabs>
+            <TabPanels>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 1" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={200} label="Panel 2" />
+              </TabPanel>
+            </TabPanels>
+          </Stack>
         </TabsProvider>
       ),
     },

--- a/lib/components/Tiles/Tiles.screenshots.tsx
+++ b/lib/components/Tiles/Tiles.screenshots.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { ComponentScreenshot } from '../../../site/src/types';
-import { Tiles, Card, Text } from '../';
+import { Tiles, Box, Text } from '../';
 import { Placeholder } from '../private/Placeholder/Placeholder';
 
 const exampleRows = 3;
@@ -34,9 +34,9 @@ export const screenshots: ComponentScreenshot = {
       Example: () => (
         <Tiles space={['none', 'small']} columns={[1, 2]} dividers>
           {[...new Array(2 * exampleRows)].map((_, i) => (
-            <Card key={i}>
+            <Box background="card" padding="gutter" key={i}>
               <Text>Tile</Text>
-            </Card>
+            </Box>
           ))}
         </Tiles>
       ),
@@ -46,9 +46,9 @@ export const screenshots: ComponentScreenshot = {
       Example: () => (
         <Tiles space={['none', 'small']} columns={[1, 2]} dividers="strong">
           {[...new Array(2 * exampleRows)].map((_, i) => (
-            <Card key={i}>
+            <Box background="card" padding="gutter" key={i}>
               <Text>Tile</Text>
-            </Card>
+            </Box>
           ))}
         </Tiles>
       ),


### PR DESCRIPTION
These tests should not be bound to the visual implementation of a `Card`, so decoupling before upcoming `Card` changes.