### PR TITLE
Autosuggest: Fix missing/invalid group headings in some cases

### DIFF
--- a/.changeset/poor-lobsters-retire.md
+++ b/.changeset/poor-lobsters-retire.md
@@ -1,0 +1,9 @@
+---
+'braid-design-system': patch
+---
+---
+updated:
+  - Autosuggest 
+---
+
+**Autosuggest:** Fix missing/invalid group headings in some cases

--- a/lib/components/Autosuggest/Autosuggest.test.tsx
+++ b/lib/components/Autosuggest/Autosuggest.test.tsx
@@ -48,7 +48,9 @@ function renderAutosuggest<Value>({
     );
   };
 
-  const { getByRole, queryByLabelText, queryByText } = render(<TestCase />);
+  const { getByRole, queryByLabelText, queryByText, getByTestId } = render(
+    <TestCase />,
+  );
   const input = getByRole('combobox');
   const getInputValue = () => input.getAttribute('value');
 
@@ -58,6 +60,7 @@ function renderAutosuggest<Value>({
     changeHandler,
     queryByLabelText,
     queryByText,
+    getByTestId,
     setSuggestions: (x: Suggestions) => act(() => setSuggestions(x)),
   };
 }
@@ -367,7 +370,7 @@ describe('Autosuggest', () => {
     });
 
     it('should support grouped suggestions', () => {
-      const { input, queryByLabelText } = renderAutosuggest({
+      const { input, queryByLabelText, getByTestId } = renderAutosuggest({
         value: { text: '' },
         suggestions: [
           {
@@ -376,6 +379,14 @@ describe('Autosuggest', () => {
               {
                 text: 'Apples',
                 value: 'apples',
+              },
+              {
+                text: 'Bananas',
+                value: 'bananas',
+              },
+              {
+                text: 'Oranges',
+                value: 'oranges',
               },
             ],
           },
@@ -386,6 +397,19 @@ describe('Autosuggest', () => {
                 text: 'Carrots',
                 value: 'carrots',
               },
+              {
+                text: 'Broccoli',
+                value: 'broccoli',
+              },
+            ],
+          },
+          {
+            label: 'Dessert',
+            suggestions: [
+              {
+                text: 'Ice cream',
+                value: 'ice-cream',
+              },
             ],
           },
         ],
@@ -395,6 +419,11 @@ describe('Autosuggest', () => {
 
       expect(queryByLabelText('Apples (Fruit)')).toBeInTheDocument();
       expect(queryByLabelText('Carrots (Vegetables)')).toBeInTheDocument();
+      expect(queryByLabelText('Ice cream (Dessert)')).toBeInTheDocument();
+
+      expect(getByTestId('group-heading-Fruit')).toBeInTheDocument();
+      expect(getByTestId('group-heading-Vegetables')).toBeInTheDocument();
+      expect(getByTestId('group-heading-Dessert')).toBeInTheDocument();
     });
 
     it('should support suggestions with descriptions', () => {

--- a/lib/components/Autosuggest/Autosuggest.tsx
+++ b/lib/components/Autosuggest/Autosuggest.tsx
@@ -197,7 +197,11 @@ function GroupHeading({ children }: GroupHeadingProps) {
           tone: 'formAccent',
         }),
       ]}
-      data-testid={`group-heading-${children}`}
+      data-testid={
+        process.env.NODE_ENV !== 'production'
+          ? `group-heading-${children}`
+          : undefined
+      }
     >
       {children}
     </Box>

--- a/lib/components/Autosuggest/Autosuggest.tsx
+++ b/lib/components/Autosuggest/Autosuggest.tsx
@@ -197,6 +197,7 @@ function GroupHeading({ children }: GroupHeadingProps) {
           tone: 'formAccent',
         }),
       ]}
+      data-testid={`group-heading-${children}`}
     >
       {children}
     </Box>
@@ -217,9 +218,9 @@ function normaliseSuggestions<Value>(
       item.suggestions.forEach((suggestion) => {
         groupHeadingForSuggestion.set(suggestion, item.label);
       });
-      index += normalisedSuggestions.push(...item.suggestions);
+      index = normalisedSuggestions.push(...item.suggestions);
     } else {
-      index += normalisedSuggestions.push(item);
+      index = normalisedSuggestions.push(item);
     }
   }
 


### PR DESCRIPTION
Went with `data-testid` but open to suggestions 😉 