### PR TITLE
Pagination: Add `pageLimit` support

### DIFF
--- a/.changeset/nervous-birds-stare.md
+++ b/.changeset/nervous-birds-stare.md
@@ -7,9 +7,9 @@ updated:
   - Pagination
 ---
 
-**Pagination:** Add `visiblePageLimit` support
+**Pagination:** Add `pageLimit` support
 
-Add support for configuring the number of pages displayed using the `visiblePageLimit` prop. The default is still set to 7, but consumers can now reduce this, useful when `Pagination` is used inside column layouts.
+Add support for configuring the number of pages displayed using the `pageLimit` prop. The default is still set to 7, but consumers can now reduce this, useful when `Pagination` is used inside column layouts.
 
 In addition, the layout is has been stabilised, preventing the links moving when the next/prev actions are shown/hidden.
 
@@ -17,6 +17,6 @@ In addition, the layout is has been stabilised, preventing the links moving when
 ```jsx
 <Pagination
   ...
-  visiblePageLimit={3}
+  pageLimit={3}
 />
 ```

--- a/.changeset/nervous-birds-stare.md
+++ b/.changeset/nervous-birds-stare.md
@@ -1,0 +1,22 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Pagination
+---
+
+**Pagination:** Add `visiblePageLimit` support
+
+Add support for configuring the number of pages displayed using the `visiblePageLimit` prop. The default is still set to 7, but consumers can now reduce this, useful when `Pagination` is used inside column layouts.
+
+In addition, the layout is has been stabilised, preventing the links moving when the next/prev actions are shown/hidden.
+
+**EXAMPLE USAGE:**
+```jsx
+<Pagination
+  ...
+  visiblePageLimit={3}
+/>
+```

--- a/.changeset/nervous-birds-stare.md
+++ b/.changeset/nervous-birds-stare.md
@@ -11,7 +11,7 @@ updated:
 
 Add support for configuring the number of pages displayed using the `pageLimit` prop. The default is still set to 7, but consumers can now reduce this, useful when `Pagination` is used inside column layouts.
 
-In addition, the layout is has been stabilised, preventing the links moving when the next/prev actions are shown/hidden.
+In addition, the layout has been stabilised, preventing the links moving when the next/prev actions are shown/hidden.
 
 **EXAMPLE USAGE:**
 ```jsx

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -6436,6 +6436,7 @@ Object {
     pageLabel?: (page: number) => string
     previousLabel?: string
     total: number
+    visiblePageLimit?: number
 },
 }
 `;

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -6434,9 +6434,9 @@ Object {
     nextLabel?: string
     page: number
     pageLabel?: (page: number) => string
+    pageLimit?: number
     previousLabel?: string
     total: number
-    visiblePageLimit?: number
 },
 }
 `;

--- a/lib/components/Pagination/Pagination.docs.tsx
+++ b/lib/components/Pagination/Pagination.docs.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import { ComponentDocs } from '../../../site/src/types';
-import { Pagination, Card } from '../';
+import { Pagination, Card, Notice } from '../';
 import source from '../../utils/source.macro';
 import { Strong } from '../Strong/Strong';
 import { Text } from '../Text/Text';
 import { TextLink } from '../TextLink/TextLink';
-import { maxPages } from './paginate';
+import { defaultVisiblePageLimit } from './Pagination';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -53,15 +53,43 @@ const docs: ComponentDocs = {
   alternatives: [],
   additional: [
     {
-      label: 'Design considerations',
+      label: 'Limiting the number of pages',
       description: (
-        <Text>
-          To keep the design simple, a maximum of {maxPages} pages are displayed
-          above <Strong>tablet</Strong> screen sizes. On <Strong>mobile</Strong>{' '}
-          only the current page along with the next and previous links are
-          displayed.
-        </Text>
+        <>
+          <Text>
+            The number of pages displayed can be limited using the{' '}
+            <Strong>visiblePageLimit</Strong> prop.
+          </Text>
+          <Notice>
+            <Text>
+              To keep the design simple, only the current page, next and
+              previous links are displayed on <Strong>mobile</Strong>, while on
+              larger devices the limit cannot be increased above the default
+              limit of {defaultVisiblePageLimit}.
+            </Text>
+          </Notice>
+        </>
       ),
+      Example: ({ setDefaultState, getState, setState }) =>
+        source(
+          <>
+            {setDefaultState('page', 5)}
+
+            <Pagination
+              page={getState('page')}
+              total={10}
+              label="Limiting the number of pages"
+              visiblePageLimit={3}
+              linkProps={({ page }) => ({
+                href: `#${page}`,
+                onClick: (e) => {
+                  e.preventDefault();
+                  setState('page', page);
+                },
+              })}
+            />
+          </>,
+        ),
     },
     {
       label: 'Development considerations',

--- a/lib/components/Pagination/Pagination.docs.tsx
+++ b/lib/components/Pagination/Pagination.docs.tsx
@@ -5,7 +5,7 @@ import source from '../../utils/source.macro';
 import { Strong } from '../Strong/Strong';
 import { Text } from '../Text/Text';
 import { TextLink } from '../TextLink/TextLink';
-import { defaultVisiblePageLimit } from './Pagination';
+import { defaultPageLimit } from './Pagination';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -58,14 +58,14 @@ const docs: ComponentDocs = {
         <>
           <Text>
             The number of pages displayed can be limited using the{' '}
-            <Strong>visiblePageLimit</Strong> prop.
+            <Strong>pageLimit</Strong> prop.
           </Text>
           <Notice>
             <Text>
               To keep the design simple, only the current page, next and
               previous links are displayed on <Strong>mobile</Strong>, while on
               larger devices the limit cannot be increased above the default
-              limit of {defaultVisiblePageLimit}.
+              limit of {defaultPageLimit}.
             </Text>
           </Notice>
         </>
@@ -79,7 +79,7 @@ const docs: ComponentDocs = {
               page={getState('page')}
               total={10}
               label="Limiting the number of pages"
-              visiblePageLimit={3}
+              pageLimit={3}
               linkProps={({ page }) => ({
                 href: `#${page}`,
                 onClick: (e) => {

--- a/lib/components/Pagination/Pagination.playroom.tsx
+++ b/lib/components/Pagination/Pagination.playroom.tsx
@@ -2,7 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Optional } from 'utility-types';
 import { StateProp } from '../../playroom/playroomState';
 import {
-  defaultVisiblePageLimit,
+  defaultPageLimit,
   Pagination as BraidPagination,
   PaginationProps,
 } from './Pagination';
@@ -36,9 +36,7 @@ const resolveFallbackTotal = (
     return total;
   }
 
-  return resolvedPage > defaultVisiblePageLimit
-    ? resolvedPage * 2
-    : defaultTotal;
+  return resolvedPage > defaultPageLimit ? resolvedPage * 2 : defaultTotal;
 };
 
 export const Pagination = ({

--- a/lib/components/Pagination/Pagination.playroom.tsx
+++ b/lib/components/Pagination/Pagination.playroom.tsx
@@ -1,8 +1,11 @@
 import React, { useEffect, useState } from 'react';
 import { Optional } from 'utility-types';
 import { StateProp } from '../../playroom/playroomState';
-import { maxPages } from './paginate';
-import { Pagination as BraidPagination, PaginationProps } from './Pagination';
+import {
+  defaultVisiblePageLimit,
+  Pagination as BraidPagination,
+  PaginationProps,
+} from './Pagination';
 
 type PlayroomPaginationProps = StateProp &
   Optional<PaginationProps, 'label' | 'linkProps' | 'page' | 'total'>;
@@ -33,7 +36,9 @@ const resolveFallbackTotal = (
     return total;
   }
 
-  return resolvedPage > maxPages ? resolvedPage * 2 : defaultTotal;
+  return resolvedPage > defaultVisiblePageLimit
+    ? resolvedPage * 2
+    : defaultTotal;
 };
 
 export const Pagination = ({

--- a/lib/components/Pagination/Pagination.screenshots.tsx
+++ b/lib/components/Pagination/Pagination.screenshots.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentScreenshot } from '../../../site/src/types';
 import { Pagination } from '../';
 import { LinkProps } from '../Link/Link';
-import { maxPages } from './paginate';
+import { defaultVisiblePageLimit } from './Pagination';
 
 const linkProps = (): LinkProps => ({ href: '#' });
 
@@ -10,122 +10,122 @@ export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320, 768],
   examples: [
     {
-      label: `First page, where total < ${maxPages}`,
+      label: `First page, where total < ${defaultVisiblePageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
           page={1}
-          total={maxPages - 3}
+          total={defaultVisiblePageLimit - 3}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `First page, where total = ${maxPages}`,
+      label: `First page, where total = ${defaultVisiblePageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
           page={1}
-          total={maxPages}
+          total={defaultVisiblePageLimit}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `First page, where total > ${maxPages}`,
+      label: `First page, where total > ${defaultVisiblePageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
           page={1}
-          total={maxPages + 3}
+          total={defaultVisiblePageLimit + 3}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `Center page, where total < ${maxPages}`,
+      label: `Center page, where total < ${defaultVisiblePageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
-          page={Math.round((maxPages - 3) / 2)}
-          total={maxPages - 3}
+          page={Math.round((defaultVisiblePageLimit - 3) / 2)}
+          total={defaultVisiblePageLimit - 3}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `Center page, where total = ${maxPages}`,
+      label: `Center page, where total = ${defaultVisiblePageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
-          page={Math.round(maxPages / 2)}
-          total={maxPages}
+          page={Math.round(defaultVisiblePageLimit / 2)}
+          total={defaultVisiblePageLimit}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `Center page, where total > ${maxPages}`,
+      label: `Center page, where total > ${defaultVisiblePageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
-          page={Math.round((maxPages + 3) / 2)}
-          total={maxPages + 3}
+          page={Math.round((defaultVisiblePageLimit + 3) / 2)}
+          total={defaultVisiblePageLimit + 3}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `Last page, where total < ${maxPages}`,
+      label: `Last page, where total < ${defaultVisiblePageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
-          page={maxPages - 3}
-          total={maxPages - 3}
+          page={defaultVisiblePageLimit - 3}
+          total={defaultVisiblePageLimit - 3}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `Last page, where total = ${maxPages}`,
+      label: `Last page, where total = ${defaultVisiblePageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
-          page={maxPages}
-          total={maxPages}
+          page={defaultVisiblePageLimit}
+          total={defaultVisiblePageLimit}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `Last page, where total > ${maxPages}`,
+      label: `Last page, where total > ${defaultVisiblePageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
-          page={maxPages + 3}
-          total={maxPages + 3}
+          page={defaultVisiblePageLimit + 3}
+          total={defaultVisiblePageLimit + 3}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `Second page, where total > ${maxPages}`,
+      label: `Second page, where total > ${defaultVisiblePageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
           page={2}
-          total={maxPages + 3}
+          total={defaultVisiblePageLimit + 3}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `Second last page, where total > ${maxPages}`,
+      label: `Second last page, where total > ${defaultVisiblePageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
-          page={maxPages + 3 - 1}
-          total={maxPages + 3}
+          page={defaultVisiblePageLimit + 3 - 1}
+          total={defaultVisiblePageLimit + 3}
           linkProps={linkProps}
         />
       ),
@@ -137,8 +137,86 @@ export const screenshots: ComponentScreenshot = {
         <Pagination
           label="Label"
           page={1}
-          total={maxPages - 3}
+          total={defaultVisiblePageLimit - 3}
           linkProps={linkProps}
+        />
+      ),
+    },
+    {
+      label: 'With visiblePageLimit set to 1, on first page',
+      background: 'surface',
+      Example: () => (
+        <Pagination
+          label="Label"
+          page={1}
+          total={10}
+          linkProps={linkProps}
+          visiblePageLimit={1}
+        />
+      ),
+    },
+    {
+      label: 'With visiblePageLimit set to 1, on last page',
+      background: 'surface',
+      Example: () => (
+        <Pagination
+          label="Label"
+          page={10}
+          total={10}
+          linkProps={linkProps}
+          visiblePageLimit={1}
+        />
+      ),
+    },
+    {
+      label: 'With visiblePageLimit set to 2, on first page',
+      background: 'surface',
+      Example: () => (
+        <Pagination
+          label="Label"
+          page={1}
+          total={10}
+          linkProps={linkProps}
+          visiblePageLimit={2}
+        />
+      ),
+    },
+    {
+      label: 'With visiblePageLimit set to 2, on last page',
+      background: 'surface',
+      Example: () => (
+        <Pagination
+          label="Label"
+          page={10}
+          total={10}
+          linkProps={linkProps}
+          visiblePageLimit={2}
+        />
+      ),
+    },
+    {
+      label: 'With visiblePageLimit set to 3, on first page',
+      background: 'surface',
+      Example: () => (
+        <Pagination
+          label="Label"
+          page={1}
+          total={10}
+          linkProps={linkProps}
+          visiblePageLimit={3}
+        />
+      ),
+    },
+    {
+      label: 'With visiblePageLimit set to 3, on last page',
+      background: 'surface',
+      Example: () => (
+        <Pagination
+          label="Label"
+          page={10}
+          total={10}
+          linkProps={linkProps}
+          visiblePageLimit={3}
         />
       ),
     },

--- a/lib/components/Pagination/Pagination.screenshots.tsx
+++ b/lib/components/Pagination/Pagination.screenshots.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { ComponentScreenshot } from '../../../site/src/types';
 import { Pagination } from '../';
 import { LinkProps } from '../Link/Link';
-import { defaultVisiblePageLimit } from './Pagination';
+import { defaultPageLimit } from './Pagination';
 
 const linkProps = (): LinkProps => ({ href: '#' });
 
@@ -10,122 +10,122 @@ export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320, 768],
   examples: [
     {
-      label: `First page, where total < ${defaultVisiblePageLimit}`,
+      label: `First page, where total < ${defaultPageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
           page={1}
-          total={defaultVisiblePageLimit - 3}
+          total={defaultPageLimit - 3}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `First page, where total = ${defaultVisiblePageLimit}`,
+      label: `First page, where total = ${defaultPageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
           page={1}
-          total={defaultVisiblePageLimit}
+          total={defaultPageLimit}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `First page, where total > ${defaultVisiblePageLimit}`,
+      label: `First page, where total > ${defaultPageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
           page={1}
-          total={defaultVisiblePageLimit + 3}
+          total={defaultPageLimit + 3}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `Center page, where total < ${defaultVisiblePageLimit}`,
+      label: `Center page, where total < ${defaultPageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
-          page={Math.round((defaultVisiblePageLimit - 3) / 2)}
-          total={defaultVisiblePageLimit - 3}
+          page={Math.round((defaultPageLimit - 3) / 2)}
+          total={defaultPageLimit - 3}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `Center page, where total = ${defaultVisiblePageLimit}`,
+      label: `Center page, where total = ${defaultPageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
-          page={Math.round(defaultVisiblePageLimit / 2)}
-          total={defaultVisiblePageLimit}
+          page={Math.round(defaultPageLimit / 2)}
+          total={defaultPageLimit}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `Center page, where total > ${defaultVisiblePageLimit}`,
+      label: `Center page, where total > ${defaultPageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
-          page={Math.round((defaultVisiblePageLimit + 3) / 2)}
-          total={defaultVisiblePageLimit + 3}
+          page={Math.round((defaultPageLimit + 3) / 2)}
+          total={defaultPageLimit + 3}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `Last page, where total < ${defaultVisiblePageLimit}`,
+      label: `Last page, where total < ${defaultPageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
-          page={defaultVisiblePageLimit - 3}
-          total={defaultVisiblePageLimit - 3}
+          page={defaultPageLimit - 3}
+          total={defaultPageLimit - 3}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `Last page, where total = ${defaultVisiblePageLimit}`,
+      label: `Last page, where total = ${defaultPageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
-          page={defaultVisiblePageLimit}
-          total={defaultVisiblePageLimit}
+          page={defaultPageLimit}
+          total={defaultPageLimit}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `Last page, where total > ${defaultVisiblePageLimit}`,
+      label: `Last page, where total > ${defaultPageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
-          page={defaultVisiblePageLimit + 3}
-          total={defaultVisiblePageLimit + 3}
+          page={defaultPageLimit + 3}
+          total={defaultPageLimit + 3}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `Second page, where total > ${defaultVisiblePageLimit}`,
+      label: `Second page, where total > ${defaultPageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
           page={2}
-          total={defaultVisiblePageLimit + 3}
+          total={defaultPageLimit + 3}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: `Second last page, where total > ${defaultVisiblePageLimit}`,
+      label: `Second last page, where total > ${defaultPageLimit}`,
       Example: () => (
         <Pagination
           label="Label"
-          page={defaultVisiblePageLimit + 3 - 1}
-          total={defaultVisiblePageLimit + 3}
+          page={defaultPageLimit + 3 - 1}
+          total={defaultPageLimit + 3}
           linkProps={linkProps}
         />
       ),
@@ -137,13 +137,13 @@ export const screenshots: ComponentScreenshot = {
         <Pagination
           label="Label"
           page={1}
-          total={defaultVisiblePageLimit - 3}
+          total={defaultPageLimit - 3}
           linkProps={linkProps}
         />
       ),
     },
     {
-      label: 'With visiblePageLimit set to 1, on first page',
+      label: 'With pageLimit set to 1, on first page',
       background: 'surface',
       Example: () => (
         <Pagination
@@ -151,12 +151,12 @@ export const screenshots: ComponentScreenshot = {
           page={1}
           total={10}
           linkProps={linkProps}
-          visiblePageLimit={1}
+          pageLimit={1}
         />
       ),
     },
     {
-      label: 'With visiblePageLimit set to 1, on last page',
+      label: 'With pageLimit set to 1, on last page',
       background: 'surface',
       Example: () => (
         <Pagination
@@ -164,12 +164,12 @@ export const screenshots: ComponentScreenshot = {
           page={10}
           total={10}
           linkProps={linkProps}
-          visiblePageLimit={1}
+          pageLimit={1}
         />
       ),
     },
     {
-      label: 'With visiblePageLimit set to 2, on first page',
+      label: 'With pageLimit set to 2, on first page',
       background: 'surface',
       Example: () => (
         <Pagination
@@ -177,12 +177,12 @@ export const screenshots: ComponentScreenshot = {
           page={1}
           total={10}
           linkProps={linkProps}
-          visiblePageLimit={2}
+          pageLimit={2}
         />
       ),
     },
     {
-      label: 'With visiblePageLimit set to 2, on last page',
+      label: 'With pageLimit set to 2, on last page',
       background: 'surface',
       Example: () => (
         <Pagination
@@ -190,12 +190,12 @@ export const screenshots: ComponentScreenshot = {
           page={10}
           total={10}
           linkProps={linkProps}
-          visiblePageLimit={2}
+          pageLimit={2}
         />
       ),
     },
     {
-      label: 'With visiblePageLimit set to 3, on first page',
+      label: 'With pageLimit set to 3, on first page',
       background: 'surface',
       Example: () => (
         <Pagination
@@ -203,12 +203,12 @@ export const screenshots: ComponentScreenshot = {
           page={1}
           total={10}
           linkProps={linkProps}
-          visiblePageLimit={3}
+          pageLimit={3}
         />
       ),
     },
     {
-      label: 'With visiblePageLimit set to 3, on last page',
+      label: 'With pageLimit set to 3, on last page',
       background: 'surface',
       Example: () => (
         <Pagination
@@ -216,7 +216,7 @@ export const screenshots: ComponentScreenshot = {
           page={10}
           total={10}
           linkProps={linkProps}
-          visiblePageLimit={3}
+          pageLimit={3}
         />
       ),
     },

--- a/lib/components/Pagination/Pagination.test.tsx
+++ b/lib/components/Pagination/Pagination.test.tsx
@@ -61,7 +61,7 @@ describe('Pagination', () => {
       </BraidTestProvider>,
     );
 
-    expect(queryByLabelText('Prev')).not.toBeInTheDocument();
+    expect(queryByLabelText('Prev')).not.toBeVisible();
     expect(document.body).toHaveFocus();
     userEvent.tab();
     expect(getByLabelText('Pg 1')).toHaveFocus();
@@ -87,7 +87,7 @@ describe('Pagination', () => {
       </BraidTestProvider>,
     );
 
-    expect(queryByLabelText('Next')).not.toBeInTheDocument();
+    expect(queryByLabelText('Next')).not.toBeVisible();
     expect(document.body).toHaveFocus();
     userEvent.tab();
     expect(getByLabelText('Prev')).toHaveFocus();

--- a/lib/components/Pagination/Pagination.tsx
+++ b/lib/components/Pagination/Pagination.tsx
@@ -26,6 +26,7 @@ export interface PaginationProps {
   pageLabel?: (page: number) => string;
   nextLabel?: string;
   previousLabel?: string;
+  visiblePageLimit?: number;
   data?: DataAttributeMap;
 }
 
@@ -123,6 +124,8 @@ const Page = ({ number, current }: { number: number; current: boolean }) => {
   );
 };
 
+export const defaultVisiblePageLimit = 7;
+
 export const Pagination = ({
   page,
   total,
@@ -131,12 +134,17 @@ export const Pagination = ({
   pageLabel = (p: number) => `Go to page ${p}`,
   nextLabel = 'Next',
   previousLabel = 'Previous',
+  visiblePageLimit = defaultVisiblePageLimit,
   data,
 }: PaginationProps) => {
   assert(total >= 1, `\`total\` must be at least 1`);
   assert(page >= 1 && page <= total, `\`page\` must be between 1 and ${total}`);
+  assert(
+    visiblePageLimit >= 1 && visiblePageLimit <= defaultVisiblePageLimit,
+    `\`visiblePageLimit\` must be between 1 and ${defaultVisiblePageLimit}`,
+  );
 
-  const pages = paginate({ page, total });
+  const pages = paginate({ page, total, maxPages: visiblePageLimit });
   const showPrevious = page > 1;
   const showNext = page < total;
 
@@ -147,30 +155,45 @@ export const Pagination = ({
       {...(data ? buildDataAttributes(data) : undefined)}
     >
       <Box component="ul" display="flex" justifyContent="center">
-        {showPrevious ? (
-          <Box component="li" paddingRight={['medium', tabletButtonSpacing]}>
-            <Link
-              {...linkProps({ page: page - 1, type: 'previous' })}
-              rel="prev"
-              aria-label={previousLabel}
-              title={previousLabel}
-            >
-              <PageNav label={previousLabel} direction="prev" />
-            </Link>
-          </Box>
-        ) : null}
+        <Box
+          component="li"
+          paddingRight={{
+            mobile: 'medium',
+            tablet: visiblePageLimit > 2 ? tabletButtonSpacing : undefined,
+          }}
+          transition="fast"
+          opacity={!showPrevious ? 0 : undefined}
+          pointerEvents={!showPrevious ? 'none' : undefined}
+        >
+          <Link
+            {...linkProps({ page: page - 1, type: 'previous' })}
+            rel="prev"
+            aria-label={previousLabel}
+            title={previousLabel}
+            aria-hidden={!showPrevious}
+            tabIndex={!showPrevious ? -1 : undefined}
+          >
+            <PageNav label={previousLabel} direction="prev" />
+          </Link>
+        </Box>
 
         {pages.map((pageNumber, index) => {
           const current = page === pageNumber;
+          const isNotLast = pages.length - 1 !== index;
 
           return (
             <Box
               component="li"
-              display={!current ? ['none', 'block'] : undefined}
-              paddingRight={[
-                'none',
-                pages.length - 1 === index ? 'none' : tabletButtonSpacing,
-              ]}
+              display={
+                !current ? { mobile: 'none', tablet: 'block' } : undefined
+              }
+              paddingRight={
+                visiblePageLimit > 2 && isNotLast
+                  ? {
+                      tablet: tabletButtonSpacing,
+                    }
+                  : undefined
+              }
               key={pageNumber}
             >
               <Link
@@ -185,18 +208,27 @@ export const Pagination = ({
           );
         })}
 
-        {showNext ? (
-          <Box component="li" paddingLeft={['medium', tabletButtonSpacing]}>
-            <Link
-              {...linkProps({ page: page + 1, type: 'next' })}
-              rel="next"
-              aria-label={nextLabel}
-              title={nextLabel}
-            >
-              <PageNav label={nextLabel} direction="next" />
-            </Link>
-          </Box>
-        ) : null}
+        <Box
+          component="li"
+          paddingLeft={{
+            mobile: 'medium',
+            tablet: visiblePageLimit > 2 ? tabletButtonSpacing : undefined,
+          }}
+          transition="fast"
+          opacity={!showNext ? 0 : undefined}
+          pointerEvents={!showNext ? 'none' : undefined}
+        >
+          <Link
+            {...linkProps({ page: page + 1, type: 'next' })}
+            rel="next"
+            aria-label={nextLabel}
+            title={nextLabel}
+            aria-hidden={!showNext}
+            tabIndex={!showNext ? -1 : undefined}
+          >
+            <PageNav label={nextLabel} direction="next" />
+          </Link>
+        </Box>
       </Box>
     </Box>
   );

--- a/lib/components/Pagination/Pagination.tsx
+++ b/lib/components/Pagination/Pagination.tsx
@@ -26,7 +26,7 @@ export interface PaginationProps {
   pageLabel?: (page: number) => string;
   nextLabel?: string;
   previousLabel?: string;
-  visiblePageLimit?: number;
+  pageLimit?: number;
   data?: DataAttributeMap;
 }
 
@@ -124,7 +124,7 @@ const Page = ({ number, current }: { number: number; current: boolean }) => {
   );
 };
 
-export const defaultVisiblePageLimit = 7;
+export const defaultPageLimit = 7;
 
 export const Pagination = ({
   page,
@@ -134,17 +134,17 @@ export const Pagination = ({
   pageLabel = (p: number) => `Go to page ${p}`,
   nextLabel = 'Next',
   previousLabel = 'Previous',
-  visiblePageLimit = defaultVisiblePageLimit,
+  pageLimit = defaultPageLimit,
   data,
 }: PaginationProps) => {
   assert(total >= 1, `\`total\` must be at least 1`);
   assert(page >= 1 && page <= total, `\`page\` must be between 1 and ${total}`);
   assert(
-    visiblePageLimit >= 1 && visiblePageLimit <= defaultVisiblePageLimit,
-    `\`visiblePageLimit\` must be between 1 and ${defaultVisiblePageLimit}`,
+    pageLimit >= 1 && pageLimit <= defaultPageLimit,
+    `\`pageLimit\` must be between 1 and ${defaultPageLimit}`,
   );
 
-  const pages = paginate({ page, total, maxPages: visiblePageLimit });
+  const pages = paginate({ page, total, maxPages: pageLimit });
   const showPrevious = page > 1;
   const showNext = page < total;
 
@@ -159,7 +159,7 @@ export const Pagination = ({
           component="li"
           paddingRight={{
             mobile: 'medium',
-            tablet: visiblePageLimit > 2 ? tabletButtonSpacing : undefined,
+            tablet: pageLimit > 2 ? tabletButtonSpacing : undefined,
           }}
           transition="fast"
           opacity={!showPrevious ? 0 : undefined}
@@ -188,7 +188,7 @@ export const Pagination = ({
                 !current ? { mobile: 'none', tablet: 'block' } : undefined
               }
               paddingRight={
-                visiblePageLimit > 2 && isNotLast
+                pageLimit > 2 && isNotLast
                   ? {
                       tablet: tabletButtonSpacing,
                     }
@@ -212,7 +212,7 @@ export const Pagination = ({
           component="li"
           paddingLeft={{
             mobile: 'medium',
-            tablet: visiblePageLimit > 2 ? tabletButtonSpacing : undefined,
+            tablet: pageLimit > 2 ? tabletButtonSpacing : undefined,
           }}
           transition="fast"
           opacity={!showNext ? 0 : undefined}

--- a/lib/components/Pagination/paginate.test.ts
+++ b/lib/components/Pagination/paginate.test.ts
@@ -1,35 +1,43 @@
-import { maxPages, paginate } from './paginate';
+import { paginate } from './paginate';
 
 describe('paginate', () => {
-  it(`should return the required pages when 'total' < ${maxPages}`, () => {
-    expect(paginate({ page: 1, total: 4 })).toEqual([1, 2, 3, 4]);
+  it(`should return the required pages when 'total' < 'maxPages'`, () => {
+    expect(paginate({ page: 1, total: 4, maxPages: 5 })).toEqual([1, 2, 3, 4]);
   });
 
-  it(`should return the first ${maxPages} pages when 'page' is '1'`, () => {
-    expect(paginate({ page: 1, total: 20 })).toEqual([1, 2, 3, 4, 5, 6, 7]);
-  });
-
-  it(`should return the ${maxPages} pages around the selected 'page'`, () => {
-    expect(paginate({ page: 12, total: 20 })).toEqual([
-      9, 10, 11, 12, 13, 14, 15,
+  it(`should return the max number of pages when 'total' > 'maxPages' and 'page' is '1'`, () => {
+    expect(paginate({ page: 1, total: 20, maxPages: 5 })).toEqual([
+      1, 2, 3, 4, 5,
     ]);
   });
 
-  it(`should return the last ${maxPages} pages when 'page' is the 'total'`, () => {
-    expect(paginate({ page: 20, total: 20 })).toEqual([
-      14, 15, 16, 17, 18, 19, 20,
+  it(`should return the max number of pages around the selected 'page'`, () => {
+    expect(paginate({ page: 12, total: 20, maxPages: 5 })).toEqual([
+      10, 11, 12, 13, 14,
+    ]);
+  });
+
+  it(`should return the last pages when 'page' is the 'total'`, () => {
+    expect(paginate({ page: 20, total: 20, maxPages: 5 })).toEqual([
+      16, 17, 18, 19, 20,
     ]);
   });
 
   it(`should return the correct pages when 'page' is < the middle page`, () => {
-    expect(paginate({ page: 3, total: 20 })).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(paginate({ page: 3, total: 20, maxPages: 5 })).toEqual([
+      1, 2, 3, 4, 5,
+    ]);
   });
 
   it(`should return the correct pages when 'page' is the middle page`, () => {
-    expect(paginate({ page: 4, total: 20 })).toEqual([1, 2, 3, 4, 5, 6, 7]);
+    expect(paginate({ page: 4, total: 20, maxPages: 5 })).toEqual([
+      2, 3, 4, 5, 6,
+    ]);
   });
 
   it(`should return the correct pages when 'page' is > the middle page`, () => {
-    expect(paginate({ page: 5, total: 20 })).toEqual([2, 3, 4, 5, 6, 7, 8]);
+    expect(paginate({ page: 5, total: 20, maxPages: 5 })).toEqual([
+      3, 4, 5, 6, 7,
+    ]);
   });
 });

--- a/lib/components/Pagination/paginate.ts
+++ b/lib/components/Pagination/paginate.ts
@@ -1,6 +1,12 @@
-export const maxPages = 7;
-
-export const paginate = ({ page, total }: { page: number; total: number }) => {
+export const paginate = ({
+  page,
+  total,
+  maxPages,
+}: {
+  page: number;
+  total: number;
+  maxPages: number;
+}) => {
   const half = (maxPages - 1) / 2;
   const smallerHalf = Math.floor(half);
   const largerHalf = Math.ceil(half);


### PR DESCRIPTION
**Pagination:** Add `pageLimit` support

Add support for configuring the number of pages displayed using the `pageLimit` prop. The default is still set to 7, but consumers can now reduce this, useful when `Pagination` is used inside column layouts.

In addition, the layout is has been stabilised, preventing the links moving when the next/prev actions are shown/hidden.

**EXAMPLE USAGE:**
```jsx
<Pagination
  ...
  pageLimit={3}
/>
```