### PR TITLE
Support data attribute boolean values

### DIFF
--- a/.changeset/giant-peas-grow.md
+++ b/.changeset/giant-peas-grow.md
@@ -1,0 +1,158 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Accordion
+  - AccordionItem
+  - Actions
+  - Alert
+  - Autosuggest
+  - Badge
+  - Box
+  - Button
+  - ButtonIcon
+  - ButtonLink
+  - Card
+  - Checkbox
+  - Columns
+  - ContentBlock
+  - Dialog
+  - Disclosure
+  - Drawer
+  - Dropdown
+  - FieldLabel
+  - FieldMessage
+  - Heading
+  - Hidden
+  - HiddenVisually
+  - IconAdd
+  - IconArrow
+  - IconBookmark
+  - IconCaution
+  - IconChevron
+  - IconClear
+  - IconCompany
+  - IconCompose
+  - IconCopy
+  - IconCreditCard
+  - IconCritical
+  - IconDate
+  - IconDelete
+  - IconDesktop
+  - IconDocument
+  - IconDocumentBroken
+  - IconDownload
+  - IconEdit
+  - IconEducation
+  - IconFilter
+  - IconFlag
+  - IconGrid
+  - IconHeart
+  - IconHelp
+  - IconHistory
+  - IconHome
+  - IconImage
+  - IconInfo
+  - IconInvoice
+  - IconLanguage
+  - IconLink
+  - IconLinkBroken
+  - IconList
+  - IconLocation
+  - IconMail
+  - IconMinus
+  - IconMobile
+  - IconMoney
+  - IconNewWindow
+  - IconNote
+  - IconNotification
+  - IconOverflow
+  - IconPeople
+  - IconPersonAdd
+  - IconPersonVerified
+  - IconPhone
+  - IconPlatformAndroid
+  - IconPlatformApple
+  - IconPositive
+  - IconPrint
+  - IconProfile
+  - IconPromote
+  - IconRecommended
+  - IconRefresh
+  - IconResume
+  - IconSearch
+  - IconSecurity
+  - IconSend
+  - IconSent
+  - IconSettings
+  - IconShare
+  - IconSocialFacebook
+  - IconSocialGitHub
+  - IconSocialInstagram
+  - IconSocialLinkedIn
+  - IconSocialMedium
+  - IconSocialTwitter
+  - IconSocialYouTube
+  - IconStar
+  - IconStatistics
+  - IconSubCategory
+  - IconTag
+  - IconThumb
+  - IconTick
+  - IconTime
+  - IconTip
+  - IconUpload
+  - IconVideo
+  - IconVisibility
+  - IconWorkExperience
+  - IconZoomIn
+  - IconZoomOut
+  - Inline
+  - List
+  - Loader
+  - MenuRenderer
+  - MenuItem
+  - MenuItemCheckbox
+  - MenuItemLink
+  - OverflowMenu
+  - MonthPicker
+  - Notice
+  - Pagination
+  - PasswordField
+  - Radio
+  - RadioGroup
+  - RadioItem
+  - Rating
+  - Secondary
+  - Stack
+  - Stepper
+  - Strong
+  - Tab
+  - Tabs
+  - TabPanel
+  - Tag
+  - Text
+  - Textarea
+  - TextDropdown
+  - TextField
+  - TextLink
+  - TextLinkButton
+  - Tiles
+  - Toggle
+---
+
+Support data attribute boolean values
+
+The `data` attribute map now supports boolean values. This provides an improvement for the developer experience, no longer having to convert values to strings explicitly.
+
+**EXAMPLE USAGE:**
+```tsx
+<Component
+  data={{
+    'custom-attribute': true,
+  }}
+/>
+// => <div data-custom-attribute="true" />
+```

--- a/.changeset/hungry-moose-think.md
+++ b/.changeset/hungry-moose-think.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - TextLink
+---
+
+**TextLink:** Allow native data attributes with anchor api
+
+Disables the validation against the use of data attributes on `TextLink`. Given it exposes the full native anchor tag api, it is `not invalid` to use the native syntax.

--- a/.changeset/serious-ties-shake.md
+++ b/.changeset/serious-ties-shake.md
@@ -1,0 +1,21 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Link
+---
+
+**Link:** Support custom `data` prop format for attributes
+
+While `Link` already supports the native HTML syntax for data attributes, e.g. `data-testid="123"`, it now supports the `data` prop too. This allows data attributes to be provided consistently to all components.
+
+**EXAMPLE USAGE:**
+```diff
+ <Link
++  data={{ testId: 'myComponent' }}
+ />
+
+```
+The above example results in the following HTML attribute being set on the element: `data-testId="myComponent"`.

--- a/.changeset/slimy-guests-melt.md
+++ b/.changeset/slimy-guests-melt.md
@@ -1,0 +1,17 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Bleed
+---
+
+**Bleed:** Add `data` attribute support
+
+**EXAMPLE USAGE:**
+```jsx
+<Bleed data={{ testid: 123 }}>
+  ...
+</Bleed>
+```

--- a/packages/braid-design-system/lib/components/Bleed/Bleed.tsx
+++ b/packages/braid-design-system/lib/components/Bleed/Bleed.tsx
@@ -3,6 +3,8 @@ import type { ResponsiveSpace } from '../../css/atoms/atoms';
 import { negativeMargin } from '../../css/negativeMargin/negativeMargin';
 import type { BoxProps } from '../Box/Box';
 import { Box } from '../Box/Box';
+import type { DataAttributeMap } from '../private/buildDataAttributes';
+import buildDataAttributes from '../private/buildDataAttributes';
 
 export const validBleedComponents = ['div', 'span'] as const;
 
@@ -16,6 +18,7 @@ export interface BleedProps {
   left?: ResponsiveSpace;
   right?: ResponsiveSpace;
   component?: typeof validBleedComponents[number];
+  data?: DataAttributeMap;
 }
 
 export const Bleed = ({
@@ -28,6 +31,8 @@ export const Bleed = ({
   right,
   children,
   component = 'div',
+  data,
+  ...restProps
 }: BleedProps) => (
   <Box
     component={component}
@@ -38,6 +43,7 @@ export const Bleed = ({
       negativeMargin('left', left || horizontal || space),
       negativeMargin('right', right || horizontal || space),
     ]}
+    {...buildDataAttributes({ data, validateRestProps: restProps })}
   >
     <Box
       component={component}

--- a/packages/braid-design-system/lib/components/Link/Link.tsx
+++ b/packages/braid-design-system/lib/components/Link/Link.tsx
@@ -4,13 +4,16 @@ import React, { forwardRef } from 'react';
 import { atoms } from '../../css/atoms/atoms';
 import type { LinkComponentProps } from '../BraidProvider/BraidProvider';
 import { useLinkComponent } from '../BraidProvider/BraidProvider';
+import type { DataAttributeMap } from '../private/buildDataAttributes';
+import buildDataAttributes from '../private/buildDataAttributes';
 
 export type LinkProps = Omit<LinkComponentProps, 'className'> & {
   className?: ClassValue;
+  data?: DataAttributeMap;
 };
 
 export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
-  ({ href, className, ...restProps }, ref) => {
+  ({ href, className, data, ...restProps }, ref) => {
     const LinkComponent = useLinkComponent(ref);
 
     return (
@@ -19,6 +22,7 @@ export const Link = forwardRef<HTMLAnchorElement, LinkProps>(
         href={href}
         className={clsx(atoms({ reset: 'a' }), className)}
         {...restProps}
+        {...buildDataAttributes({ data, validateRestProps: false })}
       />
     );
   },

--- a/packages/braid-design-system/lib/components/TextLink/TextLink.tsx
+++ b/packages/braid-design-system/lib/components/TextLink/TextLink.tsx
@@ -110,7 +110,7 @@ export const TextLink = forwardRef<HTMLAnchorElement, TextLinkProps>(
         ref={ref}
         {...restProps}
         className={classes}
-        {...buildDataAttributes({ data, validateRestProps: restProps })}
+        {...buildDataAttributes({ data, validateRestProps: false })}
       />
     );
   },

--- a/packages/braid-design-system/lib/components/private/buildDataAttributes.ts
+++ b/packages/braid-design-system/lib/components/private/buildDataAttributes.ts
@@ -1,6 +1,6 @@
 import dedent from 'dedent';
 
-export type DataAttributeMap = Record<string, string | number>;
+export type DataAttributeMap = Record<string, string | number | boolean>;
 
 interface DataAttributeParams {
   data?: DataAttributeMap;
@@ -37,14 +37,18 @@ export default ({ data, validateRestProps }: DataAttributeParams) => {
             .join('\n')}
           %c+    data={{
           ${dataAttrs
-            .map(
-              (attr) =>
-                `+      ${attr.replace(/^data-/, '')}: ${
-                  typeof validateRestProps[attr] === 'string'
-                    ? `'${validateRestProps[attr]}'`
-                    : validateRestProps[attr]
-                },`,
-            )
+            .map((attr) => {
+              const attributeName = attr.replace(/^data-/, '');
+              const property = attributeName.includes('-')
+                ? `'${attributeName}'`
+                : attributeName;
+
+              return `+      ${property}: ${
+                typeof validateRestProps[attr] === 'string'
+                  ? `'${validateRestProps[attr]}'`
+                  : validateRestProps[attr]
+              },`;
+            })
             .join('\n')}
           +    }}
             %c/>

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -189,6 +189,7 @@ exports[`Bleed 1`] = `
     component?: 
         | "div"
         | "span"
+    data?: DataAttributeMap
     horizontal?: 
         | "gutter"
         | "large"
@@ -6126,6 +6127,7 @@ exports[`Link 1`] = `
         | true
     contextMenu?: string
     dangerouslySetInnerHTML?: { __html: string; }
+    data?: DataAttributeMap
     datatype?: string
     defaultChecked?: boolean
     defaultValue?: 


### PR DESCRIPTION
The `data` attribute map now supports boolean values. This provides an improvement for the developer experience, no longer having to convert values to strings explicitly.

Also added `data` support to a few components that were missing it and disabled validation of native data attribute props on components that support native attributes.

As a side not, improved the dev/build time warning to have more valid syntax, e.g. wrapping property names in quotes where required.