### PR TITLE
site: Update a11y links to new W3 APG site

### DIFF
--- a/packages/braid-design-system/lib/components/Accordion/Accordion.docs.tsx
+++ b/packages/braid-design-system/lib/components/Accordion/Accordion.docs.tsx
@@ -35,7 +35,7 @@ const docs: ComponentDocs = {
   accessibility: (
     <Text>
       Follows the{' '}
-      <TextLink href="https://www.w3.org/TR/wai-aria-practices/#disclosure">
+      <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/">
         WAI-ARIA Disclosure Pattern.
       </TextLink>
     </Text>

--- a/packages/braid-design-system/lib/components/Alert/Alert.docs.tsx
+++ b/packages/braid-design-system/lib/components/Alert/Alert.docs.tsx
@@ -33,7 +33,7 @@ const docs: ComponentDocs = {
   accessibility: (
     <Text>
       Follows the{' '}
-      <TextLink href="https://www.w3.org/TR/wai-aria-practices/#alert">
+      <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/alert/">
         WAI-ARIA Alert Pattern
       </TextLink>
       , announcing messages with a{' '}

--- a/packages/braid-design-system/lib/components/ButtonIcon/ButtonIcon.docs.tsx
+++ b/packages/braid-design-system/lib/components/ButtonIcon/ButtonIcon.docs.tsx
@@ -39,7 +39,7 @@ const docs: ComponentDocs = {
     <>
       <Text>
         Follows the{' '}
-        <TextLink href="https://www.w3.org/TR/wai-aria-practices/#button">
+        <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/button/">
           WAI-ARIA Button Pattern
         </TextLink>
         .

--- a/packages/braid-design-system/lib/components/Checkbox/Checkbox.docs.tsx
+++ b/packages/braid-design-system/lib/components/Checkbox/Checkbox.docs.tsx
@@ -34,7 +34,7 @@ const docs: ComponentDocs = {
   accessibility: (
     <Text>
       Follows the{' '}
-      <TextLink href="https://www.w3.org/TR/wai-aria-practices/#checkbox">
+      <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/checkbox/">
         WAI-ARIA Checkbox Pattern
       </TextLink>
       , supporting both dual-state and tri-state specifications.

--- a/packages/braid-design-system/lib/components/Dialog/Dialog.docs.tsx
+++ b/packages/braid-design-system/lib/components/Dialog/Dialog.docs.tsx
@@ -41,7 +41,7 @@ const docs: ComponentDocs = {
     <>
       <Text>
         Follows the{' '}
-        <TextLink href="https://www.w3.org/TR/wai-aria-practices-1.2/#dialog_modal">
+        <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/">
           WAI-ARIA Dialog (Modal) Pattern.
         </TextLink>
       </Text>

--- a/packages/braid-design-system/lib/components/Disclosure/Disclosure.docs.tsx
+++ b/packages/braid-design-system/lib/components/Disclosure/Disclosure.docs.tsx
@@ -19,7 +19,7 @@ const docs: ComponentDocs = {
   accessibility: (
     <Text>
       Follows the{' '}
-      <TextLink href="https://www.w3.org/TR/wai-aria-practices/#disclosure">
+      <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/disclosure/">
         WAI-ARIA Disclosure Pattern.
       </TextLink>
     </Text>

--- a/packages/braid-design-system/lib/components/Drawer/Drawer.docs.tsx
+++ b/packages/braid-design-system/lib/components/Drawer/Drawer.docs.tsx
@@ -53,7 +53,7 @@ const docs: ComponentDocs = {
     <>
       <Text>
         Follows the{' '}
-        <TextLink href="https://www.w3.org/TR/wai-aria-practices-1.2/#dialog_modal">
+        <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/dialogmodal/">
           WAI-ARIA Dialog (Modal) Pattern.
         </TextLink>
       </Text>

--- a/packages/braid-design-system/lib/components/Loader/Loader.docs.tsx
+++ b/packages/braid-design-system/lib/components/Loader/Loader.docs.tsx
@@ -22,7 +22,7 @@ const docs: ComponentDocs = {
     <>
       <Text>
         Follows the{' '}
-        <TextLink href="https://www.w3.org/TR/wai-aria-practices/#alert">
+        <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/alert/">
           WAI-ARIA Alert Pattern
         </TextLink>
         , announcing its presence using an{' '}

--- a/packages/braid-design-system/lib/components/MenuItem/MenuItem.docs.tsx
+++ b/packages/braid-design-system/lib/components/MenuItem/MenuItem.docs.tsx
@@ -68,7 +68,7 @@ const docs: ComponentDocs = {
   accessibility: (
     <Text>
       Follows the{' '}
-      <TextLink href="https://www.w3.org/TR/wai-aria-practices-1.2/#menu">
+      <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/menu/">
         WAI-ARIA Menu Pattern.
       </TextLink>
     </Text>

--- a/packages/braid-design-system/lib/components/MenuItemCheckbox/MenuItemCheckbox.docs.tsx
+++ b/packages/braid-design-system/lib/components/MenuItemCheckbox/MenuItemCheckbox.docs.tsx
@@ -63,7 +63,7 @@ const docs: ComponentDocs = {
   accessibility: (
     <Text>
       Follows the{' '}
-      <TextLink href="https://www.w3.org/TR/wai-aria-practices-1.2/#menu">
+      <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/menu/">
         WAI-ARIA Menu Pattern.
       </TextLink>
     </Text>

--- a/packages/braid-design-system/lib/components/MenuItemDivider/MenuItemDivider.docs.tsx
+++ b/packages/braid-design-system/lib/components/MenuItemDivider/MenuItemDivider.docs.tsx
@@ -67,7 +67,7 @@ const docs: ComponentDocs = {
   accessibility: (
     <Text>
       Follows the{' '}
-      <TextLink href="https://www.w3.org/TR/wai-aria-practices-1.2/#menu">
+      <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/menu/">
         WAI-ARIA Menu Pattern.
       </TextLink>
     </Text>

--- a/packages/braid-design-system/lib/components/MenuRenderer/MenuRenderer.docs.tsx
+++ b/packages/braid-design-system/lib/components/MenuRenderer/MenuRenderer.docs.tsx
@@ -63,7 +63,7 @@ const docs: ComponentDocs = {
   accessibility: (
     <Text>
       Follows the{' '}
-      <TextLink href="https://www.w3.org/TR/wai-aria-practices-1.2/#menu">
+      <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/menu/">
         WAI-ARIA Menu Pattern.
       </TextLink>
     </Text>

--- a/packages/braid-design-system/lib/components/MenuRenderer/MenuRenderer.tsx
+++ b/packages/braid-design-system/lib/components/MenuRenderer/MenuRenderer.tsx
@@ -227,7 +227,7 @@ export const MenuRenderer = ({
     // first menu item is not highlighted automatically, but considering
     // space keyboard interactions are optional this is acceptable.
     //   See Firefox bug details: https://bugzilla.mozilla.org/show_bug.cgi?id=1220143
-    //   See WAI-ARIA keyboard iteractions: https://www.w3.org/TR/wai-aria-practices-1.2/#keyboard-interaction-12
+    //   See WAI-ARIA keyboard iteractions: https://www.w3.org/WAI/ARIA/apg/patterns/menu/#keyboard-interaction-12
     //
     // Firefox useragent check taken from the `bowser` package:
     // https://github.com/lancedikson/bowser/blob/ea8d9c54271d7b52fecd507ae8b1ba495842bc68/src/parser-browsers.js#L520

--- a/packages/braid-design-system/lib/components/Notice/Notice.docs.tsx
+++ b/packages/braid-design-system/lib/components/Notice/Notice.docs.tsx
@@ -29,7 +29,7 @@ const docs: ComponentDocs = {
     <>
       <Text>
         Follows the{' '}
-        <TextLink href="https://www.w3.org/TR/wai-aria-practices/#alert">
+        <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/alert/">
           WAI-ARIA Alert Pattern
         </TextLink>
         , announcing messages with a{' '}

--- a/packages/braid-design-system/lib/components/OverflowMenu/OverflowMenu.docs.tsx
+++ b/packages/braid-design-system/lib/components/OverflowMenu/OverflowMenu.docs.tsx
@@ -37,7 +37,7 @@ const docs: ComponentDocs = {
   accessibility: (
     <Text>
       Follows the{' '}
-      <TextLink href="https://www.w3.org/TR/wai-aria-practices-1.2/#menu">
+      <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/menu/">
         WAI-ARIA Menu Pattern.
       </TextLink>
     </Text>

--- a/packages/braid-design-system/lib/components/Pagination/Pagination.docs.tsx
+++ b/packages/braid-design-system/lib/components/Pagination/Pagination.docs.tsx
@@ -34,11 +34,11 @@ const docs: ComponentDocs = {
       <Text>
         Renders a semantic <Strong>nav</Strong> element to encapsulate the
         pagination links. Given this is a{' '}
-        <TextLink href="https://www.w3.org/TR/wai-aria-practices-1.2/#aria_landmark">
+        <TextLink href="https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/">
           Landmark Region
         </TextLink>
         , in order to comply with the{' '}
-        <TextLink href="https://www.w3.org/TR/wai-aria-practices-1.2/#general-principles-of-landmark-design">
+        <TextLink href="https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/#x4-2-general-principles-of-landmark-design">
           General Principles of Landmark Design
         </TextLink>{' '}
         it is neccessary for it to have an <Strong>aria-label</Strong>.

--- a/packages/braid-design-system/lib/components/RadioGroup/RadioGroup.docs.tsx
+++ b/packages/braid-design-system/lib/components/RadioGroup/RadioGroup.docs.tsx
@@ -42,7 +42,7 @@ const docs: ComponentDocs = {
   accessibility: (
     <Text>
       Follows the{' '}
-      <TextLink href="https://www.w3.org/TR/wai-aria-practices/#radiobutton">
+      <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/radiobutton/">
         WAI-ARIA Radio Group Pattern
       </TextLink>{' '}
       for radio groups not contained in a toolbar.

--- a/packages/braid-design-system/lib/components/Stepper/Stepper.docs.tsx
+++ b/packages/braid-design-system/lib/components/Stepper/Stepper.docs.tsx
@@ -35,11 +35,11 @@ const docs: ComponentDocs = {
       <Text>
         Renders a semantic <Strong>nav</Strong> element to encapsulate the step
         links. Given this is a{' '}
-        <TextLink href="https://www.w3.org/TR/wai-aria-practices-1.2/#aria_landmark">
+        <TextLink href="https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/">
           Landmark Region
         </TextLink>
         , in order to comply with the{' '}
-        <TextLink href="https://www.w3.org/TR/wai-aria-practices-1.2/#general-principles-of-landmark-design">
+        <TextLink href="https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/#x4-2-general-principles-of-landmark-design">
           General Principles of Landmark Design
         </TextLink>{' '}
         it is neccessary for it to have an <Strong>aria-label</Strong>.
@@ -51,7 +51,7 @@ const docs: ComponentDocs = {
       </Text>
       <Text>
         Implements the{' '}
-        <TextLink href="https://www.w3.org/TR/wai-aria-practices-1.2/#kbd_roving_tabindex">
+        <TextLink href="https://www.w3.org/WAI/ARIA/apg/practices/keyboard-interface/#x6-6-keyboard-navigation-inside-components">
           roving tabindex
         </TextLink>{' '}
         pattern when the steps are interactive (

--- a/packages/braid-design-system/lib/components/Tabs/Tabs.docs.tsx
+++ b/packages/braid-design-system/lib/components/Tabs/Tabs.docs.tsx
@@ -58,7 +58,7 @@ const docs: ComponentDocs = {
   accessibility: (
     <Text>
       Follows the{' '}
-      <TextLink href="https://www.w3.org/TR/wai-aria-practices/#tabpanel">
+      <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/tabpanel/">
         WAI ARIA Tabs Pattern.
       </TextLink>
     </Text>

--- a/packages/braid-design-system/lib/components/TextLinkButton/TextLinkButton.docs.tsx
+++ b/packages/braid-design-system/lib/components/TextLinkButton/TextLinkButton.docs.tsx
@@ -26,7 +26,7 @@ const docs: ComponentDocs = {
         Even though it looks like a{' '}
         <TextLink href="/components/TextLink">TextLink</TextLink>, this is
         actually a semantic button following the{' '}
-        <TextLink href="https://www.w3.org/TR/wai-aria-practices/#button">
+        <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/button/">
           WAI-ARIA Button Pattern.
         </TextLink>
       </Text>

--- a/packages/braid-design-system/lib/components/TooltipRenderer/TooltipRenderer.docs.tsx
+++ b/packages/braid-design-system/lib/components/TooltipRenderer/TooltipRenderer.docs.tsx
@@ -75,7 +75,7 @@ const docs: ComponentDocs = {
     <Stack space="large">
       <Text>
         Follows the{' '}
-        <TextLink href="https://www.w3.org/TR/wai-aria-practices/#tooltip">
+        <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/tooltip/">
           WAI-ARIA Tooltip Pattern.
         </TextLink>
       </Text>

--- a/packages/braid-design-system/lib/components/useToast/useToast.docs.tsx
+++ b/packages/braid-design-system/lib/components/useToast/useToast.docs.tsx
@@ -61,7 +61,7 @@ const docs: ComponentDocs = {
   accessibility: (
     <Text>
       Follows the{' '}
-      <TextLink href="https://www.w3.org/TR/wai-aria-practices/#alert">
+      <TextLink href="https://www.w3.org/WAI/ARIA/apg/patterns/alert/">
         WAI-ARIA Alert Pattern.
       </TextLink>
     </Text>


### PR DESCRIPTION
Since the W3C landed their new Accessibility Authoring Practices Guide (APG), the accessibility pattern links in the docs have been broken.

Updating to the new links which is a nicer experience too.

https://www.w3.org/WAI/ARIA/apg/patterns/