### PR TITLE
Use span element for field overlays

### DIFF
--- a/.changeset/gold-parrots-perform.md
+++ b/.changeset/gold-parrots-perform.md
@@ -1,0 +1,29 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Autosuggest
+  - Button
+  - ButtonLink
+  - ButtonRenderer
+  - Checkbox
+  - CheckboxStandalone
+  - Dropdown
+  - MonthPicker
+  - PasswordField
+  - Radio
+  - RadioItem
+  - Radio
+  - Textarea
+  - TextField
+  - TextLink
+  - TextLinkButton
+  - TextLinkRenderer
+  - Toggle
+---
+
+**Buttons, Fields, TextLinks, Toggle:** Use `span` for field state overlays instead of `div`
+
+Produce more valid HTML as `div` elements are not as flexible with which elements they can be inside (from a validators perspective).

--- a/lib/components/private/FieldOverlay/FieldOverlay.tsx
+++ b/lib/components/private/FieldOverlay/FieldOverlay.tsx
@@ -33,6 +33,7 @@ const boxShadowForVariant: Record<
 
 export const FieldOverlay = ({ variant, ...restProps }: FieldOverlayProps) => (
   <Overlay
+    component="span"
     borderRadius="standard"
     boxShadow={boxShadowForVariant[variant!]}
     transition="fast"


### PR DESCRIPTION
**Buttons, Fields, TextLinks, Toggle:** Use `span` for field state overlays instead of `div`

Produce more valid HTML as `div` elements are not as flexible with which elements they can be inside (from a validators perspective).