### PR TITLE
Accordion, AccordionItem: Add `weight` support

### DIFF
--- a/.changeset/curly-falcons-wave.md
+++ b/.changeset/curly-falcons-wave.md
@@ -1,0 +1,30 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Accordion
+  - AccordionItem
+---
+
+**Accordion, AccordionItem:** Add `weight` support
+
+Add support for customising the `weight` of `AccordionItem`s.
+This can be either at an `Accordion` level or on a standalone `AccordionItem` based on design requirements.
+
+Note, in order to maintain visual consistency, the `weight` prop can only be specified on an `AccordionItem` when outside of an `Accordion`.
+
+**EXAMPLE USAGE:**
+```jsx
+<Accordion weight="strong">
+  <AccordionItem />
+  ...
+</Accordion>
+```
+
+or
+
+```jsx
+<AccordionItem weight="strong" />
+```

--- a/packages/braid-design-system/lib/components/Accordion/Accordion.docs.tsx
+++ b/packages/braid-design-system/lib/components/Accordion/Accordion.docs.tsx
@@ -64,8 +64,8 @@ const docs: ComponentDocs = {
       description: (
         <>
           <Text>
-            You can customise the <Strong>size</Strong> and{' '}
-            <Strong>tone</Strong> props, and optionally set the{' '}
+            You can customise the <Strong>size</Strong>, <Strong>tone</Strong>{' '}
+            and <Strong>weight</Strong> props, and optionally set the{' '}
             <Strong>dividers</Strong> prop to <Strong>false.</Strong>
           </Text>
           <Text>
@@ -91,6 +91,7 @@ const docs: ComponentDocs = {
               size="standard"
               tone="secondary"
               space="xlarge"
+              weight="regular"
               dividers={false}
             >
               <AccordionItem

--- a/packages/braid-design-system/lib/components/Accordion/Accordion.playroom.tsx
+++ b/packages/braid-design-system/lib/components/Accordion/Accordion.playroom.tsx
@@ -30,11 +30,13 @@ export const Accordion = ({
   space,
   size,
   tone,
+  weight,
   ...restProps
 }: AccordionProps) => (
   <BraidAccordion
     size={typeof size === 'boolean' ? undefined : size}
     tone={typeof tone === 'boolean' ? undefined : tone}
+    weight={typeof weight === 'boolean' ? undefined : weight}
     space={
       typeof space === 'string' || Array.isArray(space)
         ? filterSpace(space)

--- a/packages/braid-design-system/lib/components/Accordion/Accordion.screenshots.tsx
+++ b/packages/braid-design-system/lib/components/Accordion/Accordion.screenshots.tsx
@@ -341,6 +341,43 @@ export const screenshots: ComponentScreenshot = {
       },
     },
     {
+      label: 'Accordion regular weight',
+      Example: ({ id }) => {
+        const [expanded1, setExpanded1] = useState(false);
+        const [expanded2, setExpanded2] = useState(true);
+        const [expanded3, setExpanded3] = useState(false);
+
+        return (
+          <Accordion weight="regular">
+            <AccordionItem
+              label="Accordion item 1"
+              id={`${id}_1`}
+              expanded={expanded1}
+              onToggle={setExpanded1}
+            >
+              <Placeholder height={80} />
+            </AccordionItem>
+            <AccordionItem
+              label="Accordion item 2"
+              id={`${id}_2`}
+              expanded={expanded2}
+              onToggle={setExpanded2}
+            >
+              <Placeholder height={80} />
+            </AccordionItem>
+            <AccordionItem
+              label="Accordion item 3"
+              id={`${id}_3`}
+              expanded={expanded3}
+              onToggle={setExpanded3}
+            >
+              <Placeholder height={80} />
+            </AccordionItem>
+          </Accordion>
+        );
+      },
+    },
+    {
       label: 'Default AccordionItem',
       Example: ({ id }) => (
         <AccordionItem label="Label" id={id}>
@@ -353,6 +390,14 @@ export const screenshots: ComponentScreenshot = {
       Example: ({ id }) => (
         <AccordionItem label="Label" id={id} size="small" tone="secondary">
           <Text size="small">Content</Text>
+        </AccordionItem>
+      ),
+    },
+    {
+      label: 'AccordionItem with regular weight',
+      Example: ({ id }) => (
+        <AccordionItem label="Label" id={id} weight="regular">
+          <Text>Content</Text>
         </AccordionItem>
       ),
     },

--- a/packages/braid-design-system/lib/components/Accordion/Accordion.tsx
+++ b/packages/braid-design-system/lib/components/Accordion/Accordion.tsx
@@ -18,6 +18,7 @@ export interface AccordionProps {
   dividers?: boolean;
   size?: AccordionContextValue['size'];
   tone?: AccordionContextValue['tone'];
+  weight?: AccordionContextValue['weight'];
   space?: RequiredResponsiveValue<typeof validSpaceValues[number]>;
   data?: DataAttributeMap;
 }
@@ -41,6 +42,7 @@ export const Accordion = ({
   children,
   size = 'large',
   tone,
+  weight,
   space: spaceProp,
   dividers = true,
   data,
@@ -63,7 +65,10 @@ export const Accordion = ({
       .join(', ')}`,
   );
 
-  const contextValue = useMemo(() => ({ size, tone }), [size, tone]);
+  const contextValue = useMemo(
+    () => ({ size, tone, weight }),
+    [size, tone, weight],
+  );
 
   const space =
     spaceProp ?? defaultSpaceForSize[dividers ? 'divided' : 'undivided'][size];

--- a/packages/braid-design-system/lib/components/Accordion/AccordionContext.ts
+++ b/packages/braid-design-system/lib/components/Accordion/AccordionContext.ts
@@ -6,6 +6,7 @@ export const validTones = ['neutral', 'secondary'] as const;
 export interface AccordionContextValue {
   size?: TextProps['size'];
   tone?: typeof validTones[number];
+  weight?: TextProps['weight'];
 }
 
 export const AccordionContext = createContext<AccordionContextValue | null>(

--- a/packages/braid-design-system/lib/components/Accordion/AccordionItem.playroom.tsx
+++ b/packages/braid-design-system/lib/components/Accordion/AccordionItem.playroom.tsx
@@ -23,6 +23,7 @@ export const AccordionItem = ({
   onToggle,
   size,
   tone,
+  weight,
   badge,
   icon,
   ...restProps
@@ -43,6 +44,7 @@ export const AccordionItem = ({
       label={typeof label !== 'boolean' ? label : ''}
       size={typeof size === 'boolean' ? undefined : size}
       tone={typeof tone === 'boolean' ? undefined : tone}
+      weight={typeof weight === 'boolean' ? undefined : weight}
       badge={typeof badge === 'boolean' ? undefined : badge}
       icon={typeof icon === 'boolean' ? undefined : icon}
       {...restProps}

--- a/packages/braid-design-system/lib/components/Accordion/AccordionItem.tsx
+++ b/packages/braid-design-system/lib/components/Accordion/AccordionItem.tsx
@@ -36,6 +36,7 @@ export type AccordionItemBaseProps = {
   children: ReactNode;
   size?: TextProps['size'];
   tone?: AccordionContextValue['tone'];
+  weight?: AccordionContextValue['weight'];
   icon?: TextProps['icon'];
   data?: DataAttributeMap;
   badge?: ReactElement<BadgeProps>;
@@ -51,6 +52,7 @@ export const AccordionItem = ({
   badge,
   size: sizeProp,
   tone: toneProp,
+  weight: weightProp,
   icon,
   data,
   ...restProps
@@ -64,6 +66,10 @@ export const AccordionItem = ({
   assert(
     !(accordionContext && toneProp),
     'Tone cannot be set on AccordionItem when inside Accordion. Tone should be set on Accordion instead.',
+  );
+  assert(
+    !(accordionContext && weightProp),
+    'Weight cannot be set on AccordionItem when inside Accordion. Weight should be set on Accordion instead.',
   );
 
   assert(
@@ -91,7 +97,7 @@ export const AccordionItem = ({
 
   const size = accordionContext?.size ?? sizeProp ?? 'large';
   const tone = accordionContext?.tone ?? toneProp ?? 'neutral';
-  const weight = 'medium';
+  const weight = accordionContext?.weight ?? weightProp ?? 'medium';
   const itemSpace = itemSpaceForSize[size] ?? 'none';
 
   assert(

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -21,6 +21,10 @@ exports[`Accordion 1`] = `
     tone?: 
         | "neutral"
         | "secondary"
+    weight?: 
+        | "medium"
+        | "regular"
+        | "strong"
 },
 }
 `;
@@ -45,6 +49,10 @@ exports[`AccordionItem 1`] = `
     tone?: 
         | "neutral"
         | "secondary"
+    weight?: 
+        | "medium"
+        | "regular"
+        | "strong"
 },
 }
 `;


### PR DESCRIPTION
Add support for customising the `weight` of `AccordionItem`s. This can be either at an `Accordion` level or on a standalone `AccordionItem` based on design requirements.

Note, in order to maintain visual consistency, the `weight` prop can only be specified on an `AccordionItem` when outside of an `Accordion`.

**EXAMPLE USAGE:**
```jsx
<Accordion weight="strong">
  <AccordionItem />
  ...
</Accordion>
```

or

```jsx
<AccordionItem weight="strong" />
```