### PR TITLE
Button, ButtonLink: Improve Button `bleed`

### DIFF
--- a/.changeset/brown-crabs-visit.md
+++ b/.changeset/brown-crabs-visit.md
@@ -1,0 +1,37 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Button
+  - ButtonLink
+---
+
+**Button, ButtonLink:** Improve Button `bleed`
+
+Previously the `bleedY` prop allowed the background of `Button` to bleed vertically into the surrounding layout. This worked well for all variants except `transparent`, which needed to bleed horizontally as well.
+
+To support this we have introduced the `bleed` prop which will apply the bleed based on the `variant`. We have also deprecated `bleedY` which will be removed in a future release.
+
+
+**EXAMPLE USAGE:**
+```diff
+ <Button
+-  bleedY
++  bleed
+   {...}
+ >
+   Button
+ </Button>
+```
+
+**MIGRATION GUIDE**
+
+Migration from `bleedY` to `bleed` can be automated by running the Braid upgrade command, passing the `v31.11` version. You must provide a glob to target your project’s source files. For example:
+
+```
+yarn braid-upgrade v31.11 "**/*.{ts,tsx}"
+```
+
+It is recommended to visually review the any `Button` usage with the `transparent` variant, to ensure the layout is as expected.

--- a/codemod/src/codemod.ts
+++ b/codemod/src/codemod.ts
@@ -11,7 +11,9 @@ import atomsPlugin from './plugin-deprecate/plugin-deprecate-atoms';
 import propsPlugin from './plugin-deprecate/plugin-deprecate-props';
 import varsPlugin from './plugin-deprecate/plugin-deprecate-vars';
 import importUpdatePlugin from './plugin-deprecate/plugin-import-update';
+import propRenamePlugin from './plugin-deprecate/plugin-prop-rename';
 import { v31 } from './plugin-deprecate/deprecationMaps/v31';
+import { v31_11 } from './plugin-deprecate/deprecationMaps/v31-11';
 
 const pluginsForVersion = {
   v31: [
@@ -20,6 +22,7 @@ const pluginsForVersion = {
     [varsPlugin, { deprecations: v31 }],
     importUpdatePlugin,
   ],
+  [`v31.11`]: [[propRenamePlugin, { renames: v31_11 }]],
 };
 
 type Version = keyof typeof pluginsForVersion;

--- a/codemod/src/plugin-deprecate/deprecationMaps/v31-11.ts
+++ b/codemod/src/plugin-deprecate/deprecationMaps/v31-11.ts
@@ -1,0 +1,8 @@
+export const v31_11 = {
+  Button: {
+    bleedY: 'bleed',
+  },
+  ButtonLink: {
+    bleedY: 'bleed',
+  },
+} as const;

--- a/codemod/src/plugin-deprecate/plugin-prop-rename.test.ts
+++ b/codemod/src/plugin-deprecate/plugin-prop-rename.test.ts
@@ -1,0 +1,263 @@
+import pluginTester from 'babel-plugin-tester';
+import dedent from 'dedent';
+
+import { v31_11 } from './deprecationMaps/v31-11';
+import plugin from './plugin-prop-rename';
+
+const tests: Parameters<typeof pluginTester>[0]['tests'] = [
+  {
+    title: 'Visit Braid component only',
+    code: dedent`
+    import { Button } from 'not-braid';
+    import { Button as BraidButton } from 'braid-design-system';
+    export default () => {
+      return (
+        <>
+          <Button bleedY>Button</Button>
+          <BraidButton bleedY>Button</BraidButton>
+        </>
+      );
+    };`,
+    output: dedent`
+    import { Button } from 'not-braid';
+    import { Button as BraidButton } from 'braid-design-system';
+    export default () => {
+      return (
+        <>
+          <Button bleedY>Button</Button>
+          <BraidButton bleed>Button</BraidButton>
+        </>
+      );
+    };`,
+  },
+  {
+    title: 'Updates renamed attribute only',
+    code: dedent`
+    import { Button } from 'braid-design-system';
+    export default () => {
+      return (
+        <Button variant="soft" bleedY="true">
+          Button
+        </Button>
+      );
+    };`,
+    output: dedent`
+    import { Button } from 'braid-design-system';
+    export default () => {
+      return (
+        <Button variant="soft" bleed="true">
+          Button
+        </Button>
+      );
+    };`,
+  },
+  {
+    title: 'Updates renamed attributes from inline spread',
+    code: dedent`
+    import { Button } from 'braid-design-system';
+    export default () => (
+      <Button
+        {...{
+          variant: 'soft',
+          bleedY: true,
+        }}
+      >
+        Button
+      </Button>
+    );`,
+    output: dedent`
+    import { Button } from 'braid-design-system';
+    export default () => (
+      <Button
+        {...{
+          variant: 'soft',
+          bleed: true,
+        }}
+      >
+        Button
+      </Button>
+    );`,
+  },
+  {
+    title: 'Updates renamed attributes spread from variable',
+    code: dedent`
+    import { Button } from 'braid-design-system';
+    export default () => {
+      const props = {
+        variant: 'soft',
+        bleedY: true,
+      };
+      return <Button {...props}>Button</Button>;
+    };`,
+    output: dedent`
+    import { Button } from 'braid-design-system';
+    export default () => {
+      const props = {
+        variant: 'soft',
+        bleed: true,
+      };
+      return <Button {...props}>Button</Button>;
+    };`,
+  },
+  {
+    title: 'Updates renamed attributes spread from function call',
+    code: dedent`
+    import { Button } from 'braid-design-system';
+    export default () => {
+      const props = () => ({
+        variant: 'soft',
+        bleedY: true,
+      });
+
+      return <Button {...props()}>Button</Button>;
+    };`,
+    output: dedent`
+    import { Button } from 'braid-design-system';
+    export default () => {
+      const props = () => ({
+        variant: 'soft',
+        bleed: true,
+      });
+
+      return <Button {...props()}>Button</Button>;
+    };`,
+  },
+  {
+    title: 'Updates renamed attributes with computed keys',
+    code: dedent`
+    import { Button } from 'braid-design-system';
+    export default () => {
+      const props = () => ({
+        variant: 'soft',
+        ['bleedY']: true,
+      });
+
+      return <Button {...props()}>Button</Button>;
+    };`,
+    output: dedent`
+    import { Button } from 'braid-design-system';
+    export default () => {
+      const props = () => ({
+        variant: 'soft',
+        ['bleed']: true,
+      });
+
+      return <Button {...props()}>Button</Button>;
+    };`,
+  },
+  {
+    title: 'Updates renamed attributes for namespaced elements',
+    code: dedent`
+    import * as Braid from 'braid-design-system';
+    export default () => {
+      const props = () => ({
+        variant: 'soft',
+        ['bleedY']: true,
+      });
+
+      return <Braid.Button {...props()}>Button</Braid.Button>;
+    };`,
+    output: dedent`
+    import * as Braid from 'braid-design-system';
+    export default () => {
+      const props = () => ({
+        variant: 'soft',
+        ['bleed']: true,
+      });
+
+      return <Braid.Button {...props()}>Button</Braid.Button>;
+    };`,
+  },
+  {
+    title: 'Updates renamed attributes for elements renamed locally',
+    code: dedent`
+    import { Button as Boo } from 'braid-design-system';
+    export default () => {
+      const props = () => ({
+        variant: 'soft',
+        ['bleedY']: true,
+      });
+
+      return <Boo {...props()}>Button</Boo>;
+    };`,
+    output: dedent`
+    import { Button as Boo } from 'braid-design-system';
+    export default () => {
+      const props = () => ({
+        variant: 'soft',
+        ['bleed']: true,
+      });
+
+      return <Boo {...props()}>Button</Boo>;
+    };`,
+  },
+  {
+    title: 'Updates deeply nested opening element',
+    code: dedent`
+    import { Button } from 'braid-design-system';
+
+    const Component = () => (
+      <ParentComponent
+        propName={() => (
+          <Layout space="small" align="center">
+            <Button
+              bleedY
+              onClick={() => {
+                onReloadClick();
+              }}
+              variant="ghost"
+              tone="neutral"
+              data={{
+                testid: 'reload-jdv',
+              }}
+            >
+              Reload this job
+            </Button>
+          </Layout>
+        )}
+      />
+    );
+
+    export default Component;`,
+    output: dedent`
+    import { Button } from 'braid-design-system';
+
+    const Component = () => (
+      <ParentComponent
+        propName={() => (
+          <Layout space="small" align="center">
+            <Button
+              bleed
+              onClick={() => {
+                onReloadClick();
+              }}
+              variant="ghost"
+              tone="neutral"
+              data={{
+                testid: 'reload-jdv',
+              }}
+            >
+              Reload this job
+            </Button>
+          </Layout>
+        )}
+      />
+    );
+
+    export default Component;`,
+  },
+];
+
+pluginTester({
+  pluginName: 'babel-plugin-braid-update-prop',
+  plugin,
+  pluginOptions: { renames: v31_11 },
+  babelOptions: {
+    filename: 'test-file.tsx',
+    plugins: [
+      '@babel/plugin-syntax-jsx',
+      ['@babel/plugin-syntax-typescript', { isTSX: true }],
+    ],
+  },
+  tests,
+});

--- a/codemod/src/plugin-deprecate/plugin-prop-rename.ts
+++ b/codemod/src/plugin-deprecate/plugin-prop-rename.ts
@@ -1,0 +1,173 @@
+import type { PluginObj, PluginPass, Visitor } from '@babel/core';
+import { types as t } from '@babel/core';
+import type { NodePath } from '@babel/traverse';
+import { renderRecursiveDepthWarning } from '../warning-renderer/warning';
+import { deArray } from './helpers';
+
+interface Context extends PluginPass {
+  importNames: Map<string, string>;
+  namespace: string | null;
+  renames: Record<string, Record<string, string>>;
+}
+
+interface SubVisitorContext extends Context {
+  componentName: string;
+  propName?: string;
+  propLocation?: t.SourceLocation | null;
+  recurses: number;
+}
+const subVisitor: Visitor<SubVisitorContext> = {
+  JSXIdentifier(p) {
+    const newValue = this.renames[this.componentName]?.[p.node.name];
+
+    if (Boolean(newValue)) {
+      p.node.name = newValue;
+      // @ts-expect-error
+      this.file.metadata.hasChanged = true;
+    }
+  },
+  StringLiteral(p) {
+    const newValue = this.renames[this.componentName]?.[p.node.value];
+
+    if (Boolean(newValue)) {
+      if (p.node.extra) {
+        Object.keys(p.node.extra).forEach((k) => {
+          if (
+            p.node.extra &&
+            k in p.node.extra &&
+            typeof p.node.extra[k] === 'string'
+          ) {
+            p.node.extra[k] = (p.node.extra[k] as string).replace(
+              p.node.value,
+              newValue,
+            );
+          }
+        });
+      }
+
+      p.node.value = newValue;
+      // @ts-expect-error
+      this.file.metadata.hasChanged = true;
+    }
+  },
+  JSXAttribute(p) {
+    if (
+      !(
+        typeof p.node.name.name === 'string' &&
+        Boolean(this.renames[this.componentName]?.[p.node.name.name])
+      )
+    ) {
+      p.skip();
+    }
+  },
+  Identifier(p) {
+    if (this.recurses > 9) {
+      // @ts-expect-error
+      this.file.metadata.warnings.push(
+        renderRecursiveDepthWarning({
+          filePath: this.filename,
+        }),
+      );
+      return;
+    }
+
+    if (t.isConditionalExpression(p.parent, { test: p.node })) {
+      return;
+    }
+
+    const identifierName = p.node.name;
+    const binding = p.scope.getBinding(identifierName);
+
+    if (binding && t.isVariableDeclarator(binding.path.node)) {
+      const initPath = deArray(
+        binding.path.get('init'),
+      ) as NodePath<t.Expression>;
+
+      initPath.traverse(subVisitor, {
+        ...this,
+        recurses: this.recurses + 1,
+      });
+
+      return;
+    }
+
+    if (Boolean(this.renames[this.componentName]?.[p.node.name])) {
+      p.node.name = this.renames[this.componentName][p.node.name];
+      // @ts-expect-error
+      this.file.metadata.hasChanged = true;
+    }
+  },
+};
+
+export default function (): PluginObj<Context> {
+  return {
+    pre() {
+      this.importNames = new Map<string, string>();
+      this.namespace = null;
+      // @ts-expect-error
+      this.file.metadata.warnings = this.file.metadata.warnings ?? [];
+      // @ts-expect-error
+      this.file.metadata.hasChanged = this.file.metadata.hasChanged ?? false;
+
+      if (!this.opts || !('renames' in this.opts)) {
+        throw new Error('A map of renames must be provided.');
+      }
+
+      // @ts-expect-error
+      this.renames = this.opts.renames ?? {};
+    },
+    visitor: {
+      Program: {
+        enter(path) {
+          const bodyPath = path.get('body');
+
+          for (const statement of bodyPath) {
+            if (
+              t.isImportDeclaration(statement.node) &&
+              /braid-design-system(?:\/css)?$/.test(statement.node.source.value)
+            ) {
+              for (const specifier of statement.node.specifiers) {
+                if (
+                  t.isImportSpecifier(specifier) &&
+                  t.isIdentifier(specifier.imported) &&
+                  Boolean(this.renames[specifier.imported.name])
+                ) {
+                  this.importNames.set(
+                    specifier.local.name,
+                    specifier.imported.name,
+                  );
+                } else if (t.isImportNamespaceSpecifier(specifier)) {
+                  this.namespace = specifier.local.name;
+                }
+              }
+            }
+          }
+        },
+      },
+      JSXOpeningElement(path) {
+        let elementName: string | null = null;
+
+        if (t.isJSXMemberExpression(path.node.name)) {
+          elementName =
+            t.isJSXIdentifier(path.node.name.object) &&
+            path.node.name.object.name === this.namespace
+              ? path.node.name.property.name
+              : null;
+        } else if (
+          typeof path.node.name.name === 'string' &&
+          this.importNames.has(path.node.name.name)
+        ) {
+          elementName = this.importNames.get(path.node.name.name) || null;
+        }
+
+        if (elementName) {
+          path.traverse(subVisitor, {
+            ...this,
+            componentName: elementName,
+            recurses: 0,
+          });
+        }
+      },
+    },
+  };
+}

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -1988,6 +1988,7 @@ Object {
         | "true"
         | false
         | true
+    bleed?: boolean
     bleedY?: boolean
     children?: ReactNode
     data?: DataAttributeMap
@@ -2238,6 +2239,7 @@ Object {
     autoCapitalize?: string
     autoCorrect?: string
     autoSave?: string
+    bleed?: boolean
     bleedY?: boolean
     children?: ReactNode
     color?: string

--- a/lib/components/Button/Button.css.ts
+++ b/lib/components/Button/Button.css.ts
@@ -67,7 +67,7 @@ const stylesForBreakpoint = (
   };
 };
 
-export const bleedY = style({
+export const bleedVerticallyToCapHeight = style({
   selectors: {
     [`${standard}&`]: responsiveStyle({
       mobile: stylesForBreakpoint('mobile', 'standard'),

--- a/lib/components/Button/Button.docs.tsx
+++ b/lib/components/Button/Button.docs.tsx
@@ -13,6 +13,7 @@ import {
   IconSend,
   IconDelete,
   Notice,
+  Toggle,
 } from '../';
 import source from '../../utils/source.macro';
 
@@ -49,12 +50,21 @@ const docs: ComponentDocs = {
       label: 'Variants',
       background: 'surface',
       description: (
-        <Text>
-          You can customise the appearance of the button via the{' '}
-          <Strong>variant</Strong> prop, which accepts either{' '}
-          <Strong>solid</Strong>, <Strong>ghost</Strong>, <Strong>soft</Strong>{' '}
-          or <Strong>transparent</Strong>.
-        </Text>
+        <>
+          <Text>
+            You can customise the appearance of the button via the{' '}
+            <Strong>variant</Strong> prop, which accepts either{' '}
+            <Strong>solid</Strong>, <Strong>ghost</Strong>,{' '}
+            <Strong>soft</Strong> or <Strong>transparent</Strong>.
+          </Text>
+          <Notice>
+            <Text>
+              When using a <Strong>transparent</Strong> button on it’s own,
+              consider using the <TextLink href="#bleed">bleed</TextLink> prop
+              for better alignment.
+            </Text>
+          </Notice>
+        </>
       ),
       Example: () =>
         source(
@@ -323,64 +333,107 @@ const docs: ComponentDocs = {
         ),
     },
     {
-      label: 'Vertical bleed',
+      label: 'Bleed',
       description: (
         <>
           <Text>
-            With the <Strong>bleedY</Strong> prop, you can allow the background
-            colour to bleed out into the surrounding layout.
+            The <Strong>bleed</Strong> prop allows the background colour to
+            bleed out into the surrounding layout — leaving the button to only
+            take up the space required for the label itself.
           </Text>
+          <Notice>
+            <Text>
+              The bleed is only applied vertically, with exception to the{' '}
+              <Strong>transparent</Strong> variant, which also applies
+              horizontally to facilitate better alignment with surrounding text.
+            </Text>
+          </Notice>
           <Text>
             For example, we can align a button to a{' '}
             <TextLink href="/components/Heading">Heading</TextLink> element
             using an <TextLink href="/components/Inline">Inline</TextLink>, even
             though the button is actually taller than the heading. If we didn’t
-            use the <Strong>bleedY</Strong> prop in this case, the button would
+            use the <Strong>bleed</Strong> prop in this case, the button would
             introduce unwanted space above and below the heading.
           </Text>
         </>
       ),
       background: 'surface',
-      Example: () =>
+      Example: ({ setDefaultState, toggleState, getState }) =>
         source(
-          <Stack space="large">
-            <Stack space="small">
-              <Text tone="secondary" weight="strong">
-                Standard size
-              </Text>
-              <Box
-                background="neutralLight"
-                borderRadius="standard"
-                padding="gutter"
-              >
-                <Box background="surface">
-                  <Inline space="xsmall" alignY="center">
-                    <Heading level="2">Heading</Heading>
-                    <Button bleedY>Button</Button>
-                  </Inline>
+          <>
+            {setDefaultState('bleed', true)}
+
+            <Stack space="large">
+              <Stack space="small">
+                <Toggle
+                  id="bleed"
+                  on={getState('bleed')}
+                  label="Bleed"
+                  align="right"
+                  onChange={() => toggleState('bleed')}
+                />
+                <Text tone="secondary" weight="strong">
+                  Standard size alignment
+                </Text>
+                <Box
+                  background="body"
+                  borderRadius="large"
+                  boxShadow="borderNeutralLight"
+                  padding="gutter"
+                >
+                  <Box background="surface" boxShadow="borderCriticalLight">
+                    <Inline space="xsmall" alignY="center">
+                      <Heading level="2">Heading</Heading>
+                      <Button bleed={getState('bleed')}>Solid</Button>
+                    </Inline>
+                  </Box>
                 </Box>
-              </Box>
-            </Stack>
-            <Stack space="small">
-              <Text tone="secondary" weight="strong">
-                Small size
-              </Text>
-              <Box
-                background="neutralLight"
-                borderRadius="standard"
-                padding="gutter"
-              >
-                <Box background="surface">
-                  <Inline space="xsmall" alignY="center">
-                    <Heading level="2">Heading</Heading>
-                    <Button bleedY size="small">
-                      Button
-                    </Button>
-                  </Inline>
+              </Stack>
+              <Stack space="small">
+                <Text tone="secondary" weight="strong">
+                  Small size alignment
+                </Text>
+                <Box
+                  background="body"
+                  borderRadius="large"
+                  boxShadow="borderNeutralLight"
+                  padding="gutter"
+                >
+                  <Box background="surface" boxShadow="borderCriticalLight">
+                    <Inline space="xsmall" alignY="center">
+                      <Heading level="2">Heading</Heading>
+                      <Button bleed={getState('bleed')} size="small">
+                        Solid
+                      </Button>
+                    </Inline>
+                  </Box>
                 </Box>
-              </Box>
+              </Stack>
+              <Stack space="small">
+                <Text tone="secondary" weight="strong">
+                  Transparent variant alignment
+                </Text>
+                <Box
+                  background="body"
+                  borderRadius="large"
+                  boxShadow="borderNeutralLight"
+                  padding="gutter"
+                >
+                  <Box background="surface" boxShadow="borderCriticalLight">
+                    <Stack space="gutter">
+                      <Heading level="2">Heading</Heading>
+                      <Inline space="none">
+                        <Button bleed={getState('bleed')} variant="transparent">
+                          Solid
+                        </Button>
+                      </Inline>
+                    </Stack>
+                  </Box>
+                </Box>
+              </Stack>
             </Stack>
-          </Stack>,
+          </>,
         ),
     },
   ],

--- a/lib/components/Button/Button.docs.tsx
+++ b/lib/components/Button/Button.docs.tsx
@@ -59,7 +59,7 @@ const docs: ComponentDocs = {
           </Text>
           <Notice>
             <Text>
-              When using a <Strong>transparent</Strong> button on it’s own,
+              When using a <Strong>transparent</Strong> button on its own,
               consider using the <TextLink href="#bleed">bleed</TextLink> prop
               for better alignment.
             </Text>

--- a/lib/components/Button/Button.gallery.tsx
+++ b/lib/components/Button/Button.gallery.tsx
@@ -102,13 +102,13 @@ export const galleryItems: ComponentExample[] = [
       ),
   },
   {
-    label: 'With vertical bleed',
+    label: 'With bleed',
     Example: () =>
       source(
         <Inline space="small" alignY="center">
           <Heading level="4">Heading</Heading>
-          <Button bleedY>Button</Button>
-          <Button bleedY size="small">
+          <Button bleed>Button</Button>
+          <Button bleed size="small">
             Button
           </Button>
         </Inline>,

--- a/lib/components/Button/Button.screenshots.tsx
+++ b/lib/components/Button/Button.screenshots.tsx
@@ -96,9 +96,9 @@ export const screenshots: ComponentScreenshot = {
       Example: () => (
         <Box background="neutralLight" borderRadius="standard" padding="gutter">
           <Box background="surface">
-            <Inline space="xsmall" alignY="center">
+            <Inline space="none" alignY="center">
               <Heading level="2">Heading</Heading>
-              <Button bleedY>Button</Button>
+              <Button bleed>Button</Button>
             </Inline>
           </Box>
         </Box>
@@ -110,9 +110,25 @@ export const screenshots: ComponentScreenshot = {
       Example: () => (
         <Box background="neutralLight" borderRadius="standard" padding="gutter">
           <Box background="surface">
-            <Inline space="xsmall" alignY="center">
+            <Inline space="none" alignY="center">
               <Heading level="2">Heading</Heading>
-              <Button bleedY size="small">
+              <Button bleed size="small">
+                Button
+              </Button>
+            </Inline>
+          </Box>
+        </Box>
+      ),
+    },
+    {
+      label: 'With full bleed (transparent)',
+      background: 'surface',
+      Example: () => (
+        <Box background="neutralLight" borderRadius="standard" padding="gutter">
+          <Box background="surface">
+            <Heading level="2">Heading</Heading>
+            <Inline space="none">
+              <Button bleed variant="transparent">
                 Button
               </Button>
             </Inline>

--- a/lib/components/ButtonLink/ButtonLink.tsx
+++ b/lib/components/ButtonLink/ButtonLink.tsx
@@ -1,3 +1,4 @@
+import dedent from 'dedent';
 import React, { forwardRef, ReactNode } from 'react';
 import {
   useLinkComponent,
@@ -7,6 +8,7 @@ import buildDataAttributes, {
   DataAttributeMap,
 } from '../private/buildDataAttributes';
 import {
+  ButtonContainer,
   ButtonOverlays,
   ButtonProps,
   ButtonStyleProps,
@@ -31,6 +33,7 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
       tone,
       variant,
       bleedY,
+      bleed: bleedProp,
       icon,
       loading,
       data,
@@ -40,26 +43,48 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
   ) => {
     const LinkComponent = useLinkComponent(ref);
 
-    return (
-      <Box
-        component={LinkComponent}
-        ref={ref}
-        {...restProps}
-        {...(data ? buildDataAttributes(data) : undefined)}
-        {...useButtonStyles({ variant, tone, size, bleedY, loading })}
-      >
-        <ButtonOverlays variant={variant} tone={tone} />
+    const bleed = bleedProp || bleedY;
 
-        <ButtonText
-          variant={variant}
-          tone={tone}
-          size={size}
-          loading={loading}
-          icon={icon}
+    if (process.env.NODE_ENV !== 'production') {
+      if (typeof bleedY !== 'undefined') {
+        // eslint-disable-next-line no-console
+        console.warn(
+          dedent`
+            The "bleedY" prop has been deprecated and will be removed in a future version. Use "bleed" instead.
+               <Button
+              %c-   bleedY
+              %c+   bleed
+               %c/>
+          `,
+          'color: red',
+          'color: green',
+          'color: inherit',
+        );
+      }
+    }
+
+    return (
+      <ButtonContainer bleed={bleed} variant={variant}>
+        <Box
+          component={LinkComponent}
+          ref={ref}
+          {...restProps}
+          {...(data ? buildDataAttributes(data) : undefined)}
+          {...useButtonStyles({ variant, tone, size, bleed, loading })}
         >
-          {children}
-        </ButtonText>
-      </Box>
+          <ButtonOverlays variant={variant} tone={tone} />
+
+          <ButtonText
+            variant={variant}
+            tone={tone}
+            size={size}
+            loading={loading}
+            icon={icon}
+          >
+            {children}
+          </ButtonText>
+        </Box>
+      </ButtonContainer>
     );
   },
 );

--- a/site/src/App/routes/gallery/Gallery.tsx
+++ b/site/src/App/routes/gallery/Gallery.tsx
@@ -37,7 +37,6 @@ import {
   Strong,
   TooltipRenderer,
   Button,
-  Bleed,
   Secondary,
 } from '../../../../../lib/components';
 // TODO: COLORMODE RELEASE
@@ -620,18 +619,16 @@ const GalleryInternal = () => {
                 tooltip={<Text>Zoom to actual size</Text>}
               >
                 {({ triggerProps }) => (
-                  <Bleed horizontal="xxsmall">
-                    <Button
-                      variant="transparent"
-                      tone="neutral"
-                      size="small"
-                      bleedY
-                      onClick={actualSize}
-                      {...triggerProps}
-                    >
-                      <CurrentZoom />
-                    </Button>
-                  </Bleed>
+                  <Button
+                    variant="transparent"
+                    tone="neutral"
+                    size="small"
+                    bleed
+                    onClick={actualSize}
+                    {...triggerProps}
+                  >
+                    <CurrentZoom />
+                  </Button>
                 )}
               </TooltipRenderer>
               <ButtonIcon


### PR DESCRIPTION
Previously the `bleedY` prop allowed the background of `Button` to bleed vertically into the surrounding layout. This worked well for all variants except `transparent`, which needed to bleed horizontally as well.

To support this we have introduced the `bleed` prop which will apply the bleed based on the `variant`. We have also deprecated `bleedY` which will be removed in a future release.


**EXAMPLE USAGE:**
```diff
 <Button
-  bleedY
+  bleed
  {...}
 >
   Button
 </Button>
```

**MIGRATION GUIDE**

Migration from `bleedY` to `bleed` can be automated by running the Braid upgrade command, passing the `v31.11` version. You must provide a glob to target your project’s source files. For example:

```
yarn braid-upgrade v31.11 "**/*.{ts,tsx}"
```

It is recommended to visually review the any `Button` usage with the `transparent` variant, to ensure the layout is as expected.