### PR TITLE
Fix prop typo

### DIFF
--- a/packages/braid-design-system/lib/components/Card/Card.docs.tsx
+++ b/packages/braid-design-system/lib/components/Card/Card.docs.tsx
@@ -63,7 +63,7 @@ const docs: ComponentDocs = {
           </Text>
           <Text>
             Alternatively, rounding may be applied responsively using the{' '}
-            <Strong>roundAbove</Strong> prop, and providing either{' '}
+            <Strong>roundedAbove</Strong> prop, and providing either{' '}
             <Strong>mobile</Strong>, <Strong>tablet</Strong> or{' '}
             <Strong>desktop</Strong>. This enables card edges to be softened on
             larger screens, but squared off if it runs full bleed on smaller


### PR DESCRIPTION
`roundedAbove` had its tenses wrong