### PR TITLE
Autosuggest: Add configurable message for no suggestions

### DIFF
--- a/.changeset/lucky-clouds-melt.md
+++ b/.changeset/lucky-clouds-melt.md
@@ -9,7 +9,7 @@ updated:
 
 **Autosuggest:** Add configurable message for no suggestions
 
-Provides consumers a way to give the user more context when no suggestions are available. The `noSuggestionsMessage` prop accepts either a simple message or a more structured prompt by providing an object containing **text** and **description**.
+Provides consumers a way to give the user more context when no suggestions are available. The `noSuggestionsMessage` prop accepts a simple message by providing a single piece of text. Alternatively, a more structured prompt can be shown by providing an object containing **title** and **description**.
 
 This message is only displayed when there are no available suggestions provided.
 
@@ -31,7 +31,7 @@ Or, for more a structured prompt:
   ...
   suggestions={[]}
   noSuggestionsMessage={{
-    text: "No results found",
+    title: "No results found",
     description: "Try searching for something else",
   }}
 />

--- a/.changeset/lucky-clouds-melt.md
+++ b/.changeset/lucky-clouds-melt.md
@@ -1,0 +1,53 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Autosuggest
+---
+
+**Autosuggest:** Add configurable message for no suggestions
+
+Provides consumers a way to give the user more context when no suggestions are available. The `noSuggestionsMessage` prop accepts either a simple message or a more structured prompt by providing an object containing **text** and **description**.
+
+This message is only displayed when there are no available suggestions provided.
+
+**EXAMPLE USAGE:**
+For the simple case:
+
+```jsx
+<Autosuggest
+  ...
+  suggestions={[]}
+  noSuggestionsMessage="No results found"
+/>
+```
+
+Or, for more a structured prompt:
+
+```jsx
+<Autosuggest
+  ...
+  suggestions={[]}
+  noSuggestionsMessage={{
+    text: "No results found",
+    description: "Try searching for something else",
+  }}
+/>
+```
+
+**MIGRATION GUIDE:**
+
+In addition, the old mechanism allowing consumers to pass an object to `suggestions` containing a `message` has been deprecated. This will continue to work for now but will be removed in a future release.
+
+It is recommended to migrate to the `noSuggestionsMessage` prop.
+
+```diff
+ <Autosuggest
+   ...
+-  suggestions={{ message: 'No results found' }}
++  noSuggestionsMessage="No results found"
+ />
+```
+

--- a/packages/braid-design-system/lib/components/Autosuggest/Autosuggest.docs.tsx
+++ b/packages/braid-design-system/lib/components/Autosuggest/Autosuggest.docs.tsx
@@ -601,9 +601,10 @@ const docs: ComponentDocs = {
             <Strong>noSuggestionsMessage</Strong> prop.
           </Text>
           <Text>
-            The message can either be a single piece of text, or a more
-            structured prompt by providing an object containing{' '}
-            <Strong>text</Strong> and <Strong>description</Strong>.
+            A simple message can be shown by providing a single piece of text.
+            Alternatively, a more structured prompt can be shown by providing an
+            object containing <Strong>title</Strong> and{' '}
+            <Strong>description</Strong>.
           </Text>
         </>
       ),
@@ -619,7 +620,7 @@ const docs: ComponentDocs = {
                 scrollToTopOnMobile
                 label="Label"
                 description="Focus the field to see a simple message"
-                id={id}
+                id={`${id}_noSuggestionsMessage1`}
                 value={getState('field1')}
                 onChange={setState('field1')}
                 onClear={() => resetState('field1')}
@@ -631,13 +632,13 @@ const docs: ComponentDocs = {
                 scrollToTopOnMobile
                 label="Label"
                 description="Focus the field to see more structured prompt"
-                id={id}
+                id={`${id}_noSuggestionsMessage2`}
                 value={getState('field2')}
                 onChange={setState('field2')}
                 onClear={() => resetState('field2')}
                 suggestions={[]}
                 noSuggestionsMessage={{
-                  text: 'No results found',
+                  title: 'No results found',
                   description: 'Try searching for something else',
                 }}
               />

--- a/packages/braid-design-system/lib/components/Autosuggest/Autosuggest.docs.tsx
+++ b/packages/braid-design-system/lib/components/Autosuggest/Autosuggest.docs.tsx
@@ -597,53 +597,51 @@ const docs: ComponentDocs = {
         <>
           <Text>
             If no suggestions are available and you’d like to provide messaging
-            to the user, you can provide an object with a{' '}
-            <Strong>message</Strong> property to the{' '}
-            <Strong>suggestions</Strong> prop.
+            to the user, you can provide it via the{' '}
+            <Strong>noSuggestionsMessage</Strong> prop.
+          </Text>
+          <Text>
+            The message can either be a single piece of text, or a more
+            structured prompt by providing an object containing{' '}
+            <Strong>text</Strong> and <Strong>description</Strong>.
           </Text>
         </>
       ),
       Example: ({ id, setDefaultState, getState, setState, resetState }) =>
         source(
           <>
-            {setDefaultState('value', { text: '' })}
+            {setDefaultState('field1', { text: '' })}
+            {setDefaultState('field2', { text: '' })}
 
-            <Autosuggest
-              showMobileBackdrop
-              scrollToTopOnMobile
-              label="Label"
-              id={id}
-              value={getState('value')}
-              onChange={setState('value')}
-              onClear={() => resetState('value')}
-              suggestions={(value) => {
-                const filteredSuggestions = filterSuggestions(
-                  [
-                    {
-                      text: 'Apples',
-                      value: 1,
-                    },
-                    {
-                      text: 'Bananas',
-                      value: 2,
-                    },
-                    {
-                      text: 'Broccoli',
-                      value: 3,
-                    },
-                    {
-                      text: 'Carrots',
-                      value: 4,
-                    },
-                  ],
-                  value,
-                );
-
-                return filteredSuggestions.length > 0
-                  ? filteredSuggestions
-                  : { message: 'No results found.' };
-              }}
-            />
+            <Stack space="large">
+              <Autosuggest
+                showMobileBackdrop
+                scrollToTopOnMobile
+                label="Label"
+                description="Focus the field to see a simple message"
+                id={id}
+                value={getState('field1')}
+                onChange={setState('field1')}
+                onClear={() => resetState('field1')}
+                suggestions={[]}
+                noSuggestionsMessage="No results found"
+              />
+              <Autosuggest
+                showMobileBackdrop
+                scrollToTopOnMobile
+                label="Label"
+                description="Focus the field to see more structured prompt"
+                id={id}
+                value={getState('field2')}
+                onChange={setState('field2')}
+                onClear={() => resetState('field2')}
+                suggestions={[]}
+                noSuggestionsMessage={{
+                  text: 'No results found',
+                  description: 'Try searching for something else',
+                }}
+              />
+            </Stack>
           </>,
         ),
     },

--- a/packages/braid-design-system/lib/components/Autosuggest/Autosuggest.test.tsx
+++ b/packages/braid-design-system/lib/components/Autosuggest/Autosuggest.test.tsx
@@ -3,8 +3,12 @@ import React, { useState, useRef, useEffect, Dispatch } from 'react';
 import { render, act, fireEvent } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { BraidTestProvider } from '../../../test';
-import { Autosuggest } from '..';
+import { Autosuggest, filterSuggestions } from '..';
 import { AutosuggestProps } from './Autosuggest';
+import { containerPrefix } from '../private/Announcement/Announcement';
+
+const getAnnouncements = () =>
+  document.body.querySelector(`[id*=${containerPrefix}]`)?.textContent || null;
 
 function renderAutosuggest<Value>({
   value: initialValue,
@@ -74,15 +78,20 @@ describe('Autosuggest', () => {
     });
 
     expect(queryByLabelText('Apples')).toBe(null);
+    expect(getAnnouncements()).toBeNull();
 
     await userEvent.click(input);
     expect(queryByLabelText('Apples')).toBeInTheDocument();
+    expect(getAnnouncements()).toBe(
+      '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+    );
 
     // Ensure no clear buttons are present
     expect(queryByLabelText('Clear suggestion')).not.toBeInTheDocument();
 
     fireEvent.blur(input);
     expect(queryByLabelText('Apples')).toBe(null);
+    expect(getAnnouncements()).toBeNull();
   });
 
   it('should show text highlights', async () => {
@@ -101,6 +110,9 @@ describe('Autosuggest', () => {
 
     const highlight = queryByText('Appl');
     expect(highlight && highlight.tagName).toBe('STRONG');
+    expect(getAnnouncements()).toBe(
+      '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+    );
   });
 
   it('should support suggestions as a function', async () => {
@@ -119,6 +131,9 @@ describe('Autosuggest', () => {
 
     const highlight = queryByText('Apples');
     expect(highlight && highlight.tagName).toBe('STRONG');
+    expect(getAnnouncements()).toBe(
+      '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+    );
   });
 
   it('should select suggestions on click', async () => {
@@ -137,6 +152,9 @@ describe('Autosuggest', () => {
     await userEvent.click(input);
     expect(getInputValue()).toBe('');
     expect(changeHandler).not.toHaveBeenCalled();
+    expect(getAnnouncements()).toBe(
+      '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+    );
 
     const suggestion = queryByLabelText('Apples');
     if (!suggestion) {
@@ -150,6 +168,7 @@ describe('Autosuggest', () => {
       text: 'Apples',
       value: 'apples',
     });
+    expect(getAnnouncements()).toBeNull();
   });
 
   it('should support custom suggestion labels', async () => {
@@ -168,6 +187,9 @@ describe('Autosuggest', () => {
     await userEvent.click(input);
     expect(getInputValue()).toBe('');
     expect(changeHandler).not.toHaveBeenCalled();
+    expect(getAnnouncements()).toBe(
+      '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+    );
 
     const suggestion = queryByLabelText('CUSTOM LABEL');
     if (!suggestion) {
@@ -181,6 +203,7 @@ describe('Autosuggest', () => {
       text: 'Apples',
       value: 'apples',
     });
+    expect(getAnnouncements()).toBeNull();
   });
 
   it('should keep the menu open when a selection is made if "hideSuggestionsOnSelection" is false', async () => {
@@ -215,6 +238,10 @@ describe('Autosuggest', () => {
 
     await userEvent.click(input);
 
+    expect(getAnnouncements()).toBe(
+      '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+    );
+
     const suggestion = queryByLabelText('Apples');
     if (!suggestion) {
       throw new Error('Suggestion not found');
@@ -224,6 +251,9 @@ describe('Autosuggest', () => {
 
     expect(getInputValue()).toBe('');
     expect(queryByLabelText('Apples')).toBeInTheDocument(); // Ensure menu is still open
+    expect(getAnnouncements()).toBe(
+      '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+    );
   });
 
   it('should pass through focus and blur events', async () => {
@@ -250,33 +280,38 @@ describe('Autosuggest', () => {
 
   it("should call 'onClear' handler when clearing suggestions", async () => {
     const clearHandler = jest.fn();
-    const { input, queryByLabelText, changeHandler } = renderAutosuggest({
-      value: { text: '' },
-      suggestions: [
-        {
-          text: 'Apples',
-          value: 'apples',
-          highlights: [{ start: 0, end: 4 }],
-          onClear: clearHandler,
-          clearLabel: 'Clear "Apples"',
-        },
-        {
-          text: 'Bananas',
-          value: 'bananas',
-          highlights: [{ start: 0, end: 4 }],
-          onClear: clearHandler,
-          clearLabel: 'Clear "Bananas"',
-        },
-        {
-          text: 'Carrots',
-          value: 'carrots',
-          highlights: [{ start: 0, end: 4 }],
-        },
-      ],
-    });
+    let suggestions = [
+      {
+        text: 'Apples',
+        value: 'apples',
+        highlights: [{ start: 0, end: 4 }],
+        onClear: clearHandler,
+        clearLabel: 'Clear "Apples"',
+      },
+      {
+        text: 'Bananas',
+        value: 'bananas',
+        highlights: [{ start: 0, end: 4 }],
+        onClear: clearHandler,
+        clearLabel: 'Clear "Bananas"',
+      },
+      {
+        text: 'Carrots',
+        value: 'carrots',
+        highlights: [{ start: 0, end: 4 }],
+      },
+    ];
+    const { input, queryByLabelText, changeHandler, setSuggestions } =
+      renderAutosuggest({
+        value: { text: '' },
+        suggestions,
+      });
 
     await userEvent.click(input);
 
+    expect(getAnnouncements()).toBe(
+      '3 suggestions available. Use up and down arrow keys to navigate. Press enter to select',
+    );
     expect(clearHandler).not.toHaveBeenCalled();
 
     const clearApples = queryByLabelText('Clear "Apples"');
@@ -288,6 +323,11 @@ describe('Autosuggest', () => {
       text: 'Apples',
       value: 'apples',
     });
+    suggestions = suggestions.filter(({ value }) => value !== 'apples');
+    setSuggestions(suggestions);
+    expect(getAnnouncements()).toBe(
+      '2 suggestions available. Use up and down arrow keys to navigate. Press enter to select',
+    );
     clearHandler.mockClear();
 
     const clearBananas = queryByLabelText('Clear "Bananas"');
@@ -299,7 +339,12 @@ describe('Autosuggest', () => {
       text: 'Bananas',
       value: 'bananas',
     });
+    suggestions = suggestions.filter(({ value }) => value !== 'bananas');
+    setSuggestions(suggestions);
     clearHandler.mockClear();
+    expect(getAnnouncements()).toBe(
+      '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+    );
 
     expect(changeHandler).not.toHaveBeenCalled();
   });
@@ -363,6 +408,9 @@ describe('Autosuggest', () => {
 
       await userEvent.click(input);
 
+      expect(getAnnouncements()).toBe(
+        '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+      );
       expect(queryByLabelText('Apples')).toBeInTheDocument();
     });
 
@@ -414,6 +462,10 @@ describe('Autosuggest', () => {
 
       await userEvent.click(input);
 
+      expect(getAnnouncements()).toBe(
+        '6 suggestions available. Use up and down arrow keys to navigate. Press enter to select',
+      );
+
       expect(queryByLabelText('Apples (Fruit)')).toBeInTheDocument();
       expect(queryByLabelText('Carrots (Vegetables)')).toBeInTheDocument();
       expect(queryByLabelText('Ice cream (Dessert)')).toBeInTheDocument();
@@ -437,6 +489,9 @@ describe('Autosuggest', () => {
 
       await userEvent.click(input);
 
+      expect(getAnnouncements()).toBe(
+        '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+      );
       expect(
         queryByLabelText('Apples - Juicy and delicious'),
       ).toBeInTheDocument();
@@ -461,6 +516,9 @@ describe('Autosuggest', () => {
 
       await userEvent.click(input);
 
+      expect(getAnnouncements()).toBe(
+        '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+      );
       expect(
         queryByLabelText('Apples - Juicy and delicious (Fruit)'),
       ).toBeInTheDocument();
@@ -487,12 +545,18 @@ describe('Autosuggest', () => {
         });
 
       await userEvent.click(input);
+
+      expect(getAnnouncements()).toBe(
+        '2 suggestions available. Use up and down arrow keys to navigate. Press enter to select',
+      );
+
       await userEvent.keyboard('{enter}');
 
       expect(getInputValue()).toBe('');
       expect(changeHandler).not.toHaveBeenCalled();
 
       expect(queryByLabelText('Apples')).toBe(null); // Ensure menu has closed
+      expect(getAnnouncements()).toBeNull();
     });
 
     it('should select a suggestion on enter after navigating the list', async () => {
@@ -523,7 +587,12 @@ describe('Autosuggest', () => {
       expect(getInputValue()).toBe('');
 
       await userEvent.click(input);
+      expect(getAnnouncements()).toBe(
+        '3 suggestions available. Use up and down arrow keys to navigate. Press enter to select',
+      );
       await userEvent.keyboard('{arrowdown}');
+      expect(getAnnouncements()).toBeNull();
+
       expect(getInputValue()).toBe('Apples');
 
       await userEvent.keyboard('{arrowdown}');
@@ -545,35 +614,49 @@ describe('Autosuggest', () => {
         text: 'Bananas',
         value: 'bananas',
       });
+      expect(getAnnouncements()).toBeNull();
     });
 
     it('should first clear the suggestion preview and then reset the input when pressing escape', async () => {
-      const { input, changeHandler, queryByLabelText, getInputValue } =
-        renderAutosuggest({
-          value: { text: '' },
-          suggestions: [
-            {
-              text: 'Apples',
-              value: 'apples',
-              highlights: [{ start: 0, end: 4 }],
-            },
-            {
-              text: 'Bananas',
-              value: 'bananas',
-              highlights: [{ start: 0, end: 4 }],
-            },
-            {
-              text: 'Carrots',
-              value: 'carrots',
-              highlights: [{ start: 0, end: 4 }],
-            },
-          ],
-        });
+      const suggestions = [
+        {
+          text: 'Apples',
+          value: 'apples',
+          highlights: [{ start: 0, end: 4 }],
+        },
+        {
+          text: 'Bananas',
+          value: 'bananas',
+          highlights: [{ start: 0, end: 4 }],
+        },
+        {
+          text: 'Carrots',
+          value: 'carrots',
+          highlights: [{ start: 0, end: 4 }],
+        },
+      ];
+      const {
+        input,
+        changeHandler,
+        queryByLabelText,
+        getInputValue,
+        setSuggestions,
+      } = renderAutosuggest({
+        value: { text: '' },
+        suggestions,
+      });
 
       await userEvent.click(input);
+      expect(getAnnouncements()).toBe(
+        '3 suggestions available. Use up and down arrow keys to navigate. Press enter to select',
+      );
 
       await userEvent.paste('app');
       expect(changeHandler).toHaveBeenNthCalledWith(1, { text: 'app' });
+      setSuggestions(filterSuggestions(suggestions, 'app'));
+      expect(getAnnouncements()).toBe(
+        '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+      );
       changeHandler.mockClear();
 
       await userEvent.keyboard('{arrowdown}');
@@ -582,16 +665,22 @@ describe('Autosuggest', () => {
       await userEvent.keyboard('{Escape}');
       expect(changeHandler).not.toHaveBeenCalled();
       expect(getInputValue()).toBe('app');
+      expect(getAnnouncements()).toBeNull();
 
       expect(queryByLabelText('Apples')).toBe(null); // Ensure menu has closed
 
       await userEvent.keyboard('{Escape}');
       expect(getInputValue()).toBe('');
       expect(changeHandler).toHaveBeenNthCalledWith(1, { text: '' });
+      setSuggestions(filterSuggestions(suggestions, ''));
       expect(queryByLabelText('Apples')).toBeInTheDocument(); // Ensure menu has re-opened
+      expect(getAnnouncements()).toBe(
+        '3 suggestions available. Use up and down arrow keys to navigate. Press enter to select',
+      );
 
       await userEvent.keyboard('{Escape}');
       expect(queryByLabelText('Apples')).toBe(null); // Ensure menu has closed again
+      expect(getAnnouncements()).toBeNull();
     });
 
     it('should select a suggestion on enter after navigating a single suggestion', async () => {
@@ -608,6 +697,9 @@ describe('Autosuggest', () => {
         });
 
       await userEvent.click(input);
+      expect(getAnnouncements()).toBe(
+        '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+      );
 
       await userEvent.keyboard('{arrowdown}');
       expect(getInputValue()).toBe('Apples');
@@ -620,6 +712,7 @@ describe('Autosuggest', () => {
         value: 'apples',
       });
       expect(queryByLabelText('Apples')).toBe(null); // Ensure menu has closed
+      expect(getAnnouncements()).toBeNull();
     });
 
     it('should keep the menu open on selection if "hideSuggestionsOnSelection" is false', async () => {
@@ -653,6 +746,9 @@ describe('Autosuggest', () => {
       const getInputValue = () => input.getAttribute('value');
 
       await userEvent.click(input);
+      expect(getAnnouncements()).toBe(
+        '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+      );
 
       await userEvent.keyboard('{arrowdown}');
       expect(getInputValue()).toBe('Apples');
@@ -661,6 +757,9 @@ describe('Autosuggest', () => {
 
       expect(getInputValue()).toBe('');
       expect(queryByLabelText('Apples')).toBeInTheDocument(); // Ensure menu is still open
+      expect(getAnnouncements()).toBe(
+        '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+      );
     });
 
     it('should select a grouped suggestion on enter after navigating the list', async () => {
@@ -700,6 +799,9 @@ describe('Autosuggest', () => {
         ],
       });
       await userEvent.click(input);
+      expect(getAnnouncements()).toBe(
+        '4 suggestions available. Use up and down arrow keys to navigate. Press enter to select',
+      );
 
       await userEvent.keyboard('{arrowdown}');
       expect(getInputValue()).toBe('Apples');
@@ -722,6 +824,7 @@ describe('Autosuggest', () => {
         text: 'Broccoli',
         value: 'broccoli',
       });
+      expect(getAnnouncements()).toBeNull();
     });
   });
 
@@ -742,15 +845,22 @@ describe('Autosuggest', () => {
       ],
     });
     await userEvent.click(input);
+    expect(getAnnouncements()).toBe(
+      '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+    );
     await userEvent.keyboard('{arrowdown}');
     await userEvent.keyboard('{enter}');
     expect(changeHandler).toHaveBeenNthCalledWith(1, {
       text: 'Apples',
       value: 'apples',
     });
+    expect(getAnnouncements()).toBeNull();
   });
 
-  it('should support messages', async () => {
+  it('should support legacy no results messages via `suggestions`', async () => {
+    // Hide deprecation warning from test log
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+
     const TestCase = () => (
       <BraidTestProvider>
         <Autosuggest
@@ -759,20 +869,144 @@ describe('Autosuggest', () => {
           value={{ text: '' }}
           onChange={() => {}}
           hideSuggestionsOnSelection={false}
-          suggestions={{ message: 'No suggestions' }}
+          suggestions={{ message: 'Legacy no suggestions message' }}
         />
       </BraidTestProvider>
     );
 
-    const { getByRole, queryByText } = render(<TestCase />);
-    expect(queryByText('No suggestions')).not.toBeInTheDocument();
+    const { getByRole, queryByRole } = render(<TestCase />);
+    expect(queryByRole('listitem')).not.toBeInTheDocument();
+    expect(getAnnouncements()).toBeNull();
 
     const input = getByRole('combobox');
     await userEvent.click(input);
-    expect(queryByText('No suggestions')).toBeInTheDocument();
+    expect(queryByRole('listitem')).toHaveTextContent(
+      'Legacy no suggestions message',
+    );
+    expect(getAnnouncements()).toBe('Legacy no suggestions message');
 
     fireEvent.blur(input);
-    expect(queryByText('No suggestions')).not.toBeInTheDocument();
+    expect(queryByRole('listitem')).not.toBeInTheDocument();
+    expect(getAnnouncements()).toBeNull();
+
+    // Restore console warnings
+    jest.spyOn(console, 'warn').mockRestore();
+  });
+
+  it('should not show `noSuggestionsMessage` when suggestions are provided', async () => {
+    const TestCase = () => (
+      <BraidTestProvider>
+        <Autosuggest
+          id="fruit"
+          label="Fruit"
+          value={{ text: '' }}
+          onChange={() => {}}
+          hideSuggestionsOnSelection={false}
+          suggestions={[
+            {
+              text: 'Apples',
+              value: 'apples',
+              highlights: [{ start: 0, end: 4 }],
+            },
+          ]}
+          noSuggestionsMessage={{
+            text: 'Custom no suggestions message.',
+          }}
+        />
+      </BraidTestProvider>
+    );
+
+    const { getByRole, queryByRole } = render(<TestCase />);
+    expect(queryByRole('option')).not.toBeInTheDocument();
+    expect(queryByRole('listitem')).not.toBeInTheDocument();
+    expect(getAnnouncements()).toBeNull();
+
+    const input = getByRole('combobox');
+    await userEvent.click(input);
+    expect(getByRole('option')).toHaveTextContent('Apples');
+    expect(getAnnouncements()).toBe(
+      '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+    );
+
+    fireEvent.blur(input);
+    expect(queryByRole('option')).not.toBeInTheDocument();
+    expect(queryByRole('listitem')).not.toBeInTheDocument();
+    expect(getAnnouncements()).toBeNull();
+  });
+
+  it('should show `noSuggestionsMessage` without a description when no suggestions provided', async () => {
+    const TestCase = () => (
+      <BraidTestProvider>
+        <Autosuggest
+          id="fruit"
+          label="Fruit"
+          value={{ text: '' }}
+          onChange={() => {}}
+          hideSuggestionsOnSelection={false}
+          suggestions={[]}
+          noSuggestionsMessage={{
+            text: 'Custom no suggestions message.',
+          }}
+        />
+      </BraidTestProvider>
+    );
+
+    const { getByRole, queryByRole } = render(<TestCase />);
+    expect(queryByRole('listitem')).not.toBeInTheDocument();
+    expect(queryByRole('option')).not.toBeInTheDocument();
+    expect(getAnnouncements()).toBeNull();
+
+    const input = getByRole('combobox');
+    await userEvent.click(input);
+    expect(getByRole('listitem')).toHaveTextContent(
+      'Custom no suggestions message.',
+    );
+    expect(queryByRole('option')).not.toBeInTheDocument();
+    expect(getAnnouncements()).toBe('Custom no suggestions message.');
+
+    fireEvent.blur(input);
+    expect(queryByRole('listitem')).not.toBeInTheDocument();
+    expect(queryByRole('option')).not.toBeInTheDocument();
+    expect(getAnnouncements()).toBeNull();
+  });
+
+  it('should show `noSuggestionsMessage` with a description when no suggestions provided', async () => {
+    const TestCase = () => (
+      <BraidTestProvider>
+        <Autosuggest
+          id="fruit"
+          label="Fruit"
+          value={{ text: '' }}
+          onChange={() => {}}
+          hideSuggestionsOnSelection={false}
+          suggestions={[]}
+          noSuggestionsMessage={{
+            text: 'Custom no suggestions message.',
+            description: 'Additional no suggestions description',
+          }}
+        />
+      </BraidTestProvider>
+    );
+
+    const { getByRole, queryByRole } = render(<TestCase />);
+    expect(queryByRole('listitem')).not.toBeInTheDocument();
+    expect(queryByRole('option')).not.toBeInTheDocument();
+    expect(getAnnouncements()).toBeNull();
+
+    const input = getByRole('combobox');
+    await userEvent.click(input);
+    expect(getByRole('listitem')).toHaveTextContent(
+      'Custom no suggestions message.Additional no suggestions description',
+    );
+    expect(queryByRole('option')).not.toBeInTheDocument();
+    expect(getAnnouncements()).toBe(
+      'Custom no suggestions message. Additional no suggestions description',
+    );
+
+    fireEvent.blur(input);
+    expect(queryByRole('listitem')).not.toBeInTheDocument();
+    expect(queryByRole('option')).not.toBeInTheDocument();
+    expect(getAnnouncements()).toBeNull();
   });
 
   describe('automaticSelection', () => {
@@ -799,9 +1033,13 @@ describe('Autosuggest', () => {
         ],
       });
       await userEvent.click(input);
+      expect(getAnnouncements()).toBe(
+        '3 suggestions available. Use up and down arrow keys to navigate. Press enter to select',
+      );
       await userEvent.keyboard('{enter}');
       expect(getInputValue()).toBe('');
       expect(changeHandler).not.toHaveBeenCalled();
+      expect(getAnnouncements()).toBeNull();
     });
 
     it("shouldn't select anything on blur if the user hasn't typed anything", async () => {
@@ -828,9 +1066,13 @@ describe('Autosuggest', () => {
       });
 
       await userEvent.click(input);
+      expect(getAnnouncements()).toBe(
+        '3 suggestions available. Use up and down arrow keys to navigate. Press enter to select',
+      );
       fireEvent.blur(input);
       expect(getInputValue()).toBe('');
       expect(changeHandler).not.toHaveBeenCalled();
+      expect(getAnnouncements()).toBeNull();
     });
 
     it("shouldn't select anything on blur if the field is populated and the user hasn't typed anything", async () => {
@@ -857,46 +1099,65 @@ describe('Autosuggest', () => {
       });
 
       await userEvent.click(input);
+      expect(getAnnouncements()).toBe(
+        '3 suggestions available. Suggestion Apples is automatically selected. Use up and down arrow keys to navigate. Press enter to select',
+      );
       fireEvent.blur(input);
       expect(getInputValue()).toBe('I already typed something');
       expect(changeHandler).not.toHaveBeenCalled();
+      expect(getAnnouncements()).toBeNull();
     });
 
     it("shouldn't select anything on blur if the suggestions are hidden", async () => {
-      const { input, changeHandler, getInputValue, queryByLabelText } =
-        renderAutosuggest({
-          automaticSelection: true,
-          value: { text: '' },
-          suggestions: [
-            {
-              text: 'Apples',
-              value: 'apples',
-              highlights: [{ start: 0, end: 4 }],
-            },
-            {
-              text: 'Bananas',
-              value: 'bananas',
-              highlights: [{ start: 0, end: 4 }],
-            },
-            {
-              text: 'Carrots',
-              value: 'carrots',
-              highlights: [{ start: 0, end: 4 }],
-            },
-          ],
-        });
+      const suggestions = [
+        {
+          text: 'Apples',
+          value: 'apples',
+          highlights: [{ start: 0, end: 4 }],
+        },
+        {
+          text: 'Bananas',
+          value: 'bananas',
+          highlights: [{ start: 0, end: 4 }],
+        },
+        {
+          text: 'Carrots',
+          value: 'carrots',
+          highlights: [{ start: 0, end: 4 }],
+        },
+      ];
+
+      const {
+        input,
+        changeHandler,
+        getInputValue,
+        queryByLabelText,
+        setSuggestions,
+      } = renderAutosuggest({
+        automaticSelection: true,
+        value: { text: '' },
+        suggestions,
+      });
 
       expect(getInputValue()).toBe('');
 
       await userEvent.click(input);
+      expect(getAnnouncements()).toBe(
+        '3 suggestions available. Use up and down arrow keys to navigate. Press enter to select',
+      );
 
       await userEvent.type(input, 'B');
       expect(changeHandler).toHaveBeenNthCalledWith(1, {
         text: 'B',
       });
+      setSuggestions(filterSuggestions(suggestions, 'B'));
+      expect(getAnnouncements()).toBe(
+        '1 suggestion available. Suggestion Bananas is automatically selected. Use up and down arrow keys to navigate. Press enter to select',
+      );
 
       await userEvent.keyboard('{arrowdown}');
       expect(getInputValue()).toBe('Bananas');
+      expect(getAnnouncements()).toBeNull();
 
       await userEvent.keyboard('{enter}');
       expect(getInputValue()).toBe('Bananas');
@@ -904,6 +1165,7 @@ describe('Autosuggest', () => {
         text: 'Bananas',
         value: 'bananas',
       });
+      expect(getAnnouncements()).toBeNull();
 
       // Wait a bit because we ignore blurs that happens too quickly
       // after pressing arrow down (to fix a bug in Chrome + VoiceOver)
@@ -917,6 +1179,7 @@ describe('Autosuggest', () => {
       // Ensure value hasn't changed
       expect(getInputValue()).toBe('Bananas');
       expect(changeHandler).toHaveBeenCalledTimes(2);
+      expect(getAnnouncements()).toBeNull();
     });
 
     it("shouldn't select anything on blur if the user clears the field", () => {
@@ -946,25 +1209,35 @@ describe('Autosuggest', () => {
       fireEvent.blur(input);
       expect(getInputValue()).toBe('');
       expect(changeHandler).toHaveBeenCalledWith({ text: '' });
+      expect(getAnnouncements()).toBeNull();
     });
 
     it('should select the first suggestion on enter after typing something', async () => {
-      const { input, changeHandler, getInputValue } = renderAutosuggest({
-        automaticSelection: true,
-        value: { text: '' },
-        suggestions: [
-          {
-            text: 'Apples',
-            value: 'apples',
-            highlights: [{ start: 0, end: 4 }],
-          },
-        ],
-      });
+      const suggestions = [
+        {
+          text: 'Apples',
+          value: 'apples',
+          highlights: [{ start: 0, end: 4 }],
+        },
+      ];
+      const { input, changeHandler, getInputValue, setSuggestions } =
+        renderAutosuggest({
+          automaticSelection: true,
+          value: { text: '' },
+          suggestions,
+        });
       await userEvent.click(input);
       expect(getInputValue()).toBe('');
+      expect(getAnnouncements()).toBe(
+        '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+      );
 
       await userEvent.type(input, 'a');
       expect(changeHandler).toHaveBeenNthCalledWith(1, { text: 'a' });
+      setSuggestions(filterSuggestions(suggestions, 'a'));
+      expect(getAnnouncements()).toBe(
+        '1 suggestion available. Suggestion Apples is automatically selected. Use up and down arrow keys to navigate. Press enter to select',
+      );
       changeHandler.mockClear();
 
       await userEvent.keyboard('{enter}');
@@ -973,6 +1246,7 @@ describe('Autosuggest', () => {
         text: 'Apples',
         value: 'apples',
       });
+      expect(getAnnouncements()).toBeNull();
     });
 
     it('should select the first suggestion on enter after typing something when the suggestions are async', async () => {
@@ -989,9 +1263,11 @@ describe('Autosuggest', () => {
       });
       await userEvent.click(input);
       expect(getInputValue()).toBe('');
+      expect(getAnnouncements()).toBeNull();
 
       await userEvent.type(input, 'a');
       expect(changeHandler).toHaveBeenNthCalledWith(1, { text: 'a' });
+      expect(getAnnouncements()).toBeNull();
       changeHandler.mockClear();
 
       // Simulate suggestions coming back from an API
@@ -1008,6 +1284,9 @@ describe('Autosuggest', () => {
           resolve();
         }, 100);
       });
+      expect(getAnnouncements()).toBe(
+        '1 suggestion available. Suggestion Apples is automatically selected. Use up and down arrow keys to navigate. Press enter to select',
+      );
 
       expect(queryByLabelText('Apples')).toBeInTheDocument(); // Ensure menu has opened
 
@@ -1020,6 +1299,7 @@ describe('Autosuggest', () => {
         text: 'Apples',
         value: 'apples',
       });
+      expect(getAnnouncements()).toBeNull();
     });
 
     it('should allow you to navigate a suggestions list with a single item', async () => {
@@ -1036,9 +1316,16 @@ describe('Autosuggest', () => {
       });
       await userEvent.click(input);
       expect(getInputValue()).toBe('');
+      expect(getAnnouncements()).toBe(
+        '1 suggestion available. Use up and down arrow keys to navigate. Press enter to select',
+      );
 
       await userEvent.type(input, 'a');
       expect(changeHandler).toHaveBeenNthCalledWith(1, { text: 'a' });
+      expect(getAnnouncements()).toBe(
+        '1 suggestion available. Suggestion Apples is automatically selected. Use up and down arrow keys to navigate. Press enter to select',
+      );
+
       changeHandler.mockClear();
 
       await userEvent.keyboard('{arrowdown}');
@@ -1050,35 +1337,46 @@ describe('Autosuggest', () => {
         text: 'Apples',
         value: 'apples',
       });
+      expect(getAnnouncements()).toBeNull();
     });
 
     it('should select the first suggestion on blur after typing something', async () => {
-      const { input, changeHandler, getInputValue } = renderAutosuggest({
-        automaticSelection: true,
-        value: { text: '' },
-        suggestions: [
-          {
-            text: 'Apples',
-            value: 'apples',
-            highlights: [{ start: 0, end: 4 }],
-          },
-          {
-            text: 'Bananas',
-            value: 'bananas',
-            highlights: [{ start: 0, end: 4 }],
-          },
-          {
-            text: 'Carrots',
-            value: 'carrots',
-            highlights: [{ start: 0, end: 4 }],
-          },
-        ],
-      });
+      const suggestions = [
+        {
+          text: 'Apples',
+          value: 'apples',
+          highlights: [{ start: 0, end: 4 }],
+        },
+        {
+          text: 'Bananas',
+          value: 'bananas',
+          highlights: [{ start: 0, end: 4 }],
+        },
+        {
+          text: 'Carrots',
+          value: 'carrots',
+          highlights: [{ start: 0, end: 4 }],
+        },
+      ];
+      const { input, changeHandler, getInputValue, setSuggestions } =
+        renderAutosuggest({
+          automaticSelection: true,
+          value: { text: '' },
+          suggestions,
+        });
       await userEvent.click(input);
       expect(getInputValue()).toBe('');
+      expect(getAnnouncements()).toBe(
+        '3 suggestions available. Use up and down arrow keys to navigate. Press enter to select',
+      );
 
       await userEvent.type(input, 'a');
       expect(changeHandler).toHaveBeenNthCalledWith(1, { text: 'a' });
+      setSuggestions(filterSuggestions(suggestions, 'a'));
+      expect(getAnnouncements()).toBe(
+        '1 suggestion available. Suggestion Apples is automatically selected. Use up and down arrow keys to navigate. Press enter to select',
+      );
+
       changeHandler.mockClear();
 
       fireEvent.blur(input);
@@ -1086,6 +1384,7 @@ describe('Autosuggest', () => {
         text: 'Apples',
         value: 'apples',
       });
+      expect(getAnnouncements()).toBeNull();
     });
 
     it('should initially highlight the first suggestion when navigating the list', async () => {
@@ -1112,6 +1411,9 @@ describe('Autosuggest', () => {
       });
       await userEvent.click(input);
       expect(getInputValue()).toBe('');
+      expect(getAnnouncements()).toBe(
+        '3 suggestions available. Use up and down arrow keys to navigate. Press enter to select',
+      );
 
       await userEvent.type(input, 'a');
       expect(getInputValue()).toBe('a');
@@ -1131,6 +1433,7 @@ describe('Autosuggest', () => {
         text: 'Carrots',
         value: 'carrots',
       });
+      expect(getAnnouncements()).toBeNull();
     });
 
     it('should select the highlighted suggestion on blur after navigating the list', async () => {
@@ -1156,6 +1459,9 @@ describe('Autosuggest', () => {
         ],
       });
       await userEvent.click(input);
+      expect(getAnnouncements()).toBe(
+        '3 suggestions available. Use up and down arrow keys to navigate. Press enter to select',
+      );
       await userEvent.type(input, 'a');
       expect(changeHandler).toHaveBeenNthCalledWith(1, { text: 'a' });
       changeHandler.mockClear();
@@ -1176,6 +1482,7 @@ describe('Autosuggest', () => {
         text: 'Carrots',
         value: 'carrots',
       });
+      expect(getAnnouncements()).toBeNull();
     });
   });
 });

--- a/packages/braid-design-system/lib/components/Autosuggest/Autosuggest.test.tsx
+++ b/packages/braid-design-system/lib/components/Autosuggest/Autosuggest.test.tsx
@@ -909,9 +909,7 @@ describe('Autosuggest', () => {
               highlights: [{ start: 0, end: 4 }],
             },
           ]}
-          noSuggestionsMessage={{
-            text: 'Custom no suggestions message.',
-          }}
+          noSuggestionsMessage="Custom no suggestions message"
         />
       </BraidTestProvider>
     );
@@ -934,7 +932,7 @@ describe('Autosuggest', () => {
     expect(getAnnouncements()).toBeNull();
   });
 
-  it('should show `noSuggestionsMessage` without a description when no suggestions provided', async () => {
+  it('should show simple `noSuggestionsMessage` when no suggestions provided', async () => {
     const TestCase = () => (
       <BraidTestProvider>
         <Autosuggest
@@ -944,9 +942,7 @@ describe('Autosuggest', () => {
           onChange={() => {}}
           hideSuggestionsOnSelection={false}
           suggestions={[]}
-          noSuggestionsMessage={{
-            text: 'Custom no suggestions message.',
-          }}
+          noSuggestionsMessage="Custom no suggestions message"
         />
       </BraidTestProvider>
     );
@@ -959,10 +955,10 @@ describe('Autosuggest', () => {
     const input = getByRole('combobox');
     await userEvent.click(input);
     expect(getByRole('listitem')).toHaveTextContent(
-      'Custom no suggestions message.',
+      'Custom no suggestions message',
     );
     expect(queryByRole('option')).not.toBeInTheDocument();
-    expect(getAnnouncements()).toBe('Custom no suggestions message.');
+    expect(getAnnouncements()).toBe('Custom no suggestions message');
 
     fireEvent.blur(input);
     expect(queryByRole('listitem')).not.toBeInTheDocument();
@@ -970,7 +966,7 @@ describe('Autosuggest', () => {
     expect(getAnnouncements()).toBeNull();
   });
 
-  it('should show `noSuggestionsMessage` with a description when no suggestions provided', async () => {
+  it('should show structured `noSuggestionsMessage` when no suggestions provided', async () => {
     const TestCase = () => (
       <BraidTestProvider>
         <Autosuggest
@@ -981,7 +977,7 @@ describe('Autosuggest', () => {
           hideSuggestionsOnSelection={false}
           suggestions={[]}
           noSuggestionsMessage={{
-            text: 'Custom no suggestions message.',
+            title: 'Custom no suggestions message',
             description: 'Additional no suggestions description',
           }}
         />
@@ -995,8 +991,12 @@ describe('Autosuggest', () => {
 
     const input = getByRole('combobox');
     await userEvent.click(input);
-    expect(getByRole('listitem')).toHaveTextContent(
-      'Custom no suggestions message.Additional no suggestions description',
+    const noSuggestionsMessage = getByRole('listitem');
+    expect(noSuggestionsMessage).toHaveTextContent(
+      'Custom no suggestions message',
+    );
+    expect(noSuggestionsMessage).toHaveTextContent(
+      'Additional no suggestions description',
     );
     expect(queryByRole('option')).not.toBeInTheDocument();
     expect(getAnnouncements()).toBe(

--- a/packages/braid-design-system/lib/components/Autosuggest/Autosuggest.tsx
+++ b/packages/braid-design-system/lib/components/Autosuggest/Autosuggest.tsx
@@ -12,6 +12,7 @@ import React, {
   ReactElement,
   RefAttributes,
 } from 'react';
+import dedent from 'dedent';
 import parseHighlights from 'autosuggest-highlight/parse';
 import { Box } from '../Box/Box';
 import { Text } from '../Text/Text';
@@ -264,6 +265,12 @@ const noop = () => {
 const fallbackValue = { text: '' };
 const fallbackSuggestions: Suggestion[] = [];
 
+/** @deprecated Use `noSuggestionsMessage` prop instead */
+type LegacyMessageSuggestion = {
+  /** @deprecated Use `noSuggestionsMessage` prop instead */
+  message: string;
+};
+
 export type AutosuggestBaseProps<Value> = Omit<
   FieldBaseProps,
   'value' | 'autoComplete' | 'labelId' | 'prefix'
@@ -271,10 +278,11 @@ export type AutosuggestBaseProps<Value> = Omit<
   value: AutosuggestValue<Value>;
   suggestions:
     | Suggestions<Value>
-    | { message: string }
+    | LegacyMessageSuggestion
     | ((
         value: AutosuggestValue<Value>,
-      ) => Suggestions<Value> | { message: string });
+      ) => Suggestions<Value> | LegacyMessageSuggestion);
+  noSuggestionsMessage?: string | { text: string; description?: string };
   onChange: (value: AutosuggestValue<Value>) => void;
   clearLabel?: string;
   automaticSelection?: boolean;
@@ -292,11 +300,43 @@ export type AutosuggestLabelProps = FieldLabelVariant;
 export type AutosuggestProps<Value> = AutosuggestBaseProps<Value> &
   AutosuggestLabelProps;
 
+function normaliseNoSuggestionMessage<Value>(
+  noSuggestionsMessage: AutosuggestBaseProps<Value>['noSuggestionsMessage'],
+  suggestionProp: AutosuggestBaseProps<Value>['suggestions'],
+) {
+  if (noSuggestionsMessage) {
+    return typeof noSuggestionsMessage === 'string'
+      ? { text: noSuggestionsMessage }
+      : noSuggestionsMessage;
+  }
+
+  if ('message' in suggestionProp) {
+    const message = suggestionProp.message;
+    if (process.env.NODE_ENV !== 'production') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        dedent`
+          Passing \`message\` to \`suggestions\` is deprecated and will be removed in a future version. Use "noSuggestionsMessage" instead. See the documentation for usage: https://seek-oss.github.io/braid-design-system/components/Autosuggest#messaging-when-no-suggestions-are-available
+             <Autosuggest
+            %c-   suggestions={{ message: '${message}' }}
+            %c+   noSuggestionsMessage="${message}"
+             %c/>
+        `,
+        'color: red',
+        'color: green',
+        'color: inherit',
+      );
+    }
+    return typeof message === 'string' ? { text: message } : message;
+  }
+}
+
 export const Autosuggest = forwardRef(function <Value>(
   {
     id,
     value = fallbackValue,
     suggestions: suggestionsProp = fallbackSuggestions,
+    noSuggestionsMessage: noSuggestionsMessageProp,
     onChange = noop,
     automaticSelection = false,
     showMobileBackdrop = false,
@@ -321,11 +361,11 @@ export const Autosuggest = forwardRef(function <Value>(
   const suggestions = Array.isArray(suggestionsPropValue)
     ? suggestionsPropValue
     : [];
-  const message =
-    'message' in suggestionsPropValue
-      ? suggestionsPropValue.message
-      : undefined;
-  const hasItems = suggestions.length > 0 || Boolean(message);
+  const noSuggestionsMessage = normaliseNoSuggestionMessage(
+    noSuggestionsMessageProp,
+    suggestionsPropValue,
+  );
+  const hasItems = suggestions.length > 0 || Boolean(noSuggestionsMessage);
 
   // We need a ref regardless so we can imperatively
   // focus the field when clicking the clear button
@@ -630,9 +670,6 @@ export const Autosuggest = forwardRef(function <Value>(
     isOpen &&
     (highlightedIndex === null || hasAutomaticSelection)
   ) {
-    if (message) {
-      announcements.push(message);
-    }
     if (hasSuggestions) {
       announcements.push(
         translations.suggestionsAvailableAnnouncement(suggestionCount),
@@ -648,7 +685,15 @@ export const Autosuggest = forwardRef(function <Value>(
 
       announcements.push(translations.suggestionInstructions);
     } else {
-      announcements.push(translations.noSuggestionsAvailableAnnouncement);
+      announcements.push(
+        noSuggestionsMessage
+          ? `${noSuggestionsMessage.text}${
+              noSuggestionsMessage.description
+                ? ` ${noSuggestionsMessage.description}`
+                : ''
+            }`
+          : translations.noSuggestionsAvailableAnnouncement,
+      );
     }
   }
 
@@ -724,15 +769,27 @@ export const Autosuggest = forwardRef(function <Value>(
                     className={styles.menu}
                     {...a11y.menuProps}
                   >
-                    {isOpen && message ? (
+                    {isOpen && !hasSuggestions && noSuggestionsMessage ? (
                       <Box
                         component="li"
                         paddingX="small"
                         className={touchableText.standard}
                       >
-                        <Text tone="secondary" baseline={false}>
-                          {message}
+                        <Text
+                          tone={
+                            !noSuggestionsMessage.description
+                              ? 'secondary'
+                              : undefined
+                          }
+                          baseline={false}
+                        >
+                          {noSuggestionsMessage.text}
                         </Text>
+                        {noSuggestionsMessage.description ? (
+                          <Text tone="secondary" baseline={false}>
+                            {noSuggestionsMessage.description}
+                          </Text>
+                        ) : null}
                       </Box>
                     ) : null}
                     {isOpen && hasSuggestions

--- a/packages/braid-design-system/lib/components/Autosuggest/Autosuggest.tsx
+++ b/packages/braid-design-system/lib/components/Autosuggest/Autosuggest.tsx
@@ -282,7 +282,7 @@ export type AutosuggestBaseProps<Value> = Omit<
     | ((
         value: AutosuggestValue<Value>,
       ) => Suggestions<Value> | LegacyMessageSuggestion);
-  noSuggestionsMessage?: string | { text: string; description?: string };
+  noSuggestionsMessage?: string | { title: string; description: string };
   onChange: (value: AutosuggestValue<Value>) => void;
   clearLabel?: string;
   automaticSelection?: boolean;
@@ -303,10 +303,10 @@ export type AutosuggestProps<Value> = AutosuggestBaseProps<Value> &
 function normaliseNoSuggestionMessage<Value>(
   noSuggestionsMessage: AutosuggestBaseProps<Value>['noSuggestionsMessage'],
   suggestionProp: AutosuggestBaseProps<Value>['suggestions'],
-) {
+): { title?: string; description: string } | undefined {
   if (noSuggestionsMessage) {
     return typeof noSuggestionsMessage === 'string'
-      ? { text: noSuggestionsMessage }
+      ? { description: noSuggestionsMessage }
       : noSuggestionsMessage;
   }
 
@@ -327,7 +327,7 @@ function normaliseNoSuggestionMessage<Value>(
         'color: inherit',
       );
     }
-    return typeof message === 'string' ? { text: message } : message;
+    return { description: message };
   }
 }
 
@@ -684,16 +684,14 @@ export const Autosuggest = forwardRef(function <Value>(
       }
 
       announcements.push(translations.suggestionInstructions);
+    } else if (noSuggestionsMessage) {
+      if (noSuggestionsMessage.title) {
+        announcements.push(noSuggestionsMessage.title);
+      }
+
+      announcements.push(noSuggestionsMessage.description);
     } else {
-      announcements.push(
-        noSuggestionsMessage
-          ? `${noSuggestionsMessage.text}${
-              noSuggestionsMessage.description
-                ? ` ${noSuggestionsMessage.description}`
-                : ''
-            }`
-          : translations.noSuggestionsAvailableAnnouncement,
-      );
+      announcements.push(translations.noSuggestionsAvailableAnnouncement);
     }
   }
 
@@ -760,7 +758,11 @@ export const Autosuggest = forwardRef(function <Value>(
                     display={isOpen ? 'block' : 'none'}
                     position="absolute"
                     zIndex="dropdown"
-                    background="surface"
+                    background={
+                      !hasSuggestions && noSuggestionsMessage
+                        ? { lightMode: 'neutralSoft', darkMode: 'neutral' }
+                        : 'surface'
+                    }
                     borderRadius="standard"
                     boxShadow="medium"
                     width="full"
@@ -775,21 +777,18 @@ export const Autosuggest = forwardRef(function <Value>(
                         paddingX="small"
                         className={touchableText.standard}
                       >
-                        <Text
-                          tone={
-                            !noSuggestionsMessage.description
-                              ? 'secondary'
-                              : undefined
-                          }
-                          baseline={false}
-                        >
-                          {noSuggestionsMessage.text}
-                        </Text>
-                        {noSuggestionsMessage.description ? (
-                          <Text tone="secondary" baseline={false}>
-                            {noSuggestionsMessage.description}
+                        {noSuggestionsMessage.title ? (
+                          <Text
+                            tone="secondary"
+                            weight="medium"
+                            baseline={false}
+                          >
+                            {noSuggestionsMessage.title}
                           </Text>
                         ) : null}
+                        <Text tone="secondary" baseline={false}>
+                          {noSuggestionsMessage.description}
+                        </Text>
                       </Box>
                     ) : null}
                     {isOpen && hasSuggestions

--- a/packages/braid-design-system/lib/components/private/Announcement/Announcement.tsx
+++ b/packages/braid-design-system/lib/components/private/Announcement/Announcement.tsx
@@ -5,6 +5,7 @@ import { atoms } from '../../../css/atoms/atoms';
 import * as styles from '../../HiddenVisually/HiddenVisually.css';
 
 let announcementCounter = 0;
+export const containerPrefix = 'braid-announcement-container';
 
 interface AnnouncementProps {
   children: string | undefined | null;
@@ -22,7 +23,7 @@ export const Announcement = ({ children }: AnnouncementProps) => {
   ].join(' ');
 
   useEffect(() => {
-    const announcementContainerId = `braid-announcement-container-${announcementCounter++}`;
+    const announcementContainerId = `${containerPrefix}-${announcementCounter++}`;
 
     const element = document.createElement('div');
     element.setAttribute('id', announcementContainerId);

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -100,6 +100,9 @@ Object {
     label: ReactNode
     message?: ReactNode
     name?: string
+    noSuggestionsMessage?: 
+        | string
+        | { text: string; description?: string | undefined; }
     onBlur?: () => void
     onChange: (value: AutosuggestValue<Value>) => void
     onClear?: () => void
@@ -115,9 +118,9 @@ Object {
     secondaryMessage?: ReactNode
     showMobileBackdrop?: boolean
     suggestions: 
-        | (value: AutosuggestValue<Value>) => Suggestions<Value> | { message: string; }
+        | (value: AutosuggestValue<Value>) => LegacyMessageSuggestion | Suggestions<Value>
+        | LegacyMessageSuggestion
         | Suggestions<Value>
-        | { message: string; }
     tertiaryLabel?: ReactNode
     tone?: 
         | "critical"

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -102,7 +102,7 @@ Object {
     name?: string
     noSuggestionsMessage?: 
         | string
-        | { text: string; description?: string | undefined; }
+        | { title: string; description: string; }
     onBlur?: () => void
     onChange: (value: AutosuggestValue<Value>) => void
     onClear?: () => void


### PR DESCRIPTION
Provides consumers a way to give the user more context when no suggestions are available. The `noSuggestionsMessage` prop accepts either a simple message or a more structured prompt by providing an object containing **title** and **description**.

This message is only displayed when there are no available suggestions provided.

**EXAMPLE USAGE:**
For the simple case:

```jsx
<Autosuggest
  ...
  suggestions={[]}
  noSuggestionsMessage="No results found"
/>
```

Or, for more a structured prompt:

```jsx
<Autosuggest
  ...
  suggestions={[]}
  noSuggestionsMessage={{
    title: "No results found",
    description: "Try searching for something else",
  }}
/>
```

**MIGRATION GUIDE:**

In addition, the old mechanism allowing consumers to pass an object to `suggestions` containing a `message` has been deprecated. This will continue to work for now but will be removed in a future release.

It is recommended to migrate to the `noSuggestionsMessage` prop.

```diff
 <Autosuggest
   ...
-  suggestions={{ message: 'No results found' }}
+  noSuggestionsMessage="No results found"
 />
```