### PR TITLE
Gallery: Improve Safari performance

### DIFF
--- a/site/src/App/routes/gallery/Gallery.tsx
+++ b/site/src/App/routes/gallery/Gallery.tsx
@@ -263,6 +263,7 @@ const GalleryItem = ({
                       width: isAnIcon ? undefined : '700px',
                     }}
                     key={`${example.label}_${index}`}
+                    className={styles.animationsOnlyOnHover}
                   >
                     <BraidProvider styleBody={false} theme={theme}>
                       <PlayroomStateProvider>
@@ -639,7 +640,7 @@ const GalleryInternal = () => {
           ref={contentRef}
           display="flex"
           userSelect="none"
-          style={{ transformOrigin: '0px 0px' }}
+          className={styles.contentWrapper}
         >
           <Box component="section">
             <Stage setName="components" title="Components" jumpTo={jumpTo} />

--- a/site/src/App/routes/gallery/gallery.css.ts
+++ b/site/src/App/routes/gallery/gallery.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css';
+import { globalStyle, style } from '@vanilla-extract/css';
 import { vars } from '../../../../../lib/themes/vars.css';
 
 export const loader = style({
@@ -36,4 +36,18 @@ export const panelBackground = style({
       opacity: 0.85,
     },
   },
+});
+
+export const contentWrapper = style({
+  backfaceVisibility: 'hidden',
+  transformOrigin: '0px 0px',
+  willChange: 'transform',
+});
+
+export const animationsOnlyOnHover = style({});
+
+globalStyle(`${animationsOnlyOnHover}:not(:hover) *`, {
+  animationDelay: '-0.0001s !important',
+  animationDuration: '0s !important',
+  animationPlayState: 'paused !important',
 });


### PR DESCRIPTION
Gallery performance has been unusable in Safari, a lot can be attributed to animations within the greater transform that occurs with the zooming behaviour. Disabling the animations on components (like Loader and Buttons) unless the user hovers over that Gallery item.

Hopefully this make Safari at least usable, obviously plenty of perf improvements could be made, this is just trying to get Safari to where the other browsers are at in terms of usability.