### PR TITLE
Remove redundant use of Column

### DIFF
--- a/.changeset/clean-guests-lie.md
+++ b/.changeset/clean-guests-lie.md
@@ -1,0 +1,18 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - AccordionItem
+  - Alert
+  - MonthPicker
+  - Notice
+  - Dialog
+  - Drawer
+  - Toast
+---
+
+**AccordionItem, Alert, MonthPicker, Notice, Dialog, Drawer, Toast:** Remove default Column elements
+
+Remove redundant `Column` elements when not customising the `width` prop.

--- a/css/atoms.docs.tsx
+++ b/css/atoms.docs.tsx
@@ -427,7 +427,11 @@ const docs: CssDoc = {
                     'Used for borders around “promoteLight” elements.',
                 }),
               ).map(([boxShadow, description]) => (
-                <Columns key={boxShadow} space="medium" alignY="center">
+                <Columns
+                  key={boxShadow}
+                  space="medium"
+                  alignY={{ tablet: 'center' }}
+                >
                   <Column width="content">
                     <Box
                       background={{
@@ -439,7 +443,7 @@ const docs: CssDoc = {
                           : 'surface',
                       }}
                       borderRadius="standard"
-                      padding="gutter"
+                      padding={{ mobile: 'small', tablet: 'gutter' }}
                     >
                       <Box
                         boxShadow={{
@@ -447,22 +451,16 @@ const docs: CssDoc = {
                           darkMode: boxShadow as keyof BoxShadowDocs,
                         }}
                         borderRadius="standard"
-                        padding="gutter"
+                        padding={{ mobile: 'medium', tablet: 'gutter' }}
                       />
                     </Box>
                   </Column>
-                  <Column>
-                    <Box paddingRight="medium">
-                      <Stack space="small">
-                        <Text weight="medium">
-                          <Box style={{ wordBreak: 'break-all' }}>
-                            {boxShadow}
-                          </Box>
-                        </Text>
-                        <Text tone="secondary">{description}</Text>
-                      </Stack>
-                    </Box>
-                  </Column>
+                  <Stack space="small">
+                    <Text weight="medium">
+                      <Box style={{ wordBreak: 'break-all' }}>{boxShadow}</Box>
+                    </Text>
+                    <Text tone="secondary">{description}</Text>
+                  </Stack>
                 </Columns>
               ))}
             </Tiles>

--- a/css/breakpoints.docs.tsx
+++ b/css/breakpoints.docs.tsx
@@ -56,11 +56,9 @@ const docs: CssDoc = {
                       {iconForBp[b]}
                     </Box>
                   </Column>
-                  <Column>
-                    <Text baseline={false} weight="strong">
-                      {b}
-                    </Text>
-                  </Column>
+                  <Text baseline={false} weight="strong">
+                    {b}
+                  </Text>
                   <Column width="content">
                     <Text>{`${breakpoints[b]}${index !== 0 ? 'px' : ''}`}</Text>
                   </Column>

--- a/css/vars.docs.tsx
+++ b/css/vars.docs.tsx
@@ -27,12 +27,10 @@ const Row = ({
   children: ReactNode;
 }) => (
   <Columns space="large" alignY="center">
-    <Column>
-      <Text>
-        <Hidden below="tablet">vars{group ? `.${group}` : null}.</Hidden>
-        {name}
-      </Text>
-    </Column>
+    <Text>
+      <Hidden below="tablet">vars{group ? `.${group}` : null}.</Hidden>
+      {name}
+    </Text>
     <Column width="content">
       <Box style={{ color: vars.foregroundColor.neutral as any }}>
         <ThemedExample>

--- a/lib/components/Accordion/AccordionItem.tsx
+++ b/lib/components/Accordion/AccordionItem.tsx
@@ -130,14 +130,12 @@ export const AccordionItem = ({
           */}
           <Box position="relative">
             <Columns space={itemSpace}>
-              <Column>
-                <Inline space="small" alignY="center">
-                  <Text size={size} weight={weight} tone={tone} component="div">
-                    {label}
-                  </Text>
-                  {badge ? cloneElement(badge, { bleedY: true }) : null}
-                </Inline>
-              </Column>
+              <Inline space="small" alignY="center">
+                <Text size={size} weight={weight} tone={tone} component="div">
+                  {label}
+                </Text>
+                {badge ? cloneElement(badge, { bleedY: true }) : null}
+              </Inline>
               <Column width="content">
                 <Text
                   size={size}

--- a/lib/components/Alert/Alert.tsx
+++ b/lib/components/Alert/Alert.tsx
@@ -87,9 +87,7 @@ export const Alert = ({
         <Column width="content">
           <Icon tone={tone} />
         </Column>
-        <Column>
-          <Box className={textAlignedToIcon.standard}>{children}</Box>
-        </Column>
+        <Box className={textAlignedToIcon.standard}>{children}</Box>
         {onClose ? (
           <Column width="content">
             <Box

--- a/lib/components/Box/Box.docs.tsx
+++ b/lib/components/Box/Box.docs.tsx
@@ -516,12 +516,16 @@ const docs: ComponentDocs = {
                 //   'Used for surfaces that sit on top of body elements in a dark context',
               }),
             ).map(([background, description]) => (
-              <Columns key={background} space="medium" alignY="center">
+              <Columns
+                key={background}
+                space="medium"
+                alignY={{ tablet: 'center' }}
+              >
                 <Column width="content">
                   <Box
                     background="surface"
                     borderRadius="large"
-                    padding="gutter"
+                    padding={{ mobile: 'small', tablet: 'gutter' }}
                   >
                     <Box
                       background={{
@@ -537,22 +541,16 @@ const docs: ComponentDocs = {
                         )[background]
                       }
                       borderRadius="large"
-                      padding="gutter"
+                      padding={{ mobile: 'medium', tablet: 'gutter' }}
                     />
                   </Box>
                 </Column>
-                <Column>
-                  <Box paddingRight="medium">
-                    <Stack space="small">
-                      <Text weight="medium">
-                        <Box style={{ wordBreak: 'break-all' }}>
-                          {background}
-                        </Box>
-                      </Text>
-                      <Text tone="secondary">{description}</Text>
-                    </Stack>
-                  </Box>
-                </Column>
+                <Stack space="small">
+                  <Text weight="medium">
+                    <Box style={{ wordBreak: 'break-all' }}>{background}</Box>
+                  </Text>
+                  <Text tone="secondary">{description}</Text>
+                </Stack>
               </Columns>
             ))}
           </Tiles>,
@@ -641,7 +639,11 @@ const docs: ComponentDocs = {
                   'Used for borders around “promoteLight” elements.',
               }),
             ).map(([boxShadow, description]) => (
-              <Columns key={boxShadow} space="medium" alignY="center">
+              <Columns
+                key={boxShadow}
+                space="medium"
+                alignY={{ tablet: 'center' }}
+              >
                 <Column width="content">
                   <Box
                     background={{
@@ -653,7 +655,7 @@ const docs: ComponentDocs = {
                         : 'surface',
                     }}
                     borderRadius="large"
-                    padding="gutter"
+                    padding={{ mobile: 'small', tablet: 'gutter' }}
                   >
                     <Box
                       boxShadow={{
@@ -661,22 +663,16 @@ const docs: ComponentDocs = {
                         darkMode: boxShadow as keyof BoxShadowDocs,
                       }}
                       borderRadius="large"
-                      padding="gutter"
+                      padding={{ mobile: 'medium', tablet: 'gutter' }}
                     />
                   </Box>
                 </Column>
-                <Column>
-                  <Box paddingRight="medium">
-                    <Stack space="small">
-                      <Text weight="medium">
-                        <Box style={{ wordBreak: 'break-all' }}>
-                          {boxShadow}
-                        </Box>
-                      </Text>
-                      <Text tone="secondary">{description}</Text>
-                    </Stack>
-                  </Box>
-                </Column>
+                <Stack space="small">
+                  <Text weight="medium">
+                    <Box style={{ wordBreak: 'break-all' }}>{boxShadow}</Box>
+                  </Text>
+                  <Text tone="secondary">{description}</Text>
+                </Stack>
               </Columns>
             ))}
           </Tiles>,

--- a/lib/components/List/List.docs.tsx
+++ b/lib/components/List/List.docs.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import source from '../../utils/source.macro';
 import { ComponentDocs } from '../../../site/src/types';
-import { List, Text, TextLink, Stack, Column, Columns } from '..';
+import { List, Text, TextLink, Stack, Columns } from '..';
 import { IconTick, Strong } from '../../playroom/components';
 
 const docs: ComponentDocs = {
@@ -10,41 +10,31 @@ const docs: ComponentDocs = {
   Example: () =>
     source(
       <Columns space="large" collapseBelow="desktop">
-        <Column>
-          <List>
-            <Text>Bullet</Text>
-            <Text>Bullet</Text>
-            <Text>Bullet</Text>
-          </List>
-        </Column>
-        <Column>
-          <List type="number">
-            <Text>Number</Text>
-            <Text>Number</Text>
-            <Text>Number</Text>
-          </List>
-        </Column>
-        <Column>
-          <List type="alpha">
-            <Text>Alpha</Text>
-            <Text>Alpha</Text>
-            <Text>Alpha</Text>
-          </List>
-        </Column>
-        <Column>
-          <List type="roman">
-            <Text>Roman</Text>
-            <Text>Roman</Text>
-            <Text>Roman</Text>
-          </List>
-        </Column>
-        <Column>
-          <List type="icon" icon={<IconTick />}>
-            <Text>Icon</Text>
-            <Text>Icon</Text>
-            <Text>Icon</Text>
-          </List>
-        </Column>
+        <List>
+          <Text>Bullet</Text>
+          <Text>Bullet</Text>
+          <Text>Bullet</Text>
+        </List>
+        <List type="number">
+          <Text>Number</Text>
+          <Text>Number</Text>
+          <Text>Number</Text>
+        </List>
+        <List type="alpha">
+          <Text>Alpha</Text>
+          <Text>Alpha</Text>
+          <Text>Alpha</Text>
+        </List>
+        <List type="roman">
+          <Text>Roman</Text>
+          <Text>Roman</Text>
+          <Text>Roman</Text>
+        </List>
+        <List type="icon" icon={<IconTick />}>
+          <Text>Icon</Text>
+          <Text>Icon</Text>
+          <Text>Icon</Text>
+        </List>
       </Columns>,
     ),
   accessibility: (
@@ -75,41 +65,31 @@ const docs: ComponentDocs = {
       Example: () =>
         source(
           <Columns space="large" collapseBelow="desktop">
-            <Column>
-              <List>
-                <Text>Bullet</Text>
-                <Text>Bullet</Text>
-                <Text>Bullet</Text>
-              </List>
-            </Column>
-            <Column>
-              <List type="number">
-                <Text>Number</Text>
-                <Text>Number</Text>
-                <Text>Number</Text>
-              </List>
-            </Column>
-            <Column>
-              <List type="alpha">
-                <Text>Alpha</Text>
-                <Text>Alpha</Text>
-                <Text>Alpha</Text>
-              </List>
-            </Column>
-            <Column>
-              <List type="roman">
-                <Text>Roman</Text>
-                <Text>Roman</Text>
-                <Text>Roman</Text>
-              </List>
-            </Column>
-            <Column>
-              <List type="icon" icon={<IconTick tone="positive" />}>
-                <Text>Icon</Text>
-                <Text>Icon</Text>
-                <Text>Icon</Text>
-              </List>
-            </Column>
+            <List>
+              <Text>Bullet</Text>
+              <Text>Bullet</Text>
+              <Text>Bullet</Text>
+            </List>
+            <List type="number">
+              <Text>Number</Text>
+              <Text>Number</Text>
+              <Text>Number</Text>
+            </List>
+            <List type="alpha">
+              <Text>Alpha</Text>
+              <Text>Alpha</Text>
+              <Text>Alpha</Text>
+            </List>
+            <List type="roman">
+              <Text>Roman</Text>
+              <Text>Roman</Text>
+              <Text>Roman</Text>
+            </List>
+            <List type="icon" icon={<IconTick tone="positive" />}>
+              <Text>Icon</Text>
+              <Text>Icon</Text>
+              <Text>Icon</Text>
+            </List>
           </Columns>,
         ),
     },
@@ -125,34 +105,26 @@ const docs: ComponentDocs = {
       Example: () =>
         source(
           <Columns space="large" collapseBelow="desktop">
-            <Column>
-              <List tone="secondary" size="large" space="gutter">
-                <Text>Large</Text>
-                <Text>Large</Text>
-                <Text>Large</Text>
-              </List>
-            </Column>
-            <Column>
-              <List tone="secondary" size="standard" space="medium">
-                <Text>Standard</Text>
-                <Text>Standard</Text>
-                <Text>Standard</Text>
-              </List>
-            </Column>
-            <Column>
-              <List tone="secondary" size="small" space="small">
-                <Text>Small</Text>
-                <Text>Small</Text>
-                <Text>Small</Text>
-              </List>
-            </Column>
-            <Column>
-              <List tone="secondary" size="xsmall" space="small">
-                <Text>Xsmall</Text>
-                <Text>Xsmall</Text>
-                <Text>Xsmall</Text>
-              </List>
-            </Column>
+            <List tone="secondary" size="large" space="gutter">
+              <Text>Large</Text>
+              <Text>Large</Text>
+              <Text>Large</Text>
+            </List>
+            <List tone="secondary" size="standard" space="medium">
+              <Text>Standard</Text>
+              <Text>Standard</Text>
+              <Text>Standard</Text>
+            </List>
+            <List tone="secondary" size="small" space="small">
+              <Text>Small</Text>
+              <Text>Small</Text>
+              <Text>Small</Text>
+            </List>
+            <List tone="secondary" size="xsmall" space="small">
+              <Text>Xsmall</Text>
+              <Text>Xsmall</Text>
+              <Text>Xsmall</Text>
+            </List>
           </Columns>,
         ),
     },
@@ -213,27 +185,21 @@ const docs: ComponentDocs = {
       Example: () =>
         source(
           <Columns space="large" collapseBelow="desktop">
-            <Column>
-              <List type="number" start={9}>
-                <Text>Number</Text>
-                <Text>Number</Text>
-                <Text>Number</Text>
-              </List>
-            </Column>
-            <Column>
-              <List type="alpha" start={9}>
-                <Text>Alpha</Text>
-                <Text>Alpha</Text>
-                <Text>Alpha</Text>
-              </List>
-            </Column>
-            <Column>
-              <List type="roman" start={9}>
-                <Text>Roman</Text>
-                <Text>Roman</Text>
-                <Text>Roman</Text>
-              </List>
-            </Column>
+            <List type="number" start={9}>
+              <Text>Number</Text>
+              <Text>Number</Text>
+              <Text>Number</Text>
+            </List>
+            <List type="alpha" start={9}>
+              <Text>Alpha</Text>
+              <Text>Alpha</Text>
+              <Text>Alpha</Text>
+            </List>
+            <List type="roman" start={9}>
+              <Text>Roman</Text>
+              <Text>Roman</Text>
+              <Text>Roman</Text>
+            </List>
           </Columns>,
         ),
     },

--- a/lib/components/Loader/Loader.docs.tsx
+++ b/lib/components/Loader/Loader.docs.tsx
@@ -3,7 +3,6 @@ import { ComponentDocs } from '../../../site/src/types';
 import {
   Loader,
   Columns,
-  Column,
   Stack,
   Inline,
   Text,
@@ -32,41 +31,33 @@ const docs: ComponentDocs = {
       Example: () =>
         source(
           <Columns space="xlarge" collapseBelow="tablet">
-            <Column>
-              <Stack space="medium" align="center">
-                <Text size="large" weight="medium" tone="secondary">
-                  Large
-                </Text>
-                <Loader size="large" />
-              </Stack>
-            </Column>
+            <Stack space="medium" align="center">
+              <Text size="large" weight="medium" tone="secondary">
+                Large
+              </Text>
+              <Loader size="large" />
+            </Stack>
 
-            <Column>
-              <Stack space="medium" align="center">
-                <Text size="standard" weight="medium" tone="secondary">
-                  Standard
-                </Text>
-                <Loader size="standard" />
-              </Stack>
-            </Column>
+            <Stack space="medium" align="center">
+              <Text size="standard" weight="medium" tone="secondary">
+                Standard
+              </Text>
+              <Loader size="standard" />
+            </Stack>
 
-            <Column>
-              <Stack space="medium" align="center">
-                <Text size="small" weight="medium" tone="secondary">
-                  Small
-                </Text>
-                <Loader size="small" />
-              </Stack>
-            </Column>
+            <Stack space="medium" align="center">
+              <Text size="small" weight="medium" tone="secondary">
+                Small
+              </Text>
+              <Loader size="small" />
+            </Stack>
 
-            <Column>
-              <Stack space="medium" align="center">
-                <Text size="xsmall" weight="medium" tone="secondary">
-                  Xsmall
-                </Text>
-                <Loader size="xsmall" />
-              </Stack>
-            </Column>
+            <Stack space="medium" align="center">
+              <Text size="xsmall" weight="medium" tone="secondary">
+                Xsmall
+              </Text>
+              <Loader size="xsmall" />
+            </Stack>
           </Columns>,
         ),
     },

--- a/lib/components/MonthPicker/MonthPicker.tsx
+++ b/lib/components/MonthPicker/MonthPicker.tsx
@@ -2,7 +2,6 @@ import React, { ChangeEvent, FocusEvent, createRef, Fragment } from 'react';
 import { isMobile } from 'is-mobile';
 import assert from 'assert';
 import { Box } from '../Box/Box';
-import { Column } from '../Column/Column';
 import { Columns } from '../Columns/Columns';
 import { Dropdown } from '../Dropdown/Dropdown';
 import { Field } from '../private/Field/Field';
@@ -227,38 +226,35 @@ const MonthPicker = ({
     <FieldGroup id={id} tone={tone} disabled={disabled} {...restProps}>
       {(fieldGroupProps) => (
         <Columns space="medium">
-          <Column>
-            <Dropdown
-              id={monthId}
-              value={currentValue.month || ''}
-              onChange={makeChangeHandler(onChange, value, 'month')}
-              onBlur={blurHandler}
-              onFocus={focusHandler}
-              tone={tone}
-              placeholder={monthLabel}
-              aria-label={monthLabel}
-              {...fieldGroupProps}
-              ref={monthRef}
-            >
-              {getMonths(monthNames)}
-            </Dropdown>
-          </Column>
-          <Column>
-            <Dropdown
-              id={yearId}
-              value={currentValue.year || ''}
-              onChange={makeChangeHandler(onChange, value, 'year')}
-              onBlur={blurHandler}
-              onFocus={focusHandler}
-              tone={tone}
-              placeholder={yearLabel}
-              aria-label={yearLabel}
-              {...fieldGroupProps}
-              ref={yearRef}
-            >
-              {getYears(minYear, maxYear, ascendingYears)}
-            </Dropdown>
-          </Column>
+          <Dropdown
+            id={monthId}
+            value={currentValue.month || ''}
+            onChange={makeChangeHandler(onChange, value, 'month')}
+            onBlur={blurHandler}
+            onFocus={focusHandler}
+            tone={tone}
+            placeholder={monthLabel}
+            aria-label={monthLabel}
+            {...fieldGroupProps}
+            ref={monthRef}
+          >
+            {getMonths(monthNames)}
+          </Dropdown>
+
+          <Dropdown
+            id={yearId}
+            value={currentValue.year || ''}
+            onChange={makeChangeHandler(onChange, value, 'year')}
+            onBlur={blurHandler}
+            onFocus={focusHandler}
+            tone={tone}
+            placeholder={yearLabel}
+            aria-label={yearLabel}
+            {...fieldGroupProps}
+            ref={yearRef}
+          >
+            {getYears(minYear, maxYear, ascendingYears)}
+          </Dropdown>
         </Columns>
       )}
     </FieldGroup>

--- a/lib/components/Notice/Notice.tsx
+++ b/lib/components/Notice/Notice.tsx
@@ -37,13 +37,11 @@ export const Notice = ({ tone = 'info', data, children }: NoticeProps) => {
         <Column width="content">
           <Icon tone={tone} />
         </Column>
-        <Column>
-          <Box className={textAlignedToIcon.standard}>
-            <DefaultTextPropsProvider tone={tone}>
-              {children}
-            </DefaultTextPropsProvider>
-          </Box>
-        </Column>
+        <Box className={textAlignedToIcon.standard}>
+          <DefaultTextPropsProvider tone={tone}>
+            {children}
+          </DefaultTextPropsProvider>
+        </Box>
       </Columns>
     </Box>
   );

--- a/lib/components/Stepper/Stepper.docs.tsx
+++ b/lib/components/Stepper/Stepper.docs.tsx
@@ -5,7 +5,6 @@ import { Step } from './Step';
 import { Stepper } from './Stepper';
 import {
   Button,
-  Column,
   Columns,
   IconChevron,
   Inline,
@@ -84,35 +83,31 @@ const docs: ComponentDocs = {
                 <Step>4. Forth step</Step>
               </Stepper>
               <Columns space="small">
-                <Column>
-                  <Inline space="small" align="right">
-                    {getState('progress') > 1 ? (
-                      <Button
-                        size="small"
-                        variant="ghost"
-                        onClick={() =>
-                          setState('progress', getState('progress') - 1)
-                        }
-                      >
-                        <IconChevron direction="left" /> Back
-                      </Button>
-                    ) : null}
-                  </Inline>
-                </Column>
-                <Column>
-                  <Inline space="small">
-                    {getState('progress') < 4 ? (
-                      <Button
-                        size="small"
-                        onClick={() =>
-                          setState('progress', getState('progress') + 1)
-                        }
-                      >
-                        Next <IconChevron direction="right" />
-                      </Button>
-                    ) : null}
-                  </Inline>
-                </Column>
+                <Inline space="small" align="right">
+                  {getState('progress') > 1 ? (
+                    <Button
+                      size="small"
+                      variant="ghost"
+                      onClick={() =>
+                        setState('progress', getState('progress') - 1)
+                      }
+                    >
+                      <IconChevron direction="left" /> Back
+                    </Button>
+                  ) : null}
+                </Inline>
+                <Inline space="small">
+                  {getState('progress') < 4 ? (
+                    <Button
+                      size="small"
+                      onClick={() =>
+                        setState('progress', getState('progress') + 1)
+                      }
+                    >
+                      Next <IconChevron direction="right" />
+                    </Button>
+                  ) : null}
+                </Inline>
               </Columns>
             </Stack>
           </>,

--- a/lib/components/Text/Text.screenshots.tsx
+++ b/lib/components/Text/Text.screenshots.tsx
@@ -102,11 +102,9 @@ export const screenshots: ComponentScreenshot = {
           {backgrounds.map((background) => (
             <Box key={background} background={background} padding="xsmall">
               <Columns space="medium">
-                <Column>
-                  <Text size="small">
-                    {background} <IconPositive />
-                  </Text>
-                </Column>
+                <Text size="small">
+                  {background} <IconPositive />
+                </Text>
                 <Column width="content">
                   <Text size="small" tone="secondary">
                     Secondary <IconPositive />

--- a/lib/components/TextLink/TextLink.screenshots.tsx
+++ b/lib/components/TextLink/TextLink.screenshots.tsx
@@ -141,9 +141,7 @@ export const screenshots: ComponentScreenshot = {
           {backgrounds.map((background, i) => (
             <Box key={i} background={background} padding="small">
               <Columns space="xlarge">
-                <Column>
-                  <Text>{background}</Text>
-                </Column>
+                <Text>{background}</Text>
                 <Column width="content">
                   <Text>
                     <TextLink href="#">
@@ -158,13 +156,11 @@ export const screenshots: ComponentScreenshot = {
                     </TextLink>
                   </Text>
                 </Column>
-                <Column>
-                  <Text>
-                    <TextLink href="#" weight="weak">
-                      Weak <IconNewWindow />
-                    </TextLink>
-                  </Text>
-                </Column>
+                <Text>
+                  <TextLink href="#" weight="weak">
+                    Weak <IconNewWindow />
+                  </TextLink>
+                </Text>
               </Columns>
             </Box>
           ))}

--- a/lib/components/private/Modal/ModalContent.tsx
+++ b/lib/components/private/Modal/ModalContent.tsx
@@ -168,16 +168,14 @@ export const ModalContent = ({
                 </Stack>
               ) : (
                 <Columns space="none">
-                  <Column>
-                    <ModalContentHeader
-                      title={title}
-                      headingLevel={headingLevel}
-                      description={description}
-                      descriptionId={descriptionId}
-                      center={Boolean(illustration)}
-                      ref={headingRef}
-                    />
-                  </Column>
+                  <ModalContentHeader
+                    title={title}
+                    headingLevel={headingLevel}
+                    description={description}
+                    descriptionId={descriptionId}
+                    center={Boolean(illustration)}
+                    ref={headingRef}
+                  />
                   <Column width="content">
                     <Box width="touchable" />
                   </Column>

--- a/lib/components/useToast/Toast.tsx
+++ b/lib/components/useToast/Toast.tsx
@@ -135,7 +135,7 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
                       <Icon tone={tone} />
                     </Box>
                   </Column>
-                  <Column>{content}</Column>
+                  {content}
                   <Column width="content">
                     <Box
                       width="touchable"

--- a/site/src/App/routes/examples/job-summary/job-summary.tsx
+++ b/site/src/App/routes/examples/job-summary/job-summary.tsx
@@ -17,6 +17,8 @@ import {
   IconBookmark,
   TextLink,
   List,
+  Notice,
+  Strong,
 } from '../../../../../../lib/components';
 import { TextStack } from '../../../TextStack/TextStack';
 import { Placeholder } from '../../../../../../lib/playroom/components';
@@ -55,16 +57,14 @@ const page: Page = {
         <Card>
           <Stack space="gutter">
             <Columns space="gutter">
-              <Column>
-                <Stack space="small">
-                  <Badge tone="positive">New</Badge>
-                  <Heading level="3">Product Designer</Heading>
-                  <Inline space="small">
-                    <Text tone="secondary">Braid Design Pty Ltd</Text>
-                    <Rating rating={4.5} />
-                  </Inline>
-                </Stack>
-              </Column>
+              <Stack space="small">
+                <Badge tone="positive">New</Badge>
+                <Heading level="3">Product Designer</Heading>
+                <Inline space="small">
+                  <Text tone="secondary">Braid Design Pty Ltd</Text>
+                  <Rating rating={4.5} />
+                </Inline>
+              </Stack>
               <Column width="content">
                 <IconBookmark />
               </Column>
@@ -386,51 +386,102 @@ const page: Page = {
           detail={
             <Stack space="xlarge">
               <Text>
-                Sometimes adding new features can necessitate changing the
-                layout. First, we&rsquo;ll use a{' '}
-                <TextLink href="/components/columns">Columns</TextLink>{' '}
-                component to break up our card into two columns.
+                Sometimes adding new features can necessitate moving elements
+                around to achieve a specific layout. In this case, we&rsquo;ll
+                use a <TextLink href="/components/columns">Columns</TextLink>{' '}
+                component to wrap the header of our card and split it into two
+                columns — one for the job header, the other for the save action.
               </Text>
-              <Text tone="secondary">
-                NOTE: To make this easier to follow, we&rsquo;ve replaced the
-                job content with a Placeholder.
-              </Text>
+              <Notice>
+                <Text>
+                  NOTE: To make this easier to visualise, we&rsquo;ve replaced
+                  the header content with our desired layout using Placeholders.
+                </Text>
+              </Notice>
             </Stack>
           }
         >
           <Card>
-            <Columns space="gutter">
-              <Column>
-                <Placeholder label="Job content" height={80} />
-              </Column>
-              <Column>
+            <Stack space="gutter">
+              <Columns space="gutter">
+                <Placeholder label="Job header" height={80} />
                 <Placeholder label="Save action" height={80} />
-              </Column>
-            </Columns>
+              </Columns>
+
+              <Stack space="xsmall">
+                <Text tone="secondary" size="small">
+                  <IconLocation /> Melbourne
+                </Text>
+                <Text tone="secondary" size="small">
+                  <IconTag /> Information Technology
+                </Text>
+                <Text tone="secondary" size="small">
+                  <IconMoney /> 150k+
+                </Text>
+              </Stack>
+
+              <Text>
+                Long description of card details providing more information.
+              </Text>
+
+              <Text tone="secondary" size="xsmall">
+                2d ago
+              </Text>
+            </Stack>
           </Card>
         </Step>
 
         <Step
           detail={
-            <Text>
-              In the second column we&rsquo;ll use the{' '}
-              <TextLink href="/components/IconBookmark">IconBookmark</TextLink>{' '}
-              as the save action. By default, `Columns` are of equal width. In
-              this design however, the second column should only we as wide as
-              the save action itself. This can be controlled by setting the
-              `Column` to have a &ldquo;width&rdquo; of &ldquo;content&rdquo;.
-            </Text>
+            <Stack space="xlarge">
+              <Text>
+                By default, each direct child element of{' '}
+                <Strong>Columns</Strong> will result in a column of equal width.
+                Given the second column will only contain our save action we
+                want to leave the majority of space for the job header.
+              </Text>
+              <Text>
+                We can achieve this by wrapping the save action in an explicit{' '}
+                <Strong>Column</Strong> and setting it&rsquo;s
+                &ldquo;width&rdquo; to only be as large as it&rsquo;s
+                &ldquo;content&rdquo; — in this case the{' '}
+                <TextLink href="/components/IconBookmark">
+                  IconBookmark
+                </TextLink>{' '}
+                icon.
+              </Text>
+            </Stack>
           }
         >
           <Card>
-            <Columns space="gutter">
-              <Column>
-                <Placeholder label="Job content" height={80} />
-              </Column>
-              <Column width="content">
-                <IconBookmark />
-              </Column>
-            </Columns>
+            <Stack space="gutter">
+              <Columns space="gutter">
+                <Placeholder label="Job header" height={80} />
+                <Column width="content">
+                  <IconBookmark />
+                </Column>
+              </Columns>
+
+              <Stack space="xsmall">
+                <Text tone="secondary" size="small">
+                  <IconLocation /> Melbourne
+                </Text>
+                <Text tone="secondary" size="small">
+                  <IconTag /> Information Technology
+                </Text>
+                <Text tone="secondary" size="small">
+                  <IconMoney /> 150k+
+                </Text>
+              </Stack>
+
+              <Text>
+                Long description of card details providing more information.
+              </Text>
+
+              <Text tone="secondary" size="xsmall">
+                2d ago
+              </Text>
+            </Stack>
           </Card>
         </Step>
 
@@ -438,48 +489,46 @@ const page: Page = {
           detail={
             <Text>
               Now that we&rsquo;ve adjusted the layout, let&rsquo;s reinstate
-              our job content in the main column.
+              our job header in the main column.
             </Text>
           }
         >
           <Card>
-            <Columns space="gutter">
-              <Column>
-                <Stack space="gutter">
-                  <Stack space="small">
-                    <Badge tone="positive">New</Badge>
-                    <Heading level="3">Product Designer</Heading>
-                    <Inline space="small">
-                      <Text tone="secondary">Braid Design Pty Ltd</Text>
-                      <Rating rating={4.5} />
-                    </Inline>
-                  </Stack>
-
-                  <Stack space="xsmall">
-                    <Text tone="secondary" size="small">
-                      <IconLocation /> Melbourne
-                    </Text>
-                    <Text tone="secondary" size="small">
-                      <IconTag /> Information Technology
-                    </Text>
-                    <Text tone="secondary" size="small">
-                      <IconMoney /> 150k+
-                    </Text>
-                  </Stack>
-
-                  <Text>
-                    Long description of card details providing more information.
-                  </Text>
-
-                  <Text tone="secondary" size="xsmall">
-                    2d ago
-                  </Text>
+            <Stack space="gutter">
+              <Columns space="gutter">
+                <Stack space="small">
+                  <Badge tone="positive">New</Badge>
+                  <Heading level="3">Product Designer</Heading>
+                  <Inline space="small">
+                    <Text tone="secondary">Braid Design Pty Ltd</Text>
+                    <Rating rating={4.5} />
+                  </Inline>
                 </Stack>
-              </Column>
-              <Column width="content">
-                <IconBookmark />
-              </Column>
-            </Columns>
+                <Column width="content">
+                  <IconBookmark />
+                </Column>
+              </Columns>
+
+              <Stack space="xsmall">
+                <Text tone="secondary" size="small">
+                  <IconLocation /> Melbourne
+                </Text>
+                <Text tone="secondary" size="small">
+                  <IconTag /> Information Technology
+                </Text>
+                <Text tone="secondary" size="small">
+                  <IconMoney /> 150k+
+                </Text>
+              </Stack>
+
+              <Text>
+                Long description of card details providing more information.
+              </Text>
+
+              <Text tone="secondary" size="xsmall">
+                2d ago
+              </Text>
+            </Stack>
           </Card>
         </Step>
 
@@ -502,16 +551,14 @@ const page: Page = {
           <Card>
             <Stack space="gutter">
               <Columns space="gutter">
-                <Column>
-                  <Stack space="small">
-                    <Badge tone="positive">New</Badge>
-                    <Heading level="3">Product Designer</Heading>
-                    <Inline space="small">
-                      <Text tone="secondary">Braid Design Pty Ltd</Text>
-                      <Rating rating={4.5} />
-                    </Inline>
-                  </Stack>
-                </Column>
+                <Stack space="small">
+                  <Badge tone="positive">New</Badge>
+                  <Heading level="3">Product Designer</Heading>
+                  <Inline space="small">
+                    <Text tone="secondary">Braid Design Pty Ltd</Text>
+                    <Rating rating={4.5} />
+                  </Inline>
+                </Stack>
                 <Column width="content">
                   <IconBookmark />
                 </Column>

--- a/site/src/App/routes/examples/marketing-banner/marketing-banner.tsx
+++ b/site/src/App/routes/examples/marketing-banner/marketing-banner.tsx
@@ -79,9 +79,7 @@ const page: Page = {
                     </Inline>
                   </Stack>
                 </Column>
-                <Column>
-                  <Placeholder height={300} label="Marketing illustration" />
-                </Column>
+                <Placeholder height={300} label="Marketing illustration" />
               </Columns>
             </ContentBlock>
           </Box>,
@@ -171,9 +169,7 @@ const page: Page = {
             <Column width="3/5">
               <Placeholder height={300} />
             </Column>
-            <Column>
-              <Placeholder height={300} />
-            </Column>
+            <Placeholder height={300} />
           </Columns>
         </Step>
 
@@ -193,9 +189,7 @@ const page: Page = {
                 </Heading>
                 <Button>Show me</Button>
               </Column>
-              <Column>
-                <Placeholder height={300} label="Marketing illustration" />
-              </Column>
+              <Placeholder height={300} label="Marketing illustration" />
             </Columns>
           </Box>
         </Step>
@@ -221,9 +215,7 @@ const page: Page = {
                   <Button>Show me</Button>
                 </Stack>
               </Column>
-              <Column>
-                <Placeholder height={300} label="Marketing illustration" />
-              </Column>
+              <Placeholder height={300} label="Marketing illustration" />
             </Columns>
           </Box>
         </Step>
@@ -247,9 +239,7 @@ const page: Page = {
                   <Button>Show me</Button>
                 </Stack>
               </Column>
-              <Column>
-                <Placeholder height={300} label="Marketing illustration" />
-              </Column>
+              <Placeholder height={300} label="Marketing illustration" />
             </Columns>
           </Box>
         </Step>
@@ -274,9 +264,7 @@ const page: Page = {
                   <Button variant="ghost">Show me</Button>
                 </Stack>
               </Column>
-              <Column>
-                <Placeholder height={300} label="Marketing illustration" />
-              </Column>
+              <Placeholder height={300} label="Marketing illustration" />
             </Columns>
           </Box>
         </Step>
@@ -309,9 +297,7 @@ const page: Page = {
                   </Inline>
                 </Stack>
               </Column>
-              <Column>
-                <Placeholder height={300} label="Marketing illustration" />
-              </Column>
+              <Placeholder height={300} label="Marketing illustration" />
             </Columns>
           </Box>
         </Step>
@@ -348,9 +334,7 @@ const page: Page = {
                   </Inline>
                 </Stack>
               </Column>
-              <Column>
-                <Placeholder height={300} label="Marketing illustration" />
-              </Column>
+              <Placeholder height={300} label="Marketing illustration" />
             </Columns>
           </Box>
         </Step>
@@ -407,9 +391,7 @@ const page: Page = {
                   </Inline>
                 </Stack>
               </Column>
-              <Column>
-                <Placeholder height={300} label="Marketing illustration" />
-              </Column>
+              <Placeholder height={300} label="Marketing illustration" />
             </Columns>
           </Box>
         </Step>
@@ -453,9 +435,7 @@ const page: Page = {
                   </Inline>
                 </Stack>
               </Column>
-              <Column>
-                <Placeholder height={300} label="Marketing illustration" />
-              </Column>
+              <Placeholder height={300} label="Marketing illustration" />
             </Columns>
           </Box>
         </Step>
@@ -516,9 +496,7 @@ const page: Page = {
                   </Inline>
                 </Stack>
               </Column>
-              <Column>
-                <Placeholder height={300} label="Marketing illustration" />
-              </Column>
+              <Placeholder height={300} label="Marketing illustration" />
             </Columns>
           </Box>
         </Step>
@@ -566,9 +544,7 @@ const page: Page = {
                     </Inline>
                   </Stack>
                 </Column>
-                <Column>
-                  <Placeholder height={300} label="Marketing illustration" />
-                </Column>
+                <Placeholder height={300} label="Marketing illustration" />
               </Columns>
             </ContentBlock>
           </Box>
@@ -615,9 +591,7 @@ const page: Page = {
                     </Inline>
                   </Stack>
                 </Column>
-                <Column>
-                  <Placeholder height={300} label="Marketing illustration" />
-                </Column>
+                <Placeholder height={300} label="Marketing illustration" />
               </Columns>
             </ContentBlock>
           </Box>
@@ -664,9 +638,7 @@ const page: Page = {
                     </Inline>
                   </Stack>
                 </Column>
-                <Column>
-                  <Placeholder height={300} label="Marketing illustration" />
-                </Column>
+                <Placeholder height={300} label="Marketing illustration" />
               </Columns>
             </ContentBlock>
           </Box>

--- a/site/src/App/routes/foundations/layout/layout.tsx
+++ b/site/src/App/routes/foundations/layout/layout.tsx
@@ -106,17 +106,15 @@ const page: Page = {
                 <Text baseline={false}>{space}</Text>
               </Box>
             </Column>
-            <Column>
-              <Box display="flex">
-                <ThemedExample transparent>
-                  <Box
-                    background="formAccent"
-                    paddingLeft={space}
-                    paddingTop="medium"
-                  />
-                </ThemedExample>
-              </Box>
-            </Column>
+            <Box display="flex">
+              <ThemedExample transparent>
+                <Box
+                  background="formAccent"
+                  paddingLeft={space}
+                  paddingTop="medium"
+                />
+              </ThemedExample>
+            </Box>
           </Columns>
         ))}
       </Stack>

--- a/site/src/App/routes/foundations/tones/tones.tsx
+++ b/site/src/App/routes/foundations/tones/tones.tsx
@@ -149,11 +149,9 @@ const ToneDefinition = ({ tone }: { tone: Tone }) => {
             <Box background={swatch} className={styles.square} />
           </ThemedExample>
         </Column>
-        <Column>
-          <Box height="touchable" display="flex" alignItems="center">
-            <Heading level="4">{tone}</Heading>
-          </Box>
-        </Column>
+        <Box height="touchable" display="flex" alignItems="center">
+          <Heading level="4">{tone}</Heading>
+        </Box>
       </Columns>
 
       <Columns space={['xsmall', 'medium']} collapseBelow="tablet">
@@ -162,34 +160,30 @@ const ToneDefinition = ({ tone }: { tone: Tone }) => {
             <Box width="touchable" />
           </Hidden>
         </Column>
-        <Column>
-          <TextStack space="large">
-            <Text>{description}</Text>
+        <TextStack space="large">
+          <Text>{description}</Text>
 
-            {usageTypes.map((usageType) =>
-              usage[usageType].length > 0 ? (
-                <Columns
-                  key={usageType}
-                  space={['medium', 'large']}
-                  collapseBelow="tablet"
-                >
-                  <Column width="1/5">
-                    <Text tone="secondary">{usageType}</Text>
-                  </Column>
-                  <Column>
-                    <Stack space="small">
-                      {usage[usageType].map((usageItem, index) => (
-                        <Text key={index} tone="secondary">
-                          - {usageItem}
-                        </Text>
-                      ))}
-                    </Stack>
-                  </Column>
-                </Columns>
-              ) : null,
-            )}
-          </TextStack>
-        </Column>
+          {usageTypes.map((usageType) =>
+            usage[usageType].length > 0 ? (
+              <Columns
+                key={usageType}
+                space={['medium', 'large']}
+                collapseBelow="tablet"
+              >
+                <Column width="1/5">
+                  <Text tone="secondary">{usageType}</Text>
+                </Column>
+                <Stack space="small">
+                  {usage[usageType].map((usageItem, index) => (
+                    <Text key={index} tone="secondary">
+                      - {usageItem}
+                    </Text>
+                  ))}
+                </Stack>
+              </Columns>
+            ) : null,
+          )}
+        </TextStack>
       </Columns>
     </Stack>
   );
@@ -212,22 +206,20 @@ function TonePage() {
 
       <Columns space={['small', 'gutter']}>
         {tones.map((tone) => (
-          <Column key={tone}>
-            <Stack space={['none', 'xsmall']}>
-              <ThemedExample>
-                <Box
-                  background={toneDocs[tone].swatch}
-                  width="full"
-                  className={styles.rectangle}
-                />
-              </ThemedExample>
-              <Hidden below="tablet">
-                <Box textAlign="center">
-                  <Text tone="secondary">{tone}</Text>
-                </Box>
-              </Hidden>
-            </Stack>
-          </Column>
+          <Stack space={['none', 'xsmall']} key={tone}>
+            <ThemedExample>
+              <Box
+                background={toneDocs[tone].swatch}
+                width="full"
+                className={styles.rectangle}
+              />
+            </ThemedExample>
+            <Hidden below="tablet">
+              <Box textAlign="center">
+                <Text tone="secondary">{tone}</Text>
+              </Box>
+            </Hidden>
+          </Stack>
         ))}
       </Columns>
 

--- a/site/src/App/routes/gallery/Gallery.tsx
+++ b/site/src/App/routes/gallery/Gallery.tsx
@@ -139,13 +139,11 @@ const RenderExample = ({ id, example }: RenderExampleProps) => {
     <BraidProvider styleBody={false} theme={docsTheme}>
       <Stack space="small">
         <Columns space="medium" alignY="center">
-          <Column>
-            {label ? (
-              <Text component="h5" tone="secondary">
-                {label}
-              </Text>
-            ) : null}
-          </Column>
+          {label ? (
+            <Text component="h5" tone="secondary">
+              {label}
+            </Text>
+          ) : null}
           {code ? (
             <Column width="content">
               <CodeButton

--- a/site/src/App/routes/guides/development-workflow.tsx
+++ b/site/src/App/routes/guides/development-workflow.tsx
@@ -10,7 +10,6 @@ import {
   Button,
   Stack,
   Columns,
-  Column,
   Box,
 } from '../../../../../lib/components';
 import { TextStack } from '../../TextStack/TextStack';
@@ -131,22 +130,18 @@ const DevelopmentWorkflow = () => (
     <Code>
       {source(
         <Columns space="gutter" collapseBelow="tablet">
-          <Column>
-            <Card>
-              <Stack space="small">
-                <Heading level="4">Column 1</Heading>
-                <Text>My first Braid component</Text>
-              </Stack>
-            </Card>
-          </Column>
-          <Column>
-            <Card>
-              <Stack space="small">
-                <Heading level="4">Column 2</Heading>
-                <Text>My second Braid component</Text>
-              </Stack>
-            </Card>
-          </Column>
+          <Card>
+            <Stack space="small">
+              <Heading level="4">Column 1</Heading>
+              <Text>My first Braid component</Text>
+            </Stack>
+          </Card>
+          <Card>
+            <Stack space="small">
+              <Heading level="4">Column 2</Heading>
+              <Text>My second Braid component</Text>
+            </Stack>
+          </Card>
         </Columns>,
       )}
     </Code>
@@ -162,22 +157,18 @@ const DevelopmentWorkflow = () => (
           space={{ mobile: 'xxsmall', tablet: 'gutter' }}
           collapseBelow="tablet"
         >
-          <Column>
-            <Card>
-              <Stack space="small">
-                <Heading level="4">Column 1</Heading>
-                <Text>My first Braid component</Text>
-              </Stack>
-            </Card>
-          </Column>
-          <Column>
-            <Card>
-              <Stack space="small">
-                <Heading level="4">Column 2</Heading>
-                <Text>My second Braid component</Text>
-              </Stack>
-            </Card>
-          </Column>
+          <Card>
+            <Stack space="small">
+              <Heading level="4">Column 1</Heading>
+              <Text>My first Braid component</Text>
+            </Stack>
+          </Card>
+          <Card>
+            <Stack space="small">
+              <Heading level="4">Column 2</Heading>
+              <Text>My second Braid component</Text>
+            </Stack>
+          </Card>
         </Columns>,
       )}
     </Code>


### PR DESCRIPTION
**AccordionItem, Alert, MonthPicker, Notice, Dialog, Drawer, Toast:** Remove default Column elements

Remove redundant `Column` elements when not customising the `width` prop.

---

**"Examples" on docs site**

Revisited some of the steps/flow around the `Job Summary` and `Marketing Banner` examples now that `Column` is only necessary when customising the `width` prop.