### PR TITLE
Add `small` radius & improve consistency of radius usage

### DIFF
--- a/.changeset/big-dryers-report.md
+++ b/.changeset/big-dryers-report.md
@@ -13,7 +13,7 @@ updated:
 **Box, atoms, vars:** Add `small` to border radius scale
 
 Extends the border radius scale to include `small` as a step below `standard`.
-This uplift is to support an upcoming design uplift that requires greater fidelity in the scale.
+This addition is to support an upcoming design uplift that requires greater fidelity in the scale.
 Note, the new value is also available as a responsive property.
 
 **EXAMPLE USAGE:**

--- a/.changeset/big-dryers-report.md
+++ b/.changeset/big-dryers-report.md
@@ -1,0 +1,37 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Box
+  - BoxRenderer
+  - atoms
+  - vars
+---
+
+**Box, atoms, vars:** Add `small` to border radius scale
+
+Extends the border radius scale to include `small` as a step below `standard`.
+This uplift is to support an upcoming design uplift that requires greater fidelity in the scale.
+Note, the new value is also available as a responsive property.
+
+**EXAMPLE USAGE:**
+```jsx
+<Box borderRadius="small" />
+
+{/* Or responsively: */}
+<Box borderRadius={{ mobile: 'small', tablet: 'standard' }} />
+```
+
+```ts
+import { atoms } from 'braid-design-system/css';
+
+atoms({ borderRadius: 'small' })
+```
+
+```ts
+import { vars } from 'braid-design-system/css';
+
+const radius = vars.borderRadius.small;
+```

--- a/.changeset/serious-hats-cry.md
+++ b/.changeset/serious-hats-cry.md
@@ -1,0 +1,21 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Autosuggest
+  - Badge
+  - Button
+  - Card
+  - Pagination
+  - Textarea
+  - TooltipRenderer
+  - useToast
+---
+
+Improved consistency of border radius usage across components
+
+Over time, individual components have reached for a larger radius in the scale, rather than increasing the scale at a theme level. This resulted in inconsistent use across the system, preventing uplift of the scale.
+
+Re-aligning all components to use the scale consistently enables themes to apply very different radius scales — enabling an upcoming design uplift theme.

--- a/.changeset/serious-hats-cry.md
+++ b/.changeset/serious-hats-cry.md
@@ -14,7 +14,7 @@ updated:
   - useToast
 ---
 
-Improved consistency of border radius usage across components
+Improve consistency of border radius usage across components
 
 Over time, individual components have reached for a larger radius in the scale, rather than increasing the scale at a theme level. This resulted in inconsistent use across the system, preventing uplift of the scale.
 

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.tsx
@@ -199,7 +199,6 @@ function GroupHeading({ children }: GroupHeadingProps) {
   return (
     <Box
       paddingX="small"
-      borderRadius="standard"
       className={[
         styles.groupHeading,
         touchableText.xsmall,

--- a/packages/braid-design-system/src/lib/components/Badge/Badge.tsx
+++ b/packages/braid-design-system/src/lib/components/Badge/Badge.tsx
@@ -89,7 +89,7 @@ export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
             weight === 'strong' ? tone : lightModeBackgroundForTone[tone]
           }
           paddingX="xsmall"
-          borderRadius="large"
+          borderRadius="standard"
           overflow="hidden"
         >
           <Text

--- a/packages/braid-design-system/src/lib/components/Button/Button.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.tsx
@@ -220,7 +220,7 @@ const ButtonLoader = () => (
 );
 
 const transparentPaddingX = 'small';
-const buttonRadius = 'large';
+const buttonRadius = 'standard';
 
 export const ButtonOverlays = ({
   variant = 'solid',

--- a/packages/braid-design-system/src/lib/components/Card/Card.tsx
+++ b/packages/braid-design-system/src/lib/components/Card/Card.tsx
@@ -29,7 +29,7 @@ type ResponsiveCardRounding = {
   roundedAbove?: ResponsiveRangeProps['above'];
 };
 
-const borderRadius = 'xlarge';
+const borderRadius = 'large';
 
 export type CardProps = {
   children: ReactNode;

--- a/packages/braid-design-system/src/lib/components/Pagination/Pagination.tsx
+++ b/packages/braid-design-system/src/lib/components/Pagination/Pagination.tsx
@@ -30,7 +30,7 @@ export interface PaginationProps {
   data?: DataAttributeMap;
 }
 
-const borderRadius = 'large';
+const borderRadius = 'standard';
 
 const PageNav = ({
   label,

--- a/packages/braid-design-system/src/lib/components/Textarea/Highlight/Highlight.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Highlight/Highlight.tsx
@@ -9,7 +9,7 @@ export interface HighlightProps {
 export const Highlight = ({ children }: HighlightProps) => (
   <Box
     component="mark"
-    borderRadius="standard"
+    borderRadius="small"
     background={{ lightMode: 'criticalLight', darkMode: 'critical' }}
     className={styles.root}
   >

--- a/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.css.ts
+++ b/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.css.ts
@@ -34,7 +34,7 @@ export const padding = style({
   padding: calc.add(vars.space.small, vars.grid),
 });
 
-const borderRadius = vars.borderRadius.standard;
+const borderRadius = vars.borderRadius.small;
 const offset = calc(constants.arrowSize).divide(2).negate().toString();
 export const arrow = style({
   visibility: 'hidden',

--- a/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.tsx
@@ -40,7 +40,7 @@ export const TooltipTextDefaultsProvider = ({
   );
 };
 
-const borderRadius = 'xlarge';
+const borderRadius = 'large';
 
 export type ArrowProps = ReturnType<
   ReturnType<typeof usePopperTooltip>['getArrowProps']

--- a/packages/braid-design-system/src/lib/components/useToast/Toast.tsx
+++ b/packages/braid-design-system/src/lib/components/useToast/Toast.tsx
@@ -24,7 +24,7 @@ const toneToIcon = {
 
 export const toastDuration = 10000;
 
-const borderRadius = 'xlarge';
+const borderRadius = 'large';
 
 interface ActionProps extends ToastAction {
   removeToast: () => void;

--- a/packages/braid-design-system/src/lib/themes/baseTokens/apac.ts
+++ b/packages/braid-design-system/src/lib/themes/baseTokens/apac.ts
@@ -172,6 +172,7 @@ export const makeTokens = ({
     },
     border: {
       radius: {
+        small: '2px',
         standard: '4px',
         large: '6px',
         xlarge: '10px',

--- a/packages/braid-design-system/src/lib/themes/docs/tokens.ts
+++ b/packages/braid-design-system/src/lib/themes/docs/tokens.ts
@@ -148,6 +148,7 @@ const tokens: BraidTokens = {
   },
   border: {
     radius: {
+      small: '4px',
       standard: '6px',
       large: '8px',
       xlarge: '12px',

--- a/packages/braid-design-system/src/lib/themes/tokenType.ts
+++ b/packages/braid-design-system/src/lib/themes/tokenType.ts
@@ -68,6 +68,7 @@ export interface BraidTokens {
   };
   border: {
     radius: {
+      small: string;
       standard: string;
       large: string;
       xlarge: string;

--- a/packages/braid-design-system/src/lib/themes/wireframe/tokens.ts
+++ b/packages/braid-design-system/src/lib/themes/wireframe/tokens.ts
@@ -181,6 +181,7 @@ const tokens: BraidTokens = {
   },
   border: {
     radius: {
+      small: '4px',
       standard: '6px',
       large: '8px',
       xlarge: '10px',

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -503,10 +503,11 @@ exports[`Box 1`] = `
         | "full"
         | "large"
         | "none"
+        | "small"
         | "standard"
         | "xlarge"
-        | ResponsiveArray<1 | 2 | 3 | 4, "large" | "xlarge" | "standard" | "none" | "full" | null>
-        | { mobile?: "large" | "xlarge" | "standard" | "none" | "full" | undefined; tablet?: "large" | "xlarge" | "standard" | "none" | "full" | undefined; desktop?: "large" | "xlarge" | "standard" | "none" | "full" | undefined; wide?: "large" | ... 4 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "small" | "large" | "xlarge" | "standard" | "none" | "full" | null>
+        | { mobile?: "small" | "large" | "xlarge" | "standard" | "none" | "full" | undefined; tablet?: "small" | "large" | "xlarge" | "standard" | "none" | "full" | undefined; desktop?: "small" | ... 5 more ... | undefined; wide?: "small" | ... 5 more ... | undefined; }
     bottom?: 0
     boxShadow?: 
         | "borderBrandAccentLarge"
@@ -1450,10 +1451,11 @@ exports[`BoxRenderer 1`] = `
         | "full"
         | "large"
         | "none"
+        | "small"
         | "standard"
         | "xlarge"
-        | ResponsiveArray<1 | 2 | 3 | 4, "large" | "xlarge" | "standard" | "none" | "full" | null>
-        | { mobile?: "large" | "xlarge" | "standard" | "none" | "full" | undefined; tablet?: "large" | "xlarge" | "standard" | "none" | "full" | undefined; desktop?: "large" | "xlarge" | "standard" | "none" | "full" | undefined; wide?: "large" | ... 4 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "small" | "large" | "xlarge" | "standard" | "none" | "full" | null>
+        | { mobile?: "small" | "large" | "xlarge" | "standard" | "none" | "full" | undefined; tablet?: "small" | "large" | "xlarge" | "standard" | "none" | "full" | undefined; desktop?: "small" | ... 5 more ... | undefined; wide?: "small" | ... 5 more ... | undefined; }
     bottom?: 0
     boxShadow?: 
         | "borderBrandAccentLarge"


### PR DESCRIPTION
### Add `small` to border radius scale

Extends the border radius scale to include `small` as a step below `standard`. This uplift is to support an upcoming design uplift that requires greater fidelity in the scale.

Note, the new value is also available as a responsive property.

### Improve consistency of radius usage

Over time, individual components have reached for a larger radius in the scale, rather than increasing the scale at a theme level. This resulted in inconsistent use across the system, preventing uplift of the scale.

Re-aligning all components to use the scale consistently enables themes to apply very different radius scales — enabling an upcoming design uplift theme.

![Radius](https://user-images.githubusercontent.com/912060/228083694-370f2d9f-b641-4058-9c7a-dbf2761400f2.png)
