### PR TITLE
color-mode: Add query-param entry

### DIFF
--- a/.changeset/brown-badgers-shave.md
+++ b/.changeset/brown-badgers-shave.md
@@ -1,0 +1,7 @@
+---
+'braid-design-system': minor
+---
+
+**color-mode:** Add query-param entry
+
+Add new `query-param` entry, providing a script for resolving the color mode preference from query string, as well as a utility function for retrieving the preference for constructing subsequent links.

--- a/packages/braid-design-system/color-mode/index.ts
+++ b/packages/braid-design-system/color-mode/index.ts
@@ -6,7 +6,7 @@ const flag = '_bdsdm';
 // 2 = OS Preference
 // TODO: COLORMODE RELEASE
 // Finalise import contract
-/** @deprecate Use `import { colorModeQueryParamCheck } from 'braid-design-system/color-mode/query-param'` instead. */
+/** @deprecated Use `import { colorModeQueryParamCheck } from 'braid-design-system/color-mode/query-param'` instead. */
 export const __experimentalDarkMode__ = [
   '<script>',
   `((l,w)=>{try{r=/[?&]${flag}=(\\d)/;[,s]=l.search.match(r)||[];w.${flag}=s;if(s){history.replaceState(null,'',l.pathname+l.search.replace(r,'').replace(/^&/,'?')+l.hash);if(s==1||(s==2&&matchMedia('(prefers-color-scheme:dark)').matches))document.documentElement.classList.add('${darkMode}')}}catch(e){}})(location,window)`,

--- a/packages/braid-design-system/color-mode/index.ts
+++ b/packages/braid-design-system/color-mode/index.ts
@@ -6,8 +6,9 @@ const flag = '_bdsdm';
 // 2 = OS Preference
 // TODO: COLORMODE RELEASE
 // Finalise import contract
+/** @deprecate Use `import { colorModeQueryParamCheck } from 'braid-design-system/color-mode/query-param'` instead. */
 export const __experimentalDarkMode__ = [
   '<script>',
-  `((l)=>{try{r=/[?&]${flag}=(\\d)/;[,s]=l.search.match(r)||[];if(s){history.replaceState(null,'',l.pathname+l.search.replace(r,'').replace(/^&/,'?')+l.hash);if(s==1||(s==2&&matchMedia('(prefers-color-scheme:dark)').matches))document.documentElement.classList.add('${darkMode}')}}catch(e){}})(location)`,
+  `((l,w)=>{try{r=/[?&]${flag}=(\\d)/;[,s]=l.search.match(r)||[];w.${flag}=s;if(s){history.replaceState(null,'',l.pathname+l.search.replace(r,'').replace(/^&/,'?')+l.hash);if(s==1||(s==2&&matchMedia('(prefers-color-scheme:dark)').matches))document.documentElement.classList.add('${darkMode}')}}catch(e){}})(location,window)`,
   '</script>',
 ].join('');

--- a/packages/braid-design-system/color-mode/query-param.ts
+++ b/packages/braid-design-system/color-mode/query-param.ts
@@ -40,7 +40,7 @@ export const colorModeQueryParamCheck = [
  * For Braid UIs embedded within the native mobile app.
  * Retrieves the native app color mode preference as discovered on page load from the query string.
  *
- * (Note: Requires the `colorModeQueryParamCheck` to have been included in the head of th document and evaluated first)
+ * (Note: Requires the `colorModeQueryParamCheck` to have been included in the head of the document and evaluated first)
  *
  * ---
  *

--- a/packages/braid-design-system/color-mode/query-param.ts
+++ b/packages/braid-design-system/color-mode/query-param.ts
@@ -20,11 +20,11 @@ declare global {
  *
  * Example usage:
  *
- * &nbsp;&nbsp;&lt;html&gt;
- *
- * &nbsp;&nbsp;&nbsp;&nbsp;&lt;head&gt;
- *
- * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;!-- Place script here --&gt;
+ * ```html
+ * <html>
+ *  <head>
+ *    <!-- Place script here -->
+ * ```
  *
  * ---
  *

--- a/packages/braid-design-system/color-mode/query-param.ts
+++ b/packages/braid-design-system/color-mode/query-param.ts
@@ -44,7 +44,11 @@ export const colorModeQueryParamCheck = [
  *
  * ---
  *
- * Example usage: \``/my-url?id=123&${getColorModeQueryParam()}`\`
+ * Example usage:
+ *
+ * ```ts
+ * `/my-url?id=123&${getColorModeQueryParam()}`
+ * ```
  *
  * ---
  *

--- a/packages/braid-design-system/color-mode/query-param.ts
+++ b/packages/braid-design-system/color-mode/query-param.ts
@@ -1,0 +1,59 @@
+import { darkMode } from '../lib/css/atoms/sprinkles.css';
+
+const flag = '_bdsdm';
+// VALUES
+// 0 = light mode
+// 1 = dark mode
+// 2 = OS Preference
+declare global {
+  interface Window {
+    [flag]: '0' | '1' | '2';
+  }
+}
+
+/**
+ * Script to resolve the color mode preference from the query string, used for passing the native mobile app color mode preference to an embedded Braid web UI.
+ *
+ * Pre-minified script tag, designed to be inserted at the beginning of the document head. This ensures the color mode preference is evaluated and applied before any renderering occurs, preventing the flash of light mode.
+ *
+ * ---
+ *
+ * Example usage:
+ *
+ * &nbsp;&nbsp;&lt;html&gt;
+ *
+ * &nbsp;&nbsp;&nbsp;&nbsp;&lt;head&gt;
+ *
+ * &nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&lt;!-- Place script here --&gt;
+ *
+ * ---
+ *
+ * @returns Stringified script tag to place in document head.
+ */
+export const colorModeQueryParamCheck = [
+  '<script>',
+  `((l,w)=>{try{r=/[?&]${flag}=(\\d)/;[,s]=l.search.match(r)||[];w.${flag}=s;if(s){history.replaceState(null,'',l.pathname+l.search.replace(r,'').replace(/^&/,'?')+l.hash);if(s==1||(s==2&&matchMedia('(prefers-color-scheme:dark)').matches))document.documentElement.classList.add('${darkMode}')}}catch(e){}})(location,window)`,
+  '</script>',
+].join('');
+
+/**
+ * For Braid UIs embedded within the native mobile app.
+ * Retrieves the native app color mode preference as discovered on page load from the query string.
+ *
+ * (Note: Requires the `colorModeQueryParamCheck` to have been included in the head of th document and evaluated first)
+ *
+ * ---
+ *
+ * Example usage: \``/my-url?id=123&${getColorModeQueryParam()}`\`
+ *
+ * ---
+ *
+ * @returns Braid color mode preference as query string parameter
+ */
+export const getColorModeQueryParam = () => {
+  if (typeof window !== 'undefined' && window[flag]) {
+    return `${flag}=${window[flag]}` as const;
+  }
+
+  return '';
+};

--- a/site/src/render.tsx
+++ b/site/src/render.tsx
@@ -12,7 +12,7 @@ import * as themes from 'braid-src/lib/themes';
 import { braidVersionToDate } from './getVersionDetails';
 import { initUpdates } from './App/Updates';
 import packageJson from 'braid-design-system/package.json';
-import { __experimentalDarkMode__ } from 'braid-src/color-mode';
+import { colorModeQueryParamCheck } from 'braid-src/color-mode/query-param';
 
 const { version } = packageJson;
 
@@ -88,7 +88,7 @@ const skuRender: Render<RenderContext> = {
       <!doctype html>
       <html lang="en">
         <head>
-          ${__experimentalDarkMode__}
+          ${colorModeQueryParamCheck}
           ${helmet.title.toString()}
           ${helmet.meta.toString()}
           ${helmet.link.toString()}


### PR DESCRIPTION
Add new `query-param` entry, providing a script for resolving the color mode preference from query string, as well as a utility function for retrieving the preference for constructing subsequent links.

Provides a clearer entry, co-locating all the color mode utilities by their mechanism (e.g. query param), allowing us to introduce others (e.g. local-storage) in the future.

We will be removing the previous `__experimentalDarkMode__` script once consumers have migrated.