### PR TITLE
Normalize public component imports in `screenshots` files

### DIFF
--- a/packages/braid-design-system/lib/components/Accordion/Accordion.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/Accordion/Accordion.screenshots.tsx
@@ -1,15 +1,8 @@
 import React, { useState } from 'react';
 import { ComponentScreenshot } from '../../../../../site/src/types';
-import {
-  AccordionItem,
-  Accordion,
-  Badge,
-  Text,
-  IconPromote,
-} from '../../components';
+import { AccordionItem, Accordion, Badge, Text, IconPromote, Stack } from '../';
 import { Placeholder } from '../../playroom/components';
 import { Box } from '../Box/Box';
-import { Stack } from '../Stack/Stack';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],

--- a/packages/braid-design-system/lib/components/Actions/Actions.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/Actions/Actions.screenshots.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { ComponentScreenshot } from '../../../../../site/src/types';
-import { Button } from '../../components';
-import { Actions } from './Actions';
+import { Button, Actions } from '../';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320, 768],

--- a/packages/braid-design-system/lib/components/Box/BoxRenderer.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/Box/BoxRenderer.screenshots.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ComponentScreenshot } from '../../../../../site/src/types';
 import { BoxRenderer } from './BoxRenderer';
-import { Text } from '../Text/Text';
+import { Text } from '../';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],

--- a/packages/braid-design-system/lib/components/Button/Button.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/Button/Button.screenshots.tsx
@@ -1,11 +1,9 @@
 import React, { Fragment } from 'react';
 import { ComponentScreenshot } from '../../../../../site/src/types';
-import { Button, IconSend, Stack } from '../';
+import { Button, IconSend, Stack, Inline, Heading } from '../';
 // TODO: COLORMODE RELEASE
 // Use public import
 import { Box } from '../Box/Box';
-import { Inline } from '../Inline/Inline';
-import { Heading } from '../Heading/Heading';
 import { backgrounds } from '../../utils/docsHelpers';
 
 export const screenshots: ComponentScreenshot = {

--- a/packages/braid-design-system/lib/components/ButtonLink/ButtonLink.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/ButtonLink/ButtonLink.screenshots.tsx
@@ -1,7 +1,6 @@
 import React, { ReactNode } from 'react';
 import { ComponentScreenshot } from '../../../../../site/src/types';
-import { ButtonLink, IconSend, Stack } from '../';
-import { Inline } from '../Inline/Inline';
+import { ButtonLink, IconSend, Stack, Inline } from '../';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>

--- a/packages/braid-design-system/lib/components/Disclosure/Disclosure.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/Disclosure/Disclosure.screenshots.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { ComponentScreenshot } from '../../../../../site/src/types';
-import { Disclosure, Text } from '..';
+import { Disclosure, Text } from '../';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],

--- a/packages/braid-design-system/lib/components/Hidden/Hidden.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/Hidden/Hidden.screenshots.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { ComponentScreenshot } from '../../../../../site/src/types';
-import { Hidden } from './Hidden';
-import { Text } from '../Text/Text';
+import { Hidden, Text } from '../';
 import { Box } from '../Box/Box';
 
 export const screenshots: ComponentScreenshot = {

--- a/packages/braid-design-system/lib/components/HiddenVisually/HiddenVisually.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/HiddenVisually/HiddenVisually.screenshots.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import { ComponentScreenshot } from '../../../../../site/src/types';
-import { HiddenVisually } from './HiddenVisually';
-import { Text } from '../Text/Text';
+import { Text, HiddenVisually } from '../';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],

--- a/packages/braid-design-system/lib/components/List/List.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/List/List.screenshots.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ComponentScreenshot } from '../../../../../site/src/types';
-import { List, Text, Stack } from '..';
-import { IconTick, Placeholder } from '../../playroom/components';
+import { List, Text, Stack, IconTick } from '../';
+import { Placeholder } from '../../playroom/components';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],

--- a/packages/braid-design-system/lib/components/MenuItem/MenuItem.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/MenuItem/MenuItem.screenshots.tsx
@@ -1,8 +1,15 @@
 import React from 'react';
 import { ComponentScreenshot } from '../../../../../site/src/types';
-import { Badge, Box, MenuItem, MenuItemLink } from '../';
+import {
+  Badge,
+  Box,
+  MenuItem,
+  MenuItemLink,
+  IconBookmark,
+  IconStar,
+  IconThumb,
+} from '../';
 import { Menu } from '../MenuRenderer/MenuRenderer';
-import { IconBookmark, IconStar, IconThumb } from '../icons';
 
 const defaultProps = {
   offsetSpace: 'none',

--- a/packages/braid-design-system/lib/components/MenuRenderer/MenuRenderer.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/MenuRenderer/MenuRenderer.screenshots.tsx
@@ -7,10 +7,11 @@ import {
   MenuItemLink,
   MenuItemDivider,
   MenuItemCheckbox,
+  IconBookmark,
+  IconProfile,
 } from '../';
 import { Placeholder } from '../private/Placeholder/Placeholder';
 import { Menu } from './MenuRenderer';
-import { IconBookmark, IconProfile } from '../icons';
 import { vars } from '../../../css';
 import { calc } from '@vanilla-extract/css-utils';
 

--- a/packages/braid-design-system/lib/components/RadioGroup/RadioGroup.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/RadioGroup/RadioGroup.screenshots.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 import { ComponentScreenshot } from '../../../../../site/src/types';
-import { RadioGroup, RadioItem } from '..';
+import { RadioGroup, RadioItem } from '../';
 import { Placeholder } from '../../playroom/components';
 
 export const screenshots: ComponentScreenshot = {

--- a/packages/braid-design-system/lib/components/Tabs/Tabs.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/Tabs/Tabs.screenshots.tsx
@@ -9,7 +9,7 @@ import {
   TabsProvider,
   Badge,
   IconHome,
-} from '..';
+} from '../';
 import { Placeholder } from '../../playroom/components';
 
 export const screenshots: ComponentScreenshot = {

--- a/packages/braid-design-system/lib/components/TextDropdown/TextDropdown.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/TextDropdown/TextDropdown.screenshots.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode, useState } from 'react';
 import { ComponentScreenshot } from '../../../../../site/src/types';
-import { Heading, Strong, Text, TextDropdown } from '..';
+import { Heading, Strong, Text, TextDropdown } from '../';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>

--- a/packages/braid-design-system/lib/components/TextLinkButton/TextLinkButton.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/TextLinkButton/TextLinkButton.screenshots.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { ComponentScreenshot } from '../../../../../site/src/types';
-import { Text, TextLinkButton } from '..';
+import { Text, TextLinkButton } from '../';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],

--- a/packages/braid-design-system/lib/components/TooltipRenderer/TooltipRenderer.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/TooltipRenderer/TooltipRenderer.screenshots.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { ComponentScreenshot } from '../../../../../site/src/types';
-import { Stack, Text, Box } from '../';
-import { TooltipRenderer, StaticTooltipProvider } from './TooltipRenderer';
+import { Stack, Text, Box, TooltipRenderer } from '../';
+import { StaticTooltipProvider } from './TooltipRenderer';
 
 const triggerStyles = { width: 50, height: 20, background: 'pink' } as const;
 

--- a/packages/braid-design-system/lib/components/useToast/useToast.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/useToast/useToast.screenshots.tsx
@@ -3,7 +3,7 @@ import { useTheme } from 'sku/react-treat';
 import { useBraidTheme } from '../BraidProvider/BraidThemeContext';
 import { ComponentScreenshot } from '../../../../../site/src/types';
 import Toast from './Toast';
-import { IconBookmark } from '..';
+import { IconBookmark } from '../';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320, 768],


### PR DESCRIPTION
Most `.screenshots.tsx` files import components from `../` which resolves to the top-level braid entrypoint, however a few were importing components from other places, as well as using `playroom` variants of components despite there being no need to do so in these files.

This PR normalizes all public component imports to import from `../` in order to make any future changes (e.g. using a `@braid-src` alias) a super simple find and replace. We may not use the public import going forward, but the point of this PR is to just make things consistent so we can change it easily in the future.