### PR TITLE
RadioItem, Toggle: Use formAccent border when selected

### DIFF
--- a/.changeset/hungry-donuts-suffer.md
+++ b/.changeset/hungry-donuts-suffer.md
@@ -1,0 +1,14 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Radio
+  - RadioItem
+  - Toggle
+---
+
+**RadioItem, Toggle:** Use formAccent border when selected
+
+Switch to using the `formAccent` border colour, rather than the `field` border color, when in the selected state (e.g. `checked` for `RadioItem`, `on` for `Toggle`).

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -126,7 +126,7 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
             <FieldOverlay
               variant="formAccent"
               borderRadius="full"
-              className={styles.hoverOverlay}
+              className={!on ? styles.hoverOverlay : undefined}
             />
           </Box>
         </Box>

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -107,7 +107,7 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
           <Box
             position="absolute"
             background="surface"
-            boxShadow="borderField"
+            boxShadow={on ? 'borderFormAccent' : 'borderField'}
             transition="fast"
             display="flex"
             alignItems="center"
@@ -124,7 +124,7 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
               className={styles.focusOverlay}
             />
             <FieldOverlay
-              variant="hover"
+              variant="formAccent"
               borderRadius="full"
               className={styles.hoverOverlay}
             />

--- a/packages/braid-design-system/src/lib/components/private/Field/Field.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Field/Field.tsx
@@ -140,7 +140,7 @@ export const Field = ({
         visible={tone === 'critical' && !disabled}
       />
       <FieldOverlay variant="focus" className={styles.focusOverlay} />
-      <FieldOverlay variant="hover" className={styles.hoverOverlay} />
+      <FieldOverlay variant="formAccent" className={styles.hoverOverlay} />
     </Fragment>
   );
 

--- a/packages/braid-design-system/src/lib/components/private/FieldOverlay/FieldOverlay.tsx
+++ b/packages/braid-design-system/src/lib/components/private/FieldOverlay/FieldOverlay.tsx
@@ -6,7 +6,7 @@ type FieldOverlayVariant =
   | 'default'
   | 'disabled'
   | 'focus'
-  | 'hover'
+  | 'formAccent'
   | 'critical';
 export interface FieldOverlayProps
   extends Pick<
@@ -28,7 +28,7 @@ const boxShadowForVariant: Record<
   default: 'borderField',
   disabled: 'borderNeutralLight',
   focus: 'outlineFocus',
-  hover: 'borderFormAccent',
+  formAccent: 'borderFormAccent',
   critical: 'borderCritical',
 };
 

--- a/packages/braid-design-system/src/lib/components/private/InlineField/StyledInput.tsx
+++ b/packages/braid-design-system/src/lib/components/private/InlineField/StyledInput.tsx
@@ -146,6 +146,7 @@ export const StyledInput = forwardRef<
     const fieldBackground: BoxProps['background'] = disabled
       ? { lightMode: 'neutralSoft', darkMode: 'neutral' }
       : { lightMode: 'surface' };
+    const defaultBorder = checked ? 'formAccent' : 'default';
 
     useEffect(() => {
       if (ref && typeof ref === 'object' && ref.current && isCheckbox) {
@@ -206,7 +207,7 @@ export const StyledInput = forwardRef<
           borderRadius={fieldBorderRadius}
         >
           <FieldOverlay
-            variant={disabled ? 'disabled' : 'default'}
+            variant={disabled ? 'disabled' : defaultBorder}
             borderRadius={fieldBorderRadius}
             visible={tone !== 'critical' || disabled}
           />
@@ -230,7 +231,7 @@ export const StyledInput = forwardRef<
             className={styles.focusOverlay}
           />
           <FieldOverlay
-            variant="hover"
+            variant="formAccent"
             borderRadius={fieldBorderRadius}
             className={styles.hoverOverlay}
           >


### PR DESCRIPTION
**RadioItem, Toggle:** Use formAccent border when selected

Switch to using the `formAccent` border colour, rather than the `field` border colour, when in the selected state (e.g. `checked` for `RadioItem`, `on` for `Toggle`).

### RadioItem
<img src="https://user-images.githubusercontent.com/912060/227817548-47493a08-eab1-42a7-9b93-46f606d7eb13.png" align="left" width="45%" alt="RadioItem before" />

<img src="https://user-images.githubusercontent.com/912060/227817547-36d62a6c-6607-43ea-91a3-bd028118c4b2.png"  width="45%" alt="RadioItem after" />

### Toggle
<img src="https://user-images.githubusercontent.com/912060/227817973-0a5355ca-266e-499d-9015-1608c4b9a893.png" align="left" width="45%" alt="Toggle before" />

<img src="https://user-images.githubusercontent.com/912060/227817967-f09f325f-c470-4820-b8c7-4e03ad5e6276.png" width="45%" alt="Toggle after" />

