### PR TITLE
Use theme tokens for shape of font metrics

### DIFF
--- a/.changeset/popular-cars-roll.md
+++ b/.changeset/popular-cars-roll.md
@@ -1,0 +1,8 @@
+---
+'braid-design-system': patch
+---
+
+Use theme tokens for shape of font metrics
+
+Internally some theme utilities were using Capsize’s `FontMetrics` as their expected payload, rather than correctly using the shape of the theme tokens.
+This makes Braid compatible with Capsize v3.x.

--- a/packages/braid-design-system/lib/themes/makeBraidTheme.ts
+++ b/packages/braid-design-system/lib/themes/makeBraidTheme.ts
@@ -2,7 +2,6 @@ import './treatTheme.d';
 import { createTheme } from 'sku/treat';
 import mapValues from 'lodash/mapValues';
 import values from 'lodash/values';
-import type { FontMetrics } from '@capsizecss/core';
 import { getCapHeight } from '@capsizecss/core';
 
 import { breakpoints } from '../css/breakpoints';
@@ -12,7 +11,7 @@ import type { BraidTokens, TextDefinition } from './tokenType';
 
 const fontSizeToCapHeight = (
   definition: TextDefinition,
-  fontMetrics: FontMetrics,
+  fontMetrics: BraidTokens['typography']['fontMetrics'],
 ) => {
   const { mobile, tablet } = definition;
 

--- a/packages/braid-design-system/lib/themes/makeVanillaTheme.ts
+++ b/packages/braid-design-system/lib/themes/makeVanillaTheme.ts
@@ -1,5 +1,4 @@
 import mapValues from 'lodash/mapValues';
-import type { FontMetrics } from '@capsizecss/core';
 import { getCapHeight } from '@capsizecss/core';
 import { precomputeValues } from '@capsizecss/vanilla-extract';
 
@@ -10,7 +9,7 @@ const px = (v: string | number) => `${v}px`;
 const fontSizeToCapHeight = (
   grid: number,
   definition: TextDefinition,
-  fontMetrics: FontMetrics,
+  fontMetrics: BraidTokens['typography']['fontMetrics'],
 ) => {
   const { mobile, tablet } = definition;
 


### PR DESCRIPTION
Internally some theme utilities were using Capsize’s `FontMetrics` as their expected payload, rather than correctly using the shape of the theme tokens. This makes Braid compatible with Capsize v3.x.