### PR TITLE
Tab, Tabs: Updated visual design

### DIFF
--- a/.changeset/honest-hairs-wave.md
+++ b/.changeset/honest-hairs-wave.md
@@ -1,0 +1,17 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Tab
+  - Tabs
+---
+
+**Tab, Tabs:** Updated visual design
+
+The appearance of a `Tab` has been updated. Changes include:
+- Tab button use `regular` text weight
+- Hover state of inactive tab toggles `neutral` tone instead of underline
+- Active tab indicator underlines content only, without the horizontal gutter and animates between tabs
+- The `minimal` divider under `Tabs` underlines content only, without the horizontal gutter

--- a/packages/braid-design-system/lib/components/Tabs/TabListContext.ts
+++ b/packages/braid-design-system/lib/components/Tabs/TabListContext.ts
@@ -3,7 +3,7 @@ import { createContext } from 'react';
 export interface TabListContextValues {
   tabListItemIndex: number;
   scrollContainer: HTMLElement | null;
-  divider: 'full' | 'minimal' | 'none';
+  isLast: boolean;
 }
 
 export const TabListContext = createContext<TabListContextValues | null>(null);

--- a/packages/braid-design-system/lib/components/Tabs/TabPanel.tsx
+++ b/packages/braid-design-system/lib/components/Tabs/TabPanel.tsx
@@ -63,3 +63,6 @@ export const TabPanel = ({
     </Box>
   );
 };
+
+TabPanel.displayName = 'TabPanel';
+TabPanel.__isTabPanel__ = true;

--- a/packages/braid-design-system/lib/components/Tabs/TabPanels.tsx
+++ b/packages/braid-design-system/lib/components/Tabs/TabPanels.tsx
@@ -3,7 +3,6 @@ import assert from 'assert';
 import flattenChildren from 'react-keyed-flatten-children';
 import { TabsContext } from './TabsProvider';
 import { TAB_PANELS_UPDATED } from './Tabs.actions';
-import { TabPanel } from './TabPanel';
 import { TabPanelsContext } from './TabPanelsContext';
 import type { ReactNodeNoStrings } from '../private/ReactNodeNoStrings';
 
@@ -27,7 +26,8 @@ export const TabPanels = ({
 
   const panels = Children.map(flattenChildren(children), (panel, index) => {
     assert(
-      typeof panel === 'object' && panel.type === TabPanel,
+      // @ts-expect-error
+      typeof panel === 'object' && panel.type.__isTabPanel__,
       'Only TabPanel elements can be direct children of a TabPanels',
     );
 

--- a/packages/braid-design-system/lib/components/Tabs/Tabs.actions.ts
+++ b/packages/braid-design-system/lib/components/Tabs/Tabs.actions.ts
@@ -10,6 +10,7 @@ export const TAB_BUTTON_CLICK = 7;
 export const TAB_LIST_UPDATED = 8;
 export const TAB_LIST_FOCUSED = 9;
 export const TAB_PANELS_UPDATED = 10;
+export const TAB_BUTTON_REGISTER = 11;
 
 export type Action =
   | { type: typeof TAB_BUTTON_RIGHT }
@@ -17,6 +18,11 @@ export type Action =
   | { type: typeof TAB_BUTTON_HOME }
   | { type: typeof TAB_BUTTON_END }
   | { type: typeof TAB_BUTTON_TAB }
+  | {
+      type: typeof TAB_BUTTON_REGISTER;
+      tabEl: HTMLElement;
+      tabListItemIndex: number;
+    }
   | { type: typeof TAB_BUTTON_ENTER; value: number }
   | { type: typeof TAB_BUTTON_SPACE; value: number }
   | { type: typeof TAB_BUTTON_CLICK; value: number }

--- a/packages/braid-design-system/lib/components/Tabs/Tabs.css.ts
+++ b/packages/braid-design-system/lib/components/Tabs/Tabs.css.ts
@@ -1,4 +1,5 @@
-import { style } from '@vanilla-extract/css';
+import { createVar, style } from '@vanilla-extract/css';
+import { calc } from '@vanilla-extract/css-utils';
 import { colorModeStyle } from '../../css/colorModeStyle';
 import { vars } from '../../themes/vars.css';
 
@@ -10,8 +11,16 @@ export const tab = style({
   },
 });
 
-export const hairlineMarginLeft = style({
-  marginLeft: 1,
+export const cropToIconX = style({
+  marginLeft: -2,
+});
+
+export const hoveredTab = style({
+  selectors: {
+    [`${tab}:hover &`]: {
+      opacity: 1,
+    },
+  },
 });
 
 export const nowrap = style({
@@ -51,8 +60,18 @@ export const tabFocusRing = style({
   },
 });
 
+export const underlineLeft = createVar();
+export const underlineWidth = createVar();
+
+const initialUnderlineWidth = 10;
 export const tabUnderline = style({
-  height: 2,
+  height: vars.borderWidth.large,
+  width: initialUnderlineWidth,
+  transformOrigin: '0 0',
+  transition: 'transform .3s ease',
+  transform: `translateZ(0) translateX(${calc(underlineLeft).multiply(
+    '1px',
+  )}) scaleX(${calc(underlineWidth).divide(initialUnderlineWidth)})`,
 });
 
 export const tabUnderlineActiveDarkMode = style(
@@ -62,18 +81,6 @@ export const tabUnderlineActiveDarkMode = style(
     },
   }),
 );
-
-export const tabUnderlineHover = style({
-  selectors: {
-    [`${tab}:hover &`]: {
-      opacity: 1,
-    },
-  },
-});
-
-export const tabUnderlineAnimation = style({
-  transform: 'translateY(100%)',
-});
 
 export const tabPanel = style({});
 

--- a/packages/braid-design-system/lib/components/Tabs/Tabs.docs.tsx
+++ b/packages/braid-design-system/lib/components/Tabs/Tabs.docs.tsx
@@ -262,7 +262,7 @@ const docs: ComponentDocs = {
               <Stack space="medium">
                 <Tabs label="Test tabs">
                   <Tab>The first tab</Tab>
-                  <Tab badge={<Badge tone="positive">Positive</Badge>}>
+                  <Tab badge={<Badge tone="positive">New</Badge>}>
                     The second tab
                   </Tab>
                   <Tab>The third tab</Tab>

--- a/packages/braid-design-system/lib/components/Tabs/Tabs.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/Tabs/Tabs.screenshots.tsx
@@ -16,6 +16,100 @@ export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320, 1200],
   examples: [
     {
+      label: 'Active indicator - basic',
+      Example: ({ id }) => (
+        <Stack space="medium">
+          {['1', '2', '3'].map((item) => (
+            <TabsProvider id={id} selectedItem={item} key={item}>
+              <Tabs label="Standard tabs">
+                <Tab item="1">First Tab</Tab>
+                <Tab item="2">Middle Tab</Tab>
+                <Tab item="3">Last Tab</Tab>
+              </Tabs>
+            </TabsProvider>
+          ))}
+        </Stack>
+      ),
+    },
+    {
+      label: 'Active indicator - with icons',
+      Example: ({ id }) => (
+        <Stack space="medium">
+          {['1', '2', '3'].map((item) => (
+            <TabsProvider id={id} selectedItem={item} key={item}>
+              <Tabs label="Icon tabs">
+                <Tab item="1" icon={<IconHome />}>
+                  First Tab
+                </Tab>
+                <Tab item="2" icon={<IconHome />}>
+                  Middle Tab
+                </Tab>
+                <Tab item="3" icon={<IconHome />}>
+                  Last Tab
+                </Tab>
+              </Tabs>
+            </TabsProvider>
+          ))}
+        </Stack>
+      ),
+    },
+    {
+      label: 'Active indicator - with badge',
+      Example: ({ id }) => (
+        <Stack space="medium">
+          {['1', '2', '3'].map((item) => (
+            <TabsProvider id={id} selectedItem={item} key={item}>
+              <Tabs label="Badge tabs">
+                <Tab item="1" badge={<Badge tone="positive">New</Badge>}>
+                  First Tab
+                </Tab>
+                <Tab item="2" badge={<Badge tone="positive">New</Badge>}>
+                  Middle Tab
+                </Tab>
+                <Tab item="3" badge={<Badge tone="positive">New</Badge>}>
+                  Last Tab
+                </Tab>
+              </Tabs>
+            </TabsProvider>
+          ))}
+        </Stack>
+      ),
+    },
+    {
+      label: 'Active indicator - with icons and badge',
+      Example: ({ id }) => (
+        <Stack space="medium">
+          {['1', '2', '3'].map((item) => (
+            <TabsProvider id={id} selectedItem={item} key={item}>
+              <Tabs label="Badge tabs">
+                <Tab
+                  item="1"
+                  icon={<IconHome />}
+                  badge={<Badge tone="positive">New</Badge>}
+                >
+                  First Tab
+                </Tab>
+                <Tab
+                  item="2"
+                  icon={<IconHome />}
+                  badge={<Badge tone="positive">New</Badge>}
+                >
+                  Middle Tab
+                </Tab>
+                <Tab
+                  item="3"
+                  icon={<IconHome />}
+                  badge={<Badge tone="positive">New</Badge>}
+                >
+                  Last Tab
+                </Tab>
+              </Tabs>
+            </TabsProvider>
+          ))}
+        </Stack>
+      ),
+    },
+    {
       label: 'Left aligned',
       Example: ({ id }) => (
         <TabsProvider id={id}>

--- a/packages/braid-design-system/lib/components/Tabs/TabsProvider.tsx
+++ b/packages/braid-design-system/lib/components/Tabs/TabsProvider.tsx
@@ -15,6 +15,7 @@ import {
   TAB_LIST_UPDATED,
   TAB_LIST_FOCUSED,
   TAB_PANELS_UPDATED,
+  TAB_BUTTON_REGISTER,
 } from './Tabs.actions';
 import tabA11y from './tabA11y';
 
@@ -23,6 +24,7 @@ interface State {
   focusedTabIndex: number | null;
   tabItems: Array<string | number>;
   panels: number[];
+  tabButtonElements: Record<string, HTMLElement>;
 }
 
 interface TabsContextValues extends State {
@@ -97,6 +99,15 @@ export const TabsProvider = ({
             selectedIndex: action.value,
           };
         }
+        case TAB_BUTTON_REGISTER: {
+          return {
+            ...state,
+            tabButtonElements: {
+              ...state.tabButtonElements,
+              [action.tabListItemIndex.toString()]: action.tabEl,
+            },
+          };
+        }
         case TAB_LIST_FOCUSED: {
           return {
             ...state,
@@ -126,6 +137,7 @@ export const TabsProvider = ({
       focusedTabIndex: null,
       tabItems: [],
       panels: [],
+      tabButtonElements: {},
     },
   );
 
@@ -133,9 +145,10 @@ export const TabsProvider = ({
     <TabsContext.Provider
       value={{
         ...tabsState,
-        selectedIndex: selectedItem
-          ? tabsState.tabItems.indexOf(selectedItem)
-          : tabsState.selectedIndex,
+        selectedIndex:
+          typeof selectedItem !== 'undefined'
+            ? tabsState.tabItems.indexOf(selectedItem)
+            : tabsState.selectedIndex,
         selectedItem,
         dispatch,
         a11y: tabA11y({ uniqueId: id }),

--- a/packages/braid-design-system/package.json
+++ b/packages/braid-design-system/package.json
@@ -45,6 +45,7 @@
     "@types/lodash": "^4.14.168",
     "@vanilla-extract/css": "^1.7.4",
     "@vanilla-extract/css-utils": "^0.1.1",
+    "@vanilla-extract/dynamic": "^2.0.3",
     "@vanilla-extract/sprinkles": "^1.3.3",
     "assert": "^2.0.0",
     "autosuggest-highlight": "^3.1.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -121,6 +121,7 @@ importers:
       '@types/uuid': ^8.3.0
       '@vanilla-extract/css': ^1.7.4
       '@vanilla-extract/css-utils': ^0.1.1
+      '@vanilla-extract/dynamic': ^2.0.3
       '@vanilla-extract/sprinkles': ^1.3.3
       assert: ^2.0.0
       autosuggest-highlight: ^3.1.1
@@ -161,6 +162,7 @@ importers:
       '@types/lodash': 4.14.182
       '@vanilla-extract/css': 1.9.1
       '@vanilla-extract/css-utils': 0.1.2
+      '@vanilla-extract/dynamic': 2.0.3
       '@vanilla-extract/sprinkles': 1.4.1_@vanilla-extract+css@1.9.1
       assert: 2.0.0
       autosuggest-highlight: 3.2.1
@@ -5247,6 +5249,12 @@ packages:
       media-query-parser: 2.0.2
       outdent: 0.8.0
 
+  /@vanilla-extract/dynamic/2.0.3:
+    resolution: {integrity: sha512-Rglfw2gXAYiBzAQ4jgUG7rBgE2c88e/zcG27ZVoIqMHVq56wf2C1katGMm1yFMNBgzqM7oBNYzz4YOMzznydkg==}
+    dependencies:
+      '@vanilla-extract/private': 1.0.3
+    dev: false
+
   /@vanilla-extract/integration/4.0.1:
     resolution: {integrity: sha512-s/P7FynY2/LWMCGVgHTXOpfy4pH0+cTCtTgEZEVvmf2ErX5ZSSsFe1i9MzODCYTDuvV2MWFg7oOspwx7i70h+A==}
     dependencies:
@@ -6189,7 +6197,7 @@ packages:
   /axios/0.21.4_debug@4.3.1:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.0
+      follow-redirects: 1.15.0_debug@4.3.1
     transitivePeerDependencies:
       - debug
     dev: true
@@ -6777,7 +6785,7 @@ packages:
       mississippi: 3.0.0
       mkdirp: 0.5.6
       move-concurrently: 1.0.1
-      promise-inflight: 1.0.1
+      promise-inflight: 1.0.1_bluebird@3.7.2
       rimraf: 2.7.1
       ssri: 6.0.2
       unique-filename: 1.1.1
@@ -8128,7 +8136,6 @@ packages:
         optional: true
     dependencies:
       ms: 2.1.2
-    dev: true
 
   /debug/4.3.4:
     resolution: {integrity: sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==}
@@ -10282,6 +10289,18 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
+    dev: false
+
+  /follow-redirects/1.15.0_debug@4.3.1:
+    resolution: {integrity: sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==}
+    engines: {node: '>=4.0'}
+    peerDependencies:
+      debug: '*'
+    peerDependenciesMeta:
+      debug:
+        optional: true
+    dependencies:
+      debug: 4.3.1
 
   /follow-redirects/1.15.0_debug@4.3.4:
     resolution: {integrity: sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==}
@@ -11369,7 +11388,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.0
+      follow-redirects: 1.15.0_debug@4.3.1
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -15742,6 +15761,16 @@ packages:
     peerDependenciesMeta:
       bluebird:
         optional: true
+
+  /promise-inflight/1.0.1_bluebird@3.7.2:
+    resolution: {integrity: sha512-6zWPyEOFaQBJYcGMHBKTKJ3u6TBsnMFOIZSa6ce1e/ZrrsOlnHRHbabMjLiBYKp+n44X9eUI6VUPaukCXHuG4g==}
+    peerDependencies:
+      bluebird: '*'
+    peerDependenciesMeta:
+      bluebird:
+        optional: true
+    dependencies:
+      bluebird: 3.7.2
 
   /promise.allsettled/1.0.5:
     resolution: {integrity: sha512-tVDqeZPoBC0SlzJHzWGZ2NKAguVq2oiYj7gbggbiTvH2itHohijTp7njOUA0aQ/nl+0lr/r6egmhoYu63UZ/pQ==}


### PR DESCRIPTION
The appearance of a `Tab` has been updated. Changes include:
- Inactive tab uses `regular` text weight
- Hover state of inactive tab toggles `neutral` tone instead of underline
- Active tab indicator underlines content only, without the horizontal gutter
- Active tab indicator rounds top radii
- The `minimal` divider under `Tabs` underlines content only, without the horizontal gutter

Before: (first tab active, third tab hovered)
<img width="694" alt="Screen Shot 2022-11-03 at 11 41 47 am" src="https://user-images.githubusercontent.com/912060/199627926-39416b43-4711-4de0-a78d-9bf23530b3dd.png">

After: (first tab active, third tab hovered)
<img width="694" alt="Screen Shot 2022-11-03 at 11 41 39 am" src="https://user-images.githubusercontent.com/912060/199627925-2307d88e-96fa-4661-87a7-82b91310fbb9.png">

Note: Also fixes hot reload issue with `TabPanel` in dev mode.