### PR TITLE
Rating: Only fill star for scores .75 and above

### DIFF
--- a/.changeset/beige-papayas-invent.md
+++ b/.changeset/beige-papayas-invent.md
@@ -1,0 +1,19 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Rating
+---
+
+**Rating:** Only fill star for scores .75 and above
+
+A star is only `filled` when the score is .75 and above. Fixes an issue where all scores .5 or above are shown as half filled stars.
+
+**EXAMPLE USAGE:**
+Now when a rating reaches .75 it will round up to a full star.
+
+```jsx
+<Rating rating={3.75} /> // 4 filled
+```

--- a/packages/braid-design-system/lib/components/Rating/Rating.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/Rating/Rating.screenshots.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import { ComponentScreenshot } from 'site/types';
-import { Rating } from '../';
+import { Rating, Stack, Text } from '../';
 // TODO: COLORMODE RELEASE
 // Use public import
 import { Box } from '../Box/Box';
@@ -32,6 +32,24 @@ export const screenshots: ComponentScreenshot = {
     {
       label: 'xsmall',
       Example: () => <Rating rating={1.5} size="xsmall" />,
+    },
+    {
+      label: 'Fill test',
+      Example: () => (
+        <Stack space="medium">
+          <Text>Empty</Text>
+          <Rating rating={0} />
+          <Rating rating={0.01} />
+          <Rating rating={0.24} />
+          <Text>Half</Text>
+          <Rating rating={0.25} />
+          <Rating rating={0.74} />
+          <Text>Full</Text>
+          <Rating rating={0.75} />
+          <Rating rating={0.99} />
+          <Rating rating={1} />
+        </Stack>
+      ),
     },
     {
       label: 'Rating Contrast',

--- a/packages/braid-design-system/lib/components/Rating/Rating.tsx
+++ b/packages/braid-design-system/lib/components/Rating/Rating.tsx
@@ -26,7 +26,7 @@ const RatingStar = ({ percent, ...restProps }: RatingStar) => {
     component = IconStarHalfSvg;
   }
 
-  if (percent > 50) {
+  if (percent >= 75) {
     component = IconStarFullSvg;
   }
 


### PR DESCRIPTION
A star is only `filled` when the score is .75 and above. Fixes an issue where all scores .5 or above are shown as half filled stars.

**EXAMPLE USAGE:**
Now when a rating reaches .75 it will round up to a full star.

```jsx
<Rating rating={3.75} /> // 4 filled
```