### PR TITLE
Button, ButtonLink: Improve icon alignment

### DIFF
--- a/.changeset/blue-planes-draw.md
+++ b/.changeset/blue-planes-draw.md
@@ -1,0 +1,27 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Button
+  - ButtonLink
+---
+
+**Button, ButtonLink:** Improve alignment of transparent buttons with icons against Text with icons
+
+To improve optical balance of a `Button` with an `icon`, the icon container is bled to the left to balance against the larger horizontal inset of a `standard` button.
+This alignment correction is now only applied on `standard` sized buttons that are not using the `transparent` variant.
+
+Isolating this alignment correction enables transparent buttons to better align with other components with `icon` slots, for example:
+
+```jsx
+<Stack space="small">
+  <Text icon={<IconSend />}>Text</Text>
+  <Button icon={<IconSend />} variant="transparent" bleed>
+    Button
+  </Button>
+</Stack>
+```
+
+Icons and text will now be perfectly aligned between Button components and others icon slots with the same text size.

--- a/packages/braid-design-system/lib/components/Button/Button.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/Button/Button.screenshots.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { ComponentScreenshot } from '../../../../../site/src/types';
-import { Button, IconSend, Stack, Inline, Heading } from '../';
+import { Button, IconSend, Stack, Inline, Heading, Text } from '../';
 // TODO: COLORMODE RELEASE
 // Use public import
 import { Box } from '../Box/Box';
@@ -178,6 +178,41 @@ export const screenshots: ComponentScreenshot = {
             </Button>
             <Button size="small" icon={<IconSend />} variant="transparent">
               Transparent
+            </Button>
+          </Inline>
+        </Stack>
+      ),
+    },
+    {
+      label:
+        'With icon, transparent variant and bleed, it should align with Text',
+      Example: () => (
+        <Stack space="small">
+          <Text icon={<IconSend />}>Text</Text>
+          <Inline space="none">
+            <Button icon={<IconSend />} variant="transparent" bleed>
+              Button
+            </Button>
+          </Inline>
+        </Stack>
+      ),
+    },
+    {
+      label:
+        'With icon, transparent variant, bleed and size small, it should align with Text',
+      Example: () => (
+        <Stack space="small">
+          <Text icon={<IconSend />} size="small">
+            Text
+          </Text>
+          <Inline space="none">
+            <Button
+              icon={<IconSend />}
+              size="small"
+              variant="transparent"
+              bleed
+            >
+              Button
             </Button>
           </Inline>
         </Stack>

--- a/packages/braid-design-system/lib/components/Button/Button.tsx
+++ b/packages/braid-design-system/lib/components/Button/Button.tsx
@@ -308,6 +308,7 @@ export const ButtonText = ({
   variant = 'solid',
   tone,
   labelSpacing = true,
+  bleed,
 }: ButtonProps & {
   labelSpacing?: boolean;
 }) => {
@@ -315,10 +316,8 @@ export const ButtonText = ({
   const actionsContext = useContext(ActionsContext);
   const size = sizeProp ?? actionsContext?.size ?? 'standard';
   const stylesForVariant = variants[variant][tone ?? 'default'];
-  const labelPaddingX =
-    size === 'small' || variant === 'transparent'
-      ? transparentPaddingX
-      : 'medium';
+  const shouldReducePaddingX = size === 'small' || variant === 'transparent';
+  const labelPaddingX = shouldReducePaddingX ? transparentPaddingX : 'medium';
 
   assert(
     !icon || (icon.props.size === undefined && icon.props.tone === undefined),
@@ -364,7 +363,11 @@ export const ButtonText = ({
           <Box
             component="span"
             paddingRight="xsmall"
-            className={negativeMargin('left', 'xxsmall')}
+            className={
+              shouldReducePaddingX || bleed
+                ? null
+                : negativeMargin('left', 'xxsmall')
+            }
           >
             {icon}
           </Box>
@@ -511,6 +514,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
             size={size}
             loading={loading}
             icon={icon}
+            bleed={bleed}
           >
             {children}
           </ButtonText>

--- a/packages/braid-design-system/lib/components/ButtonLink/ButtonLink.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/ButtonLink/ButtonLink.screenshots.tsx
@@ -1,6 +1,6 @@
 import React, { ReactNode } from 'react';
 import { ComponentScreenshot } from '../../../../../site/src/types';
-import { ButtonLink, IconSend, Stack, Inline } from '../';
+import { ButtonLink, IconSend, Stack, Inline, Text } from '../';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -112,6 +112,47 @@ export const screenshots: ComponentScreenshot = {
               variant="transparent"
             >
               Transparent
+            </ButtonLink>
+          </Inline>
+        </Stack>
+      ),
+    },
+    {
+      label:
+        'With icon, transparent variant and bleed, it should align with Text',
+      Example: () => (
+        <Stack space="small">
+          <Text icon={<IconSend />}>Text</Text>
+          <Inline space="none">
+            <ButtonLink
+              href="#"
+              icon={<IconSend />}
+              variant="transparent"
+              bleed
+            >
+              ButtonLink
+            </ButtonLink>
+          </Inline>
+        </Stack>
+      ),
+    },
+    {
+      label:
+        'With icon, transparent variant, bleed and size small, it should align with Text',
+      Example: () => (
+        <Stack space="small">
+          <Text icon={<IconSend />} size="small">
+            Text
+          </Text>
+          <Inline space="none">
+            <ButtonLink
+              href="#"
+              icon={<IconSend />}
+              size="small"
+              variant="transparent"
+              bleed
+            >
+              ButtonLink
             </ButtonLink>
           </Inline>
         </Stack>

--- a/packages/braid-design-system/lib/components/ButtonLink/ButtonLink.tsx
+++ b/packages/braid-design-system/lib/components/ButtonLink/ButtonLink.tsx
@@ -84,6 +84,7 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
             size={size}
             loading={loading}
             icon={icon}
+            bleed={bleed}
           >
             {children}
           </ButtonText>


### PR DESCRIPTION
To improve optical balance of a `Button` with an `icon`, the icon container is bled to the left to balance against the larger horizontal inset of a `standard` button.
This alignment correction is now only applied on `standard` sized buttons that are not using the `transparent` variant.

Isolating this alignment correction enables transparent buttons to better align with other components with `icon` slots, for example:

```jsx
<Stack space="small">
  <Text icon={<IconSend />}>Text</Text>
  <Button icon={<IconSend />} variant="transparent" bleed>
    Button
  </Button>
</Stack>
```

Icons and text will now be perfectly aligned between Button components and others icon slots with the same text size.