### PR TITLE
Fix custom changesets and generate script

### DIFF
--- a/.changeset/slow-numbers-marry.md
+++ b/.changeset/slow-numbers-marry.md
@@ -3,7 +3,7 @@
 ---
 
 ---
-updated
+updated:
   - Stepper
 ---
 

--- a/.changeset/thirty-apricots-fix.md
+++ b/.changeset/thirty-apricots-fix.md
@@ -3,7 +3,7 @@
 ---
 
 ---
-updated
+updated:
   - Stepper
 ---
 

--- a/scripts/writeBraidFrontMatter.js
+++ b/scripts/writeBraidFrontMatter.js
@@ -169,7 +169,7 @@ Example diff to generated changeset:
   const updatedChangeset = [
     changesetsFrontMatter,
     '---',
-    braidChangeType,
+    `${braidChangeType}:`,
     ...braidChangeScopes.map((s) => `  - ${s}`),
     '---',
     formattedDetails,


### PR DESCRIPTION
Fix custom Braid release front matter script, which was. missing a `:` from the new/updated scope.

Also updating changesets created and merged in master.