### PR TITLE
CheckboxStandalone: Enable alignment with Text

### DIFF
--- a/.changeset/loud-cups-switch.md
+++ b/.changeset/loud-cups-switch.md
@@ -1,0 +1,27 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - CheckboxStandalone
+---
+
+**CheckboxStandalone:** Enable alignment with Text
+
+Enables `CheckboxStandalone` to be wrapped in a `Text` component, ensuring it only occupies the same layout as as surrounding text.
+This is useful for visually aligning checkboxes in a custom layout alongside other text-based components, e.g. `AccordionItem`.
+
+**EXAMPLE USAGE:**
+```jsx
+<Columns>
+  <Column>
+    <Text>
+      <CheckboxStandalone />
+    </Text>
+  </Column>
+  <Column>
+    <AccordionItem />
+  </Column>
+</Columns>
+```

--- a/.changeset/loud-cups-switch.md
+++ b/.changeset/loud-cups-switch.md
@@ -9,7 +9,7 @@ updated:
 
 **CheckboxStandalone:** Enable alignment with Text
 
-Enables `CheckboxStandalone` to be wrapped in a `Text` component, ensuring it only occupies the same layout as as surrounding text.
+Enables `CheckboxStandalone` to be wrapped in a `Text` component, ensuring it only occupies the same layout as text.
 This is useful for visually aligning checkboxes in a custom layout alongside other text-based components, e.g. `AccordionItem`.
 
 **EXAMPLE USAGE:**

--- a/packages/braid-design-system/lib/components/Checkbox/CheckboxStandalone.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/Checkbox/CheckboxStandalone.screenshots.tsx
@@ -1,6 +1,10 @@
 import React, { useState } from 'react';
+import type { ComponentProps } from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { CheckboxStandalone, Stack } from '../';
+import { Box, CheckboxStandalone, Column, Columns, Stack, Text } from '../';
+
+type CheckboxProps = ComponentProps<typeof CheckboxStandalone>;
+const checkboxSizes: CheckboxProps['size'][] = ['small', 'standard'];
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],
@@ -87,6 +91,64 @@ export const screenshots: ComponentScreenshot = {
           aria-label="Label"
           tone="critical"
         />
+      ),
+    },
+    {
+      label: 'Text alignment',
+      Example: ({ id, handler }) => (
+        <Stack space="medium">
+          {checkboxSizes.map((size) => (
+            <Box background="surface" key={size}>
+              <Columns space="small">
+                <Column width="content">
+                  <Text size={size}>
+                    <CheckboxStandalone
+                      id={id}
+                      onChange={handler}
+                      checked={false}
+                      aria-label="Label"
+                      size={size}
+                    />
+                  </Text>
+                </Column>
+                <Column>
+                  <Text size={size}>Text alignment</Text>
+                </Column>
+              </Columns>
+            </Box>
+          ))}
+        </Stack>
+      ),
+    },
+    {
+      label: 'Text alignment with wrapping lines',
+      Example: ({ id, handler }) => (
+        <Box style={{ maxWidth: 200 }}>
+          <Stack space="medium">
+            {checkboxSizes.map((size) => (
+              <Box background="surface" key={size}>
+                <Columns space="small">
+                  <Column width="content">
+                    <Text size={size}>
+                      <CheckboxStandalone
+                        id={id}
+                        onChange={handler}
+                        checked={false}
+                        aria-label="Label"
+                        size={size}
+                      />
+                    </Text>
+                  </Column>
+                  <Column>
+                    <Text size={size}>
+                      Text with really really long wrapping lines
+                    </Text>
+                  </Column>
+                </Columns>
+              </Box>
+            ))}
+          </Stack>
+        </Box>
       ),
     },
   ],

--- a/packages/braid-design-system/lib/components/Checkbox/CheckboxStandalone.tsx
+++ b/packages/braid-design-system/lib/components/Checkbox/CheckboxStandalone.tsx
@@ -2,6 +2,7 @@ import React, { forwardRef } from 'react';
 import { Box } from '../Box/Box';
 import type { StyledInputProps } from '../private/InlineField/StyledInput';
 import { StyledInput } from '../private/InlineField/StyledInput';
+import { TextContext } from '../Text/TextContext';
 import type { CheckboxProps } from './Checkbox';
 import { resolveCheckedGroup } from './resolveCheckedGroup';
 
@@ -23,12 +24,14 @@ export const CheckboxStandalone = forwardRef<
 
   return (
     <Box position="relative">
-      <StyledInput
-        {...restProps}
-        checked={calculatedChecked}
-        type="checkbox"
-        ref={ref}
-      />
+      <TextContext.Provider value={null}>
+        <StyledInput
+          {...restProps}
+          checked={calculatedChecked}
+          type="checkbox"
+          ref={ref}
+        />
+      </TextContext.Provider>
     </Box>
   );
 });


### PR DESCRIPTION
Enables `CheckboxStandalone` to be wrapped in a `Text` component, ensuring it only occupies the same layout as as surrounding text.
This is useful for visually aligning checkboxes in a custom layout alongside other text-based components, e.g. `AccordionItem`.

**EXAMPLE USAGE:**
```jsx
<Columns>
  <Column>
    <Text>
      <CheckboxStandalone />
    </Text>
  </Column>
  <Column>
    <AccordionItem />
  </Column>
</Columns>
```


### Notes 
Made the decision to isolate this to `CheckboxStandalone` and not the internal `StyledInput` as it is only relevant to the checkbox without a label.