### PR TITLE
Bleed: Support using span elements via component prop

### DIFF
--- a/.changeset/afraid-pillows-smile.md
+++ b/.changeset/afraid-pillows-smile.md
@@ -1,0 +1,19 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Bleed
+---
+
+**Bleed:** Support using span elements via component prop
+
+Setting the `component` prop to `span` will now ensure all elements controlled by `Bleed` are `span`s. This is useful when using layout components inside dom elements that should not contain `div`s from a HTML validation perspective.
+
+**EXAMPLE USAGE:**
+```jsx
+<Bleed space="medium" component="span">
+  ...
+</Bleed>
+```

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -183,6 +183,9 @@ Object {
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     children: ReactNode
+    component?: 
+        | "div"
+        | "span"
     horizontal?: 
         | "gutter"
         | "large"
@@ -1934,6 +1937,32 @@ Object {
         vanillaTheme: string
         webFonts: { linkTag: string; }[]
     }
+},
+}
+`;
+
+exports[`BraidTestProvider 1`] = `
+Object {
+  exportType: component,
+  props: {
+    breakpoint?: 
+        | "desktop"
+        | "mobile"
+        | "tablet"
+        | "wide"
+    children: ReactNode
+    linkComponent?: 
+        | ComponentClass<LinkComponentProps, any>
+        | FunctionComponent<LinkComponentProps>
+        | { readonly __forwardRef__: ForwardRefExoticComponent<LinkComponentProps & RefAttributes<HTMLAnchorElement>>; }
+    themeName?: 
+        | "apac"
+        | "catho"
+        | "docs"
+        | "occ"
+        | "seekAnz"
+        | "seekBusiness"
+        | "wireframe"
 },
 }
 `;

--- a/lib/components/Bleed/Bleed.playroom.tsx
+++ b/lib/components/Bleed/Bleed.playroom.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Bleed as BraidBleed, BleedProps, validBleedComponents } from './Bleed';
+
+export const Bleed = ({ component, ...restProps }: BleedProps) => (
+  <BraidBleed
+    component={
+      component && validBleedComponents.indexOf(component) > -1
+        ? component
+        : undefined
+    }
+    {...restProps}
+  />
+);

--- a/lib/components/Bleed/Bleed.screenshots.tsx
+++ b/lib/components/Bleed/Bleed.screenshots.tsx
@@ -356,5 +356,18 @@ export const screenshots: ComponentScreenshot = {
         </Box>
       ),
     },
+    {
+      label: 'Test - Span',
+      Container,
+      Example: () => (
+        <Bleed component="span" space="large">
+          <Box
+            background="criticalLight"
+            boxShadow="borderCritical"
+            style={{ height: 150 }}
+          />
+        </Bleed>
+      ),
+    },
   ],
 };

--- a/lib/components/Bleed/Bleed.tsx
+++ b/lib/components/Bleed/Bleed.tsx
@@ -3,6 +3,8 @@ import { ResponsiveSpace } from '../../css/atoms/atoms';
 import { negativeMargin } from '../../css/negativeMargin/negativeMargin';
 import { Box, BoxProps } from '../Box/Box';
 
+export const validBleedComponents = ['div', 'span'] as const;
+
 export interface BleedProps {
   children: BoxProps['children'];
   space?: ResponsiveSpace;
@@ -12,6 +14,7 @@ export interface BleedProps {
   bottom?: ResponsiveSpace;
   left?: ResponsiveSpace;
   right?: ResponsiveSpace;
+  component?: typeof validBleedComponents[number];
 }
 
 export const Bleed = ({
@@ -23,8 +26,11 @@ export const Bleed = ({
   left,
   right,
   children,
+  component = 'div',
 }: BleedProps) => (
   <Box
+    component={component}
+    display={component === 'span' ? 'block' : undefined}
     className={[
       negativeMargin('top', top || vertical || space),
       negativeMargin('bottom', bottom || vertical || space),
@@ -32,6 +38,12 @@ export const Bleed = ({
       negativeMargin('right', right || horizontal || space),
     ]}
   >
-    <Box position="relative">{children}</Box>
+    <Box
+      component={component}
+      display={component === 'span' ? 'block' : undefined}
+      position="relative"
+    >
+      {children}
+    </Box>
   </Box>
 );

--- a/lib/playroom/components.ts
+++ b/lib/playroom/components.ts
@@ -6,6 +6,7 @@ export { AccordionItem } from '../components/Accordion/AccordionItem.playroom';
 export { Alert } from '../components/Alert/Alert.playroom';
 export { Autosuggest } from '../components/Autosuggest/Autosuggest.playroom';
 export { Badge } from '../components/Badge/Badge.playroom';
+export { Bleed } from '../components/Bleed/Bleed.playroom';
 export { Box } from '../components/Box/Box.playroom';
 export { Button } from '../components/Button/Button.playroom';
 export { ButtonIcon } from '../components/ButtonIcon/ButtonIcon.playroom';


### PR DESCRIPTION
Includes updated `BraidTestProvider` snapshot from previous PR. Opened [PR to sku](https://github.com/seek-oss/sku/pull/678) separately to ensure new snapshots fail the build in CI in the future.