### PR TITLE
Show `description` on fields without a `label`

### DIFF
--- a/.changeset/great-gorillas-live.md
+++ b/.changeset/great-gorillas-live.md
@@ -1,0 +1,30 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Autosuggest
+  - Dropdown
+  - FieldLabel
+  - MonthPicker
+  - PasswordField
+  - RadioGroup
+  - TextField
+  - Textarea
+---
+
+Show `description` on form fields when no `label` provided
+
+Previously, a `FieldLabel` without a `label` would return nothing. However, now that form fields can opt for [indirect or hidden labels] (via `aria-label` or `aria-labelledby`), the `description` should still be shown.
+
+> Note: The `secondaryLabel` and `tertiaryLabel` remain conditional based on the presence of a `label`. This is due to the their location in the layout being anchored off the `label`.
+
+**EXAMPLE USAGE:**
+```jsx
+<FieldLabel
+  description="Description now visible without label"
+/>
+```
+
+[indirect or hidden labels]: https://seek-oss.github.io/braid-design-system/components/TextField#indirect-or-hidden-field-labels

--- a/.changeset/great-gorillas-live.md
+++ b/.changeset/great-gorillas-live.md
@@ -18,7 +18,7 @@ Show `description` on form fields when no `label` provided
 
 Previously, a `FieldLabel` without a `label` would return nothing. However, now that form fields can opt for [indirect or hidden labels] (via `aria-label` or `aria-labelledby`), the `description` should still be shown.
 
-> Note: The `secondaryLabel` and `tertiaryLabel` remain conditional based on the presence of a `label`. This is due to the their location in the layout being anchored off the `label`.
+> Note: The `secondaryLabel` and `tertiaryLabel` remain conditional based on the presence of a `label`. This is due to their location in the layout being anchored off the `label`.
 
 **EXAMPLE USAGE:**
 ```jsx

--- a/.changeset/great-gorillas-live.md
+++ b/.changeset/great-gorillas-live.md
@@ -16,7 +16,7 @@ updated:
 
 Show `description` on form fields when no `label` provided
 
-Previously, a `FieldLabel` without a `label` would return nothing. However, now that form fields can opt for [indirect or hidden labels] (via `aria-label` or `aria-labelledby`), the `description` should still be shown.
+Previously, a `FieldLabel` without a `label` would return nothing. However, now that form fields can opt for [indirect or hidden labels] (via `aria-label` or `aria-labelledby`), the `description` should still be shown if provided.
 
 > Note: The `secondaryLabel` and `tertiaryLabel` remain conditional based on the presence of a `label`. This is due to their location in the layout being anchored off the `label`.
 

--- a/packages/braid-design-system/src/lib/components/FieldLabel/FieldLabel.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/FieldLabel/FieldLabel.screenshots.tsx
@@ -13,54 +13,77 @@ export const screenshots: ComponentScreenshot = {
     {
       label: 'Standard Field Label',
       Container,
-      Example: ({ id }) => (
-        <FieldLabel htmlFor={id} label="This is a field label" />
-      ),
+      Example: ({ id }) => <FieldLabel htmlFor={id} label="Label" />,
     },
     {
-      label: 'Field Label with secondary',
+      label: 'with secondary label',
       Container,
       Example: ({ id }) => (
         <FieldLabel
           htmlFor={id}
-          label="Username"
-          secondaryLabel="Max 30 characters"
+          label="Label"
+          secondaryLabel="Secondary Label"
         />
       ),
     },
     {
-      label: 'Field Label with tertiary label',
+      label: 'with tertiary label',
       Container,
       Example: ({ id }) => (
         <FieldLabel
           htmlFor={id}
-          label="Password"
-          tertiaryLabel={<TextLink href="#">Forgot password?</TextLink>}
+          label="Label"
+          tertiaryLabel={<TextLink href="#">Tertiary</TextLink>}
         />
       ),
     },
     {
-      label: 'Field Label with all types',
+      label: 'with description',
       Container,
       Example: ({ id }) => (
         <FieldLabel
           htmlFor={id}
-          label="Title"
-          secondaryLabel="Optional"
-          tertiaryLabel={<TextLink href="#">Help?</TextLink>}
+          label="Label"
+          description="Description with extra information about the field"
         />
       ),
     },
     {
-      label: 'Field Label when disabled',
+      label: 'with all slots',
       Container,
       Example: ({ id }) => (
         <FieldLabel
           htmlFor={id}
-          label="Title"
+          label="Label"
+          secondaryLabel="Secondary"
+          tertiaryLabel={<TextLink href="#">Tertiary</TextLink>}
+          description="Description with extra information about the field"
+        />
+      ),
+    },
+    {
+      label: 'when disabled',
+      Container,
+      Example: ({ id }) => (
+        <FieldLabel
+          htmlFor={id}
+          label="Label"
           disabled={true}
-          secondaryLabel="Optional"
-          tertiaryLabel={<TextLink href="#">Help?</TextLink>}
+          secondaryLabel="Secondary"
+          tertiaryLabel={<TextLink href="#">Tertiary?</TextLink>}
+          description="Description with extra information about the field"
+        />
+      ),
+    },
+    {
+      label: 'with description and no label',
+      Container,
+      Example: ({ id }) => (
+        <FieldLabel
+          htmlFor={id}
+          secondaryLabel="Secondary"
+          tertiaryLabel={<TextLink href="#">Tertiary?</TextLink>}
+          description="Description visible without label or additional white space above"
         />
       ),
     },

--- a/packages/braid-design-system/src/lib/components/FieldLabel/FieldLabel.tsx
+++ b/packages/braid-design-system/src/lib/components/FieldLabel/FieldLabel.tsx
@@ -30,7 +30,7 @@ export const FieldLabel = ({
   descriptionId,
   data,
 }: FieldLabelProps) => {
-  if (!label) {
+  if (!label && !description) {
     return null;
   }
 
@@ -43,18 +43,20 @@ export const FieldLabel = ({
 
   return (
     <Stack space="xsmall" data={data}>
-      <Box component="span" display="flex" justifyContent="spaceBetween">
-        {htmlFor === false ? (
-          labelEl
-        ) : (
-          <label id={id} htmlFor={htmlFor}>
-            {labelEl}
-          </label>
-        )}
-        {tertiaryLabel ? <Text>&nbsp;{tertiaryLabel}</Text> : null}
-      </Box>
+      {label ? (
+        <Box component="span" display="flex" justifyContent="spaceBetween">
+          {htmlFor === false ? (
+            labelEl
+          ) : (
+            <label id={id} htmlFor={htmlFor}>
+              {labelEl}
+            </label>
+          )}
+          {tertiaryLabel ? <Text>&nbsp;{tertiaryLabel}</Text> : null}
+        </Box>
+      ) : null}
       {description ? (
-        <Box paddingY="xxsmall">
+        <Box paddingTop={label ? 'xxsmall' : undefined} paddingBottom="xxsmall">
           <Text tone="secondary" id={descriptionId}>
             {description}
           </Text>

--- a/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.screenshots.tsx
@@ -71,12 +71,38 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
+      label: 'with a description',
+      Container,
+      Example: ({ id, handler }) => (
+        <MonthPicker
+          id={id}
+          label="Started"
+          description="Longer description of this field"
+          value={{ month: 1, year: 2019 }}
+          onChange={handler}
+        />
+      ),
+    },
+    {
       label: 'No visual label',
       Container,
       Example: ({ id, handler }) => (
         <MonthPicker
           id={id}
           aria-label="Started"
+          value={{ month: 1, year: 2019 }}
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'No visual label with a description',
+      Container,
+      Example: ({ id, handler }) => (
+        <MonthPicker
+          id={id}
+          aria-label="Started"
+          description="Longer description of this field"
           value={{ month: 1, year: 2019 }}
           onChange={handler}
         />

--- a/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.screenshots.tsx
@@ -105,6 +105,22 @@ export const screenshots: ComponentScreenshot = {
       },
     },
     {
+      label: 'PasswordField with a description and no visual label',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('qwerty');
+        return (
+          <PasswordField
+            aria-label="Password"
+            description="Must be 8 characters long and include a capital letter, a number and a symbol"
+            id={id}
+            value={value}
+            onChange={(ev) => setValue(ev.currentTarget.value)}
+          />
+        );
+      },
+    },
+    {
       label: 'PasswordField with critical message',
       Container,
       Example: ({ id }) => {

--- a/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.screenshots.tsx
@@ -209,5 +209,21 @@ export const screenshots: ComponentScreenshot = {
         </RadioGroup>
       ),
     },
+    {
+      label: 'When labelling via aria-labelledby with a description',
+      Example: ({ handler }) => (
+        <RadioGroup
+          id="arialabelledby"
+          value="2"
+          onChange={handler}
+          aria-labelledby="elementId"
+          description="How many years have you been in this role?"
+        >
+          <RadioItem label="One" value="1" />
+          <RadioItem label="Two" value="2" />
+          <RadioItem label="Three" value="3" />
+        </RadioGroup>
+      ),
+    },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.screenshots.tsx
@@ -213,7 +213,7 @@ export const screenshots: ComponentScreenshot = {
       label: 'When labelling via aria-labelledby with a description',
       Example: ({ handler }) => (
         <RadioGroup
-          id="arialabelledby"
+          id="arialabelledbywithdesc"
           value="2"
           onChange={handler}
           aria-labelledby="elementId"

--- a/packages/braid-design-system/src/lib/components/TextField/TextField.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/TextField/TextField.screenshots.tsx
@@ -130,7 +130,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'TextField with a description and no visual label ',
+      label: 'TextField with a description and no visual label',
       Container,
       Example: ({ id, handler }) => (
         <TextField

--- a/packages/braid-design-system/src/lib/components/TextField/TextField.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/TextField/TextField.screenshots.tsx
@@ -130,6 +130,19 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
+      label: 'TextField with a description and no visual label ',
+      Container,
+      Example: ({ id, handler }) => (
+        <TextField
+          aria-label="Label"
+          description="Longer description of this field"
+          id={id}
+          value=""
+          onChange={handler}
+        />
+      ),
+    },
+    {
       label: 'TextField with description',
       Container,
       Example: ({ id, handler }) => (

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.screenshots.tsx
@@ -65,7 +65,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Textarea with a description and no visual label ',
+      label: 'Textarea with a description and no visual label',
       Container,
       Example: ({ id, handler }) => (
         <Textarea

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.screenshots.tsx
@@ -65,6 +65,19 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
+      label: 'Textarea with a description and no visual label ',
+      Container,
+      Example: ({ id, handler }) => (
+        <Textarea
+          aria-label="Label"
+          description="Longer description of this field"
+          id={id}
+          value=""
+          onChange={handler}
+        />
+      ),
+    },
+    {
       label: 'Textarea with error',
       Container,
       Example: ({ id, handler }) => (

--- a/packages/braid-design-system/src/lib/components/private/Field/Field.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Field/Field.tsx
@@ -25,19 +25,16 @@ export type FieldLabelVariant =
       'aria-labelledby': string;
       secondaryLabel?: never;
       tertiaryLabel?: never;
-      description?: never;
     }
   | {
       'aria-label': string;
       secondaryLabel?: never;
       tertiaryLabel?: never;
-      description?: never;
     }
   | {
       label: FieldLabelProps['label'];
       secondaryLabel?: FieldLabelProps['secondaryLabel'];
       tertiaryLabel?: FieldLabelProps['tertiaryLabel'];
-      description?: FieldLabelProps['description'];
     };
 
 export type FieldBaseProps = {
@@ -47,6 +44,7 @@ export type FieldBaseProps = {
   name?: FormElementProps['name'];
   disabled?: FormElementProps['disabled'];
   autoComplete?: FormElementProps['autoComplete'];
+  description?: FieldLabelProps['description'];
   message?: FieldMessageProps['message'];
   secondaryMessage?: FieldMessageProps['secondaryMessage'];
   reserveMessageSpace?: FieldMessageProps['reserveMessageSpace'];
@@ -100,6 +98,7 @@ export const Field = ({
   disabled,
   autoComplete,
   children,
+  description,
   message,
   secondaryMessage,
   reserveMessageSpace = false,
@@ -120,16 +119,13 @@ export const Field = ({
   );
 
   const messageId = `${id}-message`;
-  const descriptionId =
-    'description' in restProps && restProps.description
-      ? `${id}-description`
-      : undefined;
+  const descriptionId = description ? `${id}-description` : undefined;
   const fieldBackground: BoxProps['background'] = disabled
     ? { lightMode: 'neutralSoft', darkMode: 'neutral' }
     : { lightMode: 'surface' };
 
   const hasValue = typeof value === 'string' ? value.length > 0 : value != null;
-  const hasVisualLabel = 'label' in restProps;
+  const hasVisualLabelOrDescription = 'label' in restProps || description;
   const showSecondaryIcon =
     alwaysShowSecondaryIcon || (secondaryIcon && hasValue);
 
@@ -152,7 +148,7 @@ export const Field = ({
 
   return (
     <Stack space="xsmall">
-      {hasVisualLabel ? (
+      {hasVisualLabelOrDescription ? (
         <FieldLabel
           id={labelId}
           htmlFor={id}
@@ -164,9 +160,7 @@ export const Field = ({
           tertiaryLabel={
             'tertiaryLabel' in restProps ? restProps.tertiaryLabel : undefined
           }
-          description={
-            'description' in restProps ? restProps.description : undefined
-          }
+          description={description}
           descriptionId={descriptionId}
         />
       ) : null}

--- a/packages/braid-design-system/src/lib/components/private/FieldGroup/FieldGroup.tsx
+++ b/packages/braid-design-system/src/lib/components/private/FieldGroup/FieldGroup.tsx
@@ -19,24 +19,22 @@ export type FieldLabelVariant =
       'aria-labelledby': string;
       secondaryLabel?: never;
       tertiaryLabel?: never;
-      description?: never;
     }
   | {
       'aria-label': string;
       secondaryLabel?: never;
       tertiaryLabel?: never;
-      description?: never;
     }
   | {
       label: FieldLabelProps['label'];
       secondaryLabel?: FieldLabelProps['secondaryLabel'];
       tertiaryLabel?: FieldLabelProps['tertiaryLabel'];
-      description?: FieldLabelProps['description'];
     };
 
 export type FieldGroupBaseProps = {
   id: NonNullable<FormElementProps['id']>;
   disabled?: FormElementProps['disabled'];
+  description?: FieldLabelProps['description'];
   message?: FieldMessageProps['message'];
   reserveMessageSpace?: FieldMessageProps['reserveMessageSpace'];
   tone?: FieldMessageProps['tone'];
@@ -98,11 +96,11 @@ export const FieldGroup = ({
       {...buildDataAttributes({ data, validateRestProps: restProps })}
     >
       <Stack space={space}>
-        {'label' in restProps && restProps.label ? (
+        {('label' in restProps && restProps.label) || description ? (
           <Box component="legend" id={labelId}>
             <FieldLabel
               htmlFor={false}
-              label={restProps.label}
+              label={'label' in restProps ? restProps.label : undefined}
               secondaryLabel={secondaryLabel}
               tertiaryLabel={tertiaryLabel}
               disabled={disabled}


### PR DESCRIPTION
Previously, a `FieldLabel` without a `label` would return nothing. However, now that form fields can opt for [indirect or hidden labels] (via `aria-label` or `aria-labelledby`), the `description` should still be shown if provided.

> Note: The `secondaryLabel` and `tertiaryLabel` remain conditional based on the presence of a `label`. This is due to their location in the layout being anchored off the `label`.

**EXAMPLE USAGE:**
```jsx
<FieldLabel
  description="Description now visible without label"
/>
```

[indirect or hidden labels]: https://seek-oss.github.io/braid-design-system/components/TextField#indirect-or-hidden-field-labels