### PR TITLE
TooltipRenderer: Support usage within Text elements

### DIFF
--- a/.changeset/six-carpets-sing.md
+++ b/.changeset/six-carpets-sing.md
@@ -1,0 +1,9 @@
+---
+'braid-design-system': patch
+---
+---
+updated:
+  - TooltipRenderer
+---
+
+**TooltipRenderer:** Support usage within `Text` elements

--- a/lib/components/Hidden/Hidden.tsx
+++ b/lib/components/Hidden/Hidden.tsx
@@ -1,7 +1,7 @@
 import React, { useContext, ReactNode } from 'react';
 import { useStyles } from 'sku/react-treat';
 import { Box, BoxProps } from '../Box/Box';
-import TextContext from '../Text/TextContext';
+import { TextContext } from '../Text/TextContext';
 import HeadingContext from '../Heading/HeadingContext';
 import {
   resolveResponsiveRangeProps,

--- a/lib/components/HiddenVisually/HiddenVisually.tsx
+++ b/lib/components/HiddenVisually/HiddenVisually.tsx
@@ -1,7 +1,7 @@
 import React, { useContext } from 'react';
 import { useStyles } from 'sku/react-treat';
 import { Box, BoxProps } from '../Box/Box';
-import TextContext from '../Text/TextContext';
+import { TextContext } from '../Text/TextContext';
 import HeadingContext from '../Heading/HeadingContext';
 import * as styleRefs from './HiddenVisually.treat';
 

--- a/lib/components/Text/Text.tsx
+++ b/lib/components/Text/Text.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useContext, useMemo } from 'react';
 import assert from 'assert';
-import TextContext from './TextContext';
+import { TextContext } from './TextContext';
 import { Box, BoxProps } from '../Box/Box';
 import buildDataAttributes, {
   DataAttributeMap,

--- a/lib/components/Text/TextContext.ts
+++ b/lib/components/Text/TextContext.ts
@@ -1,6 +1,4 @@
 import { createContext } from 'react';
 import { UseTextProps } from '../../hooks/typography';
 
-const textContext = createContext<UseTextProps | false>(false);
-
-export default textContext;
+export const TextContext = createContext<UseTextProps | false>(false);

--- a/lib/components/TextDropdown/TextDropdown.tsx
+++ b/lib/components/TextDropdown/TextDropdown.tsx
@@ -5,7 +5,7 @@ import { Overlay } from '../private/Overlay/Overlay';
 import { Box } from '../Box/Box';
 import { IconChevron } from '../icons';
 import * as styleRefs from './TextDropdown.treat';
-import TextContext from '../Text/TextContext';
+import { TextContext } from '../Text/TextContext';
 import HeadingContext from '../Heading/HeadingContext';
 
 interface TextDropdownOption<Value> {

--- a/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
+++ b/lib/components/TextLinkRenderer/TextLinkRenderer.tsx
@@ -4,7 +4,7 @@ import dedent from 'dedent';
 import assert from 'assert';
 import classnames from 'classnames';
 import TextLinkRendererContext from './TextLinkRendererContext';
-import TextContext from '../Text/TextContext';
+import { TextContext } from '../Text/TextContext';
 import HeadingContext from '../Heading/HeadingContext';
 import ActionsContext from '../Actions/ActionsContext';
 import { FieldOverlay } from '../private/FieldOverlay/FieldOverlay';

--- a/lib/components/TooltipRenderer/TooltipRenderer.test.tsx
+++ b/lib/components/TooltipRenderer/TooltipRenderer.test.tsx
@@ -10,13 +10,15 @@ describe('TooltipRenderer', () => {
   it('should associate the trigger with the label', async () => {
     const { getByRole, getByLabelText } = render(
       <BraidTestProvider themeName="wireframe">
-        <TooltipRenderer id="TEST_ID" tooltip={<Text>Tooltip text.</Text>}>
-          {({ triggerProps }) => (
-            <Box aria-label="Trigger" {...triggerProps}>
-              <Text>Trigger</Text>
-            </Box>
-          )}
-        </TooltipRenderer>
+        <Text>
+          <TooltipRenderer id="TEST_ID" tooltip={<Text>Tooltip text.</Text>}>
+            {({ triggerProps }) => (
+              <Box component="span" aria-label="Trigger" {...triggerProps}>
+                Trigger
+              </Box>
+            )}
+          </TooltipRenderer>
+        </Text>
       </BraidTestProvider>,
     );
 
@@ -30,13 +32,15 @@ describe('TooltipRenderer', () => {
   it('should handle hover', async () => {
     const { getByRole, getByLabelText } = render(
       <BraidTestProvider themeName="wireframe">
-        <TooltipRenderer id="TEST_ID" tooltip={<Text>Tooltip text.</Text>}>
-          {({ triggerProps }) => (
-            <Box aria-label="Trigger" {...triggerProps}>
-              <Text>Trigger</Text>
-            </Box>
-          )}
-        </TooltipRenderer>
+        <Text>
+          <TooltipRenderer id="TEST_ID" tooltip={<Text>Tooltip text.</Text>}>
+            {({ triggerProps }) => (
+              <Box component="span" aria-label="Trigger" {...triggerProps}>
+                Trigger
+              </Box>
+            )}
+          </TooltipRenderer>
+        </Text>
       </BraidTestProvider>,
     );
 
@@ -62,13 +66,15 @@ describe('TooltipRenderer', () => {
   it('should hide on scroll', async () => {
     const { getByRole, getByLabelText, container } = render(
       <BraidTestProvider themeName="wireframe">
-        <TooltipRenderer id="TEST_ID" tooltip={<Text>Tooltip text.</Text>}>
-          {({ triggerProps }) => (
-            <Box aria-label="Trigger" {...triggerProps}>
-              <Text>Trigger</Text>
-            </Box>
-          )}
-        </TooltipRenderer>
+        <Text>
+          <TooltipRenderer id="TEST_ID" tooltip={<Text>Tooltip text.</Text>}>
+            {({ triggerProps }) => (
+              <Box component="span" aria-label="Trigger" {...triggerProps}>
+                Trigger
+              </Box>
+            )}
+          </TooltipRenderer>
+        </Text>
       </BraidTestProvider>,
     );
 
@@ -94,13 +100,15 @@ describe('TooltipRenderer', () => {
   it('should handle keyboard focus', async () => {
     const { getByRole, getByLabelText } = render(
       <BraidTestProvider themeName="wireframe">
-        <TooltipRenderer id="TEST_ID" tooltip={<Text>Tooltip text.</Text>}>
-          {({ triggerProps }) => (
-            <Box aria-label="Trigger" {...triggerProps}>
-              <Text>Trigger</Text>
-            </Box>
-          )}
-        </TooltipRenderer>
+        <Text>
+          <TooltipRenderer id="TEST_ID" tooltip={<Text>Tooltip text.</Text>}>
+            {({ triggerProps }) => (
+              <Box component="span" aria-label="Trigger" {...triggerProps}>
+                Trigger
+              </Box>
+            )}
+          </TooltipRenderer>
+        </Text>
       </BraidTestProvider>,
     );
 

--- a/lib/components/TooltipRenderer/TooltipRenderer.tsx
+++ b/lib/components/TooltipRenderer/TooltipRenderer.tsx
@@ -13,6 +13,7 @@ import assert from 'assert';
 import { ReactNodeNoStrings } from '../private/ReactNodeNoStrings';
 import { BackgroundProvider } from '../Box/BackgroundContext';
 import { useBoxStyles } from '../Box/useBoxStyles';
+import { TextContext } from '../Text/TextContext';
 import { DefaultTextPropsProvider } from '../private/defaultTextProps';
 import { useSpace } from '../useSpace/useSpace';
 import { useThemeName } from '../useThemeName/useThemeName';
@@ -270,21 +271,23 @@ export const TooltipRenderer = ({
 
       {triggerRef &&
         createPortal(
-          <div
-            id={id}
-            role="tooltip"
-            hidden={!visible ? true : undefined}
-            className={tooltipStyles}
-            {...(visible
-              ? getTooltipProps({
-                  ref: setTooltipRef,
-                })
-              : null)}
-          >
-            <TooltipContent opacity={opacity} arrowProps={getArrowProps()}>
-              {tooltip}
-            </TooltipContent>
-          </div>,
+          <TextContext.Provider value={false}>
+            <div
+              id={id}
+              role="tooltip"
+              hidden={!visible ? true : undefined}
+              className={tooltipStyles}
+              {...(visible
+                ? getTooltipProps({
+                    ref: setTooltipRef,
+                  })
+                : null)}
+            >
+              <TooltipContent opacity={opacity} arrowProps={getArrowProps()}>
+                {tooltip}
+              </TooltipContent>
+            </div>
+          </TextContext.Provider>,
           document.body,
         )}
     </>

--- a/lib/hooks/useIcon/index.ts
+++ b/lib/hooks/useIcon/index.ts
@@ -5,7 +5,7 @@ import classnames from 'classnames';
 
 import { OptionalTitle } from '../../components/icons/SVGTypes';
 import { BoxProps } from '../../components/Box/Box';
-import TextContext from '../../components/Text/TextContext';
+import { TextContext } from '../../components/Text/TextContext';
 import HeadingContext from '../../components/Heading/HeadingContext';
 import { useTextSize, useTextTone, UseTextProps } from '../typography';
 import { useLineHeightContainer } from '../useLineHeightContainer/useLineHeightContainer';


### PR DESCRIPTION
Because we're rendering the tooltip into a portal, we need to reset the TextContext so we don't trigger the Text within Text check. Updated the test suite to exercise this new logic.

Also refactored TextContext to use a named export because auto import was giving me grief.