### PR TITLE
CI cleanup and potential fix

### DIFF
--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -12,14 +12,13 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: pnpm/action-setup@v2.2.2
-        with:
-          version: 7.8.0
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v2.2.2
 
       - name: Checkout Repo
         uses: actions/checkout@main
 
-      - name: Setup Node.js 16.x
+      - name: Set up Node.js 16.x
         uses: actions/setup-node@main
         with:
           node-version: 16.x

--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -12,11 +12,11 @@ jobs:
     env:
       CI: true
     steps:
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v2.2.2
-
       - name: Checkout Repo
         uses: actions/checkout@main
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v2.2.2
 
       - name: Set up Node.js 16.x
         uses: actions/setup-node@main

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,9 +12,8 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: pnpm/action-setup@v2.2.2
-        with:
-          version: 7.8.0
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v2.2.2
 
       - name: Checkout Repo
         uses: actions/checkout@main
@@ -23,7 +22,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
 
-      - name: Setup Node.js 16.x
+      - name: Set up Node.js 16.x
         uses: actions/setup-node@main
         with:
           node-version: 16.x
@@ -33,7 +32,7 @@ jobs:
         run: pnpm i
 
       - name: Create Release Pull Request or Publish to npm
-        uses: changesets/action@c2918239208f2162b9d27a87f491375c51592434
+        uses: changesets/action@v1
         with:
           version: pnpm run version
           publish: pnpm release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,15 +12,15 @@ jobs:
     env:
       CI: true
     steps:
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v2.2.2
-
       - name: Checkout Repo
         uses: actions/checkout@main
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
           token: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v2.2.2
 
       - name: Set up Node.js 16.x
         uses: actions/setup-node@main

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -9,9 +9,8 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: pnpm/action-setup@v2.2.2
-        with:
-          version: 7.8.0
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v2.2.2
 
       - name: Checkout Repo
         uses: actions/checkout@main
@@ -20,7 +19,7 @@ jobs:
           fetch-depth: 0
           token: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
 
-      - name: Setup Node.js 16.x
+      - name: Set up Node.js 16.x
         uses: actions/setup-node@main
         with:
           node-version: 16.x

--- a/.github/workflows/snapshot.yml
+++ b/.github/workflows/snapshot.yml
@@ -9,15 +9,15 @@ jobs:
     env:
       CI: true
     steps:
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v2.2.2
-
       - name: Checkout Repo
         uses: actions/checkout@main
         with:
           # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
           fetch-depth: 0
           token: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v2.2.2
 
       - name: Set up Node.js 16.x
         uses: actions/setup-node@main

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,9 +9,8 @@ jobs:
     env:
       CI: true
     steps:
-      - uses: pnpm/action-setup@v2.2.2
-        with:
-          version: 7.8.0
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v2.2.2
 
       - name: Checkout Repo
         uses: actions/checkout@main
@@ -19,7 +18,7 @@ jobs:
           # This makes Actions fetch all Git history so that chromatic can diff against previous commits
           fetch-depth: 0
 
-      - name: Setup Node.js 16.x
+      - name: Set up Node.js 16.x
         uses: actions/setup-node@main
         with:
           node-version: 16.x

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -9,14 +9,14 @@ jobs:
     env:
       CI: true
     steps:
-      - name: Set up pnpm
-        uses: pnpm/action-setup@v2.2.2
-
       - name: Checkout Repo
         uses: actions/checkout@main
         with:
           # This makes Actions fetch all Git history so that chromatic can diff against previous commits
           fetch-depth: 0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v2.2.2
 
       - name: Set up Node.js 16.x
         uses: actions/setup-node@main

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "post-commit-status": "node scripts/postCommitStatus.js",
     "release": "pnpm prepare-publish && changeset publish && pnpm build-site && pnpm run deploy",
     "prepare-publish": "nx run braid-design-system:build",
-    "version": "changeset version && ts-node scripts/versionComponentUpdates",
+    "version": "changeset version && ts-node scripts/versionComponentUpdates && pnpm install --lockfile-only",
     "changeset": "EDITOR=scripts/writeBraidFrontMatter.js ./node_modules/.bin/changeset add --open"
   },
   "repository": {


### PR DESCRIPTION
`pnpm/action-setup` can read the `packageManager` field in `package.json` now, so we don't need an explicit version in the github actions workflows.

There's also an issue in [this renovate PR's](https://github.com/seek-oss/braid-design-system/pull/1147) build where [the lockfile is out of date](https://github.com/seek-oss/braid-design-system/runs/8108055773?check_suite_focus=true#step:5:10). I'm not exactly sure if adding `pnpm install --lockfile-only` to the `version` script will fix it, but it's likely worth doing anyway.