### PR TITLE
Fix error reading `standard` of undefined

### DIFF
--- a/.changeset/polite-candles-float.md
+++ b/.changeset/polite-candles-float.md
@@ -2,7 +2,7 @@
 'braid-design-system': patch
 ---
 
-Fix error reading \`standard\` of undefined
+Fix error reading `standard` of undefined
 
 The use of dynamic property access left some styles exposed to being marked as unused and tree shaken away.
 

--- a/.changeset/polite-candles-float.md
+++ b/.changeset/polite-candles-float.md
@@ -3,3 +3,7 @@
 ---
 
 Fix error reading \`standard\` of undefined
+
+The use of dynamic property access left some styles exposed to being marked as unused and tree shaken away.
+
+Refactoring these styles to be explicitly referenced to ensure this will not be the case.

--- a/.changeset/polite-candles-float.md
+++ b/.changeset/polite-candles-float.md
@@ -1,0 +1,5 @@
+---
+'braid-design-system': patch
+---
+
+Fix error reading \`standard\` of undefined

--- a/packages/braid-design-system/src/lib/css/negativeMargin/negativeMargin.ts
+++ b/packages/braid-design-system/src/lib/css/negativeMargin/negativeMargin.ts
@@ -11,11 +11,6 @@ const directionStyles = {
   left: styles.left,
 };
 
-const preventCollapsePseudoStyles = {
-  top: styles.preventCollapsePseudo.top,
-  bottom: styles.preventCollapsePseudo.bottom,
-};
-
 export const negativeMargin = (
   direction: Exclude<keyof typeof styles, 'preventCollapsePseudo'>,
   space?: RequiredResponsiveValue<Space>,
@@ -23,7 +18,7 @@ export const negativeMargin = (
   space
     ? clsx([
         direction === 'top' || direction === 'bottom'
-          ? preventCollapsePseudoStyles[direction]
+          ? styles.preventCollapsePseudo[direction]
           : undefined,
         resolveResponsiveProp(
           space,

--- a/packages/braid-design-system/src/lib/css/negativeMargin/negativeMargin.ts
+++ b/packages/braid-design-system/src/lib/css/negativeMargin/negativeMargin.ts
@@ -4,6 +4,18 @@ import type { RequiredResponsiveValue } from '../atoms/sprinkles.css';
 import { resolveResponsiveProp } from '../../utils/resolveResponsiveProp';
 import * as styles from './negativeMargin.css';
 
+const directionStyles = {
+  top: styles.top,
+  right: styles.right,
+  bottom: styles.bottom,
+  left: styles.left,
+};
+
+const preventCollapsePseudoStyles = {
+  top: styles.preventCollapsePseudo.top,
+  bottom: styles.preventCollapsePseudo.bottom,
+};
+
 export const negativeMargin = (
   direction: Exclude<keyof typeof styles, 'preventCollapsePseudo'>,
   space?: RequiredResponsiveValue<Space>,
@@ -11,14 +23,14 @@ export const negativeMargin = (
   space
     ? clsx([
         direction === 'top' || direction === 'bottom'
-          ? styles.preventCollapsePseudo[direction]
+          ? preventCollapsePseudoStyles[direction]
           : undefined,
         resolveResponsiveProp(
           space,
-          styles[direction].mobile,
-          styles[direction].tablet,
-          styles[direction].desktop,
-          styles[direction].wide,
+          directionStyles[direction].mobile,
+          directionStyles[direction].tablet,
+          directionStyles[direction].desktop,
+          directionStyles[direction].wide,
         ),
       ])
     : null;

--- a/packages/braid-design-system/src/lib/css/typography.ts
+++ b/packages/braid-design-system/src/lib/css/typography.ts
@@ -17,6 +17,6 @@ export function textStyles({
     styles.fontFamily,
     styles.fontWeight[weight],
     styles.tone[tone],
-    styles[baseline ? 'textSizeTrimmed' : 'textSizeUntrimmed'][size],
+    (baseline ? styles.textSizeTrimmed : styles.textSizeUntrimmed)[size],
   ];
 }


### PR DESCRIPTION
Fix error reading `standard` of undefined

The use of dynamic property access left some styles exposed to being marked as unused and tree shaken away.

Refactoring these styles to be explicitly referenced to ensure this will not be the case.