### PR TITLE
Add `size` support to Checkbox, RadioGroup & Toggle

### DIFF
--- a/.changeset/ninety-otters-beg.md
+++ b/.changeset/ninety-otters-beg.md
@@ -1,0 +1,29 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Checkbox
+  - RadioGroup
+  - Toggle
+---
+
+**Checkbox,RadioGroup,Toggle:** Add `size` support to Checkbox, RadioGroup & Toggle
+
+Adds support for adjusting the `size` of a `Checkbox`, the RadioItems within a `RadioGroup` or a `Toggle`. Setting the size adjusts both the visual control and the text size of the label.
+
+**EXAMPLE USAGE:**
+```jsx
+  <Checkbox size="small" label="Label" />
+```
+
+```jsx
+  <RadioGroup size="small" label="Label">
+    ...
+  </RadioGroup>
+```
+
+```jsx
+  <Toggle size="small" label="Label" />
+```

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -2317,6 +2317,9 @@ Object {
         | RefObject<HTMLInputElement>
     required?: boolean
     reserveMessageSpace?: boolean
+    size?: 
+        | "small"
+        | "standard"
     tone?: 
         | "critical"
         | "neutral"
@@ -5917,6 +5920,9 @@ Object {
     required?: boolean
     reserveMessageSpace?: boolean
     secondaryLabel?: ReactNode
+    size?: 
+        | "small"
+        | "standard"
     tertiaryLabel?: ReactNode
     tone?: 
         | "critical"
@@ -6961,6 +6967,9 @@ Object {
     label: ReactNode
     on: boolean
     onChange: ChangeHandler
+    size?: 
+        | "small"
+        | "standard"
 },
 }
 `;

--- a/lib/components/Checkbox/Checkbox.docs.tsx
+++ b/lib/components/Checkbox/Checkbox.docs.tsx
@@ -100,6 +100,35 @@ const docs: ComponentDocs = {
         ),
     },
     {
+      label: 'Sizes',
+      description: (
+        <Text>
+          You can customise the size of the checkbox via the{' '}
+          <Strong>size</Strong> prop, which accepts either{' '}
+          <Strong>standard</Strong> or <Strong>small.</Strong>
+        </Text>
+      ),
+      Example: ({ id, getState, toggleState }) =>
+        source(
+          <Stack space="medium">
+            <Checkbox
+              id={`${id}_standard`}
+              label="Standard"
+              checked={getState('two')}
+              onChange={() => toggleState('two')}
+              size="standard"
+            />
+            <Checkbox
+              id={`${id}_small`}
+              label="Small"
+              checked={getState('one')}
+              onChange={() => toggleState('one')}
+              size="small"
+            />
+          </Stack>,
+        ),
+    },
+    {
       label: 'Disabled field',
       description: (
         <Text>

--- a/lib/components/Checkbox/Checkbox.gallery.tsx
+++ b/lib/components/Checkbox/Checkbox.gallery.tsx
@@ -14,25 +14,6 @@ export const galleryItems: ComponentExample[] = [
           checked={getState('checked')}
           onChange={() => toggleState('checked')}
           label="Label"
-          badge={
-            <Badge tone="positive" weight="strong">
-              New
-            </Badge>
-          }
-        />,
-      ),
-  },
-  {
-    label: 'With a critical message',
-    Example: ({ id, getState, toggleState }) =>
-      source(
-        <Checkbox
-          id={id}
-          checked={getState('checked')}
-          onChange={() => toggleState('checked')}
-          label="Label"
-          message="Critical message"
-          tone="critical"
         />,
       ),
   },
@@ -115,6 +96,19 @@ export const galleryItems: ComponentExample[] = [
             label="Disabled"
           />
         </Stack>,
+      ),
+  },
+  {
+    label: 'Small',
+    Example: ({ id, getState, toggleState }) =>
+      source(
+        <Checkbox
+          id={id}
+          checked={getState('checked')}
+          onChange={() => toggleState('checked')}
+          label="Label"
+          size="small"
+        />,
       ),
   },
 ];

--- a/lib/components/Checkbox/Checkbox.screenshots.tsx
+++ b/lib/components/Checkbox/Checkbox.screenshots.tsx
@@ -6,7 +6,7 @@ export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],
   examples: [
     {
-      label: 'Standard Checkbox',
+      label: 'Standard',
       Example: ({ id }) => {
         const [state, setState] = useState(false);
         return (
@@ -20,19 +20,34 @@ export const screenshots: ComponentScreenshot = {
       },
     },
     {
-      label: 'Checked Checkbox',
+      label: 'Small',
+      Example: ({ id }) => {
+        const [state, setState] = useState(false);
+        return (
+          <Checkbox
+            id={id}
+            checked={state}
+            onChange={() => setState(!state)}
+            label="Label"
+            size="small"
+          />
+        );
+      },
+    },
+    {
+      label: 'Checked',
       Example: ({ id, handler }) => (
         <Checkbox id={id} checked={true} onChange={handler} label="Label" />
       ),
     },
     {
-      label: 'Mixed state Checkbox',
+      label: 'Mixed state',
       Example: ({ id, handler }) => (
         <Checkbox id={id} checked="mixed" onChange={handler} label="Label" />
       ),
     },
     {
-      label: 'Disabled Checkbox',
+      label: 'Disabled',
       background: 'card',
       Example: ({ id, handler }) => (
         <Checkbox
@@ -45,7 +60,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Critical Checkbox',
+      label: 'Critical',
       Example: ({ id, handler }) => (
         <Checkbox
           id={id}
@@ -58,7 +73,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Checkbox with description',
+      label: 'With a description',
       Example: ({ id, handler }) => (
         <Checkbox
           id={id}
@@ -70,7 +85,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Checkbox with a Badge',
+      label: 'With a Badge',
       Example: ({ id, handler }) => (
         <Checkbox
           id={id}
@@ -86,7 +101,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Checkbox with a Badge and description',
+      label: 'With a Badge and description',
       Example: ({ id, handler }) => (
         <Checkbox
           id={id}
@@ -103,7 +118,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Checkbox with nested content visible only when checked',
+      label: 'With nested content visible only when checked',
       Example: ({ id }) => {
         const [state, setState] = useState(true);
         return (
@@ -119,7 +134,7 @@ export const screenshots: ComponentScreenshot = {
       },
     },
     {
-      label: 'Checkbox with nested content and description',
+      label: 'With nested content and description',
       Example: ({ id, handler }) => (
         <Checkbox
           id={id}
@@ -133,7 +148,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Checkbox with a message and description',
+      label: 'With a message and description',
       Example: ({ id, handler }) => (
         <Checkbox
           id={id}
@@ -147,7 +162,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Checkbox with nested content, a message and description',
+      label: 'With nested content, a message and description',
       Example: ({ id, handler }) => (
         <Checkbox
           id={id}

--- a/lib/components/Checkbox/Checkbox.snippets.tsx
+++ b/lib/components/Checkbox/Checkbox.snippets.tsx
@@ -9,6 +9,10 @@ export const snippets: Snippets = [
     code: source(<Checkbox label="Label" />),
   },
   {
+    name: 'Small',
+    code: source(<Checkbox label="Label" size="small" />),
+  },
+  {
     name: 'With a critical message',
     code: source(
       <Checkbox label="Label" tone="critical" message="Critical message" />,

--- a/lib/components/Radio/Radio.tsx
+++ b/lib/components/Radio/Radio.tsx
@@ -10,7 +10,7 @@ import dedent from 'dedent';
 export interface RadioProps
   extends Omit<
     InlineFieldProps,
-    'message' | 'reserveMessageSpace' | 'required'
+    'message' | 'reserveMessageSpace' | 'required' | 'size'
   > {}
 
 /** @deprecated Individual `Radio` elements have been deprecated. Use [RadioGroup](https://seek-oss.github.io/braid-design-system/components/RadioGroup) instead. */
@@ -51,6 +51,7 @@ export const Radio = forwardRef<HTMLInputElement, RadioProps>((props, ref) => {
       message={null}
       reserveMessageSpace={false}
       required={undefined}
+      size={undefined}
       ref={ref}
     />
   );

--- a/lib/components/RadioGroup/RadioGroup.docs.tsx
+++ b/lib/components/RadioGroup/RadioGroup.docs.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Badge, Text, TextLink, RadioGroup, RadioItem, Strong } from '..';
+import {
+  Badge,
+  Text,
+  TextLink,
+  RadioGroup,
+  RadioItem,
+  Strong,
+  Tiles,
+} from '..';
 import { Placeholder } from '../../playroom/components';
 import source from '../../utils/source.macro';
 
@@ -104,6 +112,45 @@ const docs: ComponentDocs = {
             <RadioItem label="Two" value="2" />
             <RadioItem label="Three" value="3" />
           </RadioGroup>,
+        ),
+    },
+    {
+      label: 'Sizes',
+      description: (
+        <Text>
+          You can customise the size of the radio items via the{' '}
+          <Strong>size</Strong> prop, which accepts either{' '}
+          <Strong>standard</Strong> or <Strong>small.</Strong>
+        </Text>
+      ),
+      Example: ({ id, getState, setState }) =>
+        source(
+          <Tiles space="large" columns={[1, 2]}>
+            <RadioGroup
+              id={`${id}_standard`}
+              value={getState('radio')}
+              onChange={({ currentTarget: { value } }) =>
+                setState('radio', value)
+              }
+              label="Standard"
+              size="standard"
+            >
+              <RadioItem label="One" value="1" />
+              <RadioItem label="Two" value="2" />
+            </RadioGroup>
+            <RadioGroup
+              id={`${id}_small`}
+              value={getState('radio2')}
+              onChange={({ currentTarget: { value } }) =>
+                setState('radio2', value)
+              }
+              label="Small"
+              size="small"
+            >
+              <RadioItem label="One" value="1" />
+              <RadioItem label="Two" value="2" />
+            </RadioGroup>
+          </Tiles>,
         ),
     },
     {

--- a/lib/components/RadioGroup/RadioGroup.gallery.tsx
+++ b/lib/components/RadioGroup/RadioGroup.gallery.tsx
@@ -109,6 +109,23 @@ export const galleryItems: ComponentExample[] = [
       ),
   },
   {
+    label: 'Small',
+    Example: ({ id, getState, setState }) =>
+      source(
+        <RadioGroup
+          id={id}
+          value={getState('radio')}
+          onChange={({ currentTarget: { value } }) => setState('radio', value)}
+          label="Label"
+          size="small"
+        >
+          <RadioItem label="One" value="1" />
+          <RadioItem label="Two" value="2" />
+          <RadioItem label="Three" value="3" />
+        </RadioGroup>,
+      ),
+  },
+  {
     label: 'Toggling nested content',
     Example: ({ id, getState, setState, setDefaultState }) =>
       source(

--- a/lib/components/RadioGroup/RadioGroup.screenshots.tsx
+++ b/lib/components/RadioGroup/RadioGroup.screenshots.tsx
@@ -146,5 +146,25 @@ export const screenshots: ComponentScreenshot = {
         );
       },
     },
+    {
+      label: 'Small',
+      Example: () => {
+        const [state, setState] = useState('');
+        return (
+          <RadioGroup
+            id="radiolistsmall"
+            value={state}
+            onChange={(e) => setState(e.currentTarget.value)}
+            label="Experience"
+            size="small"
+          >
+            <RadioItem label="Less than one year" value="0" />
+            <RadioItem label="1 year" value="1" />
+            <RadioItem label="2 years" value="2" />
+            <RadioItem label="3+ years " value="3" />
+          </RadioGroup>
+        );
+      },
+    },
   ],
 };

--- a/lib/components/RadioGroup/RadioGroup.snippets.tsx
+++ b/lib/components/RadioGroup/RadioGroup.snippets.tsx
@@ -63,6 +63,15 @@ export const snippets: Snippets = [
     ),
   },
   {
+    name: 'Small',
+    code: source(
+      <RadioGroup label="Label" size="small">
+        <RadioItem label="One" value="1" />
+        <RadioItem label="Two" value="2" />
+      </RadioGroup>,
+    ),
+  },
+  {
     name: 'With nested content',
     code: source(
       <RadioGroup label="Label">

--- a/lib/components/RadioGroup/RadioGroup.tsx
+++ b/lib/components/RadioGroup/RadioGroup.tsx
@@ -18,10 +18,8 @@ export interface RadioGroupProps<Value = NonNullable<string | number>>
 }
 
 const stackSpaceForSize = {
-  xsmall: 'small',
   small: 'small',
   standard: 'medium',
-  large: 'medium',
 } as Record<NonNullable<RadioGroupProps['size']>, StackProps['space']>;
 
 const RadioGroup = ({

--- a/lib/components/RadioGroup/RadioGroup.tsx
+++ b/lib/components/RadioGroup/RadioGroup.tsx
@@ -3,9 +3,10 @@ import assert from 'assert';
 import flattenChildren from 'react-keyed-flatten-children';
 import { FieldGroup, FieldGroupProps } from '../private/FieldGroup/FieldGroup';
 import { RadioItem, RadioItemProps } from '../RadioGroup/RadioItem';
-import { Stack } from '../Stack/Stack';
+import { Stack, StackProps } from '../Stack/Stack';
 import { RadioGroupContext, RadioItemContext } from './RadioGroupContext';
 import { Box } from '../Box/Box';
+import { InlineFieldProps } from '../private/InlineField/InlineField';
 
 export interface RadioGroupProps<Value = NonNullable<string | number>>
   extends FieldGroupProps {
@@ -13,7 +14,15 @@ export interface RadioGroupProps<Value = NonNullable<string | number>>
   value: Value;
   onChange: (event: FormEvent<HTMLInputElement>) => void;
   name?: string;
+  size?: InlineFieldProps['size'];
 }
+
+const stackSpaceForSize = {
+  xsmall: 'small',
+  small: 'small',
+  standard: 'medium',
+  large: 'medium',
+} as Record<NonNullable<RadioGroupProps['size']>, StackProps['space']>;
 
 const RadioGroup = ({
   children,
@@ -23,6 +32,7 @@ const RadioGroup = ({
   onChange,
   disabled,
   tone,
+  size,
   ...props
 }: RadioGroupProps) => {
   const items = flattenChildren(children);
@@ -53,6 +63,7 @@ const RadioGroup = ({
             onChange,
             disabled,
             tone,
+            size,
             ...fieldGroupProps,
           }}
         >
@@ -60,7 +71,7 @@ const RadioGroup = ({
             paddingTop={props.description ? 'xxsmall' : 'xsmall'}
             paddingBottom={props.message ? 'xsmall' : undefined}
           >
-            <Stack space="medium">
+            <Stack space={stackSpaceForSize[size || 'standard']}>
               {items.map((item, i) => (
                 <RadioItemContext.Provider key={i} value={i}>
                   {item}

--- a/lib/components/RadioGroup/RadioGroupContext.ts
+++ b/lib/components/RadioGroup/RadioGroupContext.ts
@@ -7,6 +7,7 @@ interface RadioGroupContextValues {
   value: RadioGroupProps['value'];
   disabled?: boolean;
   tone?: RadioGroupProps['tone'];
+  size?: RadioGroupProps['size'];
   'aria-describedby'?: string;
   onChange: RadioGroupProps['onChange'];
 }

--- a/lib/components/RadioGroup/RadioItem.tsx
+++ b/lib/components/RadioGroup/RadioItem.tsx
@@ -21,6 +21,7 @@ export interface RadioItemProps
     | 'id'
     | 'disabled'
     | 'tone'
+    | 'size'
   > {
   value: NonNullable<InlineFieldProps['value']>;
 }
@@ -58,6 +59,7 @@ const NamedRadioItem = forwardRef<HTMLInputElement, RadioItemProps>(
             ? radioGroupContext.tone
             : undefined
         }
+        size={radioGroupContext.size}
         disabled={radioGroupContext.disabled}
         aria-describedby={radioGroupContext['aria-describedby']}
         tabIndex={tababble ? 0 : -1}

--- a/lib/components/Toggle/Toggle.docs.tsx
+++ b/lib/components/Toggle/Toggle.docs.tsx
@@ -59,6 +59,35 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
+    {
+      label: 'Sizes',
+      description: (
+        <Text>
+          You can customise the size of the toggle via the <Strong>size</Strong>{' '}
+          prop, which accepts either <Strong>standard</Strong> or{' '}
+          <Strong>small.</Strong>
+        </Text>
+      ),
+      Example: ({ id, getState, toggleState }) =>
+        source(
+          <Stack space="medium">
+            <Toggle
+              id={`${id}_standard`}
+              label="Standard"
+              on={getState('two')}
+              onChange={() => toggleState('two')}
+              size="standard"
+            />
+            <Toggle
+              id={`${id}_small`}
+              label="Small"
+              on={getState('one')}
+              onChange={() => toggleState('one')}
+              size="small"
+            />
+          </Stack>,
+        ),
+    },
   ],
 };
 

--- a/lib/components/Toggle/Toggle.gallery.tsx
+++ b/lib/components/Toggle/Toggle.gallery.tsx
@@ -17,6 +17,19 @@ export const galleryItems: ComponentExample[] = [
       ),
   },
   {
+    label: 'Small',
+    Example: ({ id, getState, toggleState }) =>
+      source(
+        <Toggle
+          label="Label"
+          id={id}
+          on={getState('toggle')}
+          onChange={() => toggleState('toggle')}
+          size="small"
+        />,
+      ),
+  },
+  {
     label: 'Toggle Alignment: "left" | "justify" | "right"',
     Example: ({ id, getState, toggleState }) =>
       source(

--- a/lib/components/Toggle/Toggle.screenshots.tsx
+++ b/lib/components/Toggle/Toggle.screenshots.tsx
@@ -18,6 +18,18 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
+      label: 'Small size',
+      Example: ({ id, handler }) => (
+        <Toggle
+          on={true}
+          size="small"
+          label="Small"
+          id={id}
+          onChange={handler}
+        />
+      ),
+    },
+    {
       label: 'Right aligned',
       Container: ({ children }) => (
         <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -48,8 +60,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label:
-        'Test: Should have space between the label and the toggle when justified in a flex container',
+      label: 'Space between the label and toggle preserved',
       Container: ({ children }) => (
         <div style={{ maxWidth: '300px' }}>{children}</div>
       ),
@@ -66,7 +77,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Test: Should support long labels',
+      label: 'With a long label',
       Container: ({ children }) => (
         <div style={{ maxWidth: '300px' }}>{children}</div>
       ),

--- a/lib/components/Toggle/Toggle.snippets.tsx
+++ b/lib/components/Toggle/Toggle.snippets.tsx
@@ -9,6 +9,10 @@ export const snippets: Snippets = [
     code: source(<Toggle label="Label" />),
   },
   {
+    name: 'Small',
+    code: source(<Toggle label="Label" size="small" />),
+  },
+  {
     name: 'Right aligned',
     code: source(<Toggle label="Label" align="right" />),
   },

--- a/lib/components/Toggle/Toggle.treat.ts
+++ b/lib/components/Toggle/Toggle.treat.ts
@@ -1,4 +1,5 @@
-import { style } from 'sku/treat';
+import { Theme } from 'treat/theme';
+import { style, styleMap } from 'sku/treat';
 import getSize from '../private/InlineField/getSize';
 import { hitArea } from '../private/touchable/hitArea';
 import { debugTouchable } from '../private/touchable/debugTouchable';
@@ -14,58 +15,97 @@ export const root = style({
   },
 });
 
-const realFieldBase = style({
+export const realFieldBase = style({
   height: hitArea,
   selectors: {
     ...debugTouchable(),
   },
 });
 
-const realFieldPosition = style((theme) => {
-  const centerOffset = -(hitArea - getSize(theme)) / 2;
+const resolveRealFieldPosition = (
+  textSize: keyof Theme['typography']['text'],
+  theme: Theme,
+) => {
+  const centerOffset = -(hitArea - getSize(textSize, theme)) / 2;
 
   return {
     top: centerOffset,
   };
-});
+};
 
-export const realField = [realFieldBase, realFieldPosition];
+export const realFieldPosition = styleMap((theme) => ({
+  small: resolveRealFieldPosition('small', theme),
+  standard: resolveRealFieldPosition('standard', theme),
+}));
 
-export const label = style((theme) => {
-  const size = getSize(theme);
-  const lineHeight = theme.grid * theme.typography.text.standard.mobile.rows;
+const resolveLabelOffset = (
+  textSize: keyof Theme['typography']['text'],
+  theme: Theme,
+) => {
+  const size = getSize(textSize, theme);
+  const lineHeight = theme.grid * theme.typography.text[textSize].mobile.rows;
   const padding = (size - lineHeight) / 2;
   return {
     paddingTop: padding,
     paddingBottom: padding,
   };
+};
+
+export const label = styleMap((theme) => ({
+  small: resolveLabelOffset('small', theme),
+  standard: resolveLabelOffset('standard', theme),
+}));
+
+const resolveFieldSize = (
+  textSize: keyof Theme['typography']['text'],
+  theme: Theme,
+) => ({
+  width: getSize(textSize, theme) * toggleWidthRatio,
 });
 
-export const fieldSize = style((theme) => ({
-  width: getSize(theme) * toggleWidthRatio,
+export const fieldSize = styleMap((theme) => ({
+  small: resolveFieldSize('small', theme),
+  standard: resolveFieldSize('standard', theme),
 }));
 
-const slideContainerBase = style({});
+export const slideContainerBase = style({});
 
-const slideContainerHeight = style((theme) => ({
-  height: getSize(theme),
+const resolveSlideContainerHeight = (
+  textSize: keyof Theme['typography']['text'],
+  theme: Theme,
+) => ({
+  height: getSize(textSize, theme),
+});
+
+export const slideContainerHeight = styleMap((theme) => ({
+  small: resolveSlideContainerHeight('small', theme),
+  standard: resolveSlideContainerHeight('standard', theme),
 }));
 
-export const slideContainer = [slideContainerBase, slideContainerHeight];
-
-export const slideTrack = style((theme) => {
-  const size = getSize(theme);
+const resolveSlideTrack = (
+  textSize: keyof Theme['typography']['text'],
+  theme: Theme,
+) => {
+  const size = getSize(textSize, theme);
   const height = size - theme.grid;
 
   return {
     height,
     borderRadius: height / 2,
-    backgroundColor: theme.border.color.standard,
-    // Fix for Safari border-radius, overflow hidden, transform bug:
-    // https://gist.github.com/ayamflow/b602ab436ac9f05660d9c15190f4fd7b
-    '-webkit-mask-image': '-webkit-radial-gradient(white, black)',
   };
-});
+};
+
+export const slideTrack = styleMap((theme) => ({
+  small: resolveSlideTrack('small', theme),
+  standard: resolveSlideTrack('standard', theme),
+}));
+
+export const slideTrackBackground = style((theme) => ({
+  backgroundColor: theme.border.color.standard,
+  // Fix for Safari border-radius, overflow hidden, transform bug:
+  // https://gist.github.com/ayamflow/b602ab436ac9f05660d9c15190f4fd7b
+  '-webkit-mask-image': '-webkit-radial-gradient(white, black)',
+}));
 
 export const slideTrackSelected = style((theme) => {
   const trackWidth = theme.grid * theme.touchableSize;
@@ -79,8 +119,11 @@ export const slideTrackSelected = style((theme) => {
   };
 });
 
-export const slider = style((theme) => {
-  const size = getSize(theme);
+const resolveSlider = (
+  textSize: keyof Theme['typography']['text'],
+  theme: Theme,
+) => {
+  const size = getSize(textSize, theme);
   const trackWidth = size * toggleWidthRatio;
   const anticipation = size * anticipationRatio;
   const slideDistance = trackWidth - size;
@@ -100,7 +143,12 @@ export const slider = style((theme) => {
       },
     },
   };
-});
+};
+
+export const slider = styleMap((theme) => ({
+  small: resolveSlider('small', theme),
+  standard: resolveSlider('standard', theme),
+}));
 
 export const icon = style({
   transform: 'scale(.75)',

--- a/lib/components/Toggle/Toggle.tsx
+++ b/lib/components/Toggle/Toggle.tsx
@@ -16,6 +16,7 @@ export interface ToggleProps {
   on: boolean;
   onChange: ChangeHandler;
   align?: 'left' | 'right' | 'justify';
+  size?: keyof typeof styleRefs.fieldSize;
 }
 
 const handleChange = (onChange: ChangeHandler) => (
@@ -32,6 +33,7 @@ export const Toggle = ({
   onChange,
   label,
   align = 'left',
+  size = 'standard',
 }: ToggleProps) => {
   const styles = useStyles(styleRefs);
   const showBorder = useBackgroundLightness() === 'light';
@@ -54,20 +56,28 @@ export const Toggle = ({
         zIndex={1}
         cursor="pointer"
         opacity={0}
-        className={[styles.realField, styles.fieldSize]}
+        className={[
+          styles.realFieldBase,
+          styles.realFieldPosition[size],
+          styles.fieldSize[size],
+        ]}
       />
       <Box
         position="relative"
         display="flex"
         alignItems="center"
         flexShrink={0}
-        className={[styles.slideContainer, styles.fieldSize]}
+        className={[
+          styles.slideContainerBase,
+          styles.slideContainerHeight[size],
+          styles.fieldSize[size],
+        ]}
       >
         <Box
           position="absolute"
           width="full"
           overflow="hidden"
-          className={styles.slideTrack}
+          className={[styles.slideTrack[size], styles.slideTrackBackground]}
         >
           <Box
             position="absolute"
@@ -87,7 +97,7 @@ export const Toggle = ({
           alignItems="center"
           justifyContent="center"
           borderRadius="full"
-          className={styles.slider}
+          className={styles.slider[size]}
         >
           <FieldOverlay className={styles.icon}>
             <IconTick tone="formAccent" size="fill" />
@@ -114,9 +124,9 @@ export const Toggle = ({
         flexGrow={align === 'justify' ? 1 : undefined}
         userSelect="none"
         cursor="pointer"
-        className={[styles.label, useVirtualTouchable()]}
+        className={[styles.label[size], useVirtualTouchable()]}
       >
-        <Text baseline={false} weight={on ? 'strong' : undefined}>
+        <Text baseline={false} weight={on ? 'strong' : undefined} size={size}>
           {label}
         </Text>
       </Box>

--- a/lib/components/private/InlineField/InlineField.treat.ts
+++ b/lib/components/private/InlineField/InlineField.treat.ts
@@ -1,4 +1,5 @@
-import { style } from 'sku/treat';
+import { Theme } from 'treat/theme';
+import { style, styleMap } from 'sku/treat';
 import getSize from './getSize';
 import { hitArea } from '../touchable/hitArea';
 import { debugTouchable } from '../touchable/debugTouchable';
@@ -20,7 +21,7 @@ const realFieldBase = style({
 });
 
 export const realFieldPosition = style((theme) => {
-  const size = getSize(theme);
+  const size = getSize('standard', theme);
   const centerOffset = -(hitArea - size) / 2;
 
   return { top: centerOffset, left: centerOffset };
@@ -28,34 +29,51 @@ export const realFieldPosition = style((theme) => {
 
 export const realField = [realFieldBase, realFieldPosition];
 
-const fakeFieldBase = style({});
+export const fakeFieldBase = style({});
 
-const fakeFieldSize = style((theme) => {
-  const size = getSize(theme);
+const resolveFakeFieldSize = (
+  textSize: keyof Theme['typography']['text'],
+  theme: Theme,
+) => {
+  const size = getSize(textSize, theme);
 
   return {
     height: size,
     width: size,
   };
-});
+};
 
-export const fakeField = [fakeFieldSize, fakeFieldBase];
+export const fakeFieldSize = styleMap((theme) => ({
+  small: resolveFakeFieldSize('small', theme),
+  standard: resolveFakeFieldSize('standard', theme),
+}));
 
-export const badgeOffset = style((theme) => {
-  // Uses mobile standard text to mirror behaviour in getSize
+const resolveBadgeOffset = (
+  textSize: keyof Theme['typography']['text'],
+  theme: Theme,
+) => {
   const badgeHeight = theme.typography.text.xsmall.mobile.rows * theme.grid;
-  const offset = Math.round((getSize(theme) - badgeHeight) / 2);
+  const offset = Math.round((getSize(textSize, theme) - badgeHeight) / 2);
 
   return {
     paddingTop: offset,
     paddingBottom: offset,
   };
-});
+};
 
-export const label = style((theme) => {
-  // Uses mobile standard text to mirror behaviour in getSize
-  const standardTextHeight = theme.typography.text.standard.mobile.capHeight;
-  const offset = Math.round((getSize(theme) - standardTextHeight) / 2);
+export const badgeOffset = styleMap((theme) => ({
+  small: resolveBadgeOffset('small', theme),
+  standard: resolveBadgeOffset('standard', theme),
+}));
+
+const resolveLabelOffset = (
+  textSize: keyof Theme['typography']['text'],
+  theme: Theme,
+) => {
+  const standardTextHeight = theme.typography.text[textSize].mobile.capHeight;
+  const offset = Math.round(
+    (getSize(textSize, theme) - standardTextHeight) / 2,
+  );
 
   return {
     paddingTop: offset,
@@ -65,7 +83,12 @@ export const label = style((theme) => {
       },
     },
   };
-});
+};
+
+export const label = styleMap((theme) => ({
+  small: resolveLabelOffset('small', theme),
+  standard: resolveLabelOffset('standard', theme),
+}));
 
 export const isMixed = style({});
 

--- a/lib/components/private/InlineField/InlineField.tsx
+++ b/lib/components/private/InlineField/InlineField.tsx
@@ -49,6 +49,7 @@ export interface InlineFieldProps {
   badge?: ReactElement<BadgeProps>;
   data?: DataAttributeMap;
   required?: boolean;
+  size?: keyof typeof styleRefs.fakeFieldSize;
 }
 
 type FieldType = 'checkbox' | 'radio';
@@ -150,6 +151,7 @@ export const InlineField = forwardRef<
       required,
       inList = false,
       tabIndex,
+      size = 'standard',
       'aria-describedby': ariaDescribedBy,
     },
     forwardedRef,
@@ -225,7 +227,7 @@ export const InlineField = forwardRef<
           <Box
             flexShrink={0}
             position="relative"
-            className={styles.fakeField}
+            className={[styles.fakeFieldBase, styles.fakeFieldSize[size!]]}
             background={disabled ? 'inputDisabled' : 'input'}
             borderRadius={fieldBorderRadius}
           >
@@ -268,21 +270,24 @@ export const InlineField = forwardRef<
                 htmlFor={id}
                 userSelect="none"
                 display="block"
-                className={[styles.label, useVirtualTouchable()]}
+                className={[styles.label[size], useVirtualTouchable()]}
               >
                 <Text
                   weight={checked && !inList ? 'strong' : undefined}
                   tone={disabled ? 'secondary' : undefined}
+                  size={size}
                 >
                   {label}
                 </Text>
               </Box>
-              {badge ? <Box className={styles.badgeOffset}>{badge}</Box> : null}
+              {badge ? (
+                <Box className={styles.badgeOffset[size]}>{badge}</Box>
+              ) : null}
             </Inline>
 
             {description ? (
               <Box paddingTop="small">
-                <Text tone="secondary" id={descriptionId}>
+                <Text tone="secondary" size={size} id={descriptionId}>
                   {description}
                 </Text>
               </Box>

--- a/lib/components/private/InlineField/getSize.ts
+++ b/lib/components/private/InlineField/getSize.ts
@@ -1,9 +1,12 @@
 import { Theme } from 'treat/theme';
 
-export default ({ grid, touchableSize, typography }: Theme) => {
+export default (
+  textSize: keyof Theme['typography']['text'],
+  { grid, touchableSize, typography }: Theme,
+) => {
   // We currently don't support responsive checkboxes and
   // radio buttons, but nobody actually needs it (so far)
-  const scale = (typography.text.standard.mobile.rows * grid) / 42;
+  const scale = (typography.text[textSize].mobile.rows * grid) / 42;
   const rows = Math.round(touchableSize * scale);
 
   return grid * rows;


### PR DESCRIPTION
Adds support for adjusting the `size` of a `Checkbox`, the RadioItems within a `RadioGroup` or a `Toggle`. Setting the size adjusts both the visual control and the text size of the label.

**EXAMPLE USAGE:**
```jsx
  <Checkbox size="small" label="Label" />
```

```jsx
  <RadioGroup size="small" label="Label">
    ...
  </RadioGroup>
```

```jsx
  <Toggle size="small" label="Label" />
```

[Preview in Playroom](https://braid-design-system--1c775a68965d6afa676c7d0e4143a9735210e593.surge.sh/playroom/#?code=N4Igxg9gJgpiBcIA8BhAhgJygPgDoDsACQpAZQBc0wBrQgZwAcqYBeXEAG0wHMZ3CoASwBug2Bjp4ixEhSq1GzNiAC2MIQFcV7KTJlIAYoJgcoAGTQAjE4S7WOylAAsYNSxAAe-APS69hYABtdlIVNA4OdgAaQhDKfChMKHYAXQA6MIYACiy6QQAvGABKQhZsQiyCf31nV2p3L2lq4jzClmBWmDTyCDMIAHcYDHQ6GCyigF8q5uI7E3bOqabmyzQoXnakACE13kIe-FZ2Q41yDHCdAA4ABiRvHfWYbCWZ32m9Isn3km85GilvmRKDR6EwwEdVOpBFodN9iIZjKYLPZbFZ5uwACoQbjcDh8ECEN7LYhBEJhCLRWIgOQJJKpDJobK5ArFUrlSrE-RYnF4%2BgshYs7q9AZDEZjSao%2BwCwoTQl%2BD5fZZ3P7UAFKlWgpTsLgYXiwzmk6nkyIgGJxNC0rD0zI5TolMoVOH6ABKa0EEAA4hgIBoGJL5sAAAauoQQQhen1%2BrIAEg6gp6fUGwzQo3GEyKgdlnWlXQTIuTqcm8uaSBD7oAkuQYNpOdUDhCwBhBORBGALiAndVVo9Ng89vXlCczu3sDc7n2ni8ZjI5g4g7HFoRm9XCABGTOd-zCcIaCGr9ib4hE6ckMsQSvVw8ybsbYDbXYwfYQQ6DmCnc4m0e3e4P55X2ZonOgYLiysrLiohAAEwbrWW47hCkEHrBR7FtUpZuueVY1iexA3qwd4Tk%2BL7HG%2Bw6fmOP6PH%2ByEzoB7TAXGMpLlhhAAMwwThhDbhwu7KKxSEnseJbeGeEa%2BqhhCfFO8K-MCqrTMqclSHc6BYFIpogP0YjkE4dAIIErGQdcKQTEAA)