### PR TITLE
Ensure `/playroom` entry point is type checked

### DIFF
--- a/.changeset/afraid-feet-prove.md
+++ b/.changeset/afraid-feet-prove.md
@@ -1,0 +1,5 @@
+---
+'braid-design-system': patch
+---
+
+Fix type checking for Playroom config

--- a/packages/braid-design-system/playroom/components.ts
+++ b/packages/braid-design-system/playroom/components.ts
@@ -1,5 +1,8 @@
 import dedent from 'dedent';
 
+declare const global: typeof globalThis & {
+  __IS_PLAYROOM_ENVIRONMENT__?: string;
+};
 if (global?.__IS_PLAYROOM_ENVIRONMENT__ !== 'clearly') {
   throw new Error(dedent`
     Playroom prototyping components are being imported instead of Braid components.

--- a/packages/braid-design-system/tsconfig.json
+++ b/packages/braid-design-system/tsconfig.json
@@ -4,6 +4,7 @@
     "./color-mode",
     "./css",
     "./lib",
+    "./playroom",
     "./reset",
     "./scripts",
     "./test",


### PR DESCRIPTION
Forgot to include it in `tsconfig.json` so `tsc` didn't report any errors, but Metropolis did:

```
node_modules/braid-design-system/playroom/components.ts:3:13 - error TS7017: Element implicitly has an 'any' type because type 'typeof globalThis' has no index signature.

3 if (global?.__IS_PLAYROOM_ENVIRONMENT__ !== 'clearly') {
              ~~~~~~~~~~~~~~~~~~~~~~~~~~~


Found 1 error in node_modules/braid-design-system/playroom/components.ts:3
```