### PR TITLE
ButtonLink: Allow native data attributes with anchor api

### DIFF
--- a/.changeset/many-coats-repair.md
+++ b/.changeset/many-coats-repair.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - ButtonLink
+---
+
+**ButtonLink:** Allow native data attributes with anchor api
+
+Disables the validation against the use of data attributes on `ButtonLink`. Given it exposes the full native anchor tag api, it is **not invalid** to use the native syntax.

--- a/packages/braid-design-system/lib/components/ButtonLink/ButtonLink.tsx
+++ b/packages/braid-design-system/lib/components/ButtonLink/ButtonLink.tsx
@@ -67,7 +67,7 @@ export const ButtonLink = forwardRef<HTMLAnchorElement, ButtonLinkProps>(
           component={LinkComponent}
           ref={ref}
           {...restProps}
-          {...buildDataAttributes({ data, validateRestProps: restProps })}
+          {...buildDataAttributes({ data, validateRestProps: false })}
           {...useButtonStyles({
             variant,
             tone,


### PR DESCRIPTION
Disables the validation against the use of data attributes on `ButtonLink`. Given it exposes the full native anchor tag api, it is **not invalid** to use the native syntax.