### PR TITLE
Button, ButtonLink: Improve support for different typographic scales

### DIFF
--- a/.changeset/quiet-parrots-watch.md
+++ b/.changeset/quiet-parrots-watch.md
@@ -1,0 +1,15 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Button
+  - ButtonLink
+---
+
+**Button, ButtonLink:** Improve support for different typographic scales
+
+Ensure the height of a `small` sized `Button` is not reliant on the text line height.
+
+This enables different typographic scales across themes, while ensuring the `Button` height is relative.

--- a/packages/braid-design-system/src/lib/components/Button/Button.css.ts
+++ b/packages/braid-design-system/src/lib/components/Button/Button.css.ts
@@ -72,8 +72,8 @@ export const small = style(
 );
 
 export const bleedVerticallyToCapHeight = style({
-  marginTop: calc(capHeightToMinHeight).negate().toString(),
-  marginBottom: calc(capHeightToMinHeight).negate().toString(),
+  marginTop: calc.negate(capHeightToMinHeight),
+  marginBottom: calc.negate(capHeightToMinHeight),
 });
 
 export const padToMinHeight = style({

--- a/packages/braid-design-system/src/lib/components/Button/Button.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.tsx
@@ -2,7 +2,6 @@ import assert from 'assert';
 import dedent from 'dedent';
 import type { ReactNode, AllHTMLAttributes, ReactElement } from 'react';
 import React, { useContext, forwardRef } from 'react';
-import { touchableText } from '../../css/typography.css';
 import type { BoxBackgroundVariant, BoxProps } from '../Box/Box';
 import { Box } from '../Box/Box';
 import { AvoidWidowIcon } from '../private/AvoidWidowIcon/AvoidWidowIcon';
@@ -306,11 +305,8 @@ export const ButtonText = ({
   iconPosition = 'leading',
   variant = 'solid',
   tone,
-  labelSpacing = true,
   bleed,
-}: ButtonProps & {
-  labelSpacing?: boolean;
-}) => {
+}: ButtonProps) => {
   const lightness = useBackgroundLightness();
   const actionsContext = useContext(ActionsContext);
   const size = sizeProp ?? actionsContext?.size ?? 'standard';
@@ -332,15 +328,8 @@ export const ButtonText = ({
       flexWrap="wrap"
       overflow="hidden"
       pointerEvents="none"
-      paddingX={labelSpacing ? labelPaddingX : undefined}
-      paddingY={
-        labelSpacing && size === 'small'
-          ? styles.constants.smallButtonPaddingSize
-          : undefined
-      }
-      className={
-        labelSpacing && size === 'standard' ? touchableText.standard : undefined
-      }
+      paddingX={labelPaddingX}
+      className={styles.padToMinHeight}
       background={
         tone === 'neutral' && variant !== 'solid'
           ? {
@@ -355,8 +344,8 @@ export const ButtonText = ({
       <Text
         tone={stylesForVariant.textTone}
         weight="medium"
+        align="center"
         size={size}
-        baseline={false}
       >
         {icon && iconPosition === 'leading' ? (
           <AvoidWidowIcon


### PR DESCRIPTION
Ensure the height of a `small` sized `Button` is not reliant on the text line height.

This enables different typographic scales across themes, while ensuring the `Button` height is relative.