### PR TITLE
Add support for web fonts beyond Google Fonts

### DIFF
--- a/.changeset/big-hornets-prove.md
+++ b/.changeset/big-hornets-prove.md
@@ -1,0 +1,14 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - theme
+---
+
+**theme:** Add support for webfonts beyond Google Fonts
+
+Previously the `webFont` on the theme was the `familyName` and was being used to construct a link tag to a Google Fonts stylesheet and provide to consumers via a runtime token.
+To enable fonts beyond Google Fonts, we are changing `webFont` to be a URL.
+This does not impact existing themes (as there are no themes currently with a web font), and the contract of the runtime token (a constructed link tag) remains unchanged.

--- a/.changeset/big-hornets-prove.md
+++ b/.changeset/big-hornets-prove.md
@@ -11,4 +11,5 @@ updated:
 
 Previously the `webFont` on the theme was the `familyName` and was being used to construct a link tag to a Google Fonts stylesheet and provide to consumers via a runtime token.
 To enable fonts beyond Google Fonts, we are changing `webFont` to be a URL.
+
 This does not impact existing themes (as there are no themes currently with a web font), and the contract of the runtime token (a constructed link tag) remains unchanged.

--- a/packages/braid-design-system/src/lib/themes/makeRuntimeTokens.ts
+++ b/packages/braid-design-system/src/lib/themes/makeRuntimeTokens.ts
@@ -1,20 +1,14 @@
 import mapValues from 'lodash/mapValues';
-import values from 'lodash/values';
 
 import { isLight } from '../utils';
 import type { BraidTokens } from './tokenType';
 
-const makeWebFonts = ({ webFont, fontWeight }: BraidTokens['typography']) => {
+const makeWebFonts = (webFont: BraidTokens['typography']['webFont']) => {
   if (!webFont) {
     return [];
   }
 
-  const weights = values(fontWeight);
-  const linkTag = `<link href="https://fonts.googleapis.com/css?family=${encodeURIComponent(
-    `${webFont}:${weights.sort().join(',')}`,
-  )}" rel="stylesheet" />`;
-
-  return [{ linkTag }];
+  return [{ linkTag: `<link href="${webFont}" rel="stylesheet" />` }];
 };
 
 export const makeRuntimeTokens = (tokens: BraidTokens) => ({
@@ -24,7 +18,7 @@ export const makeRuntimeTokens = (tokens: BraidTokens) => ({
     lightMode: tokens.color.background.body,
     darkMode: tokens.color.background.bodyDark,
   },
-  webFonts: makeWebFonts(tokens.typography),
+  webFonts: makeWebFonts(tokens.typography.webFont),
   space: {
     grid: tokens.grid,
     space: tokens.space,


### PR DESCRIPTION
Previously the `webFont` on the theme was the `familyName` and was being used to construct a link tag to a Google Fonts stylesheet and provide to consumers via a runtime token. To enable fonts beyond Google Fonts, we are changing `webFont` to be a URL.

This does not impact existing themes (as there are no themes currently with a web font), and the contract of the runtime token (a constructed link tag) remains unchanged.