### PR TITLE
TextLink, TextLinkButton: Increase text weight of weak links

### DIFF
--- a/.changeset/soft-worms-check.md
+++ b/.changeset/soft-worms-check.md
@@ -1,0 +1,14 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - TextLink
+  - TextLinkButton
+---
+
+**TextLink, TextLinkButton:** Increase text weight of weak links
+
+Increases the text weight of `weak` links to `medium`, increasing the affordance against standard text.
+As a result, this makes the weight of all text links consistent.

--- a/packages/braid-design-system/src/lib/components/TextLink/TextLink.css.ts
+++ b/packages/braid-design-system/src/lib/components/TextLink/TextLink.css.ts
@@ -10,7 +10,6 @@ import { vars } from '../../themes/vars.css';
 const textLinkVars = createThemeContract({
   color: null,
   colorHover: null,
-  fontWeight: null,
   textDecoration: null,
   textDecorationHover: null,
 });
@@ -18,7 +17,6 @@ const textLinkVars = createThemeContract({
 const lightModeRegularLinkVars = assignVars(textLinkVars, {
   color: vars.foregroundColor.link,
   colorHover: vars.foregroundColor.linkHover,
-  fontWeight: vars.textWeight.medium,
   textDecoration: 'none',
   textDecorationHover: 'underline',
 });
@@ -26,7 +24,6 @@ const lightModeRegularLinkVars = assignVars(textLinkVars, {
 const darkModeRegularLinkVars = assignVars(textLinkVars, {
   color: vars.foregroundColor.linkLight,
   colorHover: vars.foregroundColor.linkLight,
-  fontWeight: vars.textWeight.medium,
   textDecoration: 'none',
   textDecorationHover: 'underline',
 });
@@ -34,14 +31,12 @@ const darkModeRegularLinkVars = assignVars(textLinkVars, {
 const weakLinkVars = assignVars(textLinkVars, {
   color: 'inherit',
   colorHover: 'inherit',
-  fontWeight: 'inherit',
   textDecoration: 'underline',
   textDecorationHover: 'underline',
 });
 
 export const base = style({
   color: textLinkVars.color,
-  fontWeight: textLinkVars.fontWeight,
   textDecoration: textLinkVars.textDecoration,
   ':hover': {
     color: textLinkVars.colorHover,

--- a/packages/braid-design-system/src/lib/components/TextLink/TextLink.tsx
+++ b/packages/braid-design-system/src/lib/components/TextLink/TextLink.tsx
@@ -18,6 +18,7 @@ import buildDataAttributes from '../private/buildDataAttributes';
 import { virtualTouchable } from '../private/touchable/virtualTouchable';
 import type { UseIconProps } from '../../hooks/useIcon';
 import * as styles from './TextLink.css';
+import * as typographyStyles from '../../css/typography.css';
 
 export interface TextLinkStyles {
   weight?: 'regular' | 'weak';
@@ -82,6 +83,7 @@ export const useLinkStyles = ({
   return clsx(
     styles.base,
     linkStyles,
+    typographyStyles.fontWeight.medium,
     showVisited
       ? [
           styles.visitedLightMode[backgroundLightness.lightMode],


### PR DESCRIPTION
Increases the text weight of `weak` links to `medium`, increasing the affordance against standard text.
As a result, this makes the weight of all text links consistent.