### PR TITLE
Disable transitions in Chromatic

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -34,8 +34,6 @@ jobs:
         run: pnpm test
 
       - name: Chromatic
-        run: |
-          pnpm build-storybook
-          pnpm run chromatic
+        run: pnpm chromatic
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_APP_CODE }}

--- a/package.json
+++ b/package.json
@@ -82,8 +82,5 @@
     "patchedDependencies": {
       "panzoom@9.4.2": "patches/panzoom@9.4.2.patch"
     }
-  },
-  "skuSkipPostInstall": true,
-  "skuSkipConfigure": true,
-  "skuSkipValidatePeerDeps": true
+  }
 }

--- a/package.json
+++ b/package.json
@@ -82,5 +82,8 @@
     "patchedDependencies": {
       "panzoom@9.4.2": "patches/panzoom@9.4.2.patch"
     }
-  }
+  },
+  "skuSkipPostInstall": true,
+  "skuSkipConfigure": true,
+  "skuSkipValidatePeerDeps": true
 }

--- a/packages/braid-design-system/lib/stories/all.stories.tsx
+++ b/packages/braid-design-system/lib/stories/all.stories.tsx
@@ -138,30 +138,30 @@ Object.keys(allStories)
           <BrowserRouter>
             <BraidProvider theme={theme}>
               <ToastProvider>
-                <style type="text/css">
-                  {`
-              .noAnimation * {
-                animation-delay: -0.0001s !important;
-                animation-duration: 0s !important;
-                animation-play-state: paused !important;
-              }
-              .artboard {
-                --deepColor: ${
-                  theme.name === 'apacDark'
-                    ? `rgba(255, 255, 255, .1)`
-                    : `rgba(0, 0, 0, .05)`
-                };
-                --cubeSize: 12px;
-                background-color: ${
-                  theme.name === 'apacDark' ? `black` : `white`
-                };
-                background-image: linear-gradient(45deg, var(--deepColor) 25%, transparent 25%, transparent 75%, var(--deepColor) 75%, var(--deepColor)),
-                  linear-gradient(45deg, var(--deepColor) 25%, transparent 25%, transparent 75%, var(--deepColor) 75%, var(--deepColor));
-                background-size: calc(var(--cubeSize) * 2) calc(var(--cubeSize) * 2);
-                background-position: 0 0, var(--cubeSize) var(--cubeSize);
-              }
-              `}
-                </style>
+                <style type="text/css">{`
+                  .noAnimation * {
+                    animation-delay: -0.0001s !important;
+                    animation-duration: 0s !important;
+                    animation-play-state: paused !important;
+                    transition-delay: 0s !important;
+                    transition-duration: 0s !important;
+                  }
+                  .artboard {
+                    --deepColor: ${
+                      theme.name === 'apacDark'
+                        ? `rgba(255, 255, 255, .1)`
+                        : `rgba(0, 0, 0, .05)`
+                    };
+                    --cubeSize: 12px;
+                    background-color: ${
+                      theme.name === 'apacDark' ? `black` : `white`
+                    };
+                    background-image: linear-gradient(45deg, var(--deepColor) 25%, transparent 25%, transparent 75%, var(--deepColor) 75%, var(--deepColor)),
+                      linear-gradient(45deg, var(--deepColor) 25%, transparent 25%, transparent 75%, var(--deepColor) 75%, var(--deepColor));
+                    background-size: calc(var(--cubeSize) * 2) calc(var(--cubeSize) * 2);
+                    background-position: 0 0, var(--cubeSize) var(--cubeSize);
+                  }
+                `}</style>
                 <div className="noAnimation artboard">
                   {docs.examples.map((example, i) => (
                     <PlayroomStateProvider key={i}>

--- a/packages/braid-design-system/package.json
+++ b/packages/braid-design-system/package.json
@@ -103,5 +103,8 @@
     "sku": "11.7.0",
     "svgo": "^2.8.0",
     "title-case": "^3.0.3"
-  }
+  },
+  "skuSkipPostInstall": true,
+  "skuSkipConfigure": true,
+  "skuSkipValidatePeerDeps": true
 }

--- a/packages/braid-design-system/package.json
+++ b/packages/braid-design-system/package.json
@@ -16,7 +16,7 @@
     "*.css.ts"
   ],
   "scripts": {
-    "chromatic": "chromatic --storybook-build-dir ./dist-storybook --exit-zero-on-changes --auto-accept-changes master",
+    "chromatic": "chromatic --storybook-build-dir ./dist-storybook --exit-zero-on-changes --exit-once-uploaded --auto-accept-changes master",
     "eslint": "eslint --cache .",
     "format": "eslint --cache --fix . && prettier --cache --write .",
     "prettier": "prettier --cache --list-different .",

--- a/packages/braid-design-system/project.json
+++ b/packages/braid-design-system/project.json
@@ -11,6 +11,13 @@
       "options": {
         "script": "copy-codemod"
       }
+    },
+    "chromatic": {
+      "dependsOn": ["build-storybook"],
+      "executor": "nx:run-script",
+      "options": {
+        "script": "chromatic"
+      }
     }
   },
   "implicitDependencies": ["codemod"]


### PR DESCRIPTION
Now that `Tabs` uses transitions when switching between tabs, Chromatic snapshots trigger a review almost every time.
This PR disables CSS transiitions along with CSS animations.