### PR TITLE
Columns: Optional Column children & component span support

### DIFF
--- a/.changeset/brown-llamas-raise.md
+++ b/.changeset/brown-llamas-raise.md
@@ -1,0 +1,33 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Columns
+---
+
+**Columns:** Make child Column optional and default internally
+
+As an optimisation to the default use of `Columns`, it is now only necessary use `Column` as a child element when customising the `width` property. If the use case is equally distributed columns, wrapping in `Columns` will now be enough.
+
+**EXAMPLE USAGE:**
+The following will now result in two columns equally distributed:
+```jsx
+<Columns space="medium">
+  <Card>...</Card>
+  <Card>...</Card>
+</Columns>
+```
+
+or wrap a single child in a `Column` to customise it's width:
+
+```jsx
+<Columns space="medium">
+  <Card>...</Card>
+  <Card>...</Card>
+  <Column width="content">
+    <OverflowMenu />
+  </Column>
+</Columns>
+```

--- a/.changeset/perfect-keys-lay.md
+++ b/.changeset/perfect-keys-lay.md
@@ -1,0 +1,19 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Columns
+---
+
+**Columns:** Support using span elements via component prop
+
+Setting the `component` prop to `span` will now ensure all elements controlled by `Columns` are `span`s. This is useful when using layout components inside dom elements that should not contain `div`s from a HTML validation perspective.
+
+**EXAMPLE USAGE:**
+```jsx
+<Columns space="medium" component="span">
+  ...
+</Columns>
+```

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -2535,6 +2535,9 @@ Object {
         | "desktop"
         | "tablet"
         | "wide"
+    component?: 
+        | "div"
+        | "span"
     data?: DataAttributeMap
     reverse?: boolean
     space: 

--- a/lib/components/Card/Card.snippets.tsx
+++ b/lib/components/Card/Card.snippets.tsx
@@ -61,9 +61,7 @@ export const snippets: Snippets = [
       <Card>
         <Stack space="gutter">
           <Columns space="gutter">
-            <Column>
-              <Heading level="3">Heading</Heading>
-            </Column>
+            <Heading level="3">Heading</Heading>
             <Column width="content">
               <OverflowMenu label="Options">
                 <MenuItem>Menu Item</MenuItem>

--- a/lib/components/Column/Column.screenshots.tsx
+++ b/lib/components/Column/Column.screenshots.tsx
@@ -17,15 +17,9 @@ export const screenshots: ComponentScreenshot = {
       label: 'Standard Columns',
       Example: () => (
         <Columns space="small">
-          <Column>
-            <Placeholder height={60} />
-          </Column>
-          <Column>
-            <Placeholder height={60} />
-          </Column>
-          <Column>
-            <Placeholder height={60} />
-          </Column>
+          <Placeholder height={60} />
+          <Placeholder height={60} />
+          <Placeholder height={60} />
         </Columns>
       ),
     },
@@ -38,9 +32,7 @@ export const screenshots: ComponentScreenshot = {
               <Column width={width}>
                 <Placeholder height={60} label={width} />
               </Column>
-              <Column>
-                <Placeholder height={60} label="Fluid" />
-              </Column>
+              <Placeholder height={60} label="Fluid" />
             </Columns>
           ))}
         </Stack>
@@ -52,12 +44,8 @@ export const screenshots: ComponentScreenshot = {
         <Fragment>
           <Box marginBottom="medium">
             <Columns space="small">
-              <Column>
-                <Placeholder height={60} label="Fluid" />
-              </Column>
-              <Column>
-                <Placeholder height={60} label="Fluid" />
-              </Column>
+              <Placeholder height={60} label="Fluid" />
+              <Placeholder height={60} label="Fluid" />
             </Columns>
           </Box>
           <Box marginBottom="medium">
@@ -65,9 +53,7 @@ export const screenshots: ComponentScreenshot = {
               <Column width="1/2">
                 <Placeholder height={60} label="&#189;" />
               </Column>
-              <Column>
-                <Placeholder height={60} label="Fluid" />
-              </Column>
+              <Placeholder height={60} label="Fluid" />
             </Columns>
           </Box>
           <Box marginBottom="medium">
@@ -88,9 +74,7 @@ export const screenshots: ComponentScreenshot = {
               <Column width="1/4">
                 <Placeholder height={60} label="&#188;" />
               </Column>
-              <Column>
-                <Placeholder height={60} label="Fluid" />
-              </Column>
+              <Placeholder height={60} label="Fluid" />
             </Columns>
           </Box>
           <Box marginBottom="medium">

--- a/lib/components/Column/Column.tsx
+++ b/lib/components/Column/Column.tsx
@@ -1,7 +1,7 @@
 import React, { ReactNode, useContext } from 'react';
 import { optimizeResponsiveArray } from '../../utils/optimizeResponsiveArray';
 import { Box } from '../Box/Box';
-import { ColumnsContext } from '../Columns/Columns';
+import { ColumnsContext } from '../Columns/ColumnsContext';
 import buildDataAttributes, {
   DataAttributeMap,
 } from '../private/buildDataAttributes';
@@ -23,10 +23,13 @@ export const Column = ({ children, data, width }: ColumnProps) => {
     desktopSpace,
     wideSpace,
     collapsibleAlignmentChildProps,
+    component,
   } = useContext(ColumnsContext);
 
   return (
     <Box
+      component={component}
+      display={component === 'span' ? 'block' : undefined}
       minWidth={0}
       width={width !== 'content' ? 'full' : undefined}
       flexShrink={width === 'content' ? 0 : undefined}

--- a/lib/components/Columns/Columns.docs.tsx
+++ b/lib/components/Columns/Columns.docs.tsx
@@ -12,15 +12,9 @@ const docs: ComponentDocs = {
   Example: () =>
     source(
       <Columns space="none">
-        <Column>
-          <Placeholder height={60} />
-        </Column>
-        <Column>
-          <Placeholder height={60} />
-        </Column>
-        <Column>
-          <Placeholder height={60} />
-        </Column>
+        <Placeholder height={60} />
+        <Placeholder height={60} />
+        <Placeholder height={60} />
       </Columns>,
     ),
   alternatives: [
@@ -67,12 +61,8 @@ const docs: ComponentDocs = {
               wide: 'xlarge',
             }}
           >
-            <Column>
-              <Placeholder height={60} />
-            </Column>
-            <Column>
-              <Placeholder height={60} />
-            </Column>
+            <Placeholder height={60} />
+            <Placeholder height={60} />
           </Columns>,
         ),
     },
@@ -81,10 +71,10 @@ const docs: ComponentDocs = {
       description: (
         <>
           <Text>
-            All columns are of equal width by default, but you can also
-            customise the width of each column individually.{' '}
-            <Strong>Column</Strong> supports widths fractional widths down to{' '}
-            <Strong>1/5</Strong>.
+            All columns are of equal width by default, but you can also use the{' '}
+            <TextLink href="">Column</TextLink> component to customise the width
+            of each column individually. <Strong>Column</Strong> supports widths
+            fractional widths down to <Strong>1/5</Strong>.
           </Text>
           <Text>
             If you want a column to be as small as possible, you can also set
@@ -100,81 +90,61 @@ const docs: ComponentDocs = {
               <Column width="content">
                 <Placeholder height={30} label="content" />
               </Column>
-              <Column>
-                <Placeholder height={30} label="fluid" />
-              </Column>
+              <Placeholder height={30} label="fluid" />
             </Columns>
             <Columns space="xsmall">
               <Column width="1/5">
                 <Placeholder height={30} label="1/5" />
               </Column>
-              <Column>
-                <Placeholder height={30} label="fluid" />
-              </Column>
+              <Placeholder height={30} label="fluid" />
             </Columns>
             <Columns space="xsmall">
               <Column width="1/4">
                 <Placeholder height={30} label="1/4" />
               </Column>
-              <Column>
-                <Placeholder height={30} label="fluid" />
-              </Column>
+              <Placeholder height={30} label="fluid" />
             </Columns>
             <Columns space="xsmall">
               <Column width="1/3">
                 <Placeholder height={30} label="1/3" />
               </Column>
-              <Column>
-                <Placeholder height={30} label="fluid" />
-              </Column>
+              <Placeholder height={30} label="fluid" />
             </Columns>
             <Columns space="xsmall">
               <Column width="2/5">
                 <Placeholder height={30} label="2/5" />
               </Column>
-              <Column>
-                <Placeholder height={30} label="fluid" />
-              </Column>
+              <Placeholder height={30} label="fluid" />
             </Columns>
             <Columns space="xsmall">
               <Column width="1/2">
                 <Placeholder height={30} label="1/2" />
               </Column>
-              <Column>
-                <Placeholder height={30} label="fluid" />
-              </Column>
+              <Placeholder height={30} label="fluid" />
             </Columns>
             <Columns space="xsmall">
               <Column width="3/5">
                 <Placeholder height={30} label="3/5" />
               </Column>
-              <Column>
-                <Placeholder height={30} label="fluid" />
-              </Column>
+              <Placeholder height={30} label="fluid" />
             </Columns>
             <Columns space="xsmall">
               <Column width="2/3">
                 <Placeholder height={30} label="2/3" />
               </Column>
-              <Column>
-                <Placeholder height={30} label="fluid" />
-              </Column>
+              <Placeholder height={30} label="fluid" />
             </Columns>
             <Columns space="xsmall">
               <Column width="3/4">
                 <Placeholder height={30} label="3/4" />
               </Column>
-              <Column>
-                <Placeholder height={30} label="fluid" />
-              </Column>
+              <Placeholder height={30} label="fluid" />
             </Columns>
             <Columns space="xsmall">
               <Column width="4/5">
                 <Placeholder height={30} label="4/5" />
               </Column>
-              <Column>
-                <Placeholder height={30} label="fluid" />
-              </Column>
+              <Placeholder height={30} label="fluid" />
             </Columns>
           </Stack>,
         ),
@@ -191,37 +161,19 @@ const docs: ComponentDocs = {
         source(
           <Stack space="large" dividers>
             <Columns space="small" alignY="top">
-              <Column>
-                <Placeholder height={20} />
-              </Column>
-              <Column>
-                <Placeholder height={80} label="top" />
-              </Column>
-              <Column>
-                <Placeholder height={20} />
-              </Column>
+              <Placeholder height={20} />
+              <Placeholder height={80} label="top" />
+              <Placeholder height={20} />
             </Columns>
             <Columns space="small" alignY="center">
-              <Column>
-                <Placeholder height={20} />
-              </Column>
-              <Column>
-                <Placeholder height={80} label="center" />
-              </Column>
-              <Column>
-                <Placeholder height={20} />
-              </Column>
+              <Placeholder height={20} />
+              <Placeholder height={80} label="center" />
+              <Placeholder height={20} />
             </Columns>
             <Columns space="small" alignY="bottom">
-              <Column>
-                <Placeholder height={20} />
-              </Column>
-              <Column>
-                <Placeholder height={80} label="bottom" />
-              </Column>
-              <Column>
-                <Placeholder height={20} />
-              </Column>
+              <Placeholder height={20} />
+              <Placeholder height={80} label="bottom" />
+              <Placeholder height={20} />
             </Columns>
           </Stack>,
         ),
@@ -278,15 +230,9 @@ const docs: ComponentDocs = {
       Example: () =>
         source(
           <Columns space="small" collapseBelow="tablet">
-            <Column>
-              <Placeholder height={60} />
-            </Column>
-            <Column>
-              <Placeholder height={60} />
-            </Column>
-            <Column>
-              <Placeholder height={60} />
-            </Column>
+            <Placeholder height={60} />
+            <Placeholder height={60} />
+            <Placeholder height={60} />
           </Columns>,
         ),
     },
@@ -305,9 +251,7 @@ const docs: ComponentDocs = {
             <Column width="1/5">
               <Placeholder height={60} label="First" />
             </Column>
-            <Column>
-              <Placeholder height={60} label="Second" />
-            </Column>
+            <Placeholder height={60} label="Second" />
           </Columns>,
         ),
     },

--- a/lib/components/Columns/Columns.gallery.tsx
+++ b/lib/components/Columns/Columns.gallery.tsx
@@ -10,12 +10,8 @@ export const galleryItems: ComponentExample[] = [
     Example: () =>
       source(
         <Columns space="large">
-          <Column>
-            <Placeholder height={60} />
-          </Column>
-          <Column>
-            <Placeholder height={60} />
-          </Column>
+          <Placeholder height={60} />
+          <Placeholder height={60} />
         </Columns>,
       ),
   },
@@ -24,15 +20,9 @@ export const galleryItems: ComponentExample[] = [
     Example: () =>
       source(
         <Columns space="small" alignY="top">
-          <Column>
-            <Placeholder height={20} />
-          </Column>
-          <Column>
-            <Placeholder height={80} label="top" />
-          </Column>
-          <Column>
-            <Placeholder height={20} />
-          </Column>
+          <Placeholder height={20} />
+          <Placeholder height={80} label="top" />
+          <Placeholder height={20} />
         </Columns>,
       ),
   },
@@ -41,15 +31,9 @@ export const galleryItems: ComponentExample[] = [
     Example: () =>
       source(
         <Columns space="small" alignY="center">
-          <Column>
-            <Placeholder height={20} />
-          </Column>
-          <Column>
-            <Placeholder height={80} label="center" />
-          </Column>
-          <Column>
-            <Placeholder height={20} />
-          </Column>
+          <Placeholder height={20} />
+          <Placeholder height={80} label="center" />
+          <Placeholder height={20} />
         </Columns>,
       ),
   },
@@ -58,15 +42,9 @@ export const galleryItems: ComponentExample[] = [
     Example: () =>
       source(
         <Columns space="small" alignY="bottom">
-          <Column>
-            <Placeholder height={20} />
-          </Column>
-          <Column>
-            <Placeholder height={80} label="bottom" />
-          </Column>
-          <Column>
-            <Placeholder height={20} />
-          </Column>
+          <Placeholder height={20} />
+          <Placeholder height={80} label="bottom" />
+          <Placeholder height={20} />
         </Columns>,
       ),
   },
@@ -121,9 +99,7 @@ export const galleryItems: ComponentExample[] = [
           <Column width="1/5">
             <Placeholder height={60} label="First" />
           </Column>
-          <Column>
-            <Placeholder height={60} label="Second" />
-          </Column>
+          <Placeholder height={60} label="Second" />
         </Columns>,
       ),
   },
@@ -136,81 +112,61 @@ export const galleryItems: ComponentExample[] = [
             <Column width="content">
               <Placeholder height={30} label="content" />
             </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
+            <Placeholder height={30} label="fluid" />
           </Columns>
           <Columns space="xsmall">
             <Column width="1/5">
               <Placeholder height={30} label="1/5" />
             </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
+            <Placeholder height={30} label="fluid" />
           </Columns>
           <Columns space="xsmall">
             <Column width="1/4">
               <Placeholder height={30} label="1/4" />
             </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
+            <Placeholder height={30} label="fluid" />
           </Columns>
           <Columns space="xsmall">
             <Column width="1/3">
               <Placeholder height={30} label="1/3" />
             </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
+            <Placeholder height={30} label="fluid" />
           </Columns>
           <Columns space="xsmall">
             <Column width="2/5">
               <Placeholder height={30} label="2/5" />
             </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
+            <Placeholder height={30} label="fluid" />
           </Columns>
           <Columns space="xsmall">
             <Column width="1/2">
               <Placeholder height={30} label="1/2" />
             </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
+            <Placeholder height={30} label="fluid" />
           </Columns>
           <Columns space="xsmall">
             <Column width="3/5">
               <Placeholder height={30} label="3/5" />
             </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
+            <Placeholder height={30} label="fluid" />
           </Columns>
           <Columns space="xsmall">
             <Column width="2/3">
               <Placeholder height={30} label="2/3" />
             </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
+            <Placeholder height={30} label="fluid" />
           </Columns>
           <Columns space="xsmall">
             <Column width="3/4">
               <Placeholder height={30} label="3/4" />
             </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
+            <Placeholder height={30} label="fluid" />
           </Columns>
           <Columns space="xsmall">
             <Column width="4/5">
               <Placeholder height={30} label="4/5" />
             </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
+            <Placeholder height={30} label="fluid" />
           </Columns>
         </Stack>,
       ),

--- a/lib/components/Columns/Columns.migration.md
+++ b/lib/components/Columns/Columns.migration.md
@@ -2,7 +2,7 @@
 
 ## API Changes
 
-- All child nodes must be wrapped in a `Column` component.
+- Child nodes may be wrapped in a `Column` component to customise their `width`.
 - `collapse={boolean}` allows columns to collapse into a stack on mobile. **This is `false` by default now**.
 - `tight={boolean}` has been deprecated in favour of setting the `gutter` prop, e.g. `gutter="small"`.
 - `reverse={boolean}` no longer reverses content on mobile when the content is stacked (i.e. when `collapse={true}`). The columns will be reversed on desktop, however the document flow on mobile and screen readers is still correct.
@@ -23,15 +23,9 @@
 
 ```jsx
 <Columns space="small" collapse>
-  <Column>
-    <Text>Content...</Text>
-  </Column>
-  <Column>
-    <Text>Content...</Text>
-  </Column>
-  <Column>
-    <Text>Content...</Text>
-  </Column>
+  <Text>Content...</Text>
+  <Text>Content...</Text>
+  <Text>Content...</Text>
 </Columns>
 ```
 
@@ -51,9 +45,7 @@ If the `size` being used previously was a percentage, migrating should be a matt
 
 ```jsx
 <Columns space="gutter" collapse>
-  <Column>
-    <MainContent />
-  </Column>
+  <MainContent />
   <Column width="1/4">
     <CustomSideBar />
   </Column>
@@ -74,9 +66,7 @@ If the `size` being used was a specific pixel value, you can set the `width` to 
 
 ```jsx
 <Columns space="gutter" collapse>
-  <Column>
-    <MainContent />
-  </Column>
+  <MainContent />
   <Column width="content">
     <Box className={styles.width}>
       {/* Create a class that sets the width */}

--- a/lib/components/Columns/Columns.playroom.tsx
+++ b/lib/components/Columns/Columns.playroom.tsx
@@ -1,16 +1,23 @@
 import React from 'react';
 import { Columns as BraidColumns, ColumnsProps } from './Columns';
+import { validColumnsComponents } from './ColumnsContext';
 
 export const Columns = ({
   space,
   align,
   alignY,
+  component,
   ...restProps
 }: ColumnsProps) => (
   <BraidColumns
     space={typeof space !== 'boolean' ? space : 'none'}
     align={typeof align !== 'boolean' ? align : undefined}
     alignY={typeof alignY !== 'boolean' ? alignY : undefined}
+    component={
+      component && validColumnsComponents.indexOf(component) > -1
+        ? component
+        : undefined
+    }
     {...restProps}
   />
 );

--- a/lib/components/Columns/Columns.screenshots.tsx
+++ b/lib/components/Columns/Columns.screenshots.tsx
@@ -444,5 +444,25 @@ export const screenshots: ComponentScreenshot = {
         </Columns>
       ),
     },
+    {
+      label: 'Test - component span with no explicit Column children',
+      Example: () => (
+        <Columns space="small" component="span">
+          <Placeholder height={60} label="First" />
+          <Placeholder height={60} label="Second" />
+        </Columns>
+      ),
+    },
+    {
+      label: 'Test - component span with a one explict Column and one not',
+      Example: () => (
+        <Columns space="small" component="span">
+          <Column width="content">
+            <Placeholder height={60} label="First" />
+          </Column>
+          <Placeholder height={60} label="Second" />
+        </Columns>
+      ),
+    },
   ],
 };

--- a/lib/components/Columns/Columns.snippets.tsx
+++ b/lib/components/Columns/Columns.snippets.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { Snippets } from '../private/Snippets';
-import { Columns, Column, Stack, Placeholder } from '../../playroom/components';
+import { Columns, Column, Placeholder } from '../../playroom/components';
 import source from '../../utils/source.macro';
 
 export const snippets: Snippets = [
@@ -8,16 +8,8 @@ export const snippets: Snippets = [
     name: '2 Columns',
     code: source(
       <Columns space="gutter">
-        <Column>
-          <Stack space="small">
-            <Placeholder height={60} label="Column" />
-          </Stack>
-        </Column>
-        <Column>
-          <Stack space="small">
-            <Placeholder height={60} label="Column" />
-          </Stack>
-        </Column>
+        <Placeholder height={60} label="Column" />
+        <Placeholder height={60} label="Column" />
       </Columns>,
     ),
   },
@@ -25,16 +17,8 @@ export const snippets: Snippets = [
     name: '2 Columns (Collapse Below Tablet)',
     code: source(
       <Columns space="gutter" collapseBelow="tablet">
-        <Column>
-          <Stack space="small">
-            <Placeholder height={60} label="Column" />
-          </Stack>
-        </Column>
-        <Column>
-          <Stack space="small">
-            <Placeholder height={60} label="Column" />
-          </Stack>
-        </Column>
+        <Placeholder height={60} label="Column" />
+        <Placeholder height={60} label="Column" />
       </Columns>,
     ),
   },
@@ -42,21 +26,9 @@ export const snippets: Snippets = [
     name: '3 Columns',
     code: source(
       <Columns space="gutter">
-        <Column>
-          <Stack space="small">
-            <Placeholder height={60} label="Column" />
-          </Stack>
-        </Column>
-        <Column>
-          <Stack space="small">
-            <Placeholder height={60} label="Column" />
-          </Stack>
-        </Column>
-        <Column>
-          <Stack space="small">
-            <Placeholder height={60} label="Column" />
-          </Stack>
-        </Column>
+        <Placeholder height={60} label="Column" />
+        <Placeholder height={60} label="Column" />
+        <Placeholder height={60} label="Column" />
       </Columns>,
     ),
   },
@@ -64,21 +36,9 @@ export const snippets: Snippets = [
     name: '3 Columns (Collapse Below Tablet)',
     code: source(
       <Columns space="gutter" collapseBelow="tablet">
-        <Column>
-          <Stack space="small">
-            <Placeholder height={60} label="Column" />
-          </Stack>
-        </Column>
-        <Column>
-          <Stack space="small">
-            <Placeholder height={60} label="Column" />
-          </Stack>
-        </Column>
-        <Column>
-          <Stack space="small">
-            <Placeholder height={60} label="Column" />
-          </Stack>
-        </Column>
+        <Placeholder height={60} label="Column" />
+        <Placeholder height={60} label="Column" />
+        <Placeholder height={60} label="Column" />
       </Columns>,
     ),
   },
@@ -87,15 +47,9 @@ export const snippets: Snippets = [
     code: source(
       <Columns space="gutter" collapseBelow="tablet">
         <Column width="2/3">
-          <Stack space="small">
-            <Placeholder height={400} label="Main" />
-          </Stack>
+          <Placeholder height={400} label="Main" />
         </Column>
-        <Column>
-          <Stack space="small">
-            <Placeholder height={100} label="Sidebar" />
-          </Stack>
-        </Column>
+        <Placeholder height={100} label="Sidebar" />
       </Columns>,
     ),
   },

--- a/lib/components/Columns/ColumnsContext.ts
+++ b/lib/components/Columns/ColumnsContext.ts
@@ -1,0 +1,33 @@
+import { createContext } from 'react';
+import { Space } from '../../css/atoms/atoms';
+import { resolveCollapsibleAlignmentProps } from '../../utils/collapsibleAlignmentProps';
+
+export const validColumnsComponents = ['div', 'span'] as const;
+
+type CollapsibleAlignmentChildProps = ReturnType<
+  typeof resolveCollapsibleAlignmentProps
+>['collapsibleAlignmentChildProps'];
+
+interface ColumnsContextValue {
+  collapseMobile: boolean;
+  collapseTablet: boolean;
+  collapseDesktop: boolean;
+  mobileSpace: Space;
+  tabletSpace: Space;
+  desktopSpace: Space;
+  wideSpace: Space;
+  collapsibleAlignmentChildProps: CollapsibleAlignmentChildProps | null;
+  component: typeof validColumnsComponents[number];
+}
+
+export const ColumnsContext = createContext<ColumnsContextValue>({
+  collapseMobile: false,
+  collapseTablet: false,
+  collapseDesktop: false,
+  mobileSpace: 'none',
+  tabletSpace: 'none',
+  desktopSpace: 'none',
+  wideSpace: 'none',
+  collapsibleAlignmentChildProps: null,
+  component: 'div',
+});

--- a/site/src/App/routes/foundations/layout/layout.tsx
+++ b/site/src/App/routes/foundations/layout/layout.tsx
@@ -425,16 +425,12 @@ const page: Page = {
       <Code>
         {source(
           <Columns space="small">
-            <Column>
-              <Card>
-                <Text>Column 1</Text>
-              </Card>
-            </Column>
-            <Column>
-              <Card>
-                <Text>Column 2</Text>
-              </Card>
-            </Column>
+            <Card>
+              <Text>Column 1</Text>
+            </Card>
+            <Card>
+              <Text>Column 2</Text>
+            </Card>
           </Columns>,
         )}
       </Code>
@@ -453,27 +449,27 @@ const page: Page = {
       <Code>
         {source(
           <Columns space="small" collapseBelow="tablet">
-            <Column>
-              <Card>
-                <Text>Column 1</Text>
-              </Card>
-            </Column>
-            <Column>
-              <Card>
-                <Text>Column 2</Text>
-              </Card>
-            </Column>
+            <Card>
+              <Text>Column 1</Text>
+            </Card>
+            <Card>
+              <Text>Column 2</Text>
+            </Card>
           </Columns>,
         )}
       </Code>
       <Text>
-        All columns are of equal width by default, but you can also customise
-        the <TextLink href="/components/Columns#column-widths">width</TextLink>{' '}
-        of each column individually.
+        All columns are of equal width by default, but you can also use the{' '}
+        <TextLink href="">Column</TextLink> component to customise the{' '}
+        <TextLink href="/components/Columns#column-widths">width</TextLink> of
+        each column individually.
       </Text>
       <Text>
         For example, if you wanted to render a main content area and a sidebar,
-        collapsing to a single column on mobile:
+        collapsing to a single column on mobile, wrap the sidebar in a{' '}
+        <Strong>Column</Strong> and provide a{' '}
+        <TextLink href="/components/Columns#column-widths">width</TextLink> like
+        so:
       </Text>
       <Code>
         {source(
@@ -483,11 +479,9 @@ const page: Page = {
                 <Text>Sidebar</Text>
               </Card>
             </Column>
-            <Column>
-              <Card>
-                <Text>Main content</Text>
-              </Card>
-            </Column>
+            <Card>
+              <Text>Main content</Text>
+            </Card>
           </Columns>,
         )}
       </Code>
@@ -507,9 +501,7 @@ const page: Page = {
           <Card>
             <Stack space="medium">
               <Columns space="small">
-                <Column>
-                  <Heading level="3">Card heading</Heading>
-                </Column>
+                <Heading level="3">Card heading</Heading>
                 <Column width="content">
                   <OverflowMenu label="Options">
                     <MenuItem
@@ -551,17 +543,15 @@ const page: Page = {
                 <Text>Sidebar</Text>
               </Card>
             </Column>
-            <Column>
-              <Card>
-                <Text>Main content</Text>
-              </Card>
-            </Column>
+            <Card>
+              <Text>Main content</Text>
+            </Card>
           </Columns>,
         )}
       </Code>
       <Text>
-        If you have <Strong>Column</Strong> elements that are of varying height,
-        you can center them vertically with the{' '}
+        If you have columns are of varying height, you can center them
+        vertically with the{' '}
         <TextLink href="/components/Columns#vertical-alignment">
           alignY
         </TextLink>{' '}
@@ -570,32 +560,26 @@ const page: Page = {
       <Code>
         {source(
           <Columns space="small" alignY="center">
-            <Column>
-              <Card>
-                <Stack space="medium" align="center">
-                  <Text>Column</Text>
-                  <Text>Column</Text>
-                </Stack>
-              </Card>
-            </Column>
-            <Column>
-              <Card>
-                <Stack space="medium" align="center">
-                  <Text>Column</Text>
-                  <Text>Column</Text>
-                  <Text>Column</Text>
-                  <Text>Column</Text>
-                </Stack>
-              </Card>
-            </Column>
-            <Column>
-              <Card>
-                <Stack space="medium" align="center">
-                  <Text>Column</Text>
-                  <Text>Column</Text>
-                </Stack>
-              </Card>
-            </Column>
+            <Card>
+              <Stack space="medium" align="center">
+                <Text>Column</Text>
+                <Text>Column</Text>
+              </Stack>
+            </Card>
+            <Card>
+              <Stack space="medium" align="center">
+                <Text>Column</Text>
+                <Text>Column</Text>
+                <Text>Column</Text>
+                <Text>Column</Text>
+              </Stack>
+            </Card>
+            <Card>
+              <Stack space="medium" align="center">
+                <Text>Column</Text>
+                <Text>Column</Text>
+              </Stack>
+            </Card>
           </Columns>,
         )}
       </Code>


### PR DESCRIPTION
**Columns:** Make child Column optional and default internally

As an optimisation to the default use of `Columns`, it is now only necessary use `Column` as a child element when customising the `width` property. If the use case is equally distributed columns, wrapping in `Columns` will now be enough.

**EXAMPLE USAGE:**
The following will now result in two columns equally distributed:
```jsx
<Columns space="medium">
  <Card>...</Card>
  <Card>...</Card>
</Columns>
```

or wrap a single child in a `Column` to customise it's width:

```jsx
<Columns space="medium">
  <Card>...</Card>
  <Card>...</Card>
  <Column width="content">
    <OverflowMenu />
  </Column>
</Columns>
```
---
 **Columns:** Support using span elements via component prop

Setting the `component` prop to `span` will now ensure all elements controlled by `Columns` are `span`s. This is useful when using layout components inside dom elements that should not contain `div`s from a HTML validation perspective.

**EXAMPLE USAGE:**
```jsx
<Columns space="medium" component="span">
  ...
</Columns>
```