### PR TITLE
site: Fix source and migration links

### DIFF
--- a/site/src/App/DocNavigation/DocProps.tsx
+++ b/site/src/App/DocNavigation/DocProps.tsx
@@ -181,7 +181,7 @@ export const DocProps = () => {
   }
 
   const subfolder = /^Icon/.test(docsName) ? 'icons' : undefined;
-  const componentFolder = `packages/braid-design-system/lib/components/${
+  const componentFolder = `packages/braid-design-system/src/lib/components/${
     subfolder ? `${subfolder}/` : ''
   }${docsName}`;
   const sourceUrl = `${sourceUrlPrefix}/${componentFolder}`;


### PR DESCRIPTION
As part of compiling Braid, the internal directory structure changed. Updating the links to source and migration guides on the docs site.