### PR TITLE
Whitelist only the required FontMetrics for theme tokens

### DIFF
--- a/.changeset/sour-days-whisper.md
+++ b/.changeset/sour-days-whisper.md
@@ -1,0 +1,7 @@
+---
+'braid-design-system': patch
+---
+
+Whitelist only the required FontMetrics for theme tokens
+
+The latest version of `FontMetrics` type in Capsize adds more properties, and we only populate the properties we require on the theme. Whitelisting the required properties to keep the themes explicit.

--- a/packages/braid-design-system/lib/themes/tokenType.ts
+++ b/packages/braid-design-system/lib/themes/tokenType.ts
@@ -17,7 +17,10 @@ export interface BraidTokens {
   typography: {
     fontFamily: string;
     webFont: string | null;
-    fontMetrics: FontMetrics;
+    fontMetrics: Pick<
+      FontMetrics,
+      'capHeight' | 'ascent' | 'descent' | 'lineGap' | 'unitsPerEm'
+    >;
     fontWeight: Record<FontWeight, 400 | 500 | 600 | 700 | 800>;
     heading: {
       weight: {


### PR DESCRIPTION
The latest version of `FontMetrics` type in Capsize adds more properties, and we only populate the properties we require on the theme. Whitelisting the required properties to keep the themes explicit.