### PR TITLE
Extend changeset DX to add braid release front matter

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,8 @@
     "post-commit-status": "node scripts/postCommitStatus.js",
     "release": "pnpm run setup && pnpm build-codemod && changeset publish && pnpm build && pnpm deploy",
     "version": "changeset version && ts-node scripts/versionComponentUpdates",
-    "prepare": "patch-package && husky install"
+    "prepare": "patch-package && husky install",
+    "changeset": "EDITOR=scripts/writeBraidFrontMatter.js ./node_modules/.bin/changeset add --open"
   },
   "bin": {
     "braid-upgrade": "./codemod/dist/index.js"
@@ -113,6 +114,7 @@
     "copy-to-clipboard": "^3.3.1",
     "date-fns": "^2.28.0",
     "didyoumean2": "^5.0.0",
+    "enquirer": "^2.3.6",
     "esbuild": "^0.14.39",
     "fast-glob": "^3.2.11",
     "fs-extra": "^10.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -55,6 +55,7 @@ specifiers:
   date-fns: ^2.28.0
   dedent: 0.7.0
   didyoumean2: ^5.0.0
+  enquirer: ^2.3.6
   esbuild: ^0.14.39
   fast-glob: ^3.2.11
   fs-extra: ^10.1.0
@@ -169,6 +170,7 @@ devDependencies:
   copy-to-clipboard: 3.3.1
   date-fns: 2.28.0
   didyoumean2: 5.0.0
+  enquirer: 2.3.6
   esbuild: 0.14.39
   fast-glob: 3.2.11
   fs-extra: 10.1.0
@@ -2487,6 +2489,14 @@ packages:
       - supports-color
     dev: true
 
+  /@mdx-js/react/1.6.22_react@18.1.0:
+    resolution: {integrity: sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==}
+    peerDependencies:
+      react: ^16.13.1 || ^17.0.0
+    dependencies:
+      react: 18.1.0
+    dev: true
+
   /@mdx-js/util/1.6.22:
     resolution: {integrity: sha512-H1rQc1ZOHANWBvPcW+JpGwr+juXSxM8Q8YCkm3GhZd8REu1fHR3z99CErO1p9pkcfcxZnMdIZdIsXkOHY0NilA==}
     dev: true
@@ -3229,7 +3239,7 @@ packages:
       '@storybook/core-common': 6.5.4_5d0328c271acd7a678e253d708ff25f1
       '@storybook/core-events': 6.5.4
       '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/csf-tools': 6.5.4
+      '@storybook/csf-tools': 6.5.4_react@18.1.0
       '@storybook/manager-webpack4': 6.5.4_5d0328c271acd7a678e253d708ff25f1
       '@storybook/manager-webpack5': 6.5.4_ca58b4056bdd9f69e6efdf97d67ed844
       '@storybook/node-logger': 6.5.4
@@ -3321,7 +3331,7 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/csf-tools/6.5.4:
+  /@storybook/csf-tools/6.5.4_react@18.1.0:
     resolution: {integrity: sha512-mCAO8Ddig5PzXiI4HxiWhdLmPPpaovzVxqdh7g31k3fhpnRkQrKwftNGTW/ArFDdisMjB1+gm+ZOVACZg0pO4w==}
     peerDependencies:
       '@storybook/mdx2-csf': '*'
@@ -3337,13 +3347,14 @@ packages:
       '@babel/traverse': 7.18.0
       '@babel/types': 7.18.0
       '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/mdx1-csf': 0.0.1-canary.1.eed86d7.0_@babel+core@7.18.0
+      '@storybook/mdx1-csf': 0.0.2-canary.5.6cee405.0_@babel+core@7.18.0+react@18.1.0
       core-js: 3.22.6
       fs-extra: 9.1.0
       global: 4.4.0
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
     transitivePeerDependencies:
+      - react
       - supports-color
     dev: true
 
@@ -3483,14 +3494,15 @@ packages:
       - webpack-command
     dev: true
 
-  /@storybook/mdx1-csf/0.0.1-canary.1.eed86d7.0_@babel+core@7.18.0:
-    resolution: {integrity: sha512-KOoTWeseRyJYU5qzEWahgNRhRLgHzPrWx4jIiK4oI9MmNx81cD0B0o24Gq04Iyt89X4jTk+VPHc5REJO1Gs99Q==}
+  /@storybook/mdx1-csf/0.0.2-canary.5.6cee405.0_@babel+core@7.18.0+react@18.1.0:
+    resolution: {integrity: sha512-LRQ086H27/Ro8jQPoXb3hb0LgYokurqqFf4eDNSv/EqvzUihGrurvpiIGfTJ6JDzWZbiX1NIsqe8dx4jKpEGMw==}
     dependencies:
       '@babel/generator': 7.18.0
       '@babel/parser': 7.18.0
       '@babel/preset-env': 7.18.0_@babel+core@7.18.0
       '@babel/types': 7.18.0
       '@mdx-js/mdx': 1.6.22
+      '@mdx-js/react': 1.6.22_react@18.1.0
       '@types/lodash': 4.14.182
       js-string-escape: 1.0.1
       loader-utils: 2.0.2
@@ -3499,6 +3511,7 @@ packages:
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@babel/core'
+      - react
       - supports-color
     dev: true
 
@@ -7777,7 +7790,7 @@ packages:
     engines: {node: '>=0.10.0'}
 
   /default-browser-id/1.0.4:
-    resolution: {integrity: sha1-5Z0JpdFXuCi4dsJoFuYcPSosIDo=}
+    resolution: {integrity: sha512-qPy925qewwul9Hifs+3sx1ZYn14obHxpkX+mPD369w4Rzg+YkJBgi3SOvwUq81nWSjqGUegIgEPwD8u+HUnxlw==}
     engines: {node: '>=0.10.0'}
     hasBin: true
     requiresBuild: true
@@ -10878,7 +10891,7 @@ packages:
     dev: true
 
   /image-size/0.5.5:
-    resolution: {integrity: sha1-Cd/Uq50g4p6xw+gLiZA3jfnjy5w=}
+    resolution: {integrity: sha512-6TDAlDPZxUFCv+fuOkIoXT/V/f3Qbq8e37p+YOiYrUv3v9cc3/6x78VdfPgFVaB9dZYeLUfKgHRebpkm/oP2VQ==}
     engines: {node: '>=0.10.0'}
     hasBin: true
     requiresBuild: true
@@ -12209,7 +12222,7 @@ packages:
     dev: true
 
   /js-string-escape/1.0.1:
-    resolution: {integrity: sha1-4mJbrbwNZ8dTPp7cEGjFh65BN+8=}
+    resolution: {integrity: sha512-Smw4xcfIQ5LVjAOuJCvN/zIodzA/BBSsluuoSykP+lUvScIi4U6RJLfwHet5cxFnCswUjISV8oAXaqaJDY3chg==}
     engines: {node: '>= 0.8'}
     dev: true
 
@@ -12999,7 +13012,7 @@ packages:
     dev: true
 
   /mdurl/1.0.1:
-    resolution: {integrity: sha1-/oWy7HWlkDfyrf7BAP1sYBdhFS4=}
+    resolution: {integrity: sha512-/sKlQJCBYVY9Ers9hqzKou4H6V5UWc/M59TH2dvkt+84itfnq7uFOMLpOiOS4ujvHP4etln18fmIxA5R5fll0g==}
     dev: true
 
   /media-typer/0.3.0:

--- a/scripts/writeBraidFrontMatter.js
+++ b/scripts/writeBraidFrontMatter.js
@@ -1,0 +1,209 @@
+#!/usr/bin/env node
+/* eslint-disable no-console,no-sync */
+const fs = require('fs');
+const { prompt } = require('enquirer');
+
+/*
+This script augments the generated changeset, adding the additional
+front matter block used by Braid to enhance the documentation site
+with release information.
+
+Changes made by the script include:
+- Add additional front matter block, indicating new/updated apis
+- Standardise release note formatting, bolding scopes and conditionally
+  adding a example usage block to the provided changeset details
+
+Example diff to generated changeset:
+==========================================
+   ---
+   'braid-design-system': minor
+   ---
+
++  ---
++  updated:
++    - Button
++    - ButtonLink
++  ---
+
+-  Button, ButtonLink: Add `hero` variant
++  **Button, ButtonLink**: Add `hero` variant
+
++  Provides a `hero` variant to ensure users
++  never miss out on this action.
+
++  **EXAMPLE USAGE:**
++  ```jsx
++  <Button variant="hero">...</Button>
++  ```
+==========================================
+*/
+
+(async () => {
+  const [changesetPath] = process.argv.slice(2);
+  const changesetSrc = fs.readFileSync(changesetPath, 'utf-8');
+
+  if (!changesetPath.includes('.changeset/')) {
+    // If changeset path is not in the changeset directory,
+    // i.e. when still in temp files, we are not ready to
+    // add the braid release front matter.
+    //
+    // (This happens when the changeset `summary` is empty)
+    return;
+  }
+
+  // Parse the frontMatter and details from the generated changeset
+  const [, changesetsFrontMatter, changesetDetails = ''] = changesetSrc.split(
+    /(---\n(?:.|\n)+---\n)/,
+  );
+
+  // Prompt for Braid change type, e.g. updated/new
+  const changeTypePrompt = await prompt({
+    type: 'select',
+    message: 'What is the impact to the top level api of Braid?',
+    name: 'changeType',
+    choices: [
+      {
+        value: 'updated',
+        message: 'Update',
+      },
+      {
+        value: 'new',
+        message: 'New',
+      },
+      {
+        value: 'none',
+        message: 'No change',
+      },
+    ],
+  }).catch(() => {});
+
+  const braidChangeType = changeTypePrompt?.changeType;
+  // Leave changeset alone if exited from prompt or selected `no change`
+  if (!braidChangeType || braidChangeType === 'none') {
+    return;
+  }
+
+  // Regex to extract scopes from changeset details, e.g.
+  // `Button, ButtonLink: Add new variant` => `Button, ButtonLink`
+  const scopeMatch = changesetDetails.match(
+    /(?:\n+)?(?<scope>(?:[\w\-\,\s]+):)\s?\w+/,
+  )?.groups?.scope;
+
+  let formattedDetails = changesetDetails;
+  let inferredScopes = [];
+  if (scopeMatch) {
+    // Create array of scopes
+    inferredScopes = scopeMatch
+      .split(/,\s?/g)
+      .map((s) => s.replace(/:\s?$/, '').trim());
+    // Format scope as bold in changeset details for consistent
+    // release note formatting
+    formattedDetails = formattedDetails.replace(
+      scopeMatch,
+      `**${inferredScopes.join(', ')}:**`,
+    );
+  }
+
+  let braidChangeScopes = [];
+  if (inferredScopes.length > 0) {
+    // Ask to use scopes parsed from changeset
+    const inferredScopesPrompt = await prompt({
+      type: 'toggle',
+      enabled: 'Yes',
+      disabled: 'No',
+      initial: true,
+      name: 'confirmed',
+      message: `The following scopes were inferred from your changeset:\n${inferredScopes
+        .map((s) => `    - ${s}`)
+        .join('\n')}\n  Is this correct?`,
+    }).catch(() => {});
+
+    // Leave changeset alone if exited from prompt
+    if (!inferredScopesPrompt) {
+      return;
+    }
+
+    if (inferredScopesPrompt.confirmed) {
+      // Use scopes inferred from changeset if confirmed
+      braidChangeScopes = inferredScopes;
+    }
+  }
+
+  // If not using scopes inferred from changeset, request explicitly
+  if (braidChangeScopes.length === 0) {
+    const explicitScopesPrompt = await prompt({
+      type: 'list',
+      name: 'scopes',
+      required: true,
+      message: 'List the affected APIs (comma separated)',
+      validate(value, state) {
+        // Provided scopes list must have items
+        if (value.length === 0) {
+          return state.styles.danger('Please provide a list of scopes');
+        }
+
+        // Provided scopes should not have colons, hyphens or whitespace
+        const invalidValues = value.filter((item) => /[:-\s]/.test(item));
+        if (invalidValues.length > 0) {
+          return state.styles.danger(
+            `Invalid scope name${
+              invalidValues.length !== 1 ? 's:  \n' : ': '
+            }${invalidValues.map((v) => `"${v}"`).join(', ')}`,
+          );
+        }
+
+        return true;
+      },
+    }).catch(() => {});
+
+    // Leave changeset alone if exited from prompt
+    if (!explicitScopesPrompt) {
+      return;
+    }
+
+    // Use scopes explicitly provided
+    braidChangeScopes = explicitScopesPrompt.scopes;
+  }
+
+  // Build the updated changeset contents
+  const updatedChangeset = [
+    changesetsFrontMatter,
+    '---',
+    braidChangeType,
+    ...braidChangeScopes.map((s) => `  - ${s}`),
+    '---',
+    formattedDetails,
+  ];
+
+  // Prompt for release notes to be added to site
+  const releaseNotesPrompt = await prompt({
+    type: 'input',
+    name: 'releaseNotes',
+    message:
+      'Please provide a description of the change to be included in the release notes:',
+  }).catch(() => {});
+
+  if (releaseNotesPrompt?.releaseNotes) {
+    updatedChangeset.push(`\n${releaseNotesPrompt?.releaseNotes}\n`);
+  }
+
+  // Standardise `Example Usage` code block
+  const exampleUsagePrompt = await prompt({
+    type: 'toggle',
+    enabled: 'Yes',
+    disabled: 'No',
+    initial: true,
+    name: 'addExample',
+    message: 'Do you want to add an `Example Usage` code block?',
+  }).catch(() => {});
+
+  if (exampleUsagePrompt?.addExample) {
+    updatedChangeset.push(...['**EXAMPLE USAGE:**', '```jsx', '', '```']);
+  }
+
+  fs.writeFileSync(changesetPath, updatedChangeset.join('\n'));
+
+  console.log(
+    `\n🚀 Successfully Braid-ified the changeset:\n   ${changesetPath}`,
+  );
+})();


### PR DESCRIPTION
Extend the changeset creation experience in the cli to include prompts for creating and inserting the additional front matter block used to Braid to add release information to the website.

Running `pnpm changeset` will now prompt for the following and enrich the changeset accordingly:
- What is the impact to the top level api of Braid? (updated / new / no change)
- Add scope list (inferred from original changeset if formatted as `<scope>: <message>`, otherwise prompt for scope list explicitly)
- Add release notes to be included on site
- Add `Example Usage` code block if required
