### PR TITLE
Add support for data attribute maps on all components

### DIFF
--- a/.changeset/soft-bulldogs-notice.md
+++ b/.changeset/soft-bulldogs-notice.md
@@ -1,0 +1,127 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Accordion
+  - AccordionItem
+  - Actions
+  - Alert
+  - Badge
+  - ButtonLink
+  - Card
+  - Column
+  - Columns
+  - ContentBlock
+  - Dialog
+  - Disclosure
+  - Drawer
+  - FieldLabel
+  - FieldMessage
+  - Hidden
+  - HiddenVisually
+  - IconAdd
+  - IconBookmark
+  - IconCaution
+  - IconChevron
+  - IconClear
+  - IconCompany
+  - IconCompose
+  - IconCopy
+  - IconCreditCard
+  - IconCritical
+  - IconDate
+  - IconDelete
+  - IconDesktop
+  - IconDocument
+  - IconDocumentBroken
+  - IconDownload
+  - IconEdit
+  - IconEducation
+  - IconFilter
+  - IconGrid
+  - IconHeart
+  - IconHelp
+  - IconHistory
+  - IconHome
+  - IconImage
+  - IconInfo
+  - IconInvoice
+  - IconLanguage
+  - IconLink
+  - IconLinkBroken
+  - IconList
+  - IconLocation
+  - IconMail
+  - IconMinus
+  - IconMobile
+  - IconMoney
+  - IconNewWindow
+  - IconNote
+  - IconNotification
+  - IconOverflow
+  - IconPeople
+  - IconPersonAdd
+  - IconPersonVerified
+  - IconPhone
+  - IconPositive
+  - IconPrint
+  - IconProfile
+  - IconPromote
+  - IconRecommended
+  - IconRefresh
+  - IconResume
+  - IconSearch
+  - IconSecurity
+  - IconSend
+  - IconSent
+  - IconSettings
+  - IconShare
+  - IconSocialFacebook
+  - IconSocialGitHub
+  - IconSocialInstagram
+  - IconSocialLinkedIn
+  - IconSocialMedium
+  - IconSocialTwitter
+  - IconStar
+  - IconStatistics
+  - IconSubCategory
+  - IconTag
+  - IconTick
+  - IconTime
+  - IconUpload
+  - IconVideo
+  - IconVisibility
+  - IconWorkExperience
+  - Inline
+  - List
+  - MonthPicker
+  - Notice
+  - Pagination
+  - RadioGroup
+  - Rating
+  - Secondary
+  - Stack
+  - Strong
+  - Tag
+  - TextDropdown
+  - Tiles
+  - Toggle
+---
+
+Add support for data attribute maps on all components.
+
+**EXAMPLE USAGE:**
+```tsx
+<Alert
+  data={{
+    testId: 'message'
+  }}
+/>
+
+// => <div data-testId="message" />
+```
+
+
+

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -5,6 +5,7 @@ Object {
   exportType: component,
   props: {
     children: ReactNodeNoStrings
+    data?: DataAttributeMap
     dividers?: boolean
     size?: 
         | "large"
@@ -28,6 +29,7 @@ Object {
   exportType: component,
   props: {
     children: ReactNode
+    data?: DataAttributeMap
     expanded?: boolean
     id: string
     label: string
@@ -49,6 +51,7 @@ Object {
   exportType: component,
   props: {
     children: ReactNodeNoStrings
+    data?: DataAttributeMap
     size?: 
         | "small"
         | "standard"
@@ -62,6 +65,7 @@ Object {
   props: {
     children: ReactNode
     closeLabel?: string
+    data?: DataAttributeMap
     id?: string
     onClose?: () => void
     tone?: 
@@ -147,6 +151,7 @@ Object {
     aria-describedby?: string
     bleedY?: boolean
     children: string
+    data?: DataAttributeMap
     id?: string
     ref?: 
         | (instance: HTMLDivElement | null) => void
@@ -1985,6 +1990,7 @@ Object {
         | true
     contextMenu?: string
     dangerouslySetInnerHTML?: { __html: string; }
+    data?: DataAttributeMap
     datatype?: string
     defaultChecked?: boolean
     defaultValue?: 
@@ -2281,6 +2287,7 @@ Object {
         | "div"
         | "main"
         | "section"
+    data?: DataAttributeMap
     rounded?: boolean
     roundedAbove?: 
         | "mobile"
@@ -2336,6 +2343,7 @@ Object {
   exportType: component,
   props: {
     children: ReactNode
+    data?: DataAttributeMap
     width?: 
         | "1/2"
         | "1/3"
@@ -2371,6 +2379,7 @@ Object {
     collapseBelow?: 
         | "desktop"
         | "tablet"
+    data?: DataAttributeMap
     reverse?: boolean
     space: 
         | "gutter"
@@ -2393,6 +2402,7 @@ Object {
   exportType: component,
   props: {
     children: ReactNode
+    data?: DataAttributeMap
     width?: 
         | "large"
         | "medium"
@@ -2408,6 +2418,7 @@ Object {
   props: {
     children: ReactNode
     closeLabel?: string
+    data?: DataAttributeMap
     description?: ReactNodeNoStrings
     id: string
     illustration?: ReactNodeNoStrings
@@ -2430,6 +2441,7 @@ Object {
   props: {
     children: ReactNode
     collapseLabel?: string
+    data?: DataAttributeMap
     expandLabel: string
     expanded?: boolean
     id: string
@@ -2467,6 +2479,7 @@ Object {
   props: {
     children: ReactNode
     closeLabel?: string
+    data?: DataAttributeMap
     description?: ReactNodeNoStrings
     id: string
     onClose: (openState: false) => void
@@ -2525,6 +2538,7 @@ exports[`FieldLabel 1`] = `
 Object {
   exportType: component,
   props: {
+    data?: DataAttributeMap
     description?: ReactNode
     descriptionId?: string
     htmlFor: 
@@ -2542,6 +2556,7 @@ exports[`FieldMessage 1`] = `
 Object {
   exportType: component,
   props: {
+    data?: DataAttributeMap
     disabled?: boolean
     id: string
     message: ReactNode
@@ -2947,6 +2962,7 @@ Object {
         | "webview"
         | ComponentClass<any, any>
         | FunctionComponent<any>
+    data?: DataAttributeMap
     inline?: boolean
     print?: boolean
     screen?: boolean
@@ -2959,6 +2975,7 @@ Object {
   exportType: component,
   props: {
     children: ReactNode
+    data?: DataAttributeMap
     id?: string
 },
 }
@@ -2971,6 +2988,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3002,6 +3020,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3032,6 +3051,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3062,6 +3082,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     direction?: 
         | "down"
         | "left"
@@ -3097,6 +3118,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3127,6 +3149,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3157,6 +3180,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3187,6 +3211,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3217,6 +3242,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3247,6 +3273,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3277,6 +3304,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3307,6 +3335,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3337,6 +3366,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3367,6 +3397,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3397,6 +3428,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3427,6 +3459,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3457,6 +3490,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3487,6 +3521,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3517,6 +3552,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3547,6 +3583,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3578,6 +3615,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3608,6 +3646,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3638,6 +3677,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3668,6 +3708,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3698,6 +3739,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3728,6 +3770,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3758,6 +3801,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3788,6 +3832,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3818,6 +3863,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3848,6 +3894,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3878,6 +3925,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3908,6 +3956,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3938,6 +3987,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3968,6 +4018,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -3998,6 +4049,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4028,6 +4080,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4058,6 +4111,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4088,6 +4142,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4118,6 +4173,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4148,6 +4204,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4178,6 +4235,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4208,6 +4266,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4238,6 +4297,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4268,6 +4328,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4298,6 +4359,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4328,6 +4390,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4358,6 +4421,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4388,6 +4452,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4418,6 +4483,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4448,6 +4514,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4478,6 +4545,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4508,6 +4576,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4538,6 +4607,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4568,6 +4638,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4598,6 +4669,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4628,6 +4700,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4658,6 +4731,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4688,6 +4762,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4718,6 +4793,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4748,6 +4824,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4778,6 +4855,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4808,6 +4886,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4838,6 +4917,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4869,6 +4949,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4899,6 +4980,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4929,6 +5011,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4959,6 +5042,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -4989,6 +5073,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -5019,6 +5104,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -5049,6 +5135,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -5079,6 +5166,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -5109,6 +5197,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     hidden?: boolean
     size?: 
         | "fill"
@@ -5140,6 +5229,7 @@ Object {
     alignY?: 
         | "lowercase"
         | "uppercase"
+    data?: DataAttributeMap
     size?: 
         | "fill"
         | "large"
@@ -5185,6 +5275,7 @@ Object {
         | "div"
         | "ol"
         | "ul"
+    data?: DataAttributeMap
     reverse?: boolean
     space: 
         | "gutter"
@@ -5634,6 +5725,7 @@ Object {
   exportType: component,
   props: {
     children: ReactNodeNoStrings
+    data?: DataAttributeMap
     icon?: ReactNode
     size?: 
         | "large"
@@ -5679,6 +5771,7 @@ Object {
   exportType: component,
   props: {
     aria-label?: string
+    data?: DataAttributeMap
     delayVisibility?: boolean
     size?: 
         | "large"
@@ -5766,6 +5859,7 @@ Object {
   exportType: component,
   props: {
     ascendingYears?: boolean
+    data?: DataAttributeMap
     description?: ReactNode
     disabled?: boolean
     id: string
@@ -5800,6 +5894,7 @@ Object {
   exportType: component,
   props: {
     children: ReactNode
+    data?: DataAttributeMap
     tone?: 
         | "critical"
         | "info"
@@ -5826,6 +5921,7 @@ exports[`Pagination 1`] = `
 Object {
   exportType: component,
   props: {
+    data?: DataAttributeMap
     label: string
     linkProps: ({ page, type, }: { page: number; type: "next" | "previous" | "pageNumber"; }) => LinkProps
     nextLabel?: string
@@ -5910,6 +6006,7 @@ Object {
   exportType: component,
   props: {
     children: ReactElement<RadioItemProps, string | JSXElementConstructor<any>>[]
+    data?: DataAttributeMap
     description?: ReactNode
     disabled?: boolean
     id: string
@@ -5961,6 +6058,7 @@ Object {
   exportType: component,
   props: {
     aria-label?: string
+    data?: DataAttributeMap
     rating: number
     showTextRating?: boolean
     size?: 
@@ -5977,6 +6075,7 @@ Object {
   exportType: component,
   props: {
     children: ReactNode
+    data?: DataAttributeMap
     id?: string
 },
 }
@@ -5996,6 +6095,7 @@ Object {
         | "div"
         | "ol"
         | "ul"
+    data?: DataAttributeMap
     dividers?: 
         | "regular"
         | "strong"
@@ -6022,6 +6122,7 @@ Object {
   exportType: component,
   props: {
     children: ReactNode
+    data?: DataAttributeMap
     id?: string
 },
 }
@@ -6109,6 +6210,7 @@ Object {
   props: {
     children: string
     clearLabel?: string
+    data?: DataAttributeMap
     onClear?: () => void
 },
 }
@@ -6334,6 +6436,7 @@ exports[`TextDropdown 1`] = `
 Object {
   exportType: component,
   props: {
+    data?: DataAttributeMap
     id: string
     label: string
     onBlur?: () => void
@@ -6570,6 +6673,7 @@ Object {
         | true
     contextMenu?: string
     dangerouslySetInnerHTML?: { __html: string; }
+    data?: DataAttributeMap
     datatype?: string
     defaultChecked?: boolean
     defaultValue?: 
@@ -6925,6 +7029,7 @@ Object {
         | 5
         | 6
     >
+    data?: DataAttributeMap
     dividers?: 
         | "regular"
         | "strong"
@@ -6963,6 +7068,7 @@ Object {
         | "justify"
         | "left"
         | "right"
+    data?: DataAttributeMap
     id: string
     label: ReactNode
     on: boolean

--- a/lib/components/Accordion/Accordion.tsx
+++ b/lib/components/Accordion/Accordion.tsx
@@ -13,6 +13,9 @@ import {
   normaliseResponsiveProp,
   ResponsiveProp,
 } from '../../utils/responsiveProp';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 
 export const validSpaceValues = ['medium', 'large', 'xlarge'] as const;
 
@@ -22,6 +25,7 @@ export interface AccordionProps {
   size?: AccordionContextValue['size'];
   tone?: AccordionContextValue['tone'];
   space?: ResponsiveProp<typeof validSpaceValues[number]>;
+  data?: DataAttributeMap;
 }
 
 const defaultSpaceForSize = {
@@ -45,6 +49,7 @@ export const Accordion = ({
   tone,
   space: spaceProp,
   dividers = true,
+  data,
 }: AccordionProps) => {
   assert(
     spaceProp === undefined ||
@@ -71,9 +76,11 @@ export const Accordion = ({
   return (
     <AccordionContext.Provider value={contextValue}>
       {!dividers ? (
-        <Stack space={space}>{children}</Stack>
+        <Stack space={space} data={data}>
+          {children}
+        </Stack>
       ) : (
-        <Box>
+        <Box {...(data ? buildDataAttributes(data) : undefined)}>
           <Divider />
           <Box paddingY={space}>
             <Stack space={space} dividers>

--- a/lib/components/Accordion/AccordionItem.tsx
+++ b/lib/components/Accordion/AccordionItem.tsx
@@ -20,6 +20,9 @@ import {
   AccordionContextValue,
   validTones,
 } from './AccordionContext';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 import * as styleRefs from './AccordionItem.treat';
 
 const itemSpaceForSize = {
@@ -34,6 +37,7 @@ export type AccordionItemBaseProps = {
   children: ReactNode;
   size?: TextProps['size'];
   tone?: AccordionContextValue['tone'];
+  data?: DataAttributeMap;
 };
 
 export type AccordionItemProps = AccordionItemBaseProps & UseDisclosureProps;
@@ -45,6 +49,7 @@ export const AccordionItem = ({
   children,
   size: sizeProp,
   tone: toneProp,
+  data,
   ...restProps
 }: AccordionItemProps) => {
   const styles = useStyles(styleRefs);
@@ -90,7 +95,7 @@ export const AccordionItem = ({
   });
 
   return (
-    <Box>
+    <Box {...(data ? buildDataAttributes(data) : undefined)}>
       <Box position="relative" display="flex">
         <Box
           component="button"

--- a/lib/components/Actions/Actions.tsx
+++ b/lib/components/Actions/Actions.tsx
@@ -6,14 +6,15 @@ import { PrivateButtonRendererProps } from '../ButtonRenderer/ButtonRenderer';
 export interface ActionsProps {
   size?: PrivateButtonRendererProps['size'];
   children: InlineProps['children'];
+  data?: InlineProps['data'];
 }
 
-export const Actions = ({ size, children }: ActionsProps) => {
+export const Actions = ({ size, data, children }: ActionsProps) => {
   const contextValue = useMemo(() => ({ size }), [size]);
 
   return (
     <ActionsContext.Provider value={contextValue}>
-      <Inline collapseBelow="tablet" space="xsmall">
+      <Inline collapseBelow="tablet" space="xsmall" data={data}>
         {children}
       </Inline>
     </ActionsContext.Provider>

--- a/lib/components/Alert/Alert.tsx
+++ b/lib/components/Alert/Alert.tsx
@@ -15,6 +15,9 @@ import { Column } from '../Column/Column';
 import { Overlay } from '../private/Overlay/Overlay';
 import { useBackground } from '../Box/BackgroundContext';
 import { useTextAlignedToIcon } from '../../hooks/useTextAlignedToIcon/useTextAlignedToIcon';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 import * as styleRefs from './Alert.treat';
 
 type Tone = 'promote' | 'info' | 'positive' | 'caution' | 'critical';
@@ -24,6 +27,7 @@ type CloseProps = AllOrNone<{ onClose: () => void; closeLabel: string }>;
 export type AlertProps = {
   tone?: Tone;
   children: ReactNode;
+  data?: DataAttributeMap;
   id?: string;
 } & CloseProps;
 
@@ -58,6 +62,7 @@ export const Alert = ({
   children,
   id,
   closeLabel = 'Close',
+  data,
   onClose,
 }: AlertProps) => {
   const styles = useStyles(styleRefs);
@@ -74,6 +79,7 @@ export const Alert = ({
       overflow="hidden"
       role="alert"
       aria-live="polite"
+      {...(data ? buildDataAttributes(data) : undefined)}
     >
       <Box paddingLeft={highlightBarSize}>
         <Columns space="small">

--- a/lib/components/Badge/Badge.tsx
+++ b/lib/components/Badge/Badge.tsx
@@ -4,6 +4,9 @@ import { Box, BoxProps } from '../Box/Box';
 import { Text } from '../Text/Text';
 import * as styleRefs from './Badge.treat';
 import { useStyles } from 'sku/react-treat';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 
 const validTones = [
   'promote',
@@ -22,6 +25,7 @@ export interface BadgeProps {
   title?: string;
   children: string;
   id?: string;
+  data?: DataAttributeMap;
   tabIndex?: BoxProps['tabIndex'];
   'aria-describedby'?: string;
 }
@@ -65,6 +69,7 @@ export const Badge = forwardRef<HTMLDivElement, BadgeProps>(
       title,
       children,
       id,
+      data,
       tabIndex,
       'aria-describedby': ariaDescribedBy,
     },
@@ -89,6 +94,7 @@ export const Badge = forwardRef<HTMLDivElement, BadgeProps>(
         display="flex"
         cursor="default"
         className={[styles.outer, bleedY ? styles.bleedY : null]}
+        {...(data ? buildDataAttributes(data) : undefined)}
       >
         <Box
           id={id}

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -62,7 +62,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           onClick={onClick}
           disabled={loading}
           {...buttonProps}
-          {...buildDataAttributes(data)}
+          {...(data ? buildDataAttributes(data) : undefined)}
         >
           <ButtonChildren>{children}</ButtonChildren>
         </button>

--- a/lib/components/ButtonLink/ButtonLink.tsx
+++ b/lib/components/ButtonLink/ButtonLink.tsx
@@ -7,16 +7,30 @@ import {
   useLinkComponent,
   LinkComponentProps,
 } from '../BraidProvider/BraidProvider';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 
 export interface ButtonLinkProps
   extends Omit<PrivateButtonRendererProps, 'children'>,
     Omit<LinkComponentProps, 'className' | 'style'> {
   children?: ReactNode;
+  data?: DataAttributeMap;
 }
 
 export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
   (
-    { children, size, tone, weight, variant, bleedY, loading, ...restProps },
+    {
+      children,
+      size,
+      tone,
+      weight,
+      variant,
+      bleedY,
+      loading,
+      data,
+      ...restProps
+    },
     ref,
   ) => {
     const LinkComponent = useLinkComponent(ref);
@@ -31,7 +45,12 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
         bleedY={bleedY}
       >
         {(ButtonChildren, buttonProps) => (
-          <LinkComponent ref={ref} {...restProps} {...buttonProps}>
+          <LinkComponent
+            ref={ref}
+            {...restProps}
+            {...buttonProps}
+            {...(data ? buildDataAttributes(data) : undefined)}
+          >
             <ButtonChildren>{children}</ButtonChildren>
           </LinkComponent>
         )}

--- a/lib/components/Card/Card.tsx
+++ b/lib/components/Card/Card.tsx
@@ -6,6 +6,9 @@ import {
   ResponsiveRangeProps,
 } from '../../utils/responsiveRangeProps';
 import { Box, BoxProps } from '../Box/Box';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 import * as styleRefs from './Card.treat';
 
 export const validCardComponents = [
@@ -31,12 +34,14 @@ export type CardProps = {
   children: ReactNode;
   tone?: 'promote' | 'formAccent';
   component?: typeof validCardComponents[number];
+  data?: DataAttributeMap;
 } & (SimpleCardRounding | ResponsiveCardRounding);
 
 export const Card = ({
   children,
   component = 'div',
   tone,
+  data,
   ...restProps
 }: CardProps) => {
   const styles = useStyles(styleRefs);
@@ -73,6 +78,7 @@ export const Card = ({
       background="card"
       padding="gutter"
       borderRadius={resolvedRounding}
+      {...(data ? buildDataAttributes(data) : undefined)}
     >
       {tone ? (
         <Box

--- a/lib/components/Column/Column.tsx
+++ b/lib/components/Column/Column.tsx
@@ -2,14 +2,18 @@ import React, { ReactNode, useContext } from 'react';
 import { useStyles } from 'sku/react-treat';
 import { Box } from '../Box/Box';
 import { ColumnsContext } from '../Columns/Columns';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 import * as styleRefs from './Column.treat';
 
 export interface ColumnProps {
   children: ReactNode;
   width?: keyof typeof styleRefs.width | 'content';
+  data?: DataAttributeMap;
 }
 
-export const Column = ({ children, width }: ColumnProps) => {
+export const Column = ({ children, data, width }: ColumnProps) => {
   const styles = useStyles(styleRefs);
   const {
     collapseMobile,
@@ -29,6 +33,7 @@ export const Column = ({ children, width }: ColumnProps) => {
         styles.column,
         width !== 'content' ? styles.width[width!] : null,
       ]}
+      {...(data ? buildDataAttributes(data) : undefined)}
     >
       <Box
         paddingLeft={[

--- a/lib/components/Columns/Columns.tsx
+++ b/lib/components/Columns/Columns.tsx
@@ -8,6 +8,9 @@ import {
   resolveCollapsibleAlignmentProps,
   CollapsibleAlignmentProps,
 } from '../../utils/collapsibleAlignmentProps';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 
 type CollapsibleAlignmentChildProps = ReturnType<
   typeof resolveCollapsibleAlignmentProps
@@ -37,6 +40,7 @@ export interface ColumnsProps extends CollapsibleAlignmentProps {
     | Array<ReactElement<ColumnProps> | null>
     | ReactElement<ColumnProps>
     | null;
+  data?: DataAttributeMap;
 }
 
 export const Columns = ({
@@ -46,6 +50,7 @@ export const Columns = ({
   space = 'none',
   align,
   alignY,
+  data,
 }: ColumnsProps) => {
   const [mobileSpace, tabletSpace, desktopSpace] = normaliseResponsiveProp(
     space,
@@ -71,7 +76,11 @@ export const Columns = ({
   ]);
 
   return (
-    <Box {...collapsibleAlignmentProps} className={negativeMarginLeft}>
+    <Box
+      {...collapsibleAlignmentProps}
+      className={negativeMarginLeft}
+      {...(data ? buildDataAttributes(data) : undefined)}
+    >
       <ColumnsContext.Provider
         value={{
           collapseMobile,

--- a/lib/components/ContentBlock/ContentBlock.tsx
+++ b/lib/components/ContentBlock/ContentBlock.tsx
@@ -1,21 +1,31 @@
 import React, { ReactNode } from 'react';
 import { useStyles } from 'sku/react-treat';
 import { Box, BoxProps } from '../Box/Box';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 import * as styleRefs from './ContentBlock.treat';
 
 export interface ContentBlockProps {
   children: ReactNode;
   width?: BoxProps['maxWidth'];
+  data?: DataAttributeMap;
 }
 
 export const ContentBlock = ({
   width = 'medium',
+  data,
   children,
 }: ContentBlockProps) => {
   const styles = useStyles(styleRefs);
 
   return (
-    <Box width="full" maxWidth={width} className={styles.marginAuto}>
+    <Box
+      width="full"
+      maxWidth={width}
+      className={styles.marginAuto}
+      {...(data ? buildDataAttributes(data) : undefined)}
+    >
       {children}
     </Box>
   );

--- a/lib/components/Disclosure/Disclosure.tsx
+++ b/lib/components/Disclosure/Disclosure.tsx
@@ -5,11 +5,15 @@ import { Text } from '../Text/Text';
 import { TextLinkButton } from '../TextLinkButton/TextLinkButton';
 import { IconChevron } from '../icons';
 import { useDisclosure, UseDisclosureProps } from './useDisclosure';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 
 export type DisclosureBaseProps = {
   expandLabel: string;
   collapseLabel?: string;
   space?: BoxProps['paddingTop'];
+  data?: DataAttributeMap;
   children: ReactNode;
 };
 export type DisclosureProps = DisclosureBaseProps & UseDisclosureProps;
@@ -21,6 +25,7 @@ export const Disclosure = ({
   collapseLabel = expandLabel,
   space = 'medium',
   children,
+  data,
   ...restProps
 }: DisclosureProps) => {
   assert(
@@ -46,7 +51,7 @@ export const Disclosure = ({
   });
 
   return (
-    <Box>
+    <Box {...(data ? buildDataAttributes(data) : undefined)}>
       <Box userSelect="none">
         <Text>
           <TextLinkButton hitArea="large" {...buttonProps}>

--- a/lib/components/FieldLabel/FieldLabel.tsx
+++ b/lib/components/FieldLabel/FieldLabel.tsx
@@ -4,6 +4,7 @@ import { Secondary } from '../Secondary/Secondary';
 import { Strong } from '../Strong/Strong';
 import { Text } from '../Text/Text';
 import { Stack } from '../Stack/Stack';
+import { DataAttributeMap } from '../private/buildDataAttributes';
 
 export interface FieldLabelProps {
   id?: string;
@@ -13,6 +14,7 @@ export interface FieldLabelProps {
   tertiaryLabel?: ReactNode;
   description?: ReactNode;
   descriptionId?: string;
+  data?: DataAttributeMap;
 }
 
 export const FieldLabel = ({
@@ -23,6 +25,7 @@ export const FieldLabel = ({
   tertiaryLabel,
   description,
   descriptionId,
+  data,
 }: FieldLabelProps) => {
   if (!label) {
     return null;
@@ -36,7 +39,7 @@ export const FieldLabel = ({
   );
 
   return (
-    <Stack space="xsmall">
+    <Stack space="xsmall" data={data}>
       <Box component="span" display="flex" justifyContent="spaceBetween">
         {htmlFor === false ? (
           labelEl

--- a/lib/components/FieldMessage/FieldMessage.tsx
+++ b/lib/components/FieldMessage/FieldMessage.tsx
@@ -2,6 +2,9 @@ import React, { ReactNode } from 'react';
 import { Box } from '../Box/Box';
 import { Text } from '../Text/Text';
 import { IconCritical, IconPositive } from '../icons';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 
 export const tones = ['neutral', 'critical', 'positive'] as const;
 type FieldTone = typeof tones[number];
@@ -13,6 +16,7 @@ export interface FieldMessageProps {
   tone?: FieldTone;
   secondaryMessage?: ReactNode;
   disabled?: boolean;
+  data?: DataAttributeMap;
 }
 
 const Icon: Record<'critical' | 'positive', ReactNode> = {
@@ -26,6 +30,7 @@ export const FieldMessage = ({
   secondaryMessage,
   reserveMessageSpace = true,
   disabled,
+  data,
 }: FieldMessageProps) => {
   if (tones.indexOf(tone) === -1) {
     throw new Error(`Invalid tone: ${tone}`);
@@ -38,7 +43,12 @@ export const FieldMessage = ({
   const showMessage = !disabled && message;
 
   return (
-    <Box id={id} display="flex" justifyContent="flexEnd">
+    <Box
+      id={id}
+      display="flex"
+      justifyContent="flexEnd"
+      {...(data ? buildDataAttributes(data) : undefined)}
+    >
       <Box flexGrow={1}>
         <Text size="small" tone={tone === 'neutral' ? 'secondary' : tone}>
           <Box display="flex" userSelect={showMessage ? undefined : 'none'}>

--- a/lib/components/Hidden/Hidden.tsx
+++ b/lib/components/Hidden/Hidden.tsx
@@ -7,6 +7,9 @@ import {
   resolveResponsiveRangeProps,
   ResponsiveRangeProps,
 } from '../../utils/responsiveRangeProps';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 import * as styleRefs from './Hidden.treat';
 
 export interface HiddenProps extends ResponsiveRangeProps {
@@ -15,6 +18,7 @@ export interface HiddenProps extends ResponsiveRangeProps {
   screen?: boolean;
   print?: boolean;
   inline?: boolean;
+  data?: DataAttributeMap;
 }
 
 export const Hidden = ({
@@ -25,6 +29,7 @@ export const Hidden = ({
   screen,
   print,
   inline: inlineProp,
+  data,
 }: HiddenProps) => {
   if (process.env.NODE_ENV === 'development' && screen) {
     // eslint-disable-next-line no-console
@@ -61,6 +66,7 @@ export const Hidden = ({
       }
       className={hiddenOnPrint ? styles.hiddenOnPrint : undefined}
       component={component || (inline ? 'span' : 'div')}
+      {...(data ? buildDataAttributes(data) : undefined)}
     >
       {children}
     </Box>

--- a/lib/components/HiddenVisually/HiddenVisually.tsx
+++ b/lib/components/HiddenVisually/HiddenVisually.tsx
@@ -3,14 +3,18 @@ import { useStyles } from 'sku/react-treat';
 import { Box, BoxProps } from '../Box/Box';
 import { TextContext } from '../Text/TextContext';
 import HeadingContext from '../Heading/HeadingContext';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 import * as styleRefs from './HiddenVisually.treat';
 
 interface HiddenVisuallyProps {
   id?: string;
   children: BoxProps['children'];
+  data?: DataAttributeMap;
 }
 
-export const HiddenVisually = ({ id, children }: HiddenVisuallyProps) => {
+export const HiddenVisually = ({ id, data, children }: HiddenVisuallyProps) => {
   const styles = useStyles(styleRefs);
   const inText = Boolean(useContext(TextContext));
   const inHeading = Boolean(useContext(HeadingContext));
@@ -24,6 +28,7 @@ export const HiddenVisually = ({ id, children }: HiddenVisuallyProps) => {
       position="absolute"
       overflow="hidden"
       className={styles.root}
+      {...(data ? buildDataAttributes(data) : undefined)}
     >
       {children}
     </Box>

--- a/lib/components/Inline/Inline.tsx
+++ b/lib/components/Inline/Inline.tsx
@@ -13,12 +13,16 @@ import {
   resolveCollapsibleAlignmentProps,
   CollapsibleAlignmentProps,
 } from '../../utils/collapsibleAlignmentProps';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 
 export const validInlineComponents = ['div', 'ol', 'ul'] as const;
 
 export interface InlineProps extends CollapsibleAlignmentProps {
   space: ResponsiveSpace;
   component?: typeof validInlineComponents[number];
+  data?: DataAttributeMap;
   children: ReactNodeNoStrings;
 }
 
@@ -29,6 +33,7 @@ export const Inline = ({
   collapseBelow,
   reverse,
   component = 'div',
+  data,
   children,
 }: InlineProps) => {
   assert(
@@ -56,7 +61,10 @@ export const Inline = ({
   });
 
   return (
-    <Box className={negativeMarginTop}>
+    <Box
+      className={negativeMarginTop}
+      {...(data ? buildDataAttributes(data) : undefined)}
+    >
       <Box
         component={component}
         className={negativeMarginLeft}

--- a/lib/components/List/List.tsx
+++ b/lib/components/List/List.tsx
@@ -96,6 +96,7 @@ export type ListProps = {
   space?: StackProps['space'];
   tone?: TextProps['tone'];
   start?: number;
+  data?: StackProps['data'];
 } & (ListTypeIcon | ListTypeCharacter);
 
 export const List = ({
@@ -105,6 +106,7 @@ export const List = ({
   space = 'medium',
   type = 'bullet',
   start = 1,
+  data,
   ...restProps
 }: ListProps) => {
   const styles = useStyles(styleRefs);
@@ -122,6 +124,7 @@ export const List = ({
       <Stack
         component={/^(bullet|icon)$/.test(type) ? 'ul' : 'ol'}
         space={space}
+        data={data}
       >
         {Children.map(listItems, (listItem, index) => {
           const resolvedIndex = index + (start - 1);

--- a/lib/components/Loader/Loader.tsx
+++ b/lib/components/Loader/Loader.tsx
@@ -3,6 +3,9 @@ import { useStyles } from 'sku/react-treat';
 import { Box } from '../Box/Box';
 import { useBackgroundLightness } from '../Box/BackgroundContext';
 import * as styleRefs from './Loader.treat';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 
 const indicators = [...Array(3)];
 
@@ -10,12 +13,14 @@ interface LoaderProps {
   size?: keyof typeof styleRefs.rootSize;
   'aria-label'?: string;
   delayVisibility?: boolean;
+  data?: DataAttributeMap;
 }
 
 export const Loader = ({
   size = 'standard',
   'aria-label': ariaLabel = 'Loading',
   delayVisibility = false,
+  data,
 }: LoaderProps) => {
   const styles = useStyles(styleRefs);
   const parentBackgroundColor = useBackgroundLightness();
@@ -28,6 +33,7 @@ export const Loader = ({
         delayVisibility ? styles.delay : undefined,
       ]}
       aria-label={ariaLabel}
+      {...(data ? buildDataAttributes(data) : undefined)}
     >
       {indicators.map((_, index) => (
         <Box

--- a/lib/components/MenuRenderer/MenuRenderer.tsx
+++ b/lib/components/MenuRenderer/MenuRenderer.tsx
@@ -264,7 +264,10 @@ export const MenuRenderer = ({
 
   return (
     <MenuRendererContext.Provider value={true}>
-      <Box className={styles.root} {...buildDataAttributes(data)}>
+      <Box
+        className={styles.root}
+        {...(data ? buildDataAttributes(data) : undefined)}
+      >
         <Box display="inlineBlock" position="relative">
           {trigger(triggerProps, { open })}
 

--- a/lib/components/MonthPicker/MonthPicker.tsx
+++ b/lib/components/MonthPicker/MonthPicker.tsx
@@ -53,7 +53,6 @@ export interface MonthPickerProps
     | 'value'
     | 'labelId'
     | 'aria-describedby'
-    | 'data'
     | 'name'
     | 'autoComplete'
     | 'secondaryMessage'
@@ -201,7 +200,6 @@ const MonthPicker = ({
       icon={undefined}
       prefix={undefined}
       labelId={undefined}
-      data={undefined}
       name={undefined}
       autoComplete={undefined}
       secondaryMessage={null}

--- a/lib/components/Notice/Notice.tsx
+++ b/lib/components/Notice/Notice.tsx
@@ -5,11 +5,15 @@ import { Column } from '../Column/Column';
 import { Box } from '../Box/Box';
 import { useTextAlignedToIcon } from '../../hooks/useTextAlignedToIcon/useTextAlignedToIcon';
 import { DefaultTextPropsProvider } from '../private/defaultTextProps';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 
 type Tone = 'promote' | 'info' | 'positive' | 'critical';
 
 export type NoticeProps = {
   tone?: Tone;
+  data?: DataAttributeMap;
   children: ReactNode;
 };
 
@@ -20,11 +24,15 @@ const icons = {
   critical: IconCritical,
 };
 
-export const Notice = ({ tone = 'info', children }: NoticeProps) => {
+export const Notice = ({ tone = 'info', data, children }: NoticeProps) => {
   const Icon = icons[tone];
 
   return (
-    <Box role="alert" aria-live="polite">
+    <Box
+      role="alert"
+      aria-live="polite"
+      {...(data ? buildDataAttributes(data) : undefined)}
+    >
       <Columns space="xsmall">
         <Column width="content">
           <Icon tone={tone} />

--- a/lib/components/Pagination/Pagination.tsx
+++ b/lib/components/Pagination/Pagination.tsx
@@ -8,6 +8,9 @@ import { Link, LinkProps } from '../Link/Link';
 import { Overlay } from '../private/Overlay/Overlay';
 import { Text } from '../Text/Text';
 import { paginate } from './paginate';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 
 import * as styleRefs from './Pagination.treat';
 
@@ -25,6 +28,7 @@ export interface PaginationProps {
   pageLabel?: (page: number) => string;
   nextLabel?: string;
   previousLabel?: string;
+  data?: DataAttributeMap;
 }
 
 const PageNav = ({
@@ -128,6 +132,7 @@ export const Pagination = ({
   pageLabel = (p: number) => `Go to page ${p}`,
   nextLabel = 'Next',
   previousLabel = 'Previous',
+  data,
 }: PaginationProps) => {
   assert(total >= 1, `\`total\` must be at least 1`);
   assert(page >= 1 && page <= total, `\`page\` must be between 1 and ${total}`);
@@ -137,7 +142,11 @@ export const Pagination = ({
   const showNext = page < total;
 
   return (
-    <Box component="nav" aria-label={label}>
+    <Box
+      component="nav"
+      aria-label={label}
+      {...(data ? buildDataAttributes(data) : undefined)}
+    >
       <Box component="ul" display="flex" justifyContent="center">
         {showPrevious ? (
           <Box component="li" paddingRight={['medium', tabletButtonSpacing]}>

--- a/lib/components/Rating/Rating.tsx
+++ b/lib/components/Rating/Rating.tsx
@@ -49,6 +49,7 @@ export interface RatingProps {
   size?: TextProps['size'];
   showTextRating?: boolean;
   'aria-label'?: string;
+  data?: TextProps['data'];
 }
 
 export const Rating = ({
@@ -56,6 +57,7 @@ export const Rating = ({
   size = 'standard',
   showTextRating = true,
   'aria-label': ariaLabel,
+  data,
 }: RatingProps) => {
   const styles = useStyles(styleRefs);
 
@@ -65,7 +67,7 @@ export const Rating = ({
   );
 
   return (
-    <Text size={size}>
+    <Text size={size} data={data}>
       <Box
         display="inlineBlock"
         aria-label={

--- a/lib/components/Secondary/Secondary.tsx
+++ b/lib/components/Secondary/Secondary.tsx
@@ -1,13 +1,21 @@
 import React, { ReactNode } from 'react';
 import { useTextTone } from '../../hooks/typography';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 
 export interface SecondaryProps {
   children: ReactNode;
   id?: string;
+  data?: DataAttributeMap;
 }
 
-export const Secondary = ({ children, id }: SecondaryProps) => (
-  <span className={useTextTone({ tone: 'secondary' })} id={id}>
+export const Secondary = ({ children, data, id }: SecondaryProps) => (
+  <span
+    className={useTextTone({ tone: 'secondary' })}
+    id={id}
+    {...(data ? buildDataAttributes(data) : undefined)}
+  >
     {children}
   </span>
 );

--- a/lib/components/Stack/Stack.tsx
+++ b/lib/components/Stack/Stack.tsx
@@ -15,6 +15,9 @@ import {
 import { resolveResponsiveRangeProps } from '../../utils/responsiveRangeProps';
 import { useNegativeMarginTop } from '../../hooks/useNegativeMargin/useNegativeMargin';
 import { ReactNodeNoStrings } from '../private/ReactNodeNoStrings';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 
 const alignToDisplay = {
   left: 'block',
@@ -85,6 +88,7 @@ export interface StackProps {
   space: BoxProps['paddingTop'];
   align?: ResponsiveProp<Align>;
   dividers?: boolean | DividerProps['weight'];
+  data?: DataAttributeMap;
 }
 
 export const Stack = ({
@@ -93,6 +97,7 @@ export const Stack = ({
   space = 'none',
   align = 'left',
   dividers = false,
+  data,
 }: StackProps) => {
   assert(
     validStackComponents.includes(component),
@@ -113,7 +118,11 @@ export const Stack = ({
   let firstItemOnDesktop: number | null = null;
 
   return (
-    <Box component={component} className={negativeMarginTop}>
+    <Box
+      component={component}
+      className={negativeMarginTop}
+      {...(data ? buildDataAttributes(data) : undefined)}
+    >
       {Children.map(stackItems, (child, index) => {
         assert(
           !(

--- a/lib/components/Strong/Strong.tsx
+++ b/lib/components/Strong/Strong.tsx
@@ -1,13 +1,21 @@
 import React, { ReactNode } from 'react';
 import { useWeight } from '../../hooks/typography';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 
 export interface StrongProps {
   children: ReactNode;
   id?: string;
+  data?: DataAttributeMap;
 }
 
-export const Strong = ({ children, id }: StrongProps) => (
-  <strong className={useWeight('strong')} id={id}>
+export const Strong = ({ children, data, id }: StrongProps) => (
+  <strong
+    className={useWeight('strong')}
+    id={id}
+    {...(data ? buildDataAttributes(data) : undefined)}
+  >
     {children}
   </strong>
 );

--- a/lib/components/Tabs/Tab.tsx
+++ b/lib/components/Tabs/Tab.tsx
@@ -215,7 +215,7 @@ export const Tab = ({ children, data, badge, item }: TabProps) => {
       paddingX={paddingX}
       paddingY="medium"
       className={styles.tab}
-      {...buildDataAttributes(data)}
+      {...(data ? buildDataAttributes(data) : undefined)}
     >
       {/*
         Rendering Text component to provide rendering context

--- a/lib/components/Tabs/TabPanel.tsx
+++ b/lib/components/Tabs/TabPanel.tsx
@@ -47,7 +47,7 @@ export const TabPanel = ({ children, data, item }: TabPanelProps) => {
       position="relative"
       outline="none"
       className={styles.tabPanel}
-      {...buildDataAttributes(data)}
+      {...(data ? buildDataAttributes(data) : undefined)}
     >
       {isSelected || renderInactive ? children : undefined}
       <Overlay

--- a/lib/components/Tabs/Tabs.tsx
+++ b/lib/components/Tabs/Tabs.tsx
@@ -136,7 +136,7 @@ export const Tabs = (props: TabsProps) => {
               <Box
                 {...a11y.tabListProps({ label })}
                 display="flex"
-                {...buildDataAttributes(data)}
+                {...(data ? buildDataAttributes(data) : undefined)}
                 flexWrap="nowrap"
               >
                 {tabs}

--- a/lib/components/Tag/Tag.tsx
+++ b/lib/components/Tag/Tag.tsx
@@ -4,15 +4,24 @@ import assert from 'assert';
 import { Box } from '../Box/Box';
 import { Text } from '../Text/Text';
 import { ClearButton } from '../iconButtons/ClearButton/ClearButton';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 import * as styleRefs from './Tag.treat';
 
 type AllOrNone<T> = T | { [K in keyof T]?: never };
 
 export type TagProps = {
   children: string;
+  data?: DataAttributeMap;
 } & AllOrNone<{ onClear: () => void; clearLabel: string }>;
 
-export const Tag = ({ onClear, clearLabel = 'Clear', children }: TagProps) => {
+export const Tag = ({
+  onClear,
+  clearLabel = 'Clear',
+  data,
+  children,
+}: TagProps) => {
   assert(
     typeof children === 'undefined' || typeof children === 'string',
     'Tag may only contain a string',
@@ -21,7 +30,7 @@ export const Tag = ({ onClear, clearLabel = 'Clear', children }: TagProps) => {
   const styles = useStyles(styleRefs);
 
   return (
-    <Box display="flex">
+    <Box display="flex" {...(data ? buildDataAttributes(data) : undefined)}>
       <Box
         display="flex"
         minWidth={0}

--- a/lib/components/TextDropdown/TextDropdown.tsx
+++ b/lib/components/TextDropdown/TextDropdown.tsx
@@ -7,6 +7,9 @@ import { IconChevron } from '../icons';
 import * as styleRefs from './TextDropdown.treat';
 import { TextContext } from '../Text/TextContext';
 import HeadingContext from '../Heading/HeadingContext';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 
 interface TextDropdownOption<Value> {
   text: string;
@@ -21,6 +24,7 @@ export interface TextDropdownProps<Value> {
   onBlur?: () => void;
   options: TextDropdownValue<Value>[];
   label: string;
+  data?: DataAttributeMap;
 }
 
 export function parseSimpleToComplexOption<Value>(
@@ -41,6 +45,7 @@ export function TextDropdown<Value>({
   onBlur,
   options,
   label,
+  data,
 }: TextDropdownProps<Value>) {
   const styles = useStyles(styleRefs);
 
@@ -66,7 +71,11 @@ export function TextDropdown<Value>({
   }
 
   return (
-    <Box display="inlineBlock" position="relative">
+    <Box
+      display="inlineBlock"
+      position="relative"
+      {...(data ? buildDataAttributes(data) : undefined)}
+    >
       <Box pointerEvents="none" userSelect="none">
         {currentText.text} <IconChevron alignY="lowercase" />
       </Box>

--- a/lib/components/TextLink/TextLink.tsx
+++ b/lib/components/TextLink/TextLink.tsx
@@ -7,13 +7,18 @@ import {
   useLinkComponent,
   LinkComponentProps,
 } from '../BraidProvider/BraidProvider';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 
 export interface TextLinkProps
   extends Omit<PrivateTextLinkRendererProps, 'children'>,
-    Omit<LinkComponentProps, 'className' | 'style'> {}
+    Omit<LinkComponentProps, 'className' | 'style'> {
+  data?: DataAttributeMap;
+}
 
 export const TextLink = forwardRef<HTMLAnchorElement, TextLinkProps>(
-  ({ weight, showVisited, hitArea, ...props }, ref) => {
+  ({ weight, showVisited, hitArea, data, ...props }, ref) => {
     const LinkComponent = useLinkComponent(ref);
 
     return (
@@ -22,7 +27,14 @@ export const TextLink = forwardRef<HTMLAnchorElement, TextLinkProps>(
         showVisited={showVisited}
         hitArea={hitArea}
       >
-        {(styleProps) => <LinkComponent ref={ref} {...props} {...styleProps} />}
+        {(styleProps) => (
+          <LinkComponent
+            ref={ref}
+            {...props}
+            {...styleProps}
+            {...(data ? buildDataAttributes(data) : undefined)}
+          />
+        )}
       </PrivateTextLinkRenderer>
     );
   },

--- a/lib/components/TextLinkButton/TextLinkButton.tsx
+++ b/lib/components/TextLinkButton/TextLinkButton.tsx
@@ -65,7 +65,7 @@ export const TextLinkButton = ({
           aria-describedby={ariaDescribedBy}
           id={id}
           {...styleProps}
-          {...buildDataAttributes(data)}
+          {...(data ? buildDataAttributes(data) : undefined)}
         >
           {children}
         </Box>

--- a/lib/components/Tiles/Tiles.tsx
+++ b/lib/components/Tiles/Tiles.tsx
@@ -15,12 +15,16 @@ import {
 } from '../../utils/responsiveProp';
 import * as styleRefs from './Tiles.treat';
 import { ReactNodeNoStrings } from '../private/ReactNodeNoStrings';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 
 export interface TilesProps {
   children: ReactNodeNoStrings;
   space: ResponsiveSpace;
   columns: ResponsiveProp<1 | 2 | 3 | 4 | 5 | 6>;
   dividers?: boolean | DividerProps['weight'];
+  data?: DataAttributeMap;
 }
 
 export const Tiles = ({
@@ -28,6 +32,7 @@ export const Tiles = ({
   space = 'none',
   columns = 1,
   dividers = false,
+  data,
 }: TilesProps) => {
   const styles = useStyles(styleRefs);
 
@@ -43,7 +48,10 @@ export const Tiles = ({
   const negativeMarginLeft = useNegativeMarginLeft(responsiveSpace);
 
   return (
-    <Box className={negativeMarginTop}>
+    <Box
+      className={negativeMarginTop}
+      {...(data ? buildDataAttributes(data) : undefined)}
+    >
       <Box display="flex" flexWrap="wrap" className={negativeMarginLeft}>
         {Children.map(flattenChildren(children), (child, i) => (
           <Box

--- a/lib/components/Toggle/Toggle.tsx
+++ b/lib/components/Toggle/Toggle.tsx
@@ -6,6 +6,9 @@ import { Text } from '../Text/Text';
 import { IconTick } from '../icons';
 import { useVirtualTouchable } from '../private/touchable/useVirtualTouchable';
 import { useBackgroundLightness } from '../Box/BackgroundContext';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../private/buildDataAttributes';
 import * as styleRefs from './Toggle.treat';
 
 type HTMLInputProps = AllHTMLAttributes<HTMLInputElement>;
@@ -17,6 +20,7 @@ export interface ToggleProps {
   onChange: ChangeHandler;
   align?: 'left' | 'right' | 'justify';
   size?: keyof typeof styleRefs.fieldSize;
+  data?: DataAttributeMap;
 }
 
 const handleChange = (onChange: ChangeHandler) => (
@@ -34,6 +38,7 @@ export const Toggle = ({
   label,
   align = 'left',
   size = 'standard',
+  data,
 }: ToggleProps) => {
   const styles = useStyles(styleRefs);
   const showBorder = useBackgroundLightness() === 'light';
@@ -45,6 +50,7 @@ export const Toggle = ({
       display="flex"
       flexDirection={align === 'left' ? undefined : 'rowReverse'}
       className={styles.root}
+      {...(data ? buildDataAttributes(data) : undefined)}
     >
       <Box
         component="input"

--- a/lib/components/iconButtons/IconButton.tsx
+++ b/lib/components/iconButtons/IconButton.tsx
@@ -108,7 +108,7 @@ export const IconButton = forwardRef<HTMLButtonElement, IconButtonProps>(
         transform="touchable"
         transition="touchable"
         tabIndex={!keyboardAccessible ? -1 : undefined}
-        {...buildDataAttributes(data)}
+        {...(data ? buildDataAttributes(data) : undefined)}
       >
         <Box
           position="relative"

--- a/lib/components/private/FieldGroup/FieldGroup.tsx
+++ b/lib/components/private/FieldGroup/FieldGroup.tsx
@@ -6,6 +6,7 @@ import {
   FieldMessageProps,
 } from '../../FieldMessage/FieldMessage';
 import { Stack, StackProps } from '../../Stack/Stack';
+import buildDataAttributes, { DataAttributeMap } from '../buildDataAttributes';
 import { mergeIds } from '../mergeIds';
 import { ReactNodeNoStrings } from '../ReactNodeNoStrings';
 
@@ -21,6 +22,7 @@ export interface FieldGroupProps {
   reserveMessageSpace?: FieldMessageProps['reserveMessageSpace'];
   tone?: FieldMessageProps['tone'];
   required?: boolean;
+  data?: DataAttributeMap;
 }
 
 interface FieldGroupRenderProps {
@@ -48,6 +50,7 @@ export const FieldGroup = ({
   required,
   role,
   space = 'xsmall',
+  data,
 }: InternalFieldGroupProps) => {
   const labelId = `${id}-label`;
   const messageId = `${id}-message`;
@@ -61,6 +64,7 @@ export const FieldGroup = ({
       role={role}
       aria-labelledby={label ? labelId : undefined}
       aria-required={required}
+      {...(data ? buildDataAttributes(data) : undefined)}
     >
       <Stack space={space}>
         {label ? (

--- a/lib/components/private/InlineField/InlineField.tsx
+++ b/lib/components/private/InlineField/InlineField.tsx
@@ -222,7 +222,7 @@ export const InlineField = forwardRef<
             disabled={disabled}
             ref={ref}
             tabIndex={tabIndex}
-            {...buildDataAttributes(data)}
+            {...(data ? buildDataAttributes(data) : undefined)}
           />
           <Box
             flexShrink={0}

--- a/lib/components/private/Modal/Modal.tsx
+++ b/lib/components/private/Modal/Modal.tsx
@@ -138,6 +138,7 @@ export const Modal = ({
   title,
   headingLevel,
   position,
+  data,
 }: ModalProps) => {
   const styles = useStyles(styleRefs);
   const [trapActive, setTrapActive] = useState(true);
@@ -272,6 +273,7 @@ export const Modal = ({
               modalRef={modalRef}
               position={position}
               scrollLock={!(state === CLOSING)}
+              data={data}
             >
               {children}
             </ModalContent>

--- a/lib/components/private/Modal/ModalContent.tsx
+++ b/lib/components/private/Modal/ModalContent.tsx
@@ -19,6 +19,7 @@ import { ReactNodeNoStrings } from '../ReactNodeNoStrings';
 import { IconClear } from '../../icons';
 import { useNegativeMarginTop } from '../../../hooks/useNegativeMargin/useNegativeMargin';
 import { useVirtualTouchable } from '../touchable/useVirtualTouchable';
+import buildDataAttributes, { DataAttributeMap } from '../buildDataAttributes';
 import * as styleRefs from './Modal.treat';
 
 export interface ModalContentProps {
@@ -35,6 +36,7 @@ export interface ModalContentProps {
   scrollLock?: boolean;
   headingRef?: Ref<HTMLElement>;
   modalRef?: Ref<HTMLElement>;
+  data?: DataAttributeMap;
 }
 
 const modalPadding = ['gutter', 'large'] as const;
@@ -90,6 +92,7 @@ export const ModalContent = ({
   scrollLock = true,
   position,
   headingLevel,
+  data,
 }: ModalContentProps) => {
   const styles = useStyles(styleRefs);
 
@@ -150,6 +153,7 @@ export const ModalContent = ({
               styles.pointerEventsAll,
               position === 'center' && styles.maxSize[position],
             ]}
+            {...(data ? buildDataAttributes(data) : undefined)}
           >
             <Stack space="large">
               {illustration ? (

--- a/lib/hooks/useIcon/index.ts
+++ b/lib/hooks/useIcon/index.ts
@@ -9,6 +9,9 @@ import { TextContext } from '../../components/Text/TextContext';
 import HeadingContext from '../../components/Heading/HeadingContext';
 import { useTextSize, useTextTone, UseTextProps } from '../typography';
 import { useLineHeightContainer } from '../useLineHeightContainer/useLineHeightContainer';
+import buildDataAttributes, {
+  DataAttributeMap,
+} from '../../components/private/buildDataAttributes';
 import * as styleRefs from './icon.treat';
 
 type IconSize = NonNullable<UseTextProps['size']> | 'fill';
@@ -36,6 +39,7 @@ export type UseIconProps = {
   size?: IconSize;
   tone?: UseTextProps['tone'];
   alignY?: 'uppercase' | 'lowercase';
+  data?: DataAttributeMap;
 } & OptionalTitle;
 
 type PrivateIconProps = {
@@ -51,7 +55,7 @@ const detaultVerticalCorrection = {
 } as const;
 
 export default (
-  { size, tone, alignY, ...titleProps }: UseIconProps,
+  { size, tone, alignY, data, ...titleProps }: UseIconProps,
   { verticalCorrection = detaultVerticalCorrection }: PrivateIconProps = {},
 ): BoxProps => {
   const styles = useStyles(styleRefs);
@@ -86,6 +90,7 @@ export default (
       height: 'full',
       display: 'block',
       className: resolvedTone,
+      ...(data ? buildDataAttributes(data) : undefined),
       ...a11yProps,
     };
   }
@@ -105,6 +110,7 @@ export default (
           ]
         : blockSizeStyles,
     ],
+    ...(data ? buildDataAttributes(data) : undefined),
     ...a11yProps,
   };
 };


### PR DESCRIPTION
Add support for data attribute maps on all components.

**EXAMPLE USAGE:**
```tsx
<Alert
  data={{
    testId: 'message'
  }}
/>
// => <div data-testId="message" />
```