### PR TITLE
RadioGroup: Remove surrounding white space with no visual label

### DIFF
--- a/.changeset/rude-frogs-listen.md
+++ b/.changeset/rude-frogs-listen.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - RadioGroup
+---
+
+**RadioGroup:** Remove surrounding white space with no visual label
+
+Removes additional white space applied above the `RadioItem`s when no visible `label` is provided, i.e. when labelling via `aria-label` or `aria-labelledby`.

--- a/lib/components/RadioGroup/RadioGroup.docs.tsx
+++ b/lib/components/RadioGroup/RadioGroup.docs.tsx
@@ -11,6 +11,8 @@ import {
 } from '..';
 import { Placeholder } from '../../playroom/components';
 import source from '../../utils/source.macro';
+import { Stack } from '../Stack/Stack';
+import { Heading } from '../Heading/Heading';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -300,6 +302,39 @@ const docs: ComponentDocs = {
               <RadioItem label="Three" value="3" />
             </RadioGroup>
           </>,
+        ),
+    },
+    {
+      label: 'Indirect or hidden field labels',
+      description: (
+        <Text>
+          In some cases it may be necessary for a field to be labelled by
+          another element or even not to have a visual label. Instead of
+          providing a <Strong>label</Strong> either <Strong>aria-label</Strong>{' '}
+          or <Strong>aria-labelledby</Strong> can be provided.
+        </Text>
+      ),
+      Example: ({ id, getState, setState }) =>
+        source(
+          <Stack space="medium">
+            <Heading level="2" id="fieldLabel">
+              Custom field label
+            </Heading>
+
+            <RadioGroup
+              id={`${id}_indirectLabel`}
+              value={getState('radio')}
+              onChange={({ currentTarget: { value } }) =>
+                setState('radio', value)
+              }
+              message="The label for this fieldset is the Heading element before it."
+              aria-labelledby="fieldLabel"
+            >
+              <RadioItem label="One" value="1" />
+              <RadioItem label="Two" value="2" />
+              <RadioItem label="Three" value="3" />
+            </RadioGroup>
+          </Stack>,
         ),
     },
   ],

--- a/lib/components/RadioGroup/RadioGroup.screenshots.tsx
+++ b/lib/components/RadioGroup/RadioGroup.screenshots.tsx
@@ -179,5 +179,35 @@ export const screenshots: ComponentScreenshot = {
         </RadioGroup>
       ),
     },
+    {
+      label: 'When labelling via aria-label',
+      Example: ({ handler }) => (
+        <RadioGroup
+          id="arialabel"
+          value="2"
+          onChange={handler}
+          aria-label="Label"
+        >
+          <RadioItem label="One" value="1" />
+          <RadioItem label="Two" value="2" />
+          <RadioItem label="Three" value="3" />
+        </RadioGroup>
+      ),
+    },
+    {
+      label: 'When labelling via aria-labelledby',
+      Example: ({ handler }) => (
+        <RadioGroup
+          id="arialabelledby"
+          value="2"
+          onChange={handler}
+          aria-labelledby="elementId"
+        >
+          <RadioItem label="One" value="1" />
+          <RadioItem label="Two" value="2" />
+          <RadioItem label="Three" value="3" />
+        </RadioGroup>
+      ),
+    },
   ],
 };

--- a/lib/components/RadioGroup/RadioGroup.tsx
+++ b/lib/components/RadioGroup/RadioGroup.tsx
@@ -41,6 +41,7 @@ const RadioGroup = ({
   ...props
 }: RadioGroupProps) => {
   const items = flattenChildren(children);
+  const labelSpace = props.description ? 'xxsmall' : 'xsmall';
 
   assert(
     items.every(
@@ -73,7 +74,7 @@ const RadioGroup = ({
           }}
         >
           <Box
-            paddingTop={props.description ? 'xxsmall' : 'xsmall'}
+            paddingTop={'label' in props ? labelSpace : undefined}
             paddingBottom={props.message ? 'xsmall' : undefined}
           >
             <Stack space={stackSpaceForSize[size || 'standard']}>


### PR DESCRIPTION
Removes additional white space applied above the `RadioItem`s when no visible `label` is provided, i.e. when labelling via `aria-label` or `aria-labelledby`.