### PR TITLE
Migrate to Capsize for font metrics

### DIFF
--- a/fixtures/consumer/__snapshots__/build.test.ts.snap
+++ b/fixtures/consumer/__snapshots__/build.test.ts.snap
@@ -24,6 +24,8 @@ exports[`build side-effects from dist 1`] = `
   "dist/side-effects/lib/themes/makeRuntimeTokens.mjs",
   "dist/side-effects/lib/themes/seekBusiness/index.cjs",
   "dist/side-effects/lib/themes/seekBusiness/index.mjs",
+  "dist/side-effects/lib/themes/tokenType.cjs",
+  "dist/side-effects/lib/themes/tokenType.mjs",
   "dist/side-effects/lib/themes/wireframe/index.cjs",
   "dist/side-effects/lib/themes/wireframe/index.mjs",
   "dist/styles/lib/css/atoms/atomicProperties.cjs",

--- a/packages/braid-design-system/package.json
+++ b/packages/braid-design-system/package.json
@@ -133,7 +133,8 @@
     "storybook:chromatic": "chromatic --storybook-build-dir ./dist-storybook --exit-zero-on-changes --exit-once-uploaded --auto-accept-changes master"
   },
   "dependencies": {
-    "@capsizecss/core": "^3.0.0",
+    "@capsizecss/core": "^3.1.0",
+    "@capsizecss/metrics": "^1.1.1",
     "@capsizecss/vanilla-extract": "^1.0.0",
     "@types/autosuggest-highlight": "^3.1.1",
     "@types/dedent": "^0.7.0",

--- a/packages/braid-design-system/src/lib/themes/baseTokens/apac.ts
+++ b/packages/braid-design-system/src/lib/themes/baseTokens/apac.ts
@@ -1,8 +1,10 @@
+import robotoMetrics from '@capsizecss/metrics/roboto';
 import type { DeepPartial } from 'utility-types';
 import { darken, lighten, rgba, saturate } from 'polished';
 import merge from 'lodash/merge';
 import { palette } from '../../color/palette';
 import type { BraidTokens } from '../tokenType';
+import { extractFontMetricsForTheme } from '../tokenType';
 
 interface MakeTokensOptions {
   name: string;
@@ -42,13 +44,7 @@ export const makeTokens = ({
       fontFamily:
         'Roboto, "Helvetica Neue", HelveticaNeue, Helvetica, Arial, sans-serif',
       webFont: null,
-      fontMetrics: {
-        capHeight: 1456,
-        ascent: 1900,
-        descent: -500,
-        lineGap: 0,
-        unitsPerEm: 2048,
-      },
+      fontMetrics: extractFontMetricsForTheme(robotoMetrics),
       fontWeight: {
         regular: 400,
         medium: 500,

--- a/packages/braid-design-system/src/lib/themes/docs/tokens.ts
+++ b/packages/braid-design-system/src/lib/themes/docs/tokens.ts
@@ -1,6 +1,8 @@
+import appleSystemMetrics from '@capsizecss/metrics/appleSystem';
 import { darken, lighten, rgba } from 'polished';
 import { palette } from '../../color/palette';
 import type { BraidTokens } from '../tokenType';
+import { extractFontMetricsForTheme } from '../tokenType';
 
 const brandAccent = palette.grey['900'];
 const formAccent = palette.indigo['600'];
@@ -18,13 +20,7 @@ const tokens: BraidTokens = {
     fontFamily:
       '-apple-system, BlinkMacSystemFont, Roboto, "Segoe UI", Helvetica, Arial, sans-serif, "Apple Color Emoji", "Segoe UI Emoji", "Segoe UI Symbol"',
     webFont: null,
-    fontMetrics: {
-      capHeight: 1443,
-      ascent: 1950,
-      descent: -494,
-      lineGap: 0,
-      unitsPerEm: 2048,
-    },
+    fontMetrics: extractFontMetricsForTheme(appleSystemMetrics),
     fontWeight: {
       regular: 400,
       medium: 500,

--- a/packages/braid-design-system/src/lib/themes/tokenType.ts
+++ b/packages/braid-design-system/src/lib/themes/tokenType.ts
@@ -1,6 +1,24 @@
 import type { FontMetrics } from '@capsizecss/core';
 import type { Breakpoint } from '../css/breakpoints';
 
+type FontMetricsForTheme = Pick<
+  FontMetrics,
+  'capHeight' | 'ascent' | 'descent' | 'lineGap' | 'unitsPerEm'
+>;
+export const extractFontMetricsForTheme = ({
+  capHeight,
+  ascent,
+  descent,
+  lineGap,
+  unitsPerEm,
+}: FontMetrics): FontMetricsForTheme => ({
+  capHeight,
+  ascent,
+  descent,
+  lineGap,
+  unitsPerEm,
+});
+
 export type TextBreakpoint = Exclude<Breakpoint, 'desktop' | 'wide'>;
 
 type FontSizeText = {
@@ -17,10 +35,7 @@ export interface BraidTokens {
   typography: {
     fontFamily: string;
     webFont: string | null;
-    fontMetrics: Pick<
-      FontMetrics,
-      'capHeight' | 'ascent' | 'descent' | 'lineGap' | 'unitsPerEm'
-    >;
+    fontMetrics: FontMetricsForTheme;
     fontWeight: Record<FontWeight, 400 | 500 | 600 | 700 | 800>;
     heading: {
       weight: {

--- a/packages/braid-design-system/src/lib/themes/wireframe/tokens.ts
+++ b/packages/braid-design-system/src/lib/themes/wireframe/tokens.ts
@@ -1,3 +1,4 @@
+import courierNewMetrics from '@capsizecss/metrics/courierNew';
 import { darken, lighten, tint } from 'polished';
 import {
   findClosestAccessibleLighterColor,
@@ -6,6 +7,7 @@ import {
   isLight,
 } from '../../utils';
 import type { BraidTokens } from '../tokenType';
+import { extractFontMetricsForTheme } from '../tokenType';
 
 const formAccent = '#767676';
 const critical = '#ef3e4a';
@@ -49,15 +51,9 @@ const tokens: BraidTokens = {
   name: 'wireframe',
   displayName: 'Wireframe',
   typography: {
-    fontFamily: 'Courier, monospace',
+    fontFamily: '"Courier New", monospace',
     webFont: null,
-    fontMetrics: {
-      capHeight: 1186, // 1544 from fontkit, but should be 1186 according to fontforge
-      ascent: 1638, // 1544 from fontkit, but should be 1638 according to general metrics table
-      descent: -410, // -504 from fontkit, but should be -410 according to general metrics table
-      lineGap: 184, // 0 from fontkit, but should be 184 according to os/2 metrics table
-      unitsPerEm: 2048,
-    },
+    fontMetrics: extractFontMetricsForTheme(courierNewMetrics),
     fontWeight: {
       regular: 400,
       medium: 500,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -157,8 +157,11 @@ importers:
   packages/braid-design-system:
     dependencies:
       '@capsizecss/core':
-        specifier: ^3.0.0
-        version: 3.0.0
+        specifier: ^3.1.0
+        version: 3.1.0
+      '@capsizecss/metrics':
+        specifier: ^1.1.1
+        version: 1.1.1
       '@capsizecss/vanilla-extract':
         specifier: ^1.0.0
         version: 1.0.0(@vanilla-extract/css@1.9.5)
@@ -2416,8 +2419,14 @@ packages:
   /@bcoe/v8-coverage@0.2.3:
     resolution: {integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==}
 
-  /@capsizecss/core@3.0.0:
-    resolution: {integrity: sha512-tJNEWMmhHcU5z6ITAiVNN9z+PCTylybVIJqgX7Ts4zN66fe/W2Fe5UWJCCZIP/5uutsl5fYOaVVHZIjsuTVhBQ==}
+  /@capsizecss/core@3.1.0:
+    resolution: {integrity: sha512-MoHbXUMqJtYL+idLVSQY57OPRyPaUBGN0o1Im0JElmfRVV+X1i1i5QsQTuEJpJgYFwi4jsck7A+jt6X7XB0p8w==}
+    dependencies:
+      csstype: 3.1.1
+    dev: false
+
+  /@capsizecss/metrics@1.1.1:
+    resolution: {integrity: sha512-YFONV2KvBPYr3FCJTMCZ5rkTHbaVCqO37VYJo9HrrzU2aLcWk5JPQln64yMmKtWUj5Pwi1vIqeFqCoYQxd20gg==}
     dev: false
 
   /@capsizecss/vanilla-extract@1.0.0(@vanilla-extract/css@1.9.5):
@@ -2425,7 +2434,7 @@ packages:
     peerDependencies:
       '@vanilla-extract/css': ^1.2.1
     dependencies:
-      '@capsizecss/core': 3.0.0
+      '@capsizecss/core': 3.1.0
       '@vanilla-extract/css': 1.9.5
     dev: false
 
@@ -8714,6 +8723,9 @@ packages:
   /csstype@3.1.0:
     resolution: {integrity: sha512-uX1KG+x9h5hIJsaKR9xHUeUraxf8IODOwq9JLNPq6BwB04a/xgpq3rcx47l5BZu5zBPlgD342tdke3Hom/nJRA==}
 
+  /csstype@3.1.1:
+    resolution: {integrity: sha512-DJR/VvkAvSZW9bTouZue2sSxDwdTN92uHjqeKVm+0dAqdfNykRzQ95tay8aXMBAAPpUiq4Qcug2L7neoRh2Egw==}
+
   /csv-generate@3.4.3:
     resolution: {integrity: sha512-w/T+rqR0vwvHqWs/1ZyMDWtHHSJaN06klRqJXBEpDJaM/+dZkso0OKh1VcuuYvK3XM53KysVNq8Ko/epCK8wOw==}
     dev: false
@@ -14473,7 +14485,7 @@ packages:
       react-dom: '*'
     dependencies:
       css-tree: 1.1.3
-      csstype: 3.1.0
+      csstype: 3.1.1
       fastest-stable-stringify: 2.0.2
       inline-style-prefixer: 6.0.1
       react: 18.2.0
@@ -19232,7 +19244,7 @@ packages:
       css-loader: 5.2.7(webpack@5.75.0)
       css-selector-parser: 1.4.1
       cssnano: 4.1.11
-      csstype: 3.1.0
+      csstype: 3.1.1
       debug: 4.3.4
       dedent: 0.7.0
       eval: 0.1.8


### PR DESCRIPTION
Cleaning up the themes internally to pull the metrics from Capsize rather than use hard coded values in Braid.

Note also switching `wireframe` to use `Courier New` instead of `Courier` which had missing metrics that were filled manually.