### PR TITLE
Refactor narrowing of `TextDropdownOption` to be compatible with typescript 4.9

### DIFF
--- a/.changeset/shaggy-tools-trade.md
+++ b/.changeset/shaggy-tools-trade.md
@@ -3,11 +3,8 @@
 ---
 
 ---
-
 updated:
-
-- TextDropdown
-
+  - TextDropdown
 ---
 
 Fix a type error affecting consumers on TypeScript versions >=4.9.0

--- a/.changeset/shaggy-tools-trade.md
+++ b/.changeset/shaggy-tools-trade.md
@@ -10,4 +10,4 @@ updated:
 
 ---
 
-Fix a type issue affecting TypeScript versions >=4.9.0
+Fix a type error affectin consumers on TypeScript versions >=4.9.0

--- a/.changeset/shaggy-tools-trade.md
+++ b/.changeset/shaggy-tools-trade.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+---
+
+updated:
+
+- TextDropdown
+
+---
+
+Fix a type issue affecting TypeScript versions >=4.9.0

--- a/.changeset/shaggy-tools-trade.md
+++ b/.changeset/shaggy-tools-trade.md
@@ -10,4 +10,4 @@ updated:
 
 ---
 
-Fix a type error affectin consumers on TypeScript versions >=4.9.0
+Fix a type error affecting consumers on TypeScript versions >=4.9.0

--- a/packages/braid-design-system/lib/components/TextDropdown/TextDropdown.tsx
+++ b/packages/braid-design-system/lib/components/TextDropdown/TextDropdown.tsx
@@ -29,8 +29,8 @@ export interface TextDropdownProps<Value> {
 export function parseSimpleToComplexOption<Value>(
   option: TextDropdownProps<Value>['options'][number],
 ) {
-  return typeof option !== 'string' &&
-    typeof option !== 'number' &&
+  return typeof option === 'object' &&
+    option !== null &&
     'text' in option &&
     'value' in option
     ? option

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -6755,7 +6755,9 @@ exports[`Radio 1`] = `
   props: {
     aria-describedby?: string
     badge?: ReactElement<BadgeProps, string | JSXElementConstructor<any>>
-    checked: boolean
+    checked: 
+        | false
+        | true
     children?: ReactNode
     data?: DataAttributeMap
     description?: ReactNode

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -79,7 +79,7 @@ importers:
       enquirer: 2.3.6
       escape-string-regexp: 4.0.0
       eslint: 8.21.0
-      eslint-config-seek: 10.1.0_cjuso6hqax2af5jwgles3svesm
+      eslint-config-seek: 10.1.0_ysrbpudmimcglvncbjkczw2fle
       fast-glob: 3.2.11
       fs-extra: 10.1.0
       gh-pages: 4.0.0
@@ -91,8 +91,8 @@ importers:
       prettier: 2.7.1
       renovate-config-seek: 0.4.0
       surge: 0.23.1
-      ts-node: 10.8.0_rbv5fvwh3qaahz6dxcho7rzsry
-      typescript: 4.6.4
+      ts-node: 10.8.0_jytyqnesmarciubgup2n7dsryu
+      typescript: 4.9.3
 
   packages/braid-design-system:
     specifiers:
@@ -219,9 +219,9 @@ importers:
       '@babel/plugin-syntax-jsx': ^7.17.12
       '@babel/plugin-syntax-typescript': ^7.17.12
       '@babel/traverse': ^7.18.11
+      '@types/babel-plugin-tester': ^9.0.5
       '@types/babel__core': ^7.1.19
       '@types/babel__traverse': ^7.18.0
-      '@types/babel-plugin-tester': ^9.0.5
       '@types/cli-progress': ^3.11.0
       '@types/dedent': ^0.7.0
       '@types/react': ^18.0.21
@@ -259,9 +259,9 @@ importers:
       recast: 0.21.1
       workerpool: 6.2.1
     devDependencies:
+      '@types/babel-plugin-tester': 9.0.5
       '@types/babel__core': 7.1.19
       '@types/babel__traverse': 7.18.0
-      '@types/babel-plugin-tester': 9.0.5
       '@types/dedent': 0.7.0
 
   packages/generate-component-docs:
@@ -282,7 +282,7 @@ importers:
       esbuild-register: 3.3.3_esbuild@0.14.39
       fs-extra: 10.1.0
       lodash: 4.17.21
-      typescript: 4.6.4
+      typescript: 4.9.3
 
   site:
     specifiers:
@@ -3461,7 +3461,7 @@ packages:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  /@storybook/builder-webpack4/6.5.12_nmceyhmqsvjarxohsn5tjc7gl4:
+  /@storybook/builder-webpack4/6.5.12_j6n3fnfl3ogrh2anobl27pcriu:
     resolution: {integrity: sha512-TsthT5jm9ZxQPNOZJbF5AV24me3i+jjYD7gbdKdSHrOVn1r3ydX4Z8aD6+BjLCtTn3T+e8NMvUkL4dInEo1x6g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3479,7 +3479,7 @@ packages:
       '@storybook/client-api': 6.5.12_biqbaboplfbrettd7655fr4n2y
       '@storybook/client-logger': 6.5.12
       '@storybook/components': 6.5.12_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-common': 6.5.12_nmceyhmqsvjarxohsn5tjc7gl4
+      '@storybook/core-common': 6.5.12_j6n3fnfl3ogrh2anobl27pcriu
       '@storybook/core-events': 6.5.12
       '@storybook/node-logger': 6.5.12
       '@storybook/preview-web': 6.5.12_biqbaboplfbrettd7655fr4n2y
@@ -3497,12 +3497,12 @@ packages:
       css-loader: 3.6.0_webpack@4.46.0
       file-loader: 6.2.0_webpack@4.46.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 4.1.6_gplzhsecki363wzvnzp4wfrwvi
+      fork-ts-checker-webpack-plugin: 4.1.6_7gjrtr2fo3jjstcxw4vighex4q
       glob: 7.2.3
       glob-promise: 3.4.0_glob@7.2.3
       global: 4.4.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
-      pnp-webpack-plugin: 1.6.4_typescript@4.6.4
+      pnp-webpack-plugin: 1.6.4_typescript@4.9.3
       postcss: 7.0.39
       postcss-flexbugs-fixes: 4.2.1
       postcss-loader: 4.3.0_gzaxsinx64nntyd3vmdqwl7coe
@@ -3513,7 +3513,7 @@ packages:
       style-loader: 1.3.0_webpack@4.46.0
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 4.6.4
+      typescript: 4.9.3
       url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -3529,7 +3529,7 @@ packages:
       - webpack-cli
       - webpack-command
 
-  /@storybook/builder-webpack5/6.5.12_yag4ocovaeivukrtnkjjf4uxum:
+  /@storybook/builder-webpack5/6.5.12_ldqikllusglrhwpikog3fqt5ry:
     resolution: {integrity: sha512-jK5jWxhSbMAM/onPB6WN7xVqwZnAmzJljOG24InO/YIjW8pQof7MeAXCYBM4rYM+BbK61gkZ/RKxwlkqXBWv+Q==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3547,7 +3547,7 @@ packages:
       '@storybook/client-api': 6.5.12_biqbaboplfbrettd7655fr4n2y
       '@storybook/client-logger': 6.5.12
       '@storybook/components': 6.5.12_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-common': 6.5.12_nmceyhmqsvjarxohsn5tjc7gl4
+      '@storybook/core-common': 6.5.12_j6n3fnfl3ogrh2anobl27pcriu
       '@storybook/core-events': 6.5.12
       '@storybook/node-logger': 6.5.12
       '@storybook/preview-web': 6.5.12_biqbaboplfbrettd7655fr4n2y
@@ -3562,7 +3562,7 @@ packages:
       case-sensitive-paths-webpack-plugin: 2.4.0
       core-js: 3.22.6
       css-loader: 5.2.7_webpack@5.72.1
-      fork-ts-checker-webpack-plugin: 6.5.2_ugfow55eyme64bvegjfzj5yvdu
+      fork-ts-checker-webpack-plugin: 6.5.2_p4naa4dozxqg4m7qdclhykuafu
       glob: 7.2.3
       glob-promise: 3.4.0_glob@7.2.3
       html-webpack-plugin: 5.5.0_webpack@5.72.1
@@ -3574,7 +3574,7 @@ packages:
       style-loader: 2.0.0_webpack@5.72.1
       terser-webpack-plugin: 5.3.1_nggqohtoo7hf64raofaye6qkmi
       ts-dedent: 2.2.0
-      typescript: 4.6.4
+      typescript: 4.9.3
       util-deprecate: 1.0.2
       webpack: 5.72.1_esbuild@0.15.10
       webpack-dev-middleware: 4.3.0_webpack@5.72.1
@@ -3669,7 +3669,7 @@ packages:
       regenerator-runtime: 0.13.9
       util-deprecate: 1.0.2
 
-  /@storybook/core-client/6.5.12_3rnyr4wzsyxsarjflruafcve6y:
+  /@storybook/core-client/6.5.12_2ahee5t4iadxs4vqsolbz22xei:
     resolution: {integrity: sha512-jyAd0ud6zO+flpLv0lEHbbt1Bv9Ms225M6WTQLrfe7kN/7j1pVKZEoeVCLZwkJUtSKcNiWQxZbS15h31pcYwqg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3700,48 +3700,48 @@ packages:
       react-dom: 18.2.0_react@18.2.0
       regenerator-runtime: 0.13.9
       ts-dedent: 2.2.0
-      typescript: 4.6.4
-      unfetch: 4.2.0
-      util-deprecate: 1.0.2
-      webpack: 4.46.0
-
-  /@storybook/core-client/6.5.12_umcgd22uaose3ay5wkidljphaq:
-    resolution: {integrity: sha512-jyAd0ud6zO+flpLv0lEHbbt1Bv9Ms225M6WTQLrfe7kN/7j1pVKZEoeVCLZwkJUtSKcNiWQxZbS15h31pcYwqg==}
-    peerDependencies:
-      react: ^16.8.0 || ^17.0.0 || ^18.0.0
-      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
-      typescript: '*'
-      webpack: '*'
-    peerDependenciesMeta:
-      typescript:
-        optional: true
-    dependencies:
-      '@storybook/addons': 6.5.12_biqbaboplfbrettd7655fr4n2y
-      '@storybook/channel-postmessage': 6.5.12
-      '@storybook/channel-websocket': 6.5.12
-      '@storybook/client-api': 6.5.12_biqbaboplfbrettd7655fr4n2y
-      '@storybook/client-logger': 6.5.12
-      '@storybook/core-events': 6.5.12
-      '@storybook/csf': 0.0.2--canary.4566f4d.1
-      '@storybook/preview-web': 6.5.12_biqbaboplfbrettd7655fr4n2y
-      '@storybook/store': 6.5.12_biqbaboplfbrettd7655fr4n2y
-      '@storybook/ui': 6.5.12_biqbaboplfbrettd7655fr4n2y
-      airbnb-js-shims: 2.2.1
-      ansi-to-html: 0.6.15
-      core-js: 3.22.6
-      global: 4.4.0
-      lodash: 4.17.21
-      qs: 6.10.3
-      react: 18.2.0
-      react-dom: 18.2.0_react@18.2.0
-      regenerator-runtime: 0.13.9
-      ts-dedent: 2.2.0
-      typescript: 4.6.4
+      typescript: 4.9.3
       unfetch: 4.2.0
       util-deprecate: 1.0.2
       webpack: 5.72.1_esbuild@0.15.10
 
-  /@storybook/core-common/6.5.12_nmceyhmqsvjarxohsn5tjc7gl4:
+  /@storybook/core-client/6.5.12_5ey2xofmun3swml4ceosmuhnmq:
+    resolution: {integrity: sha512-jyAd0ud6zO+flpLv0lEHbbt1Bv9Ms225M6WTQLrfe7kN/7j1pVKZEoeVCLZwkJUtSKcNiWQxZbS15h31pcYwqg==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0
+      typescript: '*'
+      webpack: '*'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+    dependencies:
+      '@storybook/addons': 6.5.12_biqbaboplfbrettd7655fr4n2y
+      '@storybook/channel-postmessage': 6.5.12
+      '@storybook/channel-websocket': 6.5.12
+      '@storybook/client-api': 6.5.12_biqbaboplfbrettd7655fr4n2y
+      '@storybook/client-logger': 6.5.12
+      '@storybook/core-events': 6.5.12
+      '@storybook/csf': 0.0.2--canary.4566f4d.1
+      '@storybook/preview-web': 6.5.12_biqbaboplfbrettd7655fr4n2y
+      '@storybook/store': 6.5.12_biqbaboplfbrettd7655fr4n2y
+      '@storybook/ui': 6.5.12_biqbaboplfbrettd7655fr4n2y
+      airbnb-js-shims: 2.2.1
+      ansi-to-html: 0.6.15
+      core-js: 3.22.6
+      global: 4.4.0
+      lodash: 4.17.21
+      qs: 6.10.3
+      react: 18.2.0
+      react-dom: 18.2.0_react@18.2.0
+      regenerator-runtime: 0.13.9
+      ts-dedent: 2.2.0
+      typescript: 4.9.3
+      unfetch: 4.2.0
+      util-deprecate: 1.0.2
+      webpack: 4.46.0
+
+  /@storybook/core-common/6.5.12_j6n3fnfl3ogrh2anobl27pcriu:
     resolution: {integrity: sha512-gG20+eYdIhwQNu6Xs805FLrOCWtkoc8Rt8gJiRt8yXzZh9EZkU4xgCRoCxrrJ03ys/gTiCFbBOfRi749uM3z4w==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3785,7 +3785,7 @@ packages:
       express: 4.18.1
       file-system-cache: 1.1.0
       find-up: 5.0.0
-      fork-ts-checker-webpack-plugin: 6.5.2_gplzhsecki363wzvnzp4wfrwvi
+      fork-ts-checker-webpack-plugin: 6.5.2_7gjrtr2fo3jjstcxw4vighex4q
       fs-extra: 9.1.0
       glob: 7.2.3
       handlebars: 4.7.7
@@ -3801,7 +3801,7 @@ packages:
       slash: 3.0.0
       telejson: 6.0.8
       ts-dedent: 2.2.0
-      typescript: 4.6.4
+      typescript: 4.9.3
       util-deprecate: 1.0.2
       webpack: 4.46.0
     transitivePeerDependencies:
@@ -3816,7 +3816,7 @@ packages:
     dependencies:
       core-js: 3.22.6
 
-  /@storybook/core-server/6.5.12_qdg3mj6nu2wgj6hodxumfus63e:
+  /@storybook/core-server/6.5.12_lejise5ao7nl4scxaen42yfghe:
     resolution: {integrity: sha512-q1b/XKwoLUcCoCQ+8ndPD5THkEwXZYJ9ROv16i2VGUjjjAuSqpEYBq5GMGQUgxlWp1bkxtdGL2Jz+6pZfvldzA==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -3833,19 +3833,19 @@ packages:
         optional: true
     dependencies:
       '@discoveryjs/json-ext': 0.5.7
-      '@storybook/builder-webpack4': 6.5.12_nmceyhmqsvjarxohsn5tjc7gl4
-      '@storybook/builder-webpack5': 6.5.12_yag4ocovaeivukrtnkjjf4uxum
-      '@storybook/core-client': 6.5.12_3rnyr4wzsyxsarjflruafcve6y
-      '@storybook/core-common': 6.5.12_nmceyhmqsvjarxohsn5tjc7gl4
+      '@storybook/builder-webpack4': 6.5.12_j6n3fnfl3ogrh2anobl27pcriu
+      '@storybook/builder-webpack5': 6.5.12_ldqikllusglrhwpikog3fqt5ry
+      '@storybook/core-client': 6.5.12_5ey2xofmun3swml4ceosmuhnmq
+      '@storybook/core-common': 6.5.12_j6n3fnfl3ogrh2anobl27pcriu
       '@storybook/core-events': 6.5.12
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/csf-tools': 6.5.12
-      '@storybook/manager-webpack4': 6.5.12_nmceyhmqsvjarxohsn5tjc7gl4
-      '@storybook/manager-webpack5': 6.5.12_yag4ocovaeivukrtnkjjf4uxum
+      '@storybook/manager-webpack4': 6.5.12_j6n3fnfl3ogrh2anobl27pcriu
+      '@storybook/manager-webpack5': 6.5.12_ldqikllusglrhwpikog3fqt5ry
       '@storybook/node-logger': 6.5.12
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.12_biqbaboplfbrettd7655fr4n2y
-      '@storybook/telemetry': 6.5.12_nmceyhmqsvjarxohsn5tjc7gl4
+      '@storybook/telemetry': 6.5.12_j6n3fnfl3ogrh2anobl27pcriu
       '@types/node': 16.11.36
       '@types/node-fetch': 2.6.1
       '@types/pretty-hrtime': 1.0.1
@@ -3876,7 +3876,7 @@ packages:
       slash: 3.0.0
       telejson: 6.0.8
       ts-dedent: 2.2.0
-      typescript: 4.6.4
+      typescript: 4.9.3
       util-deprecate: 1.0.2
       watchpack: 2.3.1
       webpack: 4.46.0
@@ -3894,7 +3894,7 @@ packages:
       - webpack-cli
       - webpack-command
 
-  /@storybook/core/6.5.12_jygk3trxsgd7ubdufm276b7oim:
+  /@storybook/core/6.5.12_p7pp4weyrhr23uwjwigkt6iaj4:
     resolution: {integrity: sha512-+o3psAVWL+5LSwyJmEbvhgxKO1Et5uOX8ujNVt/f1fgwJBIf6BypxyPKu9YGQDRzcRssESQQZWNrZCCAZlFeuQ==}
     peerDependencies:
       '@storybook/builder-webpack5': '*'
@@ -3911,13 +3911,13 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@storybook/builder-webpack5': 6.5.12_yag4ocovaeivukrtnkjjf4uxum
-      '@storybook/core-client': 6.5.12_umcgd22uaose3ay5wkidljphaq
-      '@storybook/core-server': 6.5.12_qdg3mj6nu2wgj6hodxumfus63e
-      '@storybook/manager-webpack5': 6.5.12_yag4ocovaeivukrtnkjjf4uxum
+      '@storybook/builder-webpack5': 6.5.12_ldqikllusglrhwpikog3fqt5ry
+      '@storybook/core-client': 6.5.12_2ahee5t4iadxs4vqsolbz22xei
+      '@storybook/core-server': 6.5.12_lejise5ao7nl4scxaen42yfghe
+      '@storybook/manager-webpack5': 6.5.12_ldqikllusglrhwpikog3fqt5ry
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
-      typescript: 4.6.4
+      typescript: 4.9.3
       webpack: 5.72.1_esbuild@0.15.10
     transitivePeerDependencies:
       - '@storybook/mdx2-csf'
@@ -3976,7 +3976,7 @@ packages:
       - react-dom
       - supports-color
 
-  /@storybook/manager-webpack4/6.5.12_nmceyhmqsvjarxohsn5tjc7gl4:
+  /@storybook/manager-webpack4/6.5.12_j6n3fnfl3ogrh2anobl27pcriu:
     resolution: {integrity: sha512-LH3e6qfvq2znEdxe2kaWtmdDPTnvSkufzoC9iwOgNvo3YrTGrYNyUTDegvW293TOTVfUn7j6TBcsOxIgRnt28g==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -3990,8 +3990,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.18.0
       '@babel/preset-react': 7.18.6_@babel+core@7.18.0
       '@storybook/addons': 6.5.12_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-client': 6.5.12_3rnyr4wzsyxsarjflruafcve6y
-      '@storybook/core-common': 6.5.12_nmceyhmqsvjarxohsn5tjc7gl4
+      '@storybook/core-client': 6.5.12_5ey2xofmun3swml4ceosmuhnmq
+      '@storybook/core-common': 6.5.12_j6n3fnfl3ogrh2anobl27pcriu
       '@storybook/node-logger': 6.5.12
       '@storybook/theming': 6.5.12_biqbaboplfbrettd7655fr4n2y
       '@storybook/ui': 6.5.12_biqbaboplfbrettd7655fr4n2y
@@ -4008,7 +4008,7 @@ packages:
       fs-extra: 9.1.0
       html-webpack-plugin: 4.5.2_webpack@4.46.0
       node-fetch: 2.6.7
-      pnp-webpack-plugin: 1.6.4_typescript@4.6.4
+      pnp-webpack-plugin: 1.6.4_typescript@4.9.3
       react: 18.2.0
       react-dom: 18.2.0_react@18.2.0
       read-pkg-up: 7.0.1
@@ -4018,7 +4018,7 @@ packages:
       telejson: 6.0.8
       terser-webpack-plugin: 4.2.3_webpack@4.46.0
       ts-dedent: 2.2.0
-      typescript: 4.6.4
+      typescript: 4.9.3
       url-loader: 4.1.1_lit45vopotvaqup7lrvlnvtxwy
       util-deprecate: 1.0.2
       webpack: 4.46.0
@@ -4033,7 +4033,7 @@ packages:
       - webpack-cli
       - webpack-command
 
-  /@storybook/manager-webpack5/6.5.12_yag4ocovaeivukrtnkjjf4uxum:
+  /@storybook/manager-webpack5/6.5.12_ldqikllusglrhwpikog3fqt5ry:
     resolution: {integrity: sha512-F+KgoINhfo1ArbirCc9L+EyADYD8Z4t0LyZYDVcBiZ8DlRIMIoUSye6tDsnyEm+OPloLVAcGwRMYgFhuHB70Lg==}
     peerDependencies:
       react: ^16.8.0 || ^17.0.0 || ^18.0.0
@@ -4047,8 +4047,8 @@ packages:
       '@babel/plugin-transform-template-literals': 7.18.9_@babel+core@7.18.0
       '@babel/preset-react': 7.18.6_@babel+core@7.18.0
       '@storybook/addons': 6.5.12_biqbaboplfbrettd7655fr4n2y
-      '@storybook/core-client': 6.5.12_umcgd22uaose3ay5wkidljphaq
-      '@storybook/core-common': 6.5.12_nmceyhmqsvjarxohsn5tjc7gl4
+      '@storybook/core-client': 6.5.12_2ahee5t4iadxs4vqsolbz22xei
+      '@storybook/core-common': 6.5.12_j6n3fnfl3ogrh2anobl27pcriu
       '@storybook/node-logger': 6.5.12
       '@storybook/theming': 6.5.12_biqbaboplfbrettd7655fr4n2y
       '@storybook/ui': 6.5.12_biqbaboplfbrettd7655fr4n2y
@@ -4073,7 +4073,7 @@ packages:
       telejson: 6.0.8
       terser-webpack-plugin: 5.3.1_nggqohtoo7hf64raofaye6qkmi
       ts-dedent: 2.2.0
-      typescript: 4.6.4
+      typescript: 4.9.3
       util-deprecate: 1.0.2
       webpack: 5.72.1_esbuild@0.15.10
       webpack-dev-middleware: 4.3.0_webpack@5.72.1
@@ -4141,7 +4141,7 @@ packages:
       unfetch: 4.2.0
       util-deprecate: 1.0.2
 
-  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_gp3atwgq76mgimstdygasg64n4:
+  /@storybook/react-docgen-typescript-plugin/1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_ofcovicxptyw3tjat2rxzptzve:
     resolution: {integrity: sha512-eVg3BxlOm2P+chijHBTByr90IZVUtgRW56qEOLX7xlww2NBuKrcavBlcmn+HH7GIUktquWkMPtvy6e0W0NgA5w==}
     peerDependencies:
       typescript: '>= 3.x'
@@ -4152,14 +4152,14 @@ packages:
       find-cache-dir: 3.3.2
       flat-cache: 3.0.4
       micromatch: 4.0.5
-      react-docgen-typescript: 2.2.2_typescript@4.6.4
+      react-docgen-typescript: 2.2.2_typescript@4.9.3
       tslib: 2.4.0
-      typescript: 4.6.4
+      typescript: 4.9.3
       webpack: 5.72.1_esbuild@0.15.10
     transitivePeerDependencies:
       - supports-color
 
-  /@storybook/react/6.5.12_z5fpv76b642hnp63anoosxxqxq:
+  /@storybook/react/6.5.12_fibidwl7fiwvdh4fue4gi5zelq:
     resolution: {integrity: sha512-1tG8EdSfp+OZAKAWPT2UrexF4o007jEMwQFFXw1atIQrQOADzSnZ7lTYJ08o5TyJwksswtr18tH3oJJ9sG3KPw==}
     engines: {node: '>=10.13.0'}
     hasBin: true
@@ -4192,15 +4192,15 @@ packages:
       '@babel/preset-react': 7.18.6_@babel+core@7.18.0
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.7_n4ncz27tdpyfamnqjsbgmqsqay
       '@storybook/addons': 6.5.12_biqbaboplfbrettd7655fr4n2y
-      '@storybook/builder-webpack5': 6.5.12_yag4ocovaeivukrtnkjjf4uxum
+      '@storybook/builder-webpack5': 6.5.12_ldqikllusglrhwpikog3fqt5ry
       '@storybook/client-logger': 6.5.12
-      '@storybook/core': 6.5.12_jygk3trxsgd7ubdufm276b7oim
-      '@storybook/core-common': 6.5.12_nmceyhmqsvjarxohsn5tjc7gl4
+      '@storybook/core': 6.5.12_p7pp4weyrhr23uwjwigkt6iaj4
+      '@storybook/core-common': 6.5.12_j6n3fnfl3ogrh2anobl27pcriu
       '@storybook/csf': 0.0.2--canary.4566f4d.1
       '@storybook/docs-tools': 6.5.12_biqbaboplfbrettd7655fr4n2y
-      '@storybook/manager-webpack5': 6.5.12_yag4ocovaeivukrtnkjjf4uxum
+      '@storybook/manager-webpack5': 6.5.12_ldqikllusglrhwpikog3fqt5ry
       '@storybook/node-logger': 6.5.12
-      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_gp3atwgq76mgimstdygasg64n4
+      '@storybook/react-docgen-typescript-plugin': 1.0.2-canary.6.9d540b91e815f8fc2f8829189deb00553559ff63.0_ofcovicxptyw3tjat2rxzptzve
       '@storybook/semver': 7.3.2
       '@storybook/store': 6.5.12_biqbaboplfbrettd7655fr4n2y
       '@types/estree': 0.0.51
@@ -4226,7 +4226,7 @@ packages:
       regenerator-runtime: 0.13.9
       require-from-string: 2.0.2
       ts-dedent: 2.2.0
-      typescript: 4.6.4
+      typescript: 4.9.3
       util-deprecate: 1.0.2
       webpack: 5.72.1_esbuild@0.15.10
     transitivePeerDependencies:
@@ -4296,11 +4296,11 @@ packages:
       ts-dedent: 2.2.0
       util-deprecate: 1.0.2
 
-  /@storybook/telemetry/6.5.12_nmceyhmqsvjarxohsn5tjc7gl4:
+  /@storybook/telemetry/6.5.12_j6n3fnfl3ogrh2anobl27pcriu:
     resolution: {integrity: sha512-mCHxx7NmQ3n7gx0nmblNlZE5ZgrjQm6B08mYeWg6Y7r4GZnqS6wZbvAwVhZZ3Gg/9fdqaBApHsdAXp0d5BrlxA==}
     dependencies:
       '@storybook/client-logger': 6.5.12
-      '@storybook/core-common': 6.5.12_nmceyhmqsvjarxohsn5tjc7gl4
+      '@storybook/core-common': 6.5.12_j6n3fnfl3ogrh2anobl27pcriu
       chalk: 4.1.2
       core-js: 3.22.6
       detect-package-manager: 2.0.1
@@ -4959,7 +4959,7 @@ packages:
     resolution: {integrity: sha512-S9q47ByT2pPvD65IvrWp7qppVMpk9WGMbVq9wbWZOHg6tnXSD4vyhao6nOSBwwfDdV2p3Kx9evA9vI+XWTfDvw==}
     dev: false
 
-  /@typescript-eslint/eslint-plugin/5.32.0_wmvu2zfnrjn5l5npmbeohygqdy:
+  /@typescript-eslint/eslint-plugin/5.32.0_osiwo2xidp3tzpindwt4xjgfde:
     resolution: {integrity: sha512-CHLuz5Uz7bHP2WgVlvoZGhf0BvFakBJKAD/43Ty0emn4wXWv5k01ND0C0fHcl/Im8Td2y/7h44E9pca9qAu2ew==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4970,22 +4970,22 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.32.0_e4zyhrvfnqudwdx5bevnvkluy4
+      '@typescript-eslint/parser': 5.32.0_77fvizpdb3y4icyeo2mf4eo7em
       '@typescript-eslint/scope-manager': 5.32.0
-      '@typescript-eslint/type-utils': 5.32.0_e4zyhrvfnqudwdx5bevnvkluy4
-      '@typescript-eslint/utils': 5.32.0_e4zyhrvfnqudwdx5bevnvkluy4
+      '@typescript-eslint/type-utils': 5.32.0_77fvizpdb3y4icyeo2mf4eo7em
+      '@typescript-eslint/utils': 5.32.0_77fvizpdb3y4icyeo2mf4eo7em
       debug: 4.3.4
       eslint: 7.32.0
       functional-red-black-tree: 1.0.1
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.6.4
-      typescript: 4.6.4
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/eslint-plugin/5.41.0_zxfaorj52qpqkjdoqagwyg6lmq:
+  /@typescript-eslint/eslint-plugin/5.41.0_6t6dsu3ksl3pxuxvgp2mpgltxi:
     resolution: {integrity: sha512-DXUS22Y57/LAFSg3x7Vi6RNAuLpTXwxB9S2nIA7msBb/Zt8p7XqMwdpdc1IU7CkOQUPgAqR5fWvxuKCbneKGmA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -4996,22 +4996,22 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.41.0_vxmhu3tyr7cxhd2vxjkubkv7im
+      '@typescript-eslint/parser': 5.41.0_4he5nxxgrmu5gxjroamasnmd3i
       '@typescript-eslint/scope-manager': 5.41.0
-      '@typescript-eslint/type-utils': 5.41.0_vxmhu3tyr7cxhd2vxjkubkv7im
-      '@typescript-eslint/utils': 5.41.0_vxmhu3tyr7cxhd2vxjkubkv7im
+      '@typescript-eslint/type-utils': 5.41.0_4he5nxxgrmu5gxjroamasnmd3i
+      '@typescript-eslint/utils': 5.41.0_4he5nxxgrmu5gxjroamasnmd3i
       debug: 4.3.4
       eslint: 8.21.0
       ignore: 5.2.0
       regexpp: 3.2.0
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.6.4
-      typescript: 4.6.4
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/parser/5.32.0_e4zyhrvfnqudwdx5bevnvkluy4:
+  /@typescript-eslint/parser/5.32.0_77fvizpdb3y4icyeo2mf4eo7em:
     resolution: {integrity: sha512-IxRtsehdGV9GFQ35IGm5oKKR2OGcazUoiNBxhRV160iF9FoyuXxjY+rIqs1gfnd+4eL98OjeGnMpE7RF/NBb3A==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5023,14 +5023,14 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.32.0
       '@typescript-eslint/types': 5.32.0
-      '@typescript-eslint/typescript-estree': 5.32.0_typescript@4.6.4
+      '@typescript-eslint/typescript-estree': 5.32.0_typescript@4.9.3
       debug: 4.3.4
       eslint: 7.32.0
-      typescript: 4.6.4
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/parser/5.41.0_vxmhu3tyr7cxhd2vxjkubkv7im:
+  /@typescript-eslint/parser/5.41.0_4he5nxxgrmu5gxjroamasnmd3i:
     resolution: {integrity: sha512-HQVfix4+RL5YRWZboMD1pUfFN8MpRH4laziWkkAzyO1fvNOY/uinZcvo3QiFJVS/siNHupV8E5+xSwQZrl6PZA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5042,10 +5042,10 @@ packages:
     dependencies:
       '@typescript-eslint/scope-manager': 5.41.0
       '@typescript-eslint/types': 5.41.0
-      '@typescript-eslint/typescript-estree': 5.41.0_typescript@4.6.4
+      '@typescript-eslint/typescript-estree': 5.41.0_typescript@4.9.3
       debug: 4.3.4
       eslint: 8.21.0
-      typescript: 4.6.4
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5065,7 +5065,7 @@ packages:
       '@typescript-eslint/visitor-keys': 5.41.0
     dev: false
 
-  /@typescript-eslint/type-utils/5.32.0_e4zyhrvfnqudwdx5bevnvkluy4:
+  /@typescript-eslint/type-utils/5.32.0_77fvizpdb3y4icyeo2mf4eo7em:
     resolution: {integrity: sha512-0gSsIhFDduBz3QcHJIp3qRCvVYbqzHg8D6bHFsDMrm0rURYDj+skBK2zmYebdCp+4nrd9VWd13egvhYFJj/wZg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5075,15 +5075,15 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/utils': 5.32.0_e4zyhrvfnqudwdx5bevnvkluy4
+      '@typescript-eslint/utils': 5.32.0_77fvizpdb3y4icyeo2mf4eo7em
       debug: 4.3.4
       eslint: 7.32.0
-      tsutils: 3.21.0_typescript@4.6.4
-      typescript: 4.6.4
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/type-utils/5.41.0_vxmhu3tyr7cxhd2vxjkubkv7im:
+  /@typescript-eslint/type-utils/5.41.0_4he5nxxgrmu5gxjroamasnmd3i:
     resolution: {integrity: sha512-L30HNvIG6A1Q0R58e4hu4h+fZqaO909UcnnPbwKiN6Rc3BUEx6ez2wgN7aC0cBfcAjZfwkzE+E2PQQ9nEuoqfA==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5093,12 +5093,12 @@ packages:
       typescript:
         optional: true
     dependencies:
-      '@typescript-eslint/typescript-estree': 5.41.0_typescript@4.6.4
-      '@typescript-eslint/utils': 5.41.0_vxmhu3tyr7cxhd2vxjkubkv7im
+      '@typescript-eslint/typescript-estree': 5.41.0_typescript@4.9.3
+      '@typescript-eslint/utils': 5.41.0_4he5nxxgrmu5gxjroamasnmd3i
       debug: 4.3.4
       eslint: 8.21.0
-      tsutils: 3.21.0_typescript@4.6.4
-      typescript: 4.6.4
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
     dev: false
@@ -5112,7 +5112,7 @@ packages:
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     dev: false
 
-  /@typescript-eslint/typescript-estree/5.32.0_typescript@4.6.4:
+  /@typescript-eslint/typescript-estree/5.32.0_typescript@4.9.3:
     resolution: {integrity: sha512-ZVAUkvPk3ITGtCLU5J4atCw9RTxK+SRc6hXqLtllC2sGSeMFWN+YwbiJR9CFrSFJ3w4SJfcWtDwNb/DmUIHdhg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5127,12 +5127,12 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.6.4
-      typescript: 4.6.4
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
 
-  /@typescript-eslint/typescript-estree/5.41.0_typescript@4.6.4:
+  /@typescript-eslint/typescript-estree/5.41.0_typescript@4.9.3:
     resolution: {integrity: sha512-SlzFYRwFSvswzDSQ/zPkIWcHv8O5y42YUskko9c4ki+fV6HATsTODUPbRbcGDFYP86gaJL5xohUEytvyNNcXWg==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5147,13 +5147,13 @@ packages:
       globby: 11.1.0
       is-glob: 4.0.3
       semver: 7.3.7
-      tsutils: 3.21.0_typescript@4.6.4
-      typescript: 4.6.4
+      tsutils: 3.21.0_typescript@4.9.3
+      typescript: 4.9.3
     transitivePeerDependencies:
       - supports-color
     dev: false
 
-  /@typescript-eslint/utils/5.32.0_e4zyhrvfnqudwdx5bevnvkluy4:
+  /@typescript-eslint/utils/5.32.0_77fvizpdb3y4icyeo2mf4eo7em:
     resolution: {integrity: sha512-W7lYIAI5Zlc5K082dGR27Fczjb3Q57ECcXefKU/f0ajM5ToM0P+N9NmJWip8GmGu/g6QISNT+K6KYB+iSHjXCQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5162,7 +5162,7 @@ packages:
       '@types/json-schema': 7.0.11
       '@typescript-eslint/scope-manager': 5.32.0
       '@typescript-eslint/types': 5.32.0
-      '@typescript-eslint/typescript-estree': 5.32.0_typescript@4.6.4
+      '@typescript-eslint/typescript-estree': 5.32.0_typescript@4.9.3
       eslint: 7.32.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@7.32.0
@@ -5170,7 +5170,7 @@ packages:
       - supports-color
       - typescript
 
-  /@typescript-eslint/utils/5.41.0_vxmhu3tyr7cxhd2vxjkubkv7im:
+  /@typescript-eslint/utils/5.41.0_4he5nxxgrmu5gxjroamasnmd3i:
     resolution: {integrity: sha512-QlvfwaN9jaMga9EBazQ+5DDx/4sAdqDkcs05AsQHMaopluVCUyu1bTRUVKzXbgjDlrRAQrYVoi/sXJ9fmG+KLQ==}
     engines: {node: ^12.22.0 || ^14.17.0 || >=16.0.0}
     peerDependencies:
@@ -5180,7 +5180,7 @@ packages:
       '@types/semver': 7.3.13
       '@typescript-eslint/scope-manager': 5.41.0
       '@typescript-eslint/types': 5.41.0
-      '@typescript-eslint/typescript-estree': 5.41.0_typescript@4.6.4
+      '@typescript-eslint/typescript-estree': 5.41.0_typescript@4.9.3
       eslint: 8.21.0
       eslint-scope: 5.1.1
       eslint-utils: 3.0.0_eslint@8.21.0
@@ -6189,7 +6189,7 @@ packages:
   /axios/0.21.4_debug@4.3.1:
     resolution: {integrity: sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==}
     dependencies:
-      follow-redirects: 1.15.0_debug@4.3.4
+      follow-redirects: 1.15.0
     transitivePeerDependencies:
       - debug
     dev: true
@@ -9247,7 +9247,7 @@ packages:
       eslint: 8.21.0
     dev: false
 
-  /eslint-config-seek/10.0.0_cz4aiw2rfefwckmfdn334lg6oy:
+  /eslint-config-seek/10.0.0_tigiruvdwgrxyqkyjokq6lk6m4:
     resolution: {integrity: sha512-P+ZcZEep3/ZehZacWe52LwOEDCTIcLCYjfzzuhgR+abEkdj5cwIsMtiOVtgiMW0skB2gA1Ej9oHP4vG7WofJBg==}
     peerDependencies:
       eslint: '>=6'
@@ -9256,25 +9256,25 @@ packages:
       '@babel/core': 7.18.0
       '@babel/eslint-parser': 7.18.9_pv54mmcbvvc2ehtbbm4mt3a4my
       '@babel/preset-react': 7.18.6_@babel+core@7.18.0
-      '@typescript-eslint/eslint-plugin': 5.32.0_wmvu2zfnrjn5l5npmbeohygqdy
-      '@typescript-eslint/parser': 5.32.0_e4zyhrvfnqudwdx5bevnvkluy4
+      '@typescript-eslint/eslint-plugin': 5.32.0_osiwo2xidp3tzpindwt4xjgfde
+      '@typescript-eslint/parser': 5.32.0_77fvizpdb3y4icyeo2mf4eo7em
       eslint: 7.32.0
       eslint-config-prettier: 8.5.0_eslint@7.32.0
       eslint-import-resolver-node: 0.3.6
       eslint-plugin-cypress: 2.12.1_eslint@7.32.0
       eslint-plugin-import: 2.26.0_nnnen5rjtzvbmadvhioouqkve4
-      eslint-plugin-jest: 27.1.1_zxxckevp5xlor3cjzgfb4gwhqm
+      eslint-plugin-jest: 27.1.1_3j4vgvguspqspkxqdnkopu4ie4
       eslint-plugin-react: 7.30.0_eslint@7.32.0
       eslint-plugin-react-hooks: 4.5.0_eslint@7.32.0
       find-root: 1.1.0
-      typescript: 4.6.4
+      typescript: 4.9.3
     transitivePeerDependencies:
       - eslint-import-resolver-typescript
       - eslint-import-resolver-webpack
       - jest
       - supports-color
 
-  /eslint-config-seek/10.1.0_cjuso6hqax2af5jwgles3svesm:
+  /eslint-config-seek/10.1.0_ysrbpudmimcglvncbjkczw2fle:
     resolution: {integrity: sha512-7W6Vzzenw370K1YwSwEEnfeHAmTKABUW2PwKpevluhpj2p2IVMD0+GXX2L9f2ZInRy1qIY6dsr0euPQbY9xKww==}
     peerDependencies:
       eslint: '>=6'
@@ -9283,18 +9283,18 @@ packages:
       '@babel/core': 7.19.6
       '@babel/eslint-parser': 7.19.1_y4hgqv36wd5sbe2zvqalcisdwe
       '@babel/preset-react': 7.18.6_@babel+core@7.19.6
-      '@typescript-eslint/eslint-plugin': 5.41.0_zxfaorj52qpqkjdoqagwyg6lmq
-      '@typescript-eslint/parser': 5.41.0_vxmhu3tyr7cxhd2vxjkubkv7im
+      '@typescript-eslint/eslint-plugin': 5.41.0_6t6dsu3ksl3pxuxvgp2mpgltxi
+      '@typescript-eslint/parser': 5.41.0_4he5nxxgrmu5gxjroamasnmd3i
       eslint: 8.21.0
       eslint-config-prettier: 8.5.0_eslint@8.21.0
       eslint-import-resolver-typescript: 3.5.2_jatgrcxl4x7ywe7ak6cnjca2ae
       eslint-plugin-cypress: 2.12.1_eslint@8.21.0
       eslint-plugin-import: 2.26.0_xb7cmeyhloccumiazv5sreylfm
-      eslint-plugin-jest: 27.1.3_3gf3skdgmnxk242q5j7nlzdjfm
+      eslint-plugin-jest: 27.1.3_pwb743x53auqysycbrcyxdr43y
       eslint-plugin-react: 7.31.10_eslint@8.21.0
       eslint-plugin-react-hooks: 4.6.0_eslint@8.21.0
       find-root: 1.1.0
-      typescript: 4.6.4
+      typescript: 4.9.3
     transitivePeerDependencies:
       - eslint-import-resolver-webpack
       - jest
@@ -9347,7 +9347,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.32.0_e4zyhrvfnqudwdx5bevnvkluy4
+      '@typescript-eslint/parser': 5.32.0_77fvizpdb3y4icyeo2mf4eo7em
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
       find-up: 2.1.0
@@ -9372,7 +9372,7 @@ packages:
       eslint-import-resolver-webpack:
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.41.0_vxmhu3tyr7cxhd2vxjkubkv7im
+      '@typescript-eslint/parser': 5.41.0_4he5nxxgrmu5gxjroamasnmd3i
       debug: 3.2.7
       eslint-import-resolver-node: 0.3.6
       eslint-import-resolver-typescript: 3.5.2_jatgrcxl4x7ywe7ak6cnjca2ae
@@ -9408,7 +9408,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.32.0_e4zyhrvfnqudwdx5bevnvkluy4
+      '@typescript-eslint/parser': 5.32.0_77fvizpdb3y4icyeo2mf4eo7em
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
@@ -9438,7 +9438,7 @@ packages:
       '@typescript-eslint/parser':
         optional: true
     dependencies:
-      '@typescript-eslint/parser': 5.41.0_vxmhu3tyr7cxhd2vxjkubkv7im
+      '@typescript-eslint/parser': 5.41.0_4he5nxxgrmu5gxjroamasnmd3i
       array-includes: 3.1.5
       array.prototype.flat: 1.3.0
       debug: 2.6.9
@@ -9459,7 +9459,7 @@ packages:
       - supports-color
     dev: false
 
-  /eslint-plugin-jest/27.1.1_zxxckevp5xlor3cjzgfb4gwhqm:
+  /eslint-plugin-jest/27.1.1_3j4vgvguspqspkxqdnkopu4ie4:
     resolution: {integrity: sha512-vuSuXGKHHi/UAffIM46QKm4g0tQP+6n52nRxUpMq6x6x9rhnv5WM7ktSu3h9cTnXE4b0Y0ODQTgRlCm9rdRLvg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -9472,15 +9472,15 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.32.0_wmvu2zfnrjn5l5npmbeohygqdy
-      '@typescript-eslint/utils': 5.32.0_e4zyhrvfnqudwdx5bevnvkluy4
+      '@typescript-eslint/eslint-plugin': 5.32.0_osiwo2xidp3tzpindwt4xjgfde
+      '@typescript-eslint/utils': 5.32.0_77fvizpdb3y4icyeo2mf4eo7em
       eslint: 7.32.0
       jest: 29.1.2
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  /eslint-plugin-jest/27.1.3_3gf3skdgmnxk242q5j7nlzdjfm:
+  /eslint-plugin-jest/27.1.3_pwb743x53auqysycbrcyxdr43y:
     resolution: {integrity: sha512-7DrIfYRQPa7JQd1Le8G/BJsfYHVUKQdJQ/6vULSp/4NjKZmSMJ/605G2hhScEra++SiH68zPEjLnrO74nHrMLg==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
     peerDependencies:
@@ -9493,8 +9493,8 @@ packages:
       jest:
         optional: true
     dependencies:
-      '@typescript-eslint/eslint-plugin': 5.41.0_zxfaorj52qpqkjdoqagwyg6lmq
-      '@typescript-eslint/utils': 5.41.0_vxmhu3tyr7cxhd2vxjkubkv7im
+      '@typescript-eslint/eslint-plugin': 5.41.0_6t6dsu3ksl3pxuxvgp2mpgltxi
+      '@typescript-eslint/utils': 5.41.0_4he5nxxgrmu5gxjroamasnmd3i
       eslint: 8.21.0
       jest: 29.1.2_2cnx3q6hfnpx7nryv75xx7ahte
     transitivePeerDependencies:
@@ -10282,7 +10282,6 @@ packages:
     peerDependenciesMeta:
       debug:
         optional: true
-    dev: false
 
   /follow-redirects/1.15.0_debug@4.3.4:
     resolution: {integrity: sha512-aExlJShTV4qOUOL7yF1U5tvLCB0xQuudbf6toyYA0E/acBNw71mvjFTnLaRp50aQaYocMR0a/RMMBIHeZnGyjQ==}
@@ -10315,7 +10314,7 @@ packages:
   /forever-agent/0.6.1:
     resolution: {integrity: sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==}
 
-  /fork-ts-checker-webpack-plugin/4.1.6_gplzhsecki363wzvnzp4wfrwvi:
+  /fork-ts-checker-webpack-plugin/4.1.6_7gjrtr2fo3jjstcxw4vighex4q:
     resolution: {integrity: sha512-DUxuQaKoqfNne8iikd14SAkh5uw4+8vNifp6gmA73yYNS6ywLIWSLD/n/mBzHQRpW3J7rbATEakmiA8JvkTyZw==}
     engines: {node: '>=6.11.5', yarn: '>=1.0.0'}
     peerDependencies:
@@ -10336,13 +10335,13 @@ packages:
       minimatch: 3.1.2
       semver: 5.7.1
       tapable: 1.1.3
-      typescript: 4.6.4
+      typescript: 4.9.3
       webpack: 4.46.0
       worker-rpc: 0.1.1
     transitivePeerDependencies:
       - supports-color
 
-  /fork-ts-checker-webpack-plugin/6.5.2_gplzhsecki363wzvnzp4wfrwvi:
+  /fork-ts-checker-webpack-plugin/6.5.2_7gjrtr2fo3jjstcxw4vighex4q:
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -10370,10 +10369,10 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.7
       tapable: 1.1.3
-      typescript: 4.6.4
+      typescript: 4.9.3
       webpack: 4.46.0
 
-  /fork-ts-checker-webpack-plugin/6.5.2_ugfow55eyme64bvegjfzj5yvdu:
+  /fork-ts-checker-webpack-plugin/6.5.2_p4naa4dozxqg4m7qdclhykuafu:
     resolution: {integrity: sha512-m5cUmF30xkZ7h4tWUgTAcEaKmUW7tfyUyTqNNOz7OxWJ0v1VWKTcOvH8FWHUwSjlW/356Ijc9vi3XfcPstpQKA==}
     engines: {node: '>=10', yarn: '>=1.0.0'}
     peerDependencies:
@@ -10401,7 +10400,7 @@ packages:
       schema-utils: 2.7.0
       semver: 7.3.7
       tapable: 1.1.3
-      typescript: 4.6.4
+      typescript: 4.9.3
       webpack: 5.72.1_esbuild@0.15.10
 
   /form-data/2.3.3:
@@ -11370,7 +11369,7 @@ packages:
     engines: {node: '>=8.0.0'}
     dependencies:
       eventemitter3: 4.0.7
-      follow-redirects: 1.15.0_debug@4.3.4
+      follow-redirects: 1.15.0
       requires-port: 1.0.0
     transitivePeerDependencies:
       - debug
@@ -12337,7 +12336,7 @@ packages:
       pretty-format: 29.1.2
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.8.0_rbv5fvwh3qaahz6dxcho7rzsry
+      ts-node: 10.8.0_jytyqnesmarciubgup2n7dsryu
     transitivePeerDependencies:
       - supports-color
 
@@ -12414,7 +12413,7 @@ packages:
       pretty-format: 29.1.2
       slash: 3.0.0
       strip-json-comments: 3.1.1
-      ts-node: 10.8.0_rbv5fvwh3qaahz6dxcho7rzsry
+      ts-node: 10.8.0_jytyqnesmarciubgup2n7dsryu
     transitivePeerDependencies:
       - supports-color
 
@@ -14947,12 +14946,12 @@ packages:
       re-resizable: 6.9.9_biqbaboplfbrettd7655fr4n2y
       react: 18.2.0
       react-codemirror2: 7.2.1_qf2wbenr4xksj7wdxeo2cy7yv4
-      react-docgen-typescript: 2.2.2_typescript@4.6.4
+      react-docgen-typescript: 2.2.2_typescript@4.9.3
       react-dom: 18.2.0_react@18.2.0
       react-use: 17.4.0_biqbaboplfbrettd7655fr4n2y
       read-pkg-up: 7.0.1
       scope-eval: 1.0.0
-      typescript: 4.6.4
+      typescript: 4.9.3
       url-join: 4.0.1
       use-debounce: 3.4.3_react@18.2.0
       webpack: 5.72.1
@@ -14978,11 +14977,11 @@ packages:
     engines: {node: '>=4'}
     dev: true
 
-  /pnp-webpack-plugin/1.6.4_typescript@4.6.4:
+  /pnp-webpack-plugin/1.6.4_typescript@4.9.3:
     resolution: {integrity: sha512-7Wjy+9E3WwLOEL30D+m8TSTF7qJJUJLONBnwQp0518siuMxUQUbgZwssaFX+QKlZkjHZcw/IpZCt/H0srrntSg==}
     engines: {node: '>=6'}
     dependencies:
-      ts-pnp: 1.2.0_typescript@4.6.4
+      ts-pnp: 1.2.0_typescript@4.9.3
     transitivePeerDependencies:
       - typescript
 
@@ -15983,12 +15982,12 @@ packages:
       - utf-8-validate
     dev: false
 
-  /react-docgen-typescript/2.2.2_typescript@4.6.4:
+  /react-docgen-typescript/2.2.2_typescript@4.9.3:
     resolution: {integrity: sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==}
     peerDependencies:
       typescript: '>= 4.3.x'
     dependencies:
-      typescript: 4.6.4
+      typescript: 4.9.3
 
   /react-docgen/5.4.0:
     resolution: {integrity: sha512-JBjVQ9cahmNlfjMGxWUxJg919xBBKAoy3hgDgKERbR+BcF4ANpDuzWAScC7j27hZfd8sJNmMPOLWo9+vB/XJEQ==}
@@ -17159,9 +17158,9 @@ packages:
       '@loadable/server': 5.15.2_ik7avrk5bhag2nqkdfypunpmvu
       '@loadable/webpack-plugin': 5.15.2_webpack@5.72.1
       '@pmmmwh/react-refresh-webpack-plugin': 0.5.7_6hcqkppu5jpkxu3zxhgb7ox4pi
-      '@storybook/builder-webpack5': 6.5.12_yag4ocovaeivukrtnkjjf4uxum
-      '@storybook/manager-webpack5': 6.5.12_yag4ocovaeivukrtnkjjf4uxum
-      '@storybook/react': 6.5.12_z5fpv76b642hnp63anoosxxqxq
+      '@storybook/builder-webpack5': 6.5.12_ldqikllusglrhwpikog3fqt5ry
+      '@storybook/manager-webpack5': 6.5.12_ldqikllusglrhwpikog3fqt5ry
+      '@storybook/react': 6.5.12_fibidwl7fiwvdh4fue4gi5zelq
       '@types/jest': 29.1.2
       '@types/loadable__component': 5.13.4
       '@vanilla-extract/babel-plugin': 1.1.7
@@ -17201,7 +17200,7 @@ packages:
       esbuild-register: 3.3.3_esbuild@0.15.10
       escape-string-regexp: 4.0.0
       eslint: 7.32.0
-      eslint-config-seek: 10.0.0_cz4aiw2rfefwckmfdn334lg6oy
+      eslint-config-seek: 10.0.0_tigiruvdwgrxyqkyjokq6lk6m4
       exception-formatter: 2.1.2
       express: 4.18.1
       fast-glob: 3.2.11
@@ -17245,7 +17244,7 @@ packages:
       traverse: 0.6.6
       treat: 2.0.4_webpack@5.72.1
       tree-kill: 1.2.2
-      typescript: 4.6.4
+      typescript: 4.9.3
       validate-npm-package-name: 4.0.0
       webpack: 5.72.1_esbuild@0.15.10
       webpack-bundle-analyzer: 4.6.1
@@ -18456,7 +18455,7 @@ packages:
   /ts-easing/0.2.0:
     resolution: {integrity: sha512-Z86EW+fFFh/IFB1fqQ3/+7Zpf9t2ebOAxNI/V6Wo7r5gqiqtxmgTlQ1qbqQcjLKYeSHPTsEmvlJUDg/EuL0uHQ==}
 
-  /ts-node/10.8.0_rbv5fvwh3qaahz6dxcho7rzsry:
+  /ts-node/10.8.0_jytyqnesmarciubgup2n7dsryu:
     resolution: {integrity: sha512-/fNd5Qh+zTt8Vt1KbYZjRHCE9sI5i7nqfD/dzBBRDeVXZXS6kToW6R7tTU6Nd4XavFs0mAVCg29Q//ML7WsZYA==}
     hasBin: true
     peerDependencies:
@@ -18482,11 +18481,11 @@ packages:
       create-require: 1.1.1
       diff: 4.0.2
       make-error: 1.3.6
-      typescript: 4.6.4
+      typescript: 4.9.3
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
 
-  /ts-pnp/1.2.0_typescript@4.6.4:
+  /ts-pnp/1.2.0_typescript@4.9.3:
     resolution: {integrity: sha512-csd+vJOb/gkzvcCHgTGSChYpy5f1/XKNsmvBGO4JXS+z1v2HobugDz4s1IeFXM3wZB44uczs+eazB5Q/ccdhQw==}
     engines: {node: '>=6'}
     peerDependencies:
@@ -18495,7 +18494,7 @@ packages:
       typescript:
         optional: true
     dependencies:
-      typescript: 4.6.4
+      typescript: 4.9.3
 
   /tsconfig-paths/3.14.1:
     resolution: {integrity: sha512-fxDhWnFSLt3VuTwtvJt5fpwxBHg5AdKWMsgcPOOIilyjymcYVZoCQF8fvFRezCNfblEXmi+PcM1eYHeOAgXCOQ==}
@@ -18511,14 +18510,14 @@ packages:
   /tslib/2.4.0:
     resolution: {integrity: sha512-d6xOpEDfsi2CZVlPQzGeux8XMwLT9hssAsaPYExaQMuYskwb+x1x7J371tWlbBdWHroy99KnVB6qIkUbs5X3UQ==}
 
-  /tsutils/3.21.0_typescript@4.6.4:
+  /tsutils/3.21.0_typescript@4.9.3:
     resolution: {integrity: sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==}
     engines: {node: '>= 6'}
     peerDependencies:
       typescript: '>=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta'
     dependencies:
       tslib: 1.14.1
-      typescript: 4.6.4
+      typescript: 4.9.3
 
   /tty-browserify/0.0.0:
     resolution: {integrity: sha1-oVe6QC2iTpv5V/mqadUk7tQpAaY=}
@@ -18616,8 +18615,8 @@ packages:
   /typedarray/0.0.6:
     resolution: {integrity: sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==}
 
-  /typescript/4.6.4:
-    resolution: {integrity: sha512-9ia/jWHIEbo49HfjrLGfKbZSuWo9iTMwXO+Ca3pRsSpbsMbc7/IU8NKdCZVRRBafVPGnoJeFL76ZOAA84I9fEg==}
+  /typescript/4.9.3:
+    resolution: {integrity: sha512-CIfGzTelbKNEnLpLdGFgdyKhG23CKdKgQPOBc+OUNrkJ2vr+KSzsSV5kq5iWhEQbok+quxgGzrAtGWCyU7tHnA==}
     engines: {node: '>=4.2.0'}
     hasBin: true
 


### PR DESCRIPTION
On typescript versions >= 4.9, the `TextDropdown` component fails to typecheck [here](https://github.com/seek-oss/braid-design-system/blob/bcb987d486f946b43a95a47261d667bdf3784d35/packages/braid-design-system/lib/components/TextDropdown/TextDropdown.tsx#L34) with the error:

```
Type 'Value' is not assignable to type 'object'
```

This error is surfacing in typescript 4.9 for two reasons. Firstly, the narrowing conditions `typeof option !== 'string' && typeof option !== 'number'` were never strict enough to rule out the possibility that `option` could be a primitive value, so by the time the `in` operator was being executed, the type of `option` hadn't changed at all (pre typescript 4.9).

Secondly, the [changes to the `in` operator](https://devblogs.microsoft.com/typescript/announcing-typescript-4-9/#unlisted-property-narrowing-with-the-in-operator) in typescript 4.9, in particular this change:
> ensuring that the left side is assignable to the type `string | number | symbol`, and the right side is assignable to `object`

resulted in a type error because `in` was being used on a RHS value (`option`) that wasn't yet of type `object`. I believe typescript 4.9 is a bit smarter about narrowing in general, as the intermediate type _does_ change, but it can't quite narrow the type all the way to `object` at this point.

The solution I went with was to flip the narrowing to explicitly check for an object (and perform a null check because `typeof null === 'object'`) first, and then narrow the type further. This change is backwards compatible with typescript <4.9.

I also updated the version of typescript within the repo to 4.9.3.