### PR TITLE
IconRenderer: Support sizing & alignment of custom icons

### DIFF
--- a/.changeset/flat-crabs-ring.md
+++ b/.changeset/flat-crabs-ring.md
@@ -1,0 +1,27 @@
+---
+'braid-design-system': minor
+---
+
+---
+new:
+  - IconRenderer
+---
+
+**IconRenderer:** Support the sizing and alignment of custom icons
+
+Provides support for sizing and aligning custom icons with Braid’s typographic components. The new `IconRenderer` component supports being used within `Text` and `Heading` components as well as inside `icon` slots of other components.
+
+Uses the render prop pattern to provide the required classes to style and align a custom icon.
+
+**EXAMPLE USAGE:**
+```jsx
+<Heading level="1">
+  <IconRenderer>
+    {({ className }) => (
+      <svg className={className}>
+        ...
+      </svg>
+    )}
+  </IconRenderer>
+</Heading>
+```

--- a/packages/braid-design-system/lib/components/icons/IconRenderer.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/icons/IconRenderer.screenshots.tsx
@@ -1,0 +1,55 @@
+import React from 'react';
+import type { ComponentScreenshot } from 'site/types';
+import { Text, Heading, IconRenderer, Stack } from '../';
+
+const customIcon = (
+  <IconRenderer>
+    {({ className }) => (
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 24 24"
+        className={className}
+        fill="currentColor"
+      >
+        <circle cx="12" cy="12" r="10" />
+      </svg>
+    )}
+  </IconRenderer>
+);
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  examples: [
+    {
+      label: 'Default',
+      Example: () => (
+        <Stack space="large">
+          <Text size="xsmall" icon={customIcon}>
+            Text xsmall with custom icon
+          </Text>
+          <Text size="small" icon={customIcon}>
+            Text small with custom icon
+          </Text>
+          <Text size="standard" icon={customIcon}>
+            Text standard with custom icon
+          </Text>
+          <Text size="large" icon={customIcon}>
+            Text large with custom icon
+          </Text>
+          <Heading level="4" icon={customIcon}>
+            Heading 4 with custom icon
+          </Heading>
+          <Heading level="3" icon={customIcon}>
+            Heading 3 with custom icon
+          </Heading>
+          <Heading level="2" icon={customIcon}>
+            Heading 2 with custom icon
+          </Heading>
+          <Heading level="1" icon={customIcon}>
+            Heading 1 with custom icon
+          </Heading>
+        </Stack>
+      ),
+    },
+  ],
+};

--- a/packages/braid-design-system/lib/components/icons/IconRenderer.tsx
+++ b/packages/braid-design-system/lib/components/icons/IconRenderer.tsx
@@ -1,0 +1,43 @@
+import assert from 'assert';
+import clsx from 'clsx';
+import type { ReactElement } from 'react';
+import { useContext } from 'react';
+import { atoms } from '../../css/atoms/atoms';
+import HeadingContext from '../Heading/HeadingContext';
+import { TextContext } from '../Text/TextContext';
+import * as styles from '../../hooks/useIcon/icon.css';
+
+type AlignY = keyof typeof styles.alignY;
+interface IconStyles {
+  alignY?: AlignY;
+  verticalCorrection?: keyof typeof styles.alignY[AlignY];
+}
+export const iconInlineSize = ({
+  alignY = 'uppercase',
+  verticalCorrection = 'none',
+}: IconStyles = {}) =>
+  clsx(
+    atoms({
+      display: 'inlineBlock',
+      position: 'relative',
+    }),
+    styles.size,
+    styles.inlineCrop,
+    styles.inline,
+    styles.alignY[alignY][verticalCorrection],
+  );
+
+interface IconRendererProps {
+  children: ({ className }: { className: string }) => ReactElement | null;
+}
+export const IconRenderer = ({ children }: IconRendererProps) => {
+  const textContext = useContext(TextContext);
+  const headingContext = useContext(HeadingContext);
+
+  assert(
+    Boolean(textContext || headingContext),
+    `IconRenderer must be inside either a \`Text\` or \`Heading\` component.`,
+  );
+
+  return children({ className: iconInlineSize() });
+};

--- a/packages/braid-design-system/lib/components/index.ts
+++ b/packages/braid-design-system/lib/components/index.ts
@@ -43,6 +43,7 @@ export { FieldMessage } from './FieldMessage/FieldMessage';
 export { Heading } from './Heading/Heading';
 export { Hidden } from './Hidden/Hidden';
 export { HiddenVisually } from './HiddenVisually/HiddenVisually';
+export { IconRenderer } from './icons/IconRenderer';
 export { Inline } from './Inline/Inline';
 export { Link } from './Link/Link';
 export { List } from './List/List';

--- a/packages/braid-design-system/lib/hooks/useIcon/index.ts
+++ b/packages/braid-design-system/lib/hooks/useIcon/index.ts
@@ -9,6 +9,8 @@ import HeadingContext from '../../components/Heading/HeadingContext';
 import { lineHeightContainer } from '../../css/lineHeightContainer.css';
 import type { DataAttributeMap } from '../../components/private/buildDataAttributes';
 import buildDataAttributes from '../../components/private/buildDataAttributes';
+import { iconInlineSize } from '../../components/icons/IconRenderer';
+import { atoms } from '../../css/atoms/atoms';
 import * as typographyStyles from '../../css/typography.css';
 import * as styles from './icon.css';
 
@@ -95,20 +97,21 @@ export default (
   }
 
   return {
-    display: isInline ? 'inlineBlock' : 'block',
-    position: isInline ? 'relative' : undefined,
     className: [
       toneClass,
       isInline
         ? [
-            styles.size,
-            styles.inlineCrop,
-            styles.inline,
-            styles.alignY[alignY || 'uppercase'][
-              verticalCorrection[alignY || 'uppercase']
-            ],
+            iconInlineSize({
+              alignY: alignY || 'uppercase',
+              verticalCorrection: verticalCorrection[alignY || 'uppercase'],
+            }),
           ]
-        : iconContainerSize(size),
+        : [
+            atoms({
+              display: 'block',
+            }),
+            iconContainerSize(size),
+          ],
     ],
     ...buildDataAttributes({ data, validateRestProps: restProps }),
     ...a11yProps,

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -5031,6 +5031,15 @@ exports[`IconRefresh 1`] = `
 }
 `;
 
+exports[`IconRenderer 1`] = `
+{
+  exportType: component,
+  props: {
+    children: ({ className }: { className: string; }) => ReactElement<any, string | JSXElementConstructor<any>> | null
+},
+}
+`;
+
 exports[`IconResume 1`] = `
 {
   exportType: component,

--- a/site/src/App/routes/foundations/iconography/IconsDetails.tsx
+++ b/site/src/App/routes/foundations/iconography/IconsDetails.tsx
@@ -19,6 +19,8 @@ import {
   IconSettings,
   IconPeople,
   IconMinus,
+  List,
+  IconRenderer,
 } from 'braid-src/lib/components';
 import { LinkableHeading } from '../../../LinkableHeading/LinkableHeading';
 import { DocExample } from '../../../DocNavigation/DocExample';
@@ -52,11 +54,33 @@ export const IconsDetails = () => (
 
     <Stack space="large">
       <LinkableHeading level="3">Accessibility</LinkableHeading>
+      <Stack space="medium">
+        <Text>
+          Follows the{' '}
+          <TextLink href="https://www.w3.org/TR/wai-aria-1.2/#img">
+            img
+          </TextLink>{' '}
+          role when a <Strong>title</Strong> is provided. As a result this
+          applies the following:
+        </Text>
+        <List>
+          <Text>
+            Applies the <Strong>img</Strong> role to the svg element,
+          </Text>
+          <Text>
+            Adds the provided title to a <Strong>title</Strong> element inside
+            the svg element,
+          </Text>
+          <Text>
+            Associates the title element with the svg via <Strong>id</Strong>{' '}
+            using <Strong>aria-labelledby</Strong>.
+          </Text>
+        </List>
+      </Stack>
       <Text>
-        Follows the{' '}
-        <TextLink href="https://www.w3.org/TR/wai-aria-1.2/#img">img</TextLink>{' '}
-        role when a <Strong>title</Strong> is provided. Otherwise the icon will
-        be assumed as decorative and hidden from assistive technologies.
+        If not being used as an image, the icon will be deemed as{' '}
+        <Strong>decorative</Strong> and hidden from assistive technologies by
+        applying the <Strong>aria-hidden</Strong> attribute.
       </Text>
       <PlayroomStateProvider>
         <DocExample
@@ -327,6 +351,178 @@ export const IconsDetails = () => (
           }
         />
       </PlayroomStateProvider>
+
+      <LinkableHeading level="3">Using custom icons</LinkableHeading>
+      <Text>
+        Braid aims to provide an icon set that caters to the majority of use
+        cases spanning across many products. However, there may be a need to
+        have product specific icons outside of the library. For this use case
+        consumers can use the <Strong>IconRenderer</Strong> component.
+      </Text>
+      <Text>
+        Uses the render prop pattern to provide the required classes to style
+        and align a custom icon.
+      </Text>
+
+      <Stack space="medium">
+        <LinkableHeading level="4" label="custom-icons-size">
+          Sizing and alignment
+        </LinkableHeading>
+        <Text>
+          To make the alignment of icons and typography as seemless as possible,
+          IconRenderer supports{' '}
+          <TextLink href="#size-inline">inline sizing</TextLink>. As a result,
+          it must be used inside either a{' '}
+          <TextLink href="/components/Text">Text</TextLink> or{' '}
+          <TextLink href="/components/Heading">Heading</TextLink> component.
+        </Text>
+        <Text>For example, here is a custom circle alongside a Heading:</Text>
+        <PlayroomStateProvider>
+          <DocExample
+            id="iconRenderer-size"
+            Example={() =>
+              source(
+                <Heading level="1">
+                  <IconRenderer>
+                    {({ className }) => (
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        className={className}
+                      >
+                        <circle cx="12" cy="12" r="10" />
+                      </svg>
+                    )}
+                  </IconRenderer>{' '}
+                  Heading
+                </Heading>,
+              )
+            }
+          />
+        </PlayroomStateProvider>
+      </Stack>
+
+      <Stack space="medium">
+        <LinkableHeading level="4" label="custom-icons-colour">
+          Colour
+        </LinkableHeading>
+        <Text>
+          The Braid icon set is designed using only a single colour (black), and
+          then configured to adopt the colour of either their parent component
+          or the specified <TextLink href="#tones">tone</TextLink> prop.
+        </Text>
+        <Text>
+          If the custom icon should inherit it’s colour, this can be done using
+          the{' '}
+          <TextLink href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentcolor_keyword">
+            currentColor
+          </TextLink>{' '}
+          value.
+        </Text>
+        <PlayroomStateProvider>
+          <DocExample
+            id="iconRenderer-colour"
+            Example={() =>
+              source(
+                <Stack space="medium">
+                  <Text size="xsmall" tone="secondary">
+                    EXAMPLE: Setting “fill=currentColor” on custom icon inside
+                    “brandAccent” Text
+                  </Text>
+                  <Text size="large" tone="brandAccent">
+                    <IconRenderer>
+                      {({ className }) => (
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 24 24"
+                          className={className}
+                          fill="currentColor"
+                        >
+                          <circle cx="12" cy="12" r="10" />
+                        </svg>
+                      )}
+                    </IconRenderer>
+                  </Text>
+                </Stack>,
+              )
+            }
+          />
+        </PlayroomStateProvider>
+      </Stack>
+
+      <Stack space="medium">
+        <LinkableHeading level="4" label="custom-icons-accessibility">
+          Accessibility
+        </LinkableHeading>
+        <Text>
+          When using custom icons, it is important to consider their purpose to
+          the end user. Are they being used as an image? Or are they purely
+          decorative?
+        </Text>
+        <Text>
+          If they are decorative only, then it is recommended they be hidden
+          from screen readers by applying the <Strong>aria-hidden</Strong>{' '}
+          attribute as in the following example:
+        </Text>
+        <PlayroomStateProvider>
+          <DocExample
+            id="iconRenderer-a11y"
+            Example={() =>
+              source(
+                <Text size="large">
+                  <IconRenderer>
+                    {({ className }) => (
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        className={className}
+                        aria-hidden
+                      >
+                        <circle cx="12" cy="12" r="10" />
+                      </svg>
+                    )}
+                  </IconRenderer>
+                </Text>,
+              )
+            }
+          />
+        </PlayroomStateProvider>
+        <Text>
+          However, if they provide value or context, then they should be titled
+          correctly as though they were an image. Below is an example of how to
+          correctly title an icon as an image:
+        </Text>
+        <PlayroomStateProvider>
+          <DocExample
+            id="iconRenderer"
+            Example={() =>
+              source(
+                <Text size="large">
+                  <IconRenderer>
+                    {({ className }) => (
+                      <svg
+                        xmlns="http://www.w3.org/2000/svg"
+                        viewBox="0 0 24 24"
+                        className={className}
+                        aria-labelledby="titleId"
+                        role="img"
+                      >
+                        <title id="titleId">My Custom Icon</title>
+                        <circle cx="12" cy="12" r="10" />
+                      </svg>
+                    )}
+                  </IconRenderer>
+                </Text>,
+              )
+            }
+          />
+        </PlayroomStateProvider>
+        <Text>
+          For more information read the{' '}
+          <TextLink href="#accessibility">Accessibility</TextLink> section
+          above.
+        </Text>
+      </Stack>
     </Stack>
   </Stack>
 );

--- a/site/src/App/routes/foundations/iconography/IconsDetails.tsx
+++ b/site/src/App/routes/foundations/iconography/IconsDetails.tsx
@@ -412,7 +412,7 @@ export const IconsDetails = () => (
           or the specified <TextLink href="#tones">tone</TextLink> prop.
         </Text>
         <Text>
-          If the custom icon should inherit it’s colour, this can be done using
+          If the custom icon should inherit its colour, this can be done using
           the{' '}
           <TextLink href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentcolor_keyword">
             currentColor

--- a/site/src/App/routes/foundations/iconography/IconsDetails.tsx
+++ b/site/src/App/routes/foundations/iconography/IconsDetails.tsx
@@ -356,7 +356,7 @@ export const IconsDetails = () => (
       <Text>
         Braid aims to provide an icon set that caters to the majority of use
         cases spanning across many products. However, there may be a need to
-        have product specific icons outside of the library. For this use case
+        have product-specific icons outside of the library. For this use case
         consumers can use the <Strong>IconRenderer</Strong> component.
       </Text>
       <Text>

--- a/site/src/App/routes/foundations/iconography/IconsDetails.tsx
+++ b/site/src/App/routes/foundations/iconography/IconsDetails.tsx
@@ -368,160 +368,167 @@ export const IconsDetails = () => (
         <LinkableHeading level="4" label="custom-icons-size">
           Sizing and alignment
         </LinkableHeading>
-        <Text>
-          To make the alignment of icons and typography as seemless as possible,
-          IconRenderer supports{' '}
-          <TextLink href="#size-inline">inline sizing</TextLink>. As a result,
-          it must be used inside either a{' '}
-          <TextLink href="/components/Text">Text</TextLink> or{' '}
-          <TextLink href="/components/Heading">Heading</TextLink> component.
-        </Text>
-        <Text>For example, here is a custom circle alongside a Heading:</Text>
-        <PlayroomStateProvider>
-          <DocExample
-            id="iconRenderer-size"
-            Example={() =>
-              source(
-                <Heading level="1">
-                  <IconRenderer>
-                    {({ className }) => (
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        className={className}
-                      >
-                        <circle cx="12" cy="12" r="10" />
-                      </svg>
-                    )}
-                  </IconRenderer>{' '}
-                  Heading
-                </Heading>,
-              )
-            }
-          />
-        </PlayroomStateProvider>
-      </Stack>
-
-      <Stack space="medium">
-        <LinkableHeading level="4" label="custom-icons-colour">
-          Colour
-        </LinkableHeading>
-        <Text>
-          The Braid icon set is designed using only a single colour (black), and
-          then configured to adopt the colour of either their parent component
-          or the specified <TextLink href="#tones">tone</TextLink> prop.
-        </Text>
-        <Text>
-          If the custom icon should inherit its colour, this can be done using
-          the{' '}
-          <TextLink href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentcolor_keyword">
-            currentColor
-          </TextLink>{' '}
-          value.
-        </Text>
-        <PlayroomStateProvider>
-          <DocExample
-            id="iconRenderer-colour"
-            Example={() =>
-              source(
-                <Stack space="medium">
-                  <Text size="xsmall" tone="secondary">
-                    EXAMPLE: Setting “fill=currentColor” on custom icon inside
-                    “brandAccent” Text
-                  </Text>
-                  <Text size="large" tone="brandAccent">
+        <Stack space="large">
+          <Text>
+            To make the alignment of icons and typography as seemless as
+            possible, IconRenderer supports{' '}
+            <TextLink href="#size-inline">inline sizing</TextLink>. As a result,
+            it must be used inside either a{' '}
+            <TextLink href="/components/Text">Text</TextLink> or{' '}
+            <TextLink href="/components/Heading">Heading</TextLink> component.
+          </Text>
+          <Text>For example, here is a custom circle alongside a Heading:</Text>
+          <PlayroomStateProvider>
+            <DocExample
+              id="iconRenderer-size"
+              Example={() =>
+                source(
+                  <Heading level="1">
                     <IconRenderer>
                       {({ className }) => (
                         <svg
                           xmlns="http://www.w3.org/2000/svg"
                           viewBox="0 0 24 24"
                           className={className}
-                          fill="currentColor"
                         >
                           <circle cx="12" cy="12" r="10" />
                         </svg>
                       )}
-                    </IconRenderer>
-                  </Text>
-                </Stack>,
-              )
-            }
-          />
-        </PlayroomStateProvider>
+                    </IconRenderer>{' '}
+                    Heading
+                  </Heading>,
+                )
+              }
+            />
+          </PlayroomStateProvider>
+        </Stack>
+      </Stack>
+
+      <Stack space="medium">
+        <LinkableHeading level="4" label="custom-icons-colour">
+          Colour
+        </LinkableHeading>
+        <Stack space="large">
+          <Text>
+            The Braid icon set is designed using only a single colour (black),
+            and then configured to adopt the colour of either their parent
+            component or the specified <TextLink href="#tones">tone</TextLink>{' '}
+            prop.
+          </Text>
+          <Text>
+            If the custom icon should inherit its colour, this can be done using
+            the{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Web/CSS/color_value#currentcolor_keyword">
+              currentColor
+            </TextLink>{' '}
+            value.
+          </Text>
+          <PlayroomStateProvider>
+            <DocExample
+              id="iconRenderer-colour"
+              Example={() =>
+                source(
+                  <Stack space="medium">
+                    <Text size="xsmall" tone="secondary">
+                      EXAMPLE: Setting “fill=currentColor” on custom icon inside
+                      “brandAccent” Text
+                    </Text>
+                    <Text size="large" tone="brandAccent">
+                      <IconRenderer>
+                        {({ className }) => (
+                          <svg
+                            xmlns="http://www.w3.org/2000/svg"
+                            viewBox="0 0 24 24"
+                            className={className}
+                            fill="currentColor"
+                          >
+                            <circle cx="12" cy="12" r="10" />
+                          </svg>
+                        )}
+                      </IconRenderer>
+                    </Text>
+                  </Stack>,
+                )
+              }
+            />
+          </PlayroomStateProvider>
+        </Stack>
       </Stack>
 
       <Stack space="medium">
         <LinkableHeading level="4" label="custom-icons-accessibility">
           Accessibility
         </LinkableHeading>
-        <Text>
-          When using custom icons, it is important to consider their purpose to
-          the end user. Are they being used as an image? Or are they purely
-          decorative?
-        </Text>
-        <Text>
-          If they are decorative only, then it is recommended they be hidden
-          from screen readers by applying the <Strong>aria-hidden</Strong>{' '}
-          attribute as in the following example:
-        </Text>
-        <PlayroomStateProvider>
-          <DocExample
-            id="iconRenderer-a11y"
-            Example={() =>
-              source(
-                <Text size="large">
-                  <IconRenderer>
-                    {({ className }) => (
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        className={className}
-                        aria-hidden
-                      >
-                        <circle cx="12" cy="12" r="10" />
-                      </svg>
-                    )}
-                  </IconRenderer>
-                </Text>,
-              )
-            }
-          />
-        </PlayroomStateProvider>
-        <Text>
-          However, if they provide value or context, then they should be titled
-          correctly as though they were an image. Below is an example of how to
-          correctly title an icon as an image:
-        </Text>
-        <PlayroomStateProvider>
-          <DocExample
-            id="iconRenderer"
-            Example={() =>
-              source(
-                <Text size="large">
-                  <IconRenderer>
-                    {({ className }) => (
-                      <svg
-                        xmlns="http://www.w3.org/2000/svg"
-                        viewBox="0 0 24 24"
-                        className={className}
-                        aria-labelledby="titleId"
-                        role="img"
-                      >
-                        <title id="titleId">My Custom Icon</title>
-                        <circle cx="12" cy="12" r="10" />
-                      </svg>
-                    )}
-                  </IconRenderer>
-                </Text>,
-              )
-            }
-          />
-        </PlayroomStateProvider>
-        <Text>
-          For more information read the{' '}
-          <TextLink href="#accessibility">Accessibility</TextLink> section
-          above.
-        </Text>
+        <Stack space="large">
+          <Text>
+            When using custom icons, it is important to consider their purpose
+            to the end user. Are they being used as an image? Or are they purely
+            decorative?
+          </Text>
+          <Text>
+            If they are decorative only, then it is recommended they be hidden
+            from screen readers by applying the <Strong>aria-hidden</Strong>{' '}
+            attribute as in the following example:
+          </Text>
+          <PlayroomStateProvider>
+            <DocExample
+              id="iconRenderer-a11y"
+              Example={() =>
+                source(
+                  <Text size="large">
+                    <IconRenderer>
+                      {({ className }) => (
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 24 24"
+                          className={className}
+                          aria-hidden
+                        >
+                          <circle cx="12" cy="12" r="10" />
+                        </svg>
+                      )}
+                    </IconRenderer>
+                  </Text>,
+                )
+              }
+            />
+          </PlayroomStateProvider>
+          <Text>
+            However, if they provide value or context, then they should be
+            titled correctly as though they were an image. Below is an example
+            of how to correctly title an icon as an image:
+          </Text>
+          <PlayroomStateProvider>
+            <DocExample
+              id="iconRenderer"
+              Example={() =>
+                source(
+                  <Text size="large">
+                    <IconRenderer>
+                      {({ className }) => (
+                        <svg
+                          xmlns="http://www.w3.org/2000/svg"
+                          viewBox="0 0 24 24"
+                          className={className}
+                          aria-labelledby="titleId"
+                          role="img"
+                        >
+                          <title id="titleId">My Custom Icon</title>
+                          <circle cx="12" cy="12" r="10" />
+                        </svg>
+                      )}
+                    </IconRenderer>
+                  </Text>,
+                )
+              }
+            />
+          </PlayroomStateProvider>
+          <Text>
+            For more information read the{' '}
+            <TextLink href="#accessibility">Accessibility</TextLink> section
+            above.
+          </Text>
+        </Stack>
       </Stack>
     </Stack>
   </Stack>

--- a/site/src/undocumentedExports.json
+++ b/site/src/undocumentedExports.json
@@ -6,6 +6,7 @@
     "Column",
     "CheckboxStandalone",
     "filterSuggestions",
+    "IconRenderer",
     "makeLinkComponent",
     "MenuItemLink",
     "RadioItem",


### PR DESCRIPTION
Provides support for sizing and aligning custom icons with Braid’s typographic components. The new `IconRenderer` component supports being used within `Text` and `Heading` components as well as inside `icon` slots of other components.

Uses the render prop pattern to provide the required classes to style and align a custom icon.

**EXAMPLE USAGE:**
```jsx
<Heading level="1">
  <IconRenderer>
    {({ className }) => (
      <svg className={className}>
        ...
      </svg>
    )}
  </IconRenderer>
</Heading>
```