### PR TITLE
TextLink: Improve screenshot tests

### DIFF
--- a/packages/braid-design-system/lib/components/TextLink/TextLink.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/TextLink/TextLink.screenshots.tsx
@@ -3,22 +3,53 @@ import { ComponentScreenshot } from '../../../../../site/src/types';
 import {
   Heading,
   IconNewWindow,
-  IconChevron,
   Text,
   TextLink,
   Columns,
   Column,
+  Stack,
+  Strong,
 } from '../';
 // TODO: COLORMODE RELEASE
 // Use public import
 import { Box } from '../Box/Box';
 import { backgrounds } from '../../utils/docsHelpers';
+import { IconHome } from '../icons';
+import { heading, tone, text } from '../../hooks/typography/typography.css';
+
+const textSizes = [
+  undefined, // test default case
+  ...(Object.keys(text) as Array<keyof typeof text>),
+];
+const textTones = [
+  undefined, // test default case
+  ...(Object.keys(tone) as Array<keyof typeof tone>),
+];
+const headingLevels = Object.keys(heading) as Array<keyof typeof heading>;
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [768],
   examples: [
     {
-      label: 'Regular TextLink',
+      label: 'weight: regular',
+      Example: () => (
+        <Text>
+          <TextLink href="#">TextLink</TextLink>
+        </Text>
+      ),
+    },
+    {
+      label: 'weight: weak',
+      Example: () => (
+        <Text>
+          <TextLink href="#" weight="weak">
+            TextLink
+          </TextLink>
+        </Text>
+      ),
+    },
+    {
+      label: 'hitArea: large',
       Example: () => (
         <Text>
           <TextLink href="#" hitArea="large">
@@ -28,114 +59,167 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Regular TextLink in a sentence',
+      label: 'showVisited',
       Example: () => (
         <Text>
-          This sentence contains a <TextLink href="#">TextLink.</TextLink>
-        </Text>
-      ),
-    },
-    {
-      label: 'Weak TextLink in a sentence',
-      Example: () => (
-        <Text>
-          This sentence contains a{' '}
-          <TextLink href="#" weight="weak">
-            weak TextLink
-          </TextLink>
-          .
-        </Text>
-      ),
-    },
-    {
-      label: 'TextLink in secondary text',
-      Example: () => (
-        <Text tone="secondary">
-          This sentence contains a <TextLink href="#">TextLink.</TextLink>
-        </Text>
-      ),
-    },
-    {
-      label: 'Visited TextLink',
-      Example: () => (
-        <Text>
-          This sentence contains a{' '}
+          This is a{' '}
           <TextLink href="" showVisited>
-            visited TextLink.
-          </TextLink>
-        </Text>
-      ),
-    },
-    {
-      label: 'TextLink on dark background',
-      background: 'brand',
-      Example: () => (
-        <Text>
-          This sentence contains a <TextLink href="#">TextLink.</TextLink>
-        </Text>
-      ),
-    },
-    {
-      label: 'TextLink inside large Text',
-      Example: () => (
-        <Text size="large">
-          This sentence contains a <TextLink href="#">TextLink.</TextLink>
-        </Text>
-      ),
-    },
-    {
-      label: 'TextLink inside Heading',
-      Example: () => (
-        <Heading level="3">
-          This heading contains a <TextLink href="#">TextLink.</TextLink>
-        </Heading>
-      ),
-    },
-    {
-      label: 'TextLink inside weak Heading',
-      Example: () => (
-        <Heading level="3" weight="weak">
-          This heading contains a <TextLink href="#">TextLink.</TextLink>
-        </Heading>
-      ),
-    },
-    {
-      label: 'Weak TextLink inside Heading',
-      Example: () => (
-        <Heading level="3">
-          This heading contains a{' '}
-          <TextLink href="#" weight="weak">
-            weak TextLink.
-          </TextLink>
-        </Heading>
-      ),
-    },
-    {
-      label: 'Weak TextLink inside weak Heading',
-      Example: () => (
-        <Heading level="3" weight="weak">
-          This heading contains a{' '}
-          <TextLink href="#" weight="weak">
-            weak TextLink.
-          </TextLink>
-        </Heading>
-      ),
-    },
-    {
-      label: 'TextLink with icon',
-      Example: () => (
-        <Text>
-          This sentence contains a{' '}
-          <TextLink href="#">
-            TextLink
-            <IconChevron direction="right" />
+            visited TextLink
           </TextLink>
           .
         </Text>
       ),
     },
     {
-      label: 'TextLink Contrast',
+      label: 'Regular weight inside available text sizes',
+      Example: () => (
+        <Stack space="small">
+          {textSizes.map((size) => (
+            <Text size={size} key={size}>
+              A <TextLink href="#">“regular” TextLink</TextLink> inside{' '}
+              <Strong>
+                “{size === undefined ? 'undefined' : size}” size Text
+              </Strong>
+            </Text>
+          ))}
+        </Stack>
+      ),
+    },
+    {
+      label: 'Weak weight inside available text sizes',
+      Example: () => (
+        <Stack space="small">
+          {textSizes.map((size) => (
+            <Text size={size} key={size}>
+              A{' '}
+              <TextLink href="#" weight="weak">
+                “weak” TextLink
+              </TextLink>{' '}
+              inside{' '}
+              <Strong>
+                “{size === undefined ? 'undefined' : size}” size Text
+              </Strong>
+            </Text>
+          ))}
+        </Stack>
+      ),
+    },
+    {
+      label: 'Regular weight inside available text tones',
+      Example: () => (
+        <Stack space="small">
+          {textTones.map((t) => (
+            <Text tone={t} key={t}>
+              This is a <TextLink href="#">“regular” TextLink</TextLink> inside{' '}
+              <Strong>“{t || 'undefined'}” tone Text</Strong>
+            </Text>
+          ))}
+        </Stack>
+      ),
+    },
+    {
+      label: 'Weak weight inside available text tones',
+      Example: () => (
+        <Stack space="small">
+          {textTones.map((t) => (
+            <Text tone={t} key={t}>
+              This is a{' '}
+              <TextLink href="#" weight="weak">
+                “weak” TextLink
+              </TextLink>{' '}
+              inside <Strong>“{t || 'undefined'}” tone Text</Strong>
+            </Text>
+          ))}
+        </Stack>
+      ),
+    },
+    {
+      label: 'Regular weight inside available heading levels',
+      Example: () => (
+        <Stack space="medium">
+          {headingLevels.map((level) => (
+            <Heading level={level} key={level}>
+              A <TextLink href="#">“regular” TextLink</TextLink> inside{' '}
+              <Strong>level “{level}”</Strong>
+            </Heading>
+          ))}
+        </Stack>
+      ),
+    },
+    {
+      label: 'Weak weight inside available heading levels',
+      Example: () => (
+        <Stack space="medium">
+          {headingLevels.map((level) => (
+            <Heading level={level} key={level}>
+              A{' '}
+              <TextLink href="#" weight="weak">
+                “weak” TextLink
+              </TextLink>{' '}
+              inside <Strong>level “{level}”</Strong>
+            </Heading>
+          ))}
+        </Stack>
+      ),
+    },
+    {
+      label: 'Icons inherit regular link colour',
+      Example: () => (
+        <Stack space="small">
+          <Text>
+            This icon matches the link colour:{' '}
+            <TextLink href="#">
+              TextLink <IconHome />
+            </TextLink>
+            .
+          </Text>
+          <Text tone="secondary">
+            This icon matches the link colour:{' '}
+            <TextLink href="#">
+              TextLink <IconHome />
+            </TextLink>
+            .
+          </Text>
+          <Text tone="critical">
+            This icon matches the link colour:{' '}
+            <TextLink href="#">
+              TextLink <IconHome />
+            </TextLink>
+            .
+          </Text>
+        </Stack>
+      ),
+    },
+    {
+      label: 'Icons inherit weak link colour',
+      Example: () => (
+        <Stack space="small">
+          <Text>
+            This icon matches the link colour:{' '}
+            <TextLink href="#" weight="weak">
+              TextLink <IconHome />
+            </TextLink>
+            .
+          </Text>
+          <Text tone="secondary">
+            This icon matches the link colour:{' '}
+            <TextLink href="#" weight="weak">
+              TextLink <IconHome />
+            </TextLink>
+            .
+          </Text>
+          <Text tone="critical">
+            This icon matches the link colour:{' '}
+            <TextLink href="#" weight="weak">
+              TextLink <IconHome />
+            </TextLink>
+            .
+          </Text>
+        </Stack>
+      ),
+    },
+    {
+      label: 'Text Contrast',
       Example: () => (
         <Fragment>
           {backgrounds.map((background, i) => (
@@ -164,6 +248,43 @@ export const screenshots: ComponentScreenshot = {
                       Weak <IconNewWindow />
                     </TextLink>
                   </Text>
+                </Column>
+              </Columns>
+            </Box>
+          ))}
+        </Fragment>
+      ),
+    },
+    {
+      label: 'Heading Contrast',
+      Example: () => (
+        <Fragment>
+          {backgrounds.map((background, i) => (
+            <Box key={i} background={background} padding="small">
+              <Columns space="xlarge">
+                <Column>
+                  <Heading level="4">{background}</Heading>
+                </Column>
+                <Column width="content">
+                  <Heading level="4">
+                    <TextLink href="#">
+                      Default <IconNewWindow />
+                    </TextLink>
+                  </Heading>
+                </Column>
+                <Column width="content">
+                  <Heading level="4">
+                    <TextLink href="#" weight="regular">
+                      Regular <IconNewWindow />
+                    </TextLink>
+                  </Heading>
+                </Column>
+                <Column>
+                  <Heading level="4">
+                    <TextLink href="#" weight="weak">
+                      Weak <IconNewWindow />
+                    </TextLink>
+                  </Heading>
                 </Column>
               </Columns>
             </Box>

--- a/packages/braid-design-system/lib/components/TextLink/TextLink.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/TextLink/TextLink.screenshots.tsx
@@ -77,9 +77,7 @@ export const screenshots: ComponentScreenshot = {
           {textSizes.map((size) => (
             <Text size={size} key={size}>
               A <TextLink href="#">“regular” TextLink</TextLink> inside{' '}
-              <Strong>
-                “{size === undefined ? 'undefined' : size}” size Text
-              </Strong>
+              <Strong>“{size || 'default'}”</Strong> Text
             </Text>
           ))}
         </Stack>
@@ -95,10 +93,7 @@ export const screenshots: ComponentScreenshot = {
               <TextLink href="#" weight="weak">
                 “weak” TextLink
               </TextLink>{' '}
-              inside{' '}
-              <Strong>
-                “{size === undefined ? 'undefined' : size}” size Text
-              </Strong>
+              inside <Strong>“{size || 'default'}”</Strong> Text
             </Text>
           ))}
         </Stack>
@@ -111,7 +106,7 @@ export const screenshots: ComponentScreenshot = {
           {textTones.map((t) => (
             <Text tone={t} key={t}>
               This is a <TextLink href="#">“regular” TextLink</TextLink> inside{' '}
-              <Strong>“{t || 'undefined'}” tone Text</Strong>
+              <Strong>“{t || 'default'}”</Strong> tone Text
             </Text>
           ))}
         </Stack>
@@ -127,7 +122,7 @@ export const screenshots: ComponentScreenshot = {
               <TextLink href="#" weight="weak">
                 “weak” TextLink
               </TextLink>{' '}
-              inside <Strong>“{t || 'undefined'}” tone Text</Strong>
+              inside <Strong>“{t || 'default'}”</Strong> tone Text
             </Text>
           ))}
         </Stack>
@@ -139,8 +134,8 @@ export const screenshots: ComponentScreenshot = {
         <Stack space="medium">
           {headingLevels.map((level) => (
             <Heading level={level} key={level}>
-              A <TextLink href="#">“regular” TextLink</TextLink> inside{' '}
-              <Strong>level “{level}”</Strong>
+              A <TextLink href="#">“regular” TextLink</TextLink> inside level “
+              {level}”
             </Heading>
           ))}
         </Stack>
@@ -156,7 +151,7 @@ export const screenshots: ComponentScreenshot = {
               <TextLink href="#" weight="weak">
                 “weak” TextLink
               </TextLink>{' '}
-              inside <Strong>level “{level}”</Strong>
+              inside level “{level}”
             </Heading>
           ))}
         </Stack>
@@ -171,21 +166,18 @@ export const screenshots: ComponentScreenshot = {
             <TextLink href="#">
               TextLink <IconHome />
             </TextLink>
-            .
           </Text>
           <Text tone="secondary">
             This icon matches the link colour:{' '}
             <TextLink href="#">
               TextLink <IconHome />
             </TextLink>
-            .
           </Text>
           <Text tone="critical">
             This icon matches the link colour:{' '}
             <TextLink href="#">
               TextLink <IconHome />
             </TextLink>
-            .
           </Text>
         </Stack>
       ),
@@ -199,21 +191,18 @@ export const screenshots: ComponentScreenshot = {
             <TextLink href="#" weight="weak">
               TextLink <IconHome />
             </TextLink>
-            .
           </Text>
           <Text tone="secondary">
             This icon matches the link colour:{' '}
             <TextLink href="#" weight="weak">
               TextLink <IconHome />
             </TextLink>
-            .
           </Text>
           <Text tone="critical">
             This icon matches the link colour:{' '}
             <TextLink href="#" weight="weak">
               TextLink <IconHome />
             </TextLink>
-            .
           </Text>
         </Stack>
       ),

--- a/packages/braid-design-system/package.json
+++ b/packages/braid-design-system/package.json
@@ -16,7 +16,7 @@
   ],
   "scripts": {
     "chromatic": "chromatic --storybook-build-dir ./dist-storybook --exit-zero-on-changes --auto-accept-changes master",
-    "eslint": "eslint --debug --ignore-path ../../.eslintignore .",
+    "eslint": "eslint --ignore-path ../../.eslintignore .",
     "format": "eslint --ignore-path ../../.eslintignore --fix . && prettier --ignore-path ../.prettierignore --write .",
     "prettier": "prettier --ignore-path ../../.prettierignore --list-different .",
     "storybook": "SKU_TELEMETRY=false sku storybook",


### PR DESCRIPTION
Improving the visual testing of `TextLink` in advance of some clean ups. This will ensure no regressions slip through, but we really should have had these ages ago given their styling complexity.

The existing tests were a hangover from the shared docs and testing responsibilities, now the concerns are separate we can be more exhaustive.