### PR TITLE
site: Expose docs for test entry point

### DIFF
--- a/lib/components/BraidTestProvider/BraidTestProvider.docs.tsx
+++ b/lib/components/BraidTestProvider/BraidTestProvider.docs.tsx
@@ -22,7 +22,7 @@ const docs: ComponentDocs = {
   alternatives: [
     {
       name: 'BraidProvider',
-      description: 'For production apps with a single theme.',
+      description: 'For production apps.',
     },
   ],
   additional: [

--- a/site/src/App/navigationHelpers.ts
+++ b/site/src/App/navigationHelpers.ts
@@ -1,5 +1,6 @@
 import groupBy from 'lodash/groupBy';
 import * as components from '../../../lib/components';
+import * as testComponents from '../../../test';
 import * as css from '../../../css';
 import { BraidSnippet } from '../../../lib/components/private/Snippets';
 import { ComponentDocs, ComponentExample, CssDoc } from '../types';
@@ -53,7 +54,10 @@ const documentedCssNames = Object.keys(css).filter(
   (name) => !undocumentedExports.css.includes(name),
 );
 
-const documentedComponentNames = Object.keys(components)
+const documentedComponentNames = Object.keys({
+  ...components,
+  ...testComponents,
+})
   .filter((name) => {
     if (name.startsWith('Icon')) {
       return false;

--- a/sku.routes.js
+++ b/sku.routes.js
@@ -25,6 +25,7 @@ const getPages = (relativePath) => {
 // Remove `colorModeStyle` from `undocumentedExports.json`
 const cssNames = getExports('css/index.ts', 'css');
 const componentNames = getExports('lib/components/index.ts');
+const testNames = getExports('test/index.ts');
 const iconNames = getExports('lib/components/icons/index.ts');
 
 const guideRoutes = getPages('site/src/App/routes/guides/index.ts');
@@ -40,7 +41,7 @@ module.exports = [
   ...exampleRoutes.map((route) => ({ route })),
   { route: '/components', name: 'components' }, // Pre-rendering this route for url backwards compatibility.
   ...flatten(
-    componentNames.map((name) =>
+    [...componentNames, ...testNames].map((name) =>
       [
         { route: `/components/${name}` },
         { route: `/components/${name}/releases` },


### PR DESCRIPTION
Moving the `BraidTestProvider` to its own `test` entry point [in v31.0.0](http://localhost:8080/components/BraidTestProvider/releases) accidentally dropped it from the docs site, which builds its navigation based on the `components` and `css` entry points.

This reinstates and includes the `test` entry point to cater for future exports as well.