### PR TITLE
Use color palette for code blocks, fix release page warnings

### DIFF
--- a/site/src/App/Code/editorTheme.ts
+++ b/site/src/App/Code/editorTheme.ts
@@ -1,12 +1,14 @@
-const tag = '#99cfff';
-const attribute = '#d1eaff';
-const value = '#ffcfe2';
-const punctuation = '#d1eaff';
-const plainText = '#7b93b7';
-const meta = '#aaa';
-const other = '#ffdbed';
-const inserted = '#96ecc9';
-const deleted = '#ff99ab';
+import { palette } from '../../../../lib/color/palette';
+
+const tag = palette.blue['300'];
+const attribute = palette.blue['200'];
+const value = palette.crimson['200'];
+const punctuation = palette.blue['200'];
+const plainText = palette.seekBlue['300'];
+const meta = palette.grey['400'];
+const other = palette.crimson['200'];
+const inserted = palette.mint['300'];
+const deleted = palette.red['300'];
 
 export default {
   'code[class*="language-"]': {

--- a/site/src/App/Markdown/Markdown.css.ts
+++ b/site/src/App/Markdown/Markdown.css.ts
@@ -1,0 +1,31 @@
+import { style, composeStyles } from '@vanilla-extract/css';
+import { createTextStyle } from '@capsizecss/vanilla-extract';
+import { vars } from '../../../../lib/themes/vars.css';
+
+const toCapsizeValues = ({
+  fontSize,
+  lineHeight,
+  capsizeTrims,
+}: typeof vars.textSize.standard.mobile) =>
+  ({
+    fontSize,
+    lineHeight,
+    ...capsizeTrims,
+  } as Parameters<typeof createTextStyle>[0]);
+
+// Recreating text styles to get around Text in Text
+// within markdown renderer
+export const standardText = composeStyles(
+  style({
+    fontFamily: vars.fontFamily,
+    fontWeight: vars.textWeight.regular,
+    color: 'inherit',
+  }),
+  createTextStyle(toCapsizeValues(vars.textSize.standard.mobile), {
+    '@media': {
+      'screen and (min-width: 768px)': toCapsizeValues(
+        vars.textSize.standard.tablet,
+      ),
+    },
+  }),
+);

--- a/site/src/App/Markdown/Markdown.tsx
+++ b/site/src/App/Markdown/Markdown.tsx
@@ -14,6 +14,7 @@ import {
 import { DefaultTextPropsProvider } from '../../../../lib/components/private/defaultTextProps';
 import { InlineCode } from '../InlineCode/InlineCode';
 import { LinkableHeading } from '../LinkableHeading/LinkableHeading';
+import { standardText } from './Markdown.css';
 
 const Code = ({ language, value }: { language: string; value: string }) => (
   <Box paddingBottom="medium">
@@ -80,7 +81,11 @@ const renderers = {
       return <Stack space="medium">{children}</Stack>;
     }
 
-    return <Text>{children}</Text>;
+    return (
+      <Box component="span" className={standardText}>
+        {children}
+      </Box>
+    );
   },
   strong: Strong,
   emphasis: Strong,


### PR DESCRIPTION
Update the site to use the internal palette for styling the code blocks. Also using custom styles on the release page to get around the nested Text component warnings on the Releases page in dev, due to markdown-based rendering.