### PR TITLE
Fix clashing ids in Storybook and Playroom

### DIFF
--- a/lib/components/Accordion/Accordion.screenshots.tsx
+++ b/lib/components/Accordion/Accordion.screenshots.tsx
@@ -388,7 +388,7 @@ export const screenshots: ComponentScreenshot = {
               <AccordionItem
                 label="Label"
                 size="xsmall"
-                id={id}
+                id={`${id}_1`}
                 icon={<IconPromote />}
               >
                 <Text size="small">Content</Text>
@@ -398,7 +398,7 @@ export const screenshots: ComponentScreenshot = {
               <AccordionItem
                 label="Label"
                 size="small"
-                id={id}
+                id={`${id}_2`}
                 icon={<IconPromote />}
               >
                 <Text size="small">Content</Text>
@@ -408,7 +408,7 @@ export const screenshots: ComponentScreenshot = {
               <AccordionItem
                 label="Label"
                 size="standard"
-                id={id}
+                id={`${id}_3`}
                 icon={<IconPromote />}
               >
                 <Text size="small">Content</Text>
@@ -418,7 +418,7 @@ export const screenshots: ComponentScreenshot = {
               <AccordionItem
                 label="Label"
                 size="large"
-                id={id}
+                id={`${id}_4`}
                 icon={<IconPromote />}
               >
                 <Text size="small">Content</Text>
@@ -438,7 +438,7 @@ export const screenshots: ComponentScreenshot = {
                 label="Label"
                 size="xsmall"
                 tone="secondary"
-                id={id}
+                id={`${id}_1`}
                 icon={<IconPromote />}
               >
                 <Text size="small">Content</Text>
@@ -449,7 +449,7 @@ export const screenshots: ComponentScreenshot = {
                 label="Label"
                 size="small"
                 tone="secondary"
-                id={id}
+                id={`${id}_2`}
                 icon={<IconPromote />}
               >
                 <Text size="small">Content</Text>
@@ -460,7 +460,7 @@ export const screenshots: ComponentScreenshot = {
                 label="Label"
                 size="standard"
                 tone="secondary"
-                id={id}
+                id={`${id}_3`}
                 icon={<IconPromote />}
               >
                 <Text size="small">Content</Text>
@@ -471,7 +471,7 @@ export const screenshots: ComponentScreenshot = {
                 label="Label"
                 size="large"
                 tone="secondary"
-                id={id}
+                id={`${id}_4`}
                 icon={<IconPromote />}
               >
                 <Text size="small">Content</Text>

--- a/lib/components/Checkbox/Checkbox.docs.tsx
+++ b/lib/components/Checkbox/Checkbox.docs.tsx
@@ -147,21 +147,21 @@ const docs: ComponentDocs = {
           to the <Strong>disabled</Strong> prop.
         </Text>
       ),
-      Example: ({ id }) =>
+      Example: ({ id, toggleState }) =>
         source(
           <Stack space="medium">
             <Checkbox
               id={`${id}_unchecked`}
               disabled={true}
               checked={false}
-              onChange={() => {}}
+              onChange={() => toggleState('unchecked')}
               label="Unchecked"
             />
             <Checkbox
               id={`${id}_checked`}
               disabled={true}
               checked={true}
-              onChange={() => {}}
+              onChange={() => toggleState('checked')}
               label="Checked"
             />
           </Stack>,

--- a/lib/components/Checkbox/Checkbox.docs.tsx
+++ b/lib/components/Checkbox/Checkbox.docs.tsx
@@ -147,21 +147,21 @@ const docs: ComponentDocs = {
           to the <Strong>disabled</Strong> prop.
         </Text>
       ),
-      Example: ({ id, toggleState }) =>
+      Example: ({ id }) =>
         source(
           <Stack space="medium">
             <Checkbox
-              id={id}
+              id={`${id}_unchecked`}
               disabled={true}
               checked={false}
-              onChange={() => toggleState('checked')}
+              onChange={() => {}}
               label="Unchecked"
             />
             <Checkbox
-              id={id}
+              id={`${id}_checked`}
               disabled={true}
               checked={true}
-              onChange={() => toggleState('checked')}
+              onChange={() => {}}
               label="Checked"
             />
           </Stack>,

--- a/lib/components/Checkbox/Checkbox.screenshots.tsx
+++ b/lib/components/Checkbox/Checkbox.screenshots.tsx
@@ -51,14 +51,14 @@ export const screenshots: ComponentScreenshot = {
       Example: ({ id, handler }) => (
         <Stack space="gutter">
           <Checkbox
-            id={id}
+            id={`${id}_1`}
             disabled={true}
             checked={false}
             onChange={handler}
             label="Label"
           />
           <Checkbox
-            id={id}
+            id={`${id}_2`}
             disabled={true}
             checked={true}
             onChange={handler}

--- a/lib/components/Checkbox/CheckboxStandalone.screenshots.tsx
+++ b/lib/components/Checkbox/CheckboxStandalone.screenshots.tsx
@@ -61,14 +61,14 @@ export const screenshots: ComponentScreenshot = {
       Example: ({ id, handler }) => (
         <Stack space="gutter">
           <CheckboxStandalone
-            id={id}
+            id={`${id}_unchecked`}
             disabled={true}
             checked={false}
             onChange={handler}
             aria-label="Disabled unchecked"
           />
           <CheckboxStandalone
-            id={id}
+            id={`${id}_checked`}
             disabled={true}
             checked={true}
             onChange={handler}

--- a/lib/stories/all.stories.tsx
+++ b/lib/stories/all.stories.tsx
@@ -1,4 +1,4 @@
-import React, { ReactNode, Fragment } from 'react';
+import React, { ReactNode, Fragment, useId } from 'react';
 import { storiesOf } from 'sku/@storybook/react';
 import { BrowserRouter } from 'react-router-dom';
 import { uniq, flatten, values } from 'lodash';
@@ -46,6 +46,7 @@ const RenderExample = ({ example }: RenderExampleProps) => {
     background = 'body',
     Example,
   } = example;
+  const id = useId();
 
   return (
     <div
@@ -69,7 +70,7 @@ const RenderExample = ({ example }: RenderExampleProps) => {
       </h4>
       <Box background={background} style={{ padding: 12 }}>
         <Container>
-          {Example ? <Example id="id" handler={noop} /> : null}
+          {Example ? <Example id={id} handler={noop} /> : null}
         </Container>
       </Box>
       <div style={{ paddingTop: 18 }}>


### PR DESCRIPTION
Found this behaviour when testing Storybook in the monorepo branch:

<details>
<summary>Screen recording</summary>

![checkboxes](https://user-images.githubusercontent.com/3297808/184043001-5a8fcfde-7c58-4143-8062-968760ecd65f.gif)
 

</details>