### PR TITLE
Checkbox, RadioGroup, Radio: Use atoms for label cursor styles

### DIFF
--- a/.changeset/small-bats-joke.md
+++ b/.changeset/small-bats-joke.md
@@ -1,0 +1,16 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Checkbox
+  - RadioGroup
+  - Radio
+---
+
+**Checkbox, RadioGroup, Radio:** Use atoms for label cursor styles
+
+Since the disabled state of a checkbox can only be changed via JavaScript, cursor styles can be toggled via `Box` props rather than generating additional CSS.
+
+While this is an improvement in and of itself, this change is being made to work around a third-party testing bug where our use of `:disabled` in a complex CSS selector is causing an exception to be thrown.

--- a/lib/components/private/InlineField/InlineField.css.ts
+++ b/lib/components/private/InlineField/InlineField.css.ts
@@ -58,13 +58,6 @@ export const badgeOffset = styleVariants(sizes, (size: Size) => {
   };
 });
 
-export const labelBase = style({
-  selectors: {
-    [`${realField}:not(:disabled) ~ * &`]: {
-      cursor: 'pointer',
-    },
-  },
-});
 export const labelOffset = styleVariants(sizes, (size: Size) => ({
   paddingTop: calc(vars.inlineFieldSize[size])
     .subtract(vars.textSize[size].mobile.capHeight)

--- a/lib/components/private/InlineField/InlineField.tsx
+++ b/lib/components/private/InlineField/InlineField.tsx
@@ -101,11 +101,8 @@ export const InlineField = forwardRef<
                 htmlFor={id}
                 userSelect="none"
                 display="block"
-                className={[
-                  styles.labelBase,
-                  styles.labelOffset[size],
-                  virtualTouchable(),
-                ]}
+                cursor={!disabled ? 'pointer' : undefined}
+                className={[styles.labelOffset[size], virtualTouchable()]}
               >
                 <Text
                   weight={checked && !inList ? 'strong' : undefined}


### PR DESCRIPTION
See changeset for details.