### PR TITLE
TextLink, TextLinkButton: Add icon support

### DIFF
--- a/.changeset/early-lamps-own.md
+++ b/.changeset/early-lamps-own.md
@@ -1,0 +1,21 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - TextLink
+  - TextLinkButton
+---
+
+**TextLink, TextLinkButton:** Add `icon` support
+
+Provides a designed slot for adding an `icon` to a `TextLink` or `TextLinkButton`.
+This solves for the problem of underlining the space between the icon and text.
+
+**EXAMPLE USAGE:**
+```jsx
+<Text>
+  <TextLink icon={<IconLink />}>...</TextLink>
+</Text>
+```

--- a/packages/braid-design-system/lib/components/TextLink/TextLink.docs.tsx
+++ b/packages/braid-design-system/lib/components/TextLink/TextLink.docs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { ComponentDocs } from 'site/types';
-import { Box, Inline, Stack, Strong, Text, TextLink } from '../';
+import { Box, Inline, Stack, Strong, Text, TextLink, IconLink } from '../';
 import source from '../../utils/source.macro';
 
 const docs: ComponentDocs = {
@@ -49,6 +49,24 @@ const docs: ComponentDocs = {
             This sentence contains a{' '}
             <TextLink href="" showVisited>
               visited TextLink.
+            </TextLink>
+          </Text>,
+        ),
+    },
+    {
+      label: 'Icons',
+      description: (
+        <Text>
+          For decoration or help distinguishing between links, an{' '}
+          <Strong>icon</Strong> can be provided. This will be placed to the left
+          of the link text.
+        </Text>
+      ),
+      Example: () =>
+        source(
+          <Text>
+            <TextLink icon={<IconLink />} href="">
+              TextLink
             </TextLink>
           </Text>,
         ),

--- a/packages/braid-design-system/lib/components/TextLink/TextLink.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/TextLink/TextLink.screenshots.tsx
@@ -10,6 +10,7 @@ import {
   Column,
   Stack,
   Strong,
+  IconLink,
 } from '../';
 // TODO: COLORMODE RELEASE
 // Use public import
@@ -205,6 +206,30 @@ export const screenshots: ComponentScreenshot = {
             </TextLink>
           </Text>
         </Stack>
+      ),
+    },
+    {
+      label: 'With icon slot',
+      Example: () => (
+        <Text>
+          A sentence with a{' '}
+          <TextLink href="" icon={<IconLink />}>
+            TextLink
+          </TextLink>
+          .
+        </Text>
+      ),
+    },
+    {
+      label: 'With icon slot and weight weak',
+      Example: () => (
+        <Text>
+          A sentence with a{' '}
+          <TextLink href="" weight="weak" icon={<IconLink />}>
+            TextLink
+          </TextLink>
+          .
+        </Text>
       ),
     },
     {

--- a/packages/braid-design-system/lib/components/TextLink/TextLink.tsx
+++ b/packages/braid-design-system/lib/components/TextLink/TextLink.tsx
@@ -1,4 +1,5 @@
 import clsx from 'clsx';
+import type { ReactElement } from 'react';
 import React, { forwardRef, useContext } from 'react';
 import type { Atoms } from '../../css/atoms/atoms';
 import { atoms } from '../../css/atoms/atoms';
@@ -7,6 +8,7 @@ import {
   useBackground,
 } from '../Box/BackgroundContext';
 import type { BoxBackgroundVariant } from '../Box/Box';
+import { Box } from '../Box/Box';
 import type { LinkComponentProps } from '../BraidProvider/BraidProvider';
 import { useLinkComponent } from '../BraidProvider/BraidProvider';
 import HeadingContext from '../Heading/HeadingContext';
@@ -14,6 +16,7 @@ import { TextContext } from '../Text/TextContext';
 import type { DataAttributeMap } from '../private/buildDataAttributes';
 import buildDataAttributes from '../private/buildDataAttributes';
 import { virtualTouchable } from '../private/touchable/virtualTouchable';
+import type { UseIconProps } from '../../hooks/useIcon';
 import * as styles from './TextLink.css';
 
 export interface TextLinkStyles {
@@ -26,6 +29,7 @@ export interface TextLinkProps
   extends TextLinkStyles,
     Omit<LinkComponentProps, 'className' | 'style'> {
   data?: DataAttributeMap;
+  icon?: ReactElement<UseIconProps>;
 }
 
 const isPlainBackground = (
@@ -97,7 +101,10 @@ export const useLinkStyles = ({
 };
 
 export const TextLink = forwardRef<HTMLAnchorElement, TextLinkProps>(
-  ({ weight, showVisited, hitArea, data, ...restProps }, ref) => {
+  (
+    { weight, showVisited, hitArea, data, icon, children, ...restProps },
+    ref,
+  ) => {
     const LinkComponent = useLinkComponent(ref);
     const classes = useLinkStyles({
       weight,
@@ -111,7 +118,14 @@ export const TextLink = forwardRef<HTMLAnchorElement, TextLinkProps>(
         {...restProps}
         className={classes}
         {...buildDataAttributes({ data, validateRestProps: false })}
-      />
+      >
+        {icon ? (
+          <Box component="span" paddingRight="xxsmall">
+            {icon}
+          </Box>
+        ) : null}
+        {children}
+      </LinkComponent>
     );
   },
 );

--- a/packages/braid-design-system/lib/components/TextLinkButton/TextLinkButton.docs.tsx
+++ b/packages/braid-design-system/lib/components/TextLinkButton/TextLinkButton.docs.tsx
@@ -1,8 +1,7 @@
 import React from 'react';
 import type { ComponentDocs } from 'site/types';
-import { Text, TextLink, TextLinkButton } from '..';
+import { Text, TextLink, TextLinkButton, Strong, IconLink } from '..';
 import source from '../../utils/source.macro';
-import { Strong } from '../Strong/Strong';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -48,6 +47,22 @@ const docs: ComponentDocs = {
           <TextLink href="/components/Heading">Heading</TextLink> component.
         </Text>
       ),
+    },
+    {
+      label: 'Icons',
+      description: (
+        <Text>
+          For decoration or help distinguishing between buttons, an{' '}
+          <Strong>icon</Strong> can be provided. This will be placed to the left
+          of the label.
+        </Text>
+      ),
+      Example: () =>
+        source(
+          <Text>
+            <TextLinkButton icon={<IconLink />}>TextLinkButton</TextLinkButton>
+          </Text>,
+        ),
     },
   ],
 };

--- a/packages/braid-design-system/lib/components/TextLinkButton/TextLinkButton.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/TextLinkButton/TextLinkButton.screenshots.tsx
@@ -1,29 +1,51 @@
 import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { Text, TextLinkButton } from '../';
+import { Text, TextLinkButton, IconLink } from '../';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],
   examples: [
     {
-      label: 'TextLinkButton inside Text',
-      Example: ({ handler }) => (
+      label: 'Default',
+      Example: () => (
         <Text>
           The link in this sentence{' '}
-          <TextLinkButton onClick={handler}>
+          <TextLinkButton>
             is actually a span with an ARIA role of button.
           </TextLinkButton>
         </Text>
       ),
     },
     {
-      label: 'Weak TextLinkButton inside Text',
-      Example: ({ handler }) => (
+      label: 'Weight weak',
+      Example: () => (
         <Text>
           The link in this sentence{' '}
-          <TextLinkButton weight="weak" onClick={handler}>
-            is actually a span with an ARIA role of button.
+          <TextLinkButton weight="weak">
+            is actually a span with an ARIA role of button
           </TextLinkButton>
+          .
+        </Text>
+      ),
+    },
+    {
+      label: 'With icon',
+      Example: () => (
+        <Text>
+          A sentence with a{' '}
+          <TextLinkButton icon={<IconLink />}>TextLinkButton</TextLinkButton>.
+        </Text>
+      ),
+    },
+    {
+      label: 'With icon and weight weak',
+      Example: () => (
+        <Text>
+          A sentence with a{' '}
+          <TextLinkButton weight="weak" icon={<IconLink />}>
+            TextLinkButton
+          </TextLinkButton>
+          .
         </Text>
       ),
     },

--- a/packages/braid-design-system/lib/components/TextLinkButton/TextLinkButton.tsx
+++ b/packages/braid-design-system/lib/components/TextLinkButton/TextLinkButton.tsx
@@ -1,5 +1,11 @@
-import type { AllHTMLAttributes, ReactNode, KeyboardEvent } from 'react';
+import type {
+  AllHTMLAttributes,
+  ReactNode,
+  KeyboardEvent,
+  ReactElement,
+} from 'react';
 import React, { useRef, useCallback } from 'react';
+import type { UseIconProps } from '../../hooks/useIcon';
 import { Box } from '../Box/Box';
 import type { DataAttributeMap } from '../private/buildDataAttributes';
 import buildDataAttributes from '../private/buildDataAttributes';
@@ -17,6 +23,7 @@ export interface TextLinkButtonProps
   'aria-expanded'?: NativeSpanProps['aria-expanded'];
   'aria-describedby'?: NativeSpanProps['aria-describedby'];
   tabIndex?: NativeSpanProps['tabIndex'];
+  icon?: ReactElement<UseIconProps>;
 }
 
 const noop = () => {};
@@ -31,6 +38,7 @@ export const TextLinkButton = ({
   'aria-expanded': ariaExpanded,
   'aria-describedby': ariaDescribedBy,
   tabIndex,
+  icon,
   ...restProps
 }: TextLinkButtonProps) => {
   const buttonRef = useRef<HTMLSpanElement>(null);
@@ -65,6 +73,11 @@ export const TextLinkButton = ({
       className={classes}
       {...buildDataAttributes({ data, validateRestProps: restProps })}
     >
+      {icon ? (
+        <Box component="span" paddingRight="xxsmall">
+          {icon}
+        </Box>
+      ) : null}
       {children}
     </Box>
   );

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -7528,6 +7528,7 @@ exports[`TextLink 1`] = `
         | "standard"
     href: string
     hrefLang?: string
+    icon?: ReactElement<UseIconProps, string | JSXElementConstructor<any>>
     id?: string
     inlist?: any
     inputMode?: 
@@ -7849,6 +7850,7 @@ exports[`TextLinkButton 1`] = `
     hitArea?: 
         | "large"
         | "standard"
+    icon?: ReactElement<UseIconProps, string | JSXElementConstructor<any>>
     id?: string
     onClick?: MouseEventHandler<HTMLSpanElement>
     tabIndex?: number


### PR DESCRIPTION
Provides a designed slot for adding an `icon` to a `TextLink` or `TextLinkButton`.
This solves for the problem of underlining the space between the icon and text.

**EXAMPLE USAGE:**
```jsx
<Text>
  <TextLink icon={<IconLink />}>...</TextLink>
</Text>
```