### PR TITLE
Button, ButtonLink: Ensure bleedY backwards compat for transparent variant

### DIFF
--- a/.changeset/spicy-poems-visit.md
+++ b/.changeset/spicy-poems-visit.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Button
+  - ButtonLink
+---
+
+**Button, ButtonLink:** Ensure `bleedY` is backwards compatibile for `transparent` variant
+
+Ensure that `bleedY` applies bleed only vertically on `transparent` variant, isolating the new horizontal bleed to the new `bleed` prop exclusively.

--- a/lib/components/Button/Button.screenshots.tsx
+++ b/lib/components/Button/Button.screenshots.tsx
@@ -121,6 +121,22 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
+      label: 'With legacy bleedY (transparent)',
+      background: 'surface',
+      Example: () => (
+        <Box background="neutralLight" borderRadius="standard" padding="gutter">
+          <Box background="surface">
+            <Heading level="2">Heading</Heading>
+            <Inline space="none">
+              <Button bleedY variant="transparent">
+                Button
+              </Button>
+            </Inline>
+          </Box>
+        </Box>
+      ),
+    },
+    {
       label: 'With full bleed (transparent)',
       background: 'surface',
       Example: () => (

--- a/lib/components/Button/Button.tsx
+++ b/lib/components/Button/Button.tsx
@@ -445,7 +445,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       tone,
       icon,
       bleedY,
-      bleed: bleedProp,
+      bleed,
       variant,
       loading,
       type = 'button',
@@ -461,8 +461,6 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
     },
     ref,
   ) => {
-    const bleed = bleedProp || bleedY;
-
     if (process.env.NODE_ENV !== 'production') {
       if (typeof bleedY !== 'undefined') {
         // eslint-disable-next-line no-console
@@ -502,7 +500,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             variant,
             tone,
             size,
-            bleed,
+            bleed: bleed || bleedY,
             loading,
           })}
         >

--- a/lib/components/ButtonLink/ButtonLink.tsx
+++ b/lib/components/ButtonLink/ButtonLink.tsx
@@ -33,7 +33,7 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
       tone,
       variant,
       bleedY,
-      bleed: bleedProp,
+      bleed,
       icon,
       loading,
       data,
@@ -42,8 +42,6 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
     ref,
   ) => {
     const LinkComponent = useLinkComponent(ref);
-
-    const bleed = bleedProp || bleedY;
 
     if (process.env.NODE_ENV !== 'production') {
       if (typeof bleedY !== 'undefined') {
@@ -70,7 +68,13 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
           ref={ref}
           {...restProps}
           {...(data ? buildDataAttributes(data) : undefined)}
-          {...useButtonStyles({ variant, tone, size, bleed, loading })}
+          {...useButtonStyles({
+            variant,
+            tone,
+            size,
+            bleed: bleed || bleedY,
+            loading,
+          })}
         >
           <ButtonOverlays variant={variant} tone={tone} />
 


### PR DESCRIPTION
Ensure that `bleedY` applies bleed only vertically on `transparent` variant, isolating the new horizontal bleed to the new `bleed` prop exclusively.