### PR TITLE
useToast: Add neutral tone support

### DIFF
--- a/.changeset/sweet-carpets-kiss.md
+++ b/.changeset/sweet-carpets-kiss.md
@@ -15,7 +15,7 @@ Add support for `neutral` tone. When using a `neutral` tone, an icon may optiona
 ```jsx
 import { useToast } from "braid-design-system"
 
-export default () => {
+export const DemoButton = () => {
   const showToast = useToast();
 
   return (

--- a/.changeset/sweet-carpets-kiss.md
+++ b/.changeset/sweet-carpets-kiss.md
@@ -1,0 +1,35 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - useToast
+---
+
+**useToast:** Add neutral tone support
+
+Add support for `neutral` tone. When using a `neutral` tone, an icon may optionally be provided. For consistency, the tone of the icon is set to **secondary** and cannot be customised.
+
+**EXAMPLE USAGE:**
+```jsx
+import { useToast } from "braid-design-system"
+
+export default () => {
+  const showToast = useToast();
+
+  return (
+    <Button
+      onClick={() =>
+        showToast({
+          tone: "neutral",
+          icon: <IconBookmark />,
+          message: "Neutral with icon",
+        })
+      }
+    >
+      Show Toast
+    </Button>
+  );
+}
+```

--- a/packages/braid-design-system/lib/components/useToast/Toast.tsx
+++ b/packages/braid-design-system/lib/components/useToast/Toast.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback, useEffect } from 'react';
+import React, { cloneElement, useCallback, useEffect } from 'react';
+import assert from 'assert';
 import { TreatProvider } from 'sku/react-treat';
 import { Stack } from '../Stack/Stack';
 import { Inline } from '../Inline/Inline';
@@ -58,6 +59,7 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
       message,
       description,
       tone,
+      icon,
       onClose,
       closeLabel = 'Close',
       action,
@@ -81,7 +83,17 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
       }
     }, [shouldRemove, remove, stopTimeout]);
 
-    const Icon = toneToIcon[tone];
+    const Icon = tone !== 'neutral' ? toneToIcon[tone] : undefined;
+
+    assert(
+      !icon || (icon.props.size === undefined && icon.props.tone === undefined),
+      "Icons cannot set the 'size' or 'tone' prop when passed to a Toast component",
+    );
+
+    assert(
+      !icon || (icon && tone === 'neutral'),
+      `Icons cannot be customised on a Toast component using '${tone}' tone`,
+    );
 
     const content = description ? (
       <Stack space="xxsmall">
@@ -135,9 +147,16 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
               >
                 <Columns space="none">
                   <Column width="content">
-                    <Box paddingRight="small">
-                      <Icon tone={tone} />
-                    </Box>
+                    {Icon ? (
+                      <Box paddingRight="small">
+                        <Icon tone={tone} />
+                      </Box>
+                    ) : null}
+                    {tone === 'neutral' && icon ? (
+                      <Box paddingRight="small">
+                        {cloneElement(icon, { tone: 'secondary' })}
+                      </Box>
+                    ) : null}
                   </Column>
                   <Column>{content}</Column>
                   <Column width="content">
@@ -165,7 +184,9 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
                     </Box>
                   </Column>
                 </Columns>
-                <Keyline tone={tone} borderRadius={borderRadius} />
+                {tone !== 'neutral' ? (
+                  <Keyline tone={tone} borderRadius={borderRadius} />
+                ) : null}
               </Box>
             </ContentBlock>
           </Box>

--- a/packages/braid-design-system/lib/components/useToast/ToastTypes.ts
+++ b/packages/braid-design-system/lib/components/useToast/ToastTypes.ts
@@ -1,3 +1,6 @@
+import { ReactElement } from 'react';
+import { UseIconProps } from '../../hooks/useIcon';
+
 export interface ToastAction {
   label: string;
   onClick: () => void;
@@ -8,7 +11,8 @@ export interface InternalToast {
   dedupeKey: string;
   treatTheme: string;
   vanillaTheme: string;
-  tone: 'positive' | 'critical';
+  tone: 'positive' | 'critical' | 'neutral';
+  icon?: ReactElement<UseIconProps>;
   message: string;
   shouldRemove: boolean;
   description?: string;
@@ -16,11 +20,15 @@ export interface InternalToast {
   closeLabel?: string;
 }
 
-export interface Toast {
+export type Toast = {
   key?: string;
-  tone: 'positive' | 'critical';
   message: string;
   description?: string;
   action?: ToastAction;
   closeLabel?: string;
-}
+} & (
+  | {
+      tone: 'positive' | 'critical';
+    }
+  | { tone: 'neutral'; icon?: ReactElement<UseIconProps> }
+);

--- a/packages/braid-design-system/lib/components/useToast/useToast.docs.tsx
+++ b/packages/braid-design-system/lib/components/useToast/useToast.docs.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import { ComponentDocs } from '../../../../../site/src/types';
 import {
+  Box,
   Button,
   Text,
   Stack,
@@ -10,6 +11,7 @@ import {
   IconPromote,
   Notice,
   IconLanguage,
+  IconBookmark,
 } from '..';
 import { useThemeSettings } from '../../../../../site/src/App/ThemeSetting';
 import Code from '../../../../../site/src/App/Code/Code';
@@ -128,42 +130,78 @@ const docs: ComponentDocs = {
     {
       label: 'Tones',
       description: (
-        <Text>
-          Toasts support <Strong>positive</Strong> and <Strong>critical</Strong>{' '}
-          tones.
-        </Text>
+        <>
+          <Text>
+            Toasts support <Strong>positive</Strong>, <Strong>critical</Strong>{' '}
+            and <Strong>neutral</Strong> tones.
+          </Text>
+          <Notice>
+            <Text>
+              When using a <Strong>neutral</Strong> tone, an{' '}
+              <Strong>icon</Strong> may optionally be provided. For consistency,
+              the tone of the icon is set to <Strong>secondary</Strong> and
+              cannot be customised.
+            </Text>
+          </Notice>
+        </>
       ),
       Example: ({ id, showToast }) => {
         const { theme } = useThemeSettings();
 
         const { code } = source(
-          <Stack space="small">
-            <Inline space="small" align="center">
-              <Button
-                onClick={() =>
-                  showToast({
-                    tone: 'positive',
-                    message: 'Positive message',
-                  })
-                }
-              >
-                Show positive toast <IconPromote alignY="lowercase" />
-              </Button>
-            </Inline>
+          <Box padding="medium">
+            <Stack space="small">
+              <Text>
+                Show toast <Strong>tone</Strong> example:
+              </Text>
+              <Inline space="small">
+                <Button
+                  onClick={() =>
+                    showToast({
+                      tone: 'positive',
+                      message: 'Positive message',
+                    })
+                  }
+                >
+                  Positive
+                </Button>
 
-            <Inline space="small" align="center">
-              <Button
-                onClick={() =>
-                  showToast({
-                    tone: 'critical',
-                    message: 'Critical message',
-                  })
-                }
-              >
-                Show critical toast <IconPromote alignY="lowercase" />
-              </Button>
-            </Inline>
-          </Stack>,
+                <Button
+                  onClick={() =>
+                    showToast({
+                      tone: 'critical',
+                      message: 'Critical message',
+                    })
+                  }
+                >
+                  Critical
+                </Button>
+
+                <Button
+                  onClick={() =>
+                    showToast({
+                      tone: 'neutral',
+                      message: 'Neutral message',
+                    })
+                  }
+                >
+                  Neutral
+                </Button>
+
+                <Button
+                  onClick={() =>
+                    showToast({
+                      tone: 'neutral',
+                      icon: <IconBookmark />,
+                      message: 'Neutral with icon',
+                    })
+                  }
+                >
+                  Neutral with icon
+                </Button>
+              </Inline>
+            </Stack>
+          </Box>,
         );
 
         const { value } = source(
@@ -187,6 +225,27 @@ const docs: ComponentDocs = {
               onClose={() => {}}
               message="Critical message"
               tone="critical"
+            />
+            <Toast
+              id={`${id}_3`}
+              dedupeKey={`${id}_3`}
+              shouldRemove={false}
+              treatTheme={theme.treatTheme}
+              vanillaTheme={theme.vanillaTheme}
+              onClose={() => {}}
+              message="Neutral message"
+              tone="neutral"
+            />
+            <Toast
+              id={`${id}_4`}
+              dedupeKey={`${id}_4`}
+              shouldRemove={false}
+              treatTheme={theme.treatTheme}
+              vanillaTheme={theme.vanillaTheme}
+              onClose={() => {}}
+              message="Neutral message with icon"
+              tone="neutral"
+              icon={<IconBookmark />}
             />
           </Stack>,
         );

--- a/packages/braid-design-system/lib/components/useToast/useToast.docs.tsx
+++ b/packages/braid-design-system/lib/components/useToast/useToast.docs.tsx
@@ -99,7 +99,7 @@ const docs: ComponentDocs = {
             {`
           import { useToast } from 'braid-design-system';
 
-          export default () => {
+          export const Demo = () => {
             const showToast = useToast();
 
             // etc...

--- a/packages/braid-design-system/lib/components/useToast/useToast.gallery.tsx
+++ b/packages/braid-design-system/lib/components/useToast/useToast.gallery.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 import { useTheme } from 'sku/react-treat';
 import { ComponentExample } from '../../../../../site/src/types';
 import { useBraidTheme } from '../BraidProvider/BraidThemeContext';
-import { Button, IconPromote, Inline } from '..';
+import { Button, IconBookmark, IconPromote, Inline } from '..';
 import Toast from './Toast';
 import source from '../../utils/source.macro';
 
@@ -81,6 +81,88 @@ export const galleryItems: ComponentExample[] = [
               onClose={handler}
               message="Critical message"
               tone="critical"
+            />
+          </Inline>
+        ),
+      };
+    },
+  },
+  {
+    label: 'With a neutral message',
+    Example: ({ id, handler, showToast }) => {
+      const theme = useTheme();
+      const { vanillaTheme } = useBraidTheme();
+
+      const { code } = source(
+        <Inline space="small">
+          <Button
+            onClick={() =>
+              showToast({
+                message: 'Neutral message',
+                tone: 'neutral',
+              })
+            }
+          >
+            Show Toast
+          </Button>
+        </Inline>,
+      );
+
+      return {
+        code,
+        value: (
+          <Inline space="gutter" align="center">
+            <Toast
+              id={id}
+              dedupeKey={id}
+              shouldRemove={false}
+              treatTheme={theme}
+              vanillaTheme={vanillaTheme}
+              onClose={handler}
+              message="Neutral message"
+              tone="neutral"
+            />
+          </Inline>
+        ),
+      };
+    },
+  },
+  {
+    label: 'With a custom icon (neutral tone only)',
+    Example: ({ id, handler, showToast }) => {
+      const theme = useTheme();
+      const { vanillaTheme } = useBraidTheme();
+
+      const { code } = source(
+        <Inline space="small">
+          <Button
+            onClick={() =>
+              showToast({
+                message: 'Neutral message with icon',
+                tone: 'neutral',
+                icon: <IconBookmark />,
+              })
+            }
+          >
+            Show Toast
+          </Button>
+        </Inline>,
+      );
+
+      return {
+        code,
+        value: (
+          <Inline space="gutter" align="center">
+            <Toast
+              id={id}
+              dedupeKey={id}
+              shouldRemove={false}
+              treatTheme={theme}
+              vanillaTheme={vanillaTheme}
+              onClose={handler}
+              message="Neutral message with icon"
+              tone="neutral"
+              icon={<IconBookmark />}
             />
           </Inline>
         ),

--- a/packages/braid-design-system/lib/components/useToast/useToast.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/useToast/useToast.screenshots.tsx
@@ -3,6 +3,7 @@ import { useTheme } from 'sku/react-treat';
 import { useBraidTheme } from '../BraidProvider/BraidThemeContext';
 import { ComponentScreenshot } from '../../../../../site/src/types';
 import Toast from './Toast';
+import { IconBookmark } from '..';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320, 768],
@@ -130,6 +131,147 @@ export const screenshots: ComponentScreenshot = {
           <Toast
             tone="positive"
             message="Positive toast"
+            description="A really long description about toast stuff that is quite long and stuff"
+            action={{
+              label: 'Action',
+              onClick: () => {},
+            }}
+            treatTheme={treatTheme}
+            vanillaTheme={vanillaTheme}
+            onClose={() => {}}
+            id="n/a"
+            dedupeKey="n/a"
+            shouldRemove={false}
+          />
+        );
+      },
+    },
+    {
+      label: 'Neutral toast',
+      Example: () => {
+        const treatTheme = useTheme();
+        const { vanillaTheme } = useBraidTheme();
+
+        return (
+          <Toast
+            tone="neutral"
+            message="Neutral toast"
+            treatTheme={treatTheme}
+            vanillaTheme={vanillaTheme}
+            onClose={() => {}}
+            id="n/a"
+            dedupeKey="n/a"
+            shouldRemove={false}
+          />
+        );
+      },
+    },
+    {
+      label: 'Neutral toast w/actions',
+      Example: () => {
+        const treatTheme = useTheme();
+        const { vanillaTheme } = useBraidTheme();
+
+        return (
+          <Toast
+            tone="neutral"
+            message="Neutral toast w/actions"
+            action={{
+              label: 'Do the action',
+              onClick: () => {},
+            }}
+            treatTheme={treatTheme}
+            vanillaTheme={vanillaTheme}
+            onClose={() => {}}
+            id="n/a"
+            dedupeKey="n/a"
+            shouldRemove={false}
+          />
+        );
+      },
+    },
+    {
+      label: 'Neutral toast w/descriptions',
+      Example: () => {
+        const treatTheme = useTheme();
+        const { vanillaTheme } = useBraidTheme();
+
+        return (
+          <Toast
+            tone="neutral"
+            message="Neutral toast"
+            description="A really long description about toast stuff that is quite long and stuff"
+            action={{
+              label: 'Action',
+              onClick: () => {},
+            }}
+            treatTheme={treatTheme}
+            vanillaTheme={vanillaTheme}
+            onClose={() => {}}
+            id="n/a"
+            dedupeKey="n/a"
+            shouldRemove={false}
+          />
+        );
+      },
+    },
+    {
+      label: 'Neutral toast with icon',
+      Example: () => {
+        const treatTheme = useTheme();
+        const { vanillaTheme } = useBraidTheme();
+
+        return (
+          <Toast
+            tone="neutral"
+            icon={<IconBookmark />}
+            message="Neutral toast with icon"
+            treatTheme={treatTheme}
+            vanillaTheme={vanillaTheme}
+            onClose={() => {}}
+            id="n/a"
+            dedupeKey="n/a"
+            shouldRemove={false}
+          />
+        );
+      },
+    },
+    {
+      label: 'Neutral toast w/actions and icon',
+      Example: () => {
+        const treatTheme = useTheme();
+        const { vanillaTheme } = useBraidTheme();
+
+        return (
+          <Toast
+            tone="neutral"
+            icon={<IconBookmark />}
+            message="Neutral toast w/actions and icon"
+            action={{
+              label: 'Do the action',
+              onClick: () => {},
+            }}
+            treatTheme={treatTheme}
+            vanillaTheme={vanillaTheme}
+            onClose={() => {}}
+            id="n/a"
+            dedupeKey="n/a"
+            shouldRemove={false}
+          />
+        );
+      },
+    },
+    {
+      label: 'Neutral toast w/descriptions and icon',
+      Example: () => {
+        const treatTheme = useTheme();
+        const { vanillaTheme } = useBraidTheme();
+
+        return (
+          <Toast
+            tone="neutral"
+            icon={<IconBookmark />}
+            message="Neutral toast with icon"
             description="A really long description about toast stuff that is quite long and stuff"
             action={{
               label: 'Action',


### PR DESCRIPTION
Add support for `neutral` tone. When using a `neutral` tone, an icon may optionally be provided. For consistency, the tone of the icon is set to **secondary** and cannot be customised.

**EXAMPLE USAGE:**
```jsx
import { useToast } from "braid-design-system"
export default () => {
  const showToast = useToast();
  return (
    <Button
      onClick={() =>
        showToast({
          tone: "neutral",
          icon: <IconBookmark />,
          message: "Neutral with icon",
        })
      }
    >
      Show Toast
    </Button>
  );
}
```