### PR TITLE
MenuRenderer, OverflowMenu: Provide context data to onClose

### DIFF
--- a/.changeset/chatty-rice-drive.md
+++ b/.changeset/chatty-rice-drive.md
@@ -1,0 +1,22 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - MenuRenderer
+  - OverflowMenu
+---
+
+**MenuRenderer, OverflowMenu:** Provide context data to onClose
+
+The `onClose` handler now receives data to allow consumers to discern why the menu closed — either by exiting or selecting an action. See the [documentation](https://seek-oss.github.io/braid-design-system/components/MenuRenderer#menu-interactions) for more details.
+
+**EXAMPLE USAGE:**
+```jsx
+<MenuRenderer
+  onClose={(closeReason) => {
+    // ...
+  }}
+/>
+```

--- a/generate-component-docs/__snapshots__/contract.test.ts.snap
+++ b/generate-component-docs/__snapshots__/contract.test.ts.snap
@@ -6386,6 +6386,7 @@ Object {
     children: ReactNode
     data?: DataAttributeMap
     icon?: ReactNode
+    id?: string
     onClick?: () => void
     tone?: "critical"
 },
@@ -6400,6 +6401,7 @@ Object {
     checked: boolean
     children: ReactNode
     data?: DataAttributeMap
+    id?: string
     onChange: (checked: boolean) => void
 },
 }
@@ -6419,6 +6421,7 @@ Object {
     data?: DataAttributeMap
     href: string
     icon?: ReactNode
+    id?: string
     onClick?: () => void
     rel?: string
     target?: 
@@ -6453,7 +6456,7 @@ Object {
         | "xxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
-    onClose?: () => void
+    onClose?: (closeReason: CloseReason) => void
     onOpen?: () => void
     placement?: 
         | "bottom"
@@ -6529,7 +6532,7 @@ Object {
     data?: DataAttributeMap
     id?: string
     label: string
-    onClose?: () => void
+    onClose?: (closeReason: CloseReason) => void
     onOpen?: () => void
     placement?: 
         | "bottom"

--- a/lib/components/MenuItem/MenuItem.tsx
+++ b/lib/components/MenuItem/MenuItem.tsx
@@ -7,7 +7,7 @@ import {
 } from './useMenuItem';
 
 export interface MenuItemProps
-  extends Pick<UseMenuItemProps, 'tone' | 'onClick' | 'data'> {
+  extends Pick<UseMenuItemProps, 'tone' | 'onClick' | 'data' | 'id'> {
   children: ReactNode;
   badge?: MenuItemChildrenProps['badge'];
   icon?: MenuItemChildrenProps['icon'];
@@ -19,11 +19,13 @@ export const MenuItem = ({
   tone,
   badge,
   icon,
+  id,
 }: MenuItemProps) => {
   const { menuItemProps, MenuItemChildren } = useMenuItem<HTMLButtonElement>({
     tone,
     onClick,
     data,
+    id,
   });
 
   return (

--- a/lib/components/MenuItem/MenuItemLink.tsx
+++ b/lib/components/MenuItem/MenuItemLink.tsx
@@ -18,12 +18,14 @@ export const MenuItemLink = ({
   children,
   badge,
   icon,
+  id,
 }: MenuItemLinkProps) => {
   const { menuItemProps, MenuItemChildren } = useMenuItem<HTMLAnchorElement>({
     displayName: 'MenuItemLink',
     onClick,
     tone,
     data,
+    id,
   });
 
   return (

--- a/lib/components/MenuItem/useMenuItem.tsx
+++ b/lib/components/MenuItem/useMenuItem.tsx
@@ -45,6 +45,7 @@ export interface UseMenuItemProps {
   data?: DataAttributeMap;
   displayName?: string;
   tone?: MenuItemTone;
+  id?: string;
 }
 export function useMenuItem<MenuItemElement extends HTMLElement>({
   displayName = 'MenuItem',
@@ -52,6 +53,7 @@ export function useMenuItem<MenuItemElement extends HTMLElement>({
   tone,
   onClick,
   data,
+  id,
 }: UseMenuItemProps) {
   const menuRendererItemContext = useContext(MenuRendererItemContext);
 
@@ -102,8 +104,8 @@ export function useMenuItem<MenuItemElement extends HTMLElement>({
     const action: Record<string, Action> = {
       ArrowDown: { type: MENU_ITEM_DOWN },
       ArrowUp: { type: MENU_ITEM_UP },
-      Enter: { type: MENU_ITEM_ENTER, formElement },
-      ' ': { type: MENU_ITEM_SPACE, formElement },
+      Enter: { type: MENU_ITEM_ENTER, formElement, index, id },
+      ' ': { type: MENU_ITEM_SPACE, formElement, index, id },
       Escape: { type: MENU_ITEM_ESCAPE },
     };
 
@@ -134,13 +136,14 @@ export function useMenuItem<MenuItemElement extends HTMLElement>({
       role: 'menuitem',
       tabIndex: -1,
       ref: menuItemRef,
+      id,
       onKeyUp,
       onKeyDown,
       onMouseEnter: () => dispatch({ type: MENU_ITEM_HOVER, value: index }),
       onClick: (event: MouseEvent) => {
         event.stopPropagation();
 
-        dispatch({ type: MENU_ITEM_CLICK, formElement });
+        dispatch({ type: MENU_ITEM_CLICK, formElement, index, id });
 
         if (typeof onClick === 'function') {
           onClick();

--- a/lib/components/MenuItemCheckbox/MenuItemCheckbox.tsx
+++ b/lib/components/MenuItemCheckbox/MenuItemCheckbox.tsx
@@ -6,7 +6,7 @@ import { useMenuItem } from '../MenuItem/useMenuItem';
 import * as styles from './MenuItemCheckbox.css';
 
 export interface MenuItemCheckboxProps
-  extends Pick<MenuItemProps, 'data' | 'badge'> {
+  extends Pick<MenuItemProps, 'data' | 'badge' | 'id'> {
   children: ReactNode;
   onChange: (checked: boolean) => void;
   checked: boolean;
@@ -17,11 +17,13 @@ export const MenuItemCheckbox = ({
   checked,
   data,
   badge,
+  id,
 }: MenuItemCheckboxProps) => {
   const { menuItemProps, MenuItemChildren } = useMenuItem<HTMLButtonElement>({
     onClick: () => onChange(!checked),
     formElement: true,
     data,
+    id,
   });
 
   return (

--- a/lib/components/MenuRenderer/MenuRenderer.actions.ts
+++ b/lib/components/MenuRenderer/MenuRenderer.actions.ts
@@ -25,9 +25,24 @@ export type Action =
   | { type: typeof actionTypes.MENU_ITEM_DOWN }
   | { type: typeof actionTypes.MENU_ITEM_ESCAPE }
   | { type: typeof actionTypes.MENU_ITEM_TAB }
-  | { type: typeof actionTypes.MENU_ITEM_ENTER; formElement: boolean }
-  | { type: typeof actionTypes.MENU_ITEM_SPACE; formElement: boolean }
-  | { type: typeof actionTypes.MENU_ITEM_CLICK; formElement: boolean }
+  | {
+      type: typeof actionTypes.MENU_ITEM_ENTER;
+      formElement: boolean;
+      index: number;
+      id?: string;
+    }
+  | {
+      type: typeof actionTypes.MENU_ITEM_SPACE;
+      formElement: boolean;
+      index: number;
+      id?: string;
+    }
+  | {
+      type: typeof actionTypes.MENU_ITEM_CLICK;
+      formElement: boolean;
+      index: number;
+      id?: string;
+    }
   | { type: typeof actionTypes.MENU_ITEM_HOVER; value: number }
   | { type: typeof actionTypes.MENU_TRIGGER_ENTER }
   | { type: typeof actionTypes.MENU_TRIGGER_SPACE }

--- a/lib/components/MenuRenderer/MenuRenderer.docs.tsx
+++ b/lib/components/MenuRenderer/MenuRenderer.docs.tsx
@@ -19,6 +19,10 @@ import {
   IconBookmark,
   IconProfile,
   MenuItemDivider,
+  Column,
+  Columns,
+  Badge,
+  List,
 } from '..';
 
 const docs: ComponentDocs = {
@@ -341,6 +345,107 @@ const docs: ComponentDocs = {
               <MenuItem onClick={() => {}}>Item</MenuItem>
             </MenuRenderer>
           </Inline>,
+        ),
+    },
+    {
+      label: 'Menu interactions',
+      background: 'surface',
+      description: (
+        <>
+          <Text>
+            The menu accepts both an <Strong>onOpen</Strong> and an{' '}
+            <Strong>onClose</Strong> function.
+          </Text>
+          <Stack space="medium">
+            <Text>The onClose function receives the following data:</Text>
+            <List>
+              <Text>
+                <Strong>reason:</Strong> &ldquo;exit&rdquo; or
+                &ldquo;selection&rdquo;
+              </Text>
+              <Text>
+                <Strong>index:</Strong> the index of the selected menu item
+              </Text>
+              <Text>
+                <Strong>id:</Strong> the id of the selected menu item as
+                provided to the <Strong>MenuItem</Strong> component itself.
+              </Text>
+            </List>
+          </Stack>
+        </>
+      ),
+      Example: ({ setDefaultState, getState, setState }) =>
+        source(
+          <>
+            {setDefaultState('closeReason', {})}
+            {setDefaultState('action', '')}
+
+            <Columns space="large">
+              <Column>
+                <Inline space="none">
+                  <MenuRenderer
+                    offsetSpace="small"
+                    width="small"
+                    onOpen={() => {
+                      setState('action', 'open');
+                      setState('closeReason', {});
+                    }}
+                    onClose={(closeReason) => {
+                      setState('action', 'close');
+                      setState('closeReason', closeReason);
+                    }}
+                    trigger={(triggerProps, { open }) => (
+                      <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                        <Text>
+                          Menu{' '}
+                          <IconChevron
+                            direction={open ? 'up' : 'down'}
+                            alignY="lowercase"
+                          />
+                        </Text>
+                      </Box>
+                    )}
+                  >
+                    <MenuItem id="menuItem1" onClick={() => {}}>
+                      Item 1
+                    </MenuItem>
+                    <MenuItem id="menuItem2" onClick={() => {}}>
+                      Item 2
+                    </MenuItem>
+                    <MenuItem id="menuItem3" onClick={() => {}}>
+                      Item 3
+                    </MenuItem>
+                  </MenuRenderer>
+                </Inline>
+              </Column>
+              <Column width="content">
+                <Inline space="small" collapseBelow="tablet">
+                  {getState('action') ? (
+                    <Badge
+                      tone="info"
+                      weight="strong"
+                      bleedY
+                    >{`Action: ${getState('action')}`}</Badge>
+                  ) : null}
+                  {getState('closeReason').reason ? (
+                    <Badge tone="info" bleedY>
+                      {`Reason: ${getState('closeReason').reason}`}
+                    </Badge>
+                  ) : null}
+                  {typeof getState('closeReason').index !== 'undefined' ? (
+                    <Badge tone="info" bleedY>
+                      {`Selected index: ${getState('closeReason').index}`}
+                    </Badge>
+                  ) : null}
+                  {getState('closeReason').id ? (
+                    <Badge tone="info" bleedY>
+                      {`Selected ID: ${getState('closeReason').id}`}
+                    </Badge>
+                  ) : null}
+                </Inline>
+              </Column>
+            </Columns>
+          </>,
         ),
     },
     {

--- a/lib/components/MenuRenderer/testHelper.tsx
+++ b/lib/components/MenuRenderer/testHelper.tsx
@@ -36,11 +36,12 @@ export const menuTestSuite = ({ name, Component }: MenuTestSuiteParams) => {
         <BraidTestProvider>
           <div onClick={parentHandler}>
             <Component onOpen={openHandler} onClose={closeHandler}>
-              <MenuItem onClick={() => menuItemHandler('MenuItem')}>
+              <MenuItem id="first" onClick={() => menuItemHandler('MenuItem')}>
                 MenuItem
               </MenuItem>
               <MenuItemDivider />
               <MenuItemLink
+                id="second"
                 href="#"
                 onClick={() => menuItemHandler('MenuItemLink')}
               >
@@ -48,6 +49,7 @@ export const menuTestSuite = ({ name, Component }: MenuTestSuiteParams) => {
               </MenuItemLink>
               <MenuItemDivider />
               <MenuItemCheckbox
+                id="third"
                 checked={checked}
                 onChange={(value) => {
                   setChecked(value);
@@ -116,7 +118,7 @@ export const menuTestSuite = ({ name, Component }: MenuTestSuiteParams) => {
 
         expect(menu).toBeVisible();
         expect(menuButton).toHaveFocus();
-        expect(openHandler).toHaveBeenCalledTimes(1);
+        expect(openHandler).toHaveBeenNthCalledWith(1);
         expect(closeHandler).not.toHaveBeenCalled();
       });
 
@@ -130,7 +132,7 @@ export const menuTestSuite = ({ name, Component }: MenuTestSuiteParams) => {
 
         expect(menu).not.toBeVisible();
         expect(menuButton).toHaveFocus();
-        expect(closeHandler).toHaveBeenCalledTimes(1);
+        expect(closeHandler).toHaveBeenNthCalledWith(1, { reason: 'exit' });
       });
 
       it('should set the focused menu item on mouse over', async () => {
@@ -189,7 +191,11 @@ export const menuTestSuite = ({ name, Component }: MenuTestSuiteParams) => {
 
         expect(menu).not.toBeVisible();
         expect(openHandler).not.toHaveBeenCalled();
-        expect(closeHandler).toHaveBeenCalledTimes(1);
+        expect(closeHandler).toHaveBeenNthCalledWith(1, {
+          reason: 'selection',
+          index: 0,
+          id: 'first',
+        });
         expect(menuItemHandler).toHaveBeenNthCalledWith(1, 'MenuItem');
         expect(menuButton).toHaveFocus();
 
@@ -242,7 +248,7 @@ export const menuTestSuite = ({ name, Component }: MenuTestSuiteParams) => {
 
         expect(menu).toBeVisible();
         expect(menuItems[0]).toHaveFocus();
-        expect(openHandler).toHaveBeenCalledTimes(1);
+        expect(openHandler).toHaveBeenNthCalledWith(1);
         expect(closeHandler).not.toHaveBeenCalled();
       });
 
@@ -258,7 +264,7 @@ export const menuTestSuite = ({ name, Component }: MenuTestSuiteParams) => {
 
         expect(menu).toBeVisible();
         expect(menuItems[0]).toHaveFocus();
-        expect(openHandler).toHaveBeenCalledTimes(1);
+        expect(openHandler).toHaveBeenNthCalledWith(1);
         expect(closeHandler).not.toHaveBeenCalled();
       });
 
@@ -274,7 +280,7 @@ export const menuTestSuite = ({ name, Component }: MenuTestSuiteParams) => {
 
         expect(menu).toBeVisible();
         expect(menuItems[0]).toHaveFocus();
-        expect(openHandler).toHaveBeenCalledTimes(1);
+        expect(openHandler).toHaveBeenNthCalledWith(1);
         expect(closeHandler).not.toHaveBeenCalled();
       });
 
@@ -290,7 +296,7 @@ export const menuTestSuite = ({ name, Component }: MenuTestSuiteParams) => {
 
         expect(menu).toBeVisible();
         expect(menuItems[2]).toHaveFocus();
-        expect(openHandler).toHaveBeenCalledTimes(1);
+        expect(openHandler).toHaveBeenNthCalledWith(1);
         expect(closeHandler).not.toHaveBeenCalled();
       });
 
@@ -309,7 +315,7 @@ export const menuTestSuite = ({ name, Component }: MenuTestSuiteParams) => {
         expect(menu).not.toBeVisible();
         expect(menuButton).toHaveFocus();
         expect(openHandler).not.toHaveBeenCalled();
-        expect(closeHandler).toHaveBeenCalledTimes(1);
+        expect(closeHandler).toHaveBeenNthCalledWith(1, { reason: 'exit' });
       });
 
       it('should close the menu with tab key', async () => {
@@ -327,7 +333,7 @@ export const menuTestSuite = ({ name, Component }: MenuTestSuiteParams) => {
         expect(menu).not.toBeVisible();
         expect(document.body).toHaveFocus();
         expect(openHandler).not.toHaveBeenCalled();
-        expect(closeHandler).toHaveBeenCalledTimes(1);
+        expect(closeHandler).toHaveBeenNthCalledWith(1, { reason: 'exit' });
       });
 
       it('should be able to navigate down the list and back to the start', async () => {
@@ -399,7 +405,11 @@ export const menuTestSuite = ({ name, Component }: MenuTestSuiteParams) => {
         await userEvent.keyboard('{enter}');
 
         expect(menu).not.toBeVisible();
-        expect(closeHandler).toHaveBeenCalledTimes(1);
+        expect(closeHandler).toHaveBeenNthCalledWith(1, {
+          reason: 'selection',
+          index: 0,
+          id: 'first',
+        });
         expect(menuItemHandler).toHaveBeenNthCalledWith(1, 'MenuItem');
         expect(menuButton).toHaveFocus();
       });
@@ -417,7 +427,11 @@ export const menuTestSuite = ({ name, Component }: MenuTestSuiteParams) => {
         await userEvent.keyboard(' ');
 
         expect(menu).not.toBeVisible();
-        expect(closeHandler).toHaveBeenCalledTimes(1);
+        expect(closeHandler).toHaveBeenNthCalledWith(1, {
+          reason: 'selection',
+          index: 0,
+          id: 'first',
+        });
         expect(menuItemHandler).toHaveBeenNthCalledWith(1, 'MenuItem');
         expect(menuButton).toHaveFocus();
       });
@@ -434,7 +448,11 @@ export const menuTestSuite = ({ name, Component }: MenuTestSuiteParams) => {
         await userEvent.keyboard('{enter}');
 
         expect(menu).not.toBeVisible();
-        expect(closeHandler).toHaveBeenCalledTimes(1);
+        expect(closeHandler).toHaveBeenNthCalledWith(1, {
+          reason: 'selection',
+          index: 1,
+          id: 'second',
+        });
         expect(menuItemHandler).toHaveBeenNthCalledWith(1, 'MenuItemLink');
         expect(menuButton).toHaveFocus();
       });
@@ -451,7 +469,11 @@ export const menuTestSuite = ({ name, Component }: MenuTestSuiteParams) => {
         await userEvent.keyboard(' ');
 
         expect(menu).not.toBeVisible();
-        expect(closeHandler).toHaveBeenCalledTimes(1);
+        expect(closeHandler).toHaveBeenNthCalledWith(1, {
+          reason: 'selection',
+          index: 1,
+          id: 'second',
+        });
         expect(menuItemHandler).toHaveBeenNthCalledWith(1, 'MenuItemLink');
         expect(menuButton).toHaveFocus();
       });
@@ -517,7 +539,7 @@ export const menuTestSuite = ({ name, Component }: MenuTestSuiteParams) => {
 
         const newOpen = jest.fn();
         await userEvent.click(menuButton);
-        expect(openHandler).toHaveBeenCalledTimes(1);
+        expect(openHandler).toHaveBeenNthCalledWith(1);
         rerender({ openHandler: newOpen });
         expect(newOpen).not.toHaveBeenCalled();
       });

--- a/lib/components/OverflowMenu/OverflowMenu.docs.tsx
+++ b/lib/components/OverflowMenu/OverflowMenu.docs.tsx
@@ -14,6 +14,11 @@ import {
   Actions,
   Button,
   IconDelete,
+  Badge,
+  Column,
+  Columns,
+  Inline,
+  List,
 } from '../';
 
 const docs: ComponentDocs = {
@@ -98,6 +103,96 @@ const docs: ComponentDocs = {
                 </Actions>
               </Stack>
             </Dialog>
+          </>,
+        ),
+    },
+    {
+      label: 'Menu interactions',
+      background: 'surface',
+      description: (
+        <>
+          <Text>
+            The menu accepts both an <Strong>onOpen</Strong> and an{' '}
+            <Strong>onClose</Strong> function.
+          </Text>
+          <Stack space="medium">
+            <Text>The onClose function receives the following data:</Text>
+            <List>
+              <Text>
+                <Strong>reason:</Strong> &ldquo;exit&rdquo; or
+                &ldquo;selection&rdquo;
+              </Text>
+              <Text>
+                <Strong>index:</Strong> the index of the selected menu item
+              </Text>
+              <Text>
+                <Strong>id:</Strong> the id of the selected menu item as
+                provided to the <Strong>MenuItem</Strong> component itself.
+              </Text>
+            </List>
+          </Stack>
+        </>
+      ),
+      Example: ({ setDefaultState, getState, setState }) =>
+        source(
+          <>
+            {setDefaultState('closeReason', {})}
+            {setDefaultState('action', '')}
+
+            <Columns space="large">
+              <Column>
+                <Box style={{ maxWidth: '100px' }}>
+                  <OverflowMenu
+                    label="Options"
+                    id="example"
+                    onOpen={() => {
+                      setState('action', 'open');
+                      setState('closeReason', {});
+                    }}
+                    onClose={(closeReason) => {
+                      setState('action', 'close');
+                      setState('closeReason', closeReason);
+                    }}
+                  >
+                    <MenuItem id="menuItem1" onClick={() => {}}>
+                      Item 1
+                    </MenuItem>
+                    <MenuItem id="menuItem2" onClick={() => {}}>
+                      Item 2
+                    </MenuItem>
+                    <MenuItem id="menuItem3" onClick={() => {}}>
+                      Item 3
+                    </MenuItem>
+                  </OverflowMenu>
+                </Box>
+              </Column>
+              <Column width="content">
+                <Inline space="small" collapseBelow="tablet">
+                  {getState('action') ? (
+                    <Badge
+                      tone="info"
+                      weight="strong"
+                      bleedY
+                    >{`Action: ${getState('action')}`}</Badge>
+                  ) : null}
+                  {getState('closeReason').reason ? (
+                    <Badge tone="info" bleedY>
+                      {`Reason: ${getState('closeReason').reason}`}
+                    </Badge>
+                  ) : null}
+                  {typeof getState('closeReason').index !== 'undefined' ? (
+                    <Badge tone="info" bleedY>
+                      {`Selected index: ${getState('closeReason').index}`}
+                    </Badge>
+                  ) : null}
+                  {getState('closeReason').id ? (
+                    <Badge tone="info" bleedY>
+                      {`Selected ID: ${getState('closeReason').id}`}
+                    </Badge>
+                  ) : null}
+                </Inline>
+              </Column>
+            </Columns>
           </>,
         ),
     },


### PR DESCRIPTION
**MenuRenderer, OverflowMenu:** Provide context data to onClose

The `onClose` handler now receives data to allow consumers to discern why the menu closed — either by exiting or selecting an action. See the [documentation](https://seek-oss.github.io/braid-design-system/components/MenuRenderer#menu-interactions) for more details.

**EXAMPLE USAGE:**
```jsx
<MenuRenderer
  onClose={(closeReason) => {
    // ...
  }}
/>
```