### PR TITLE
Add `xxxlarge` to the space scale

### DIFF
--- a/.changeset/heavy-foxes-dress.md
+++ b/.changeset/heavy-foxes-dress.md
@@ -1,0 +1,47 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - atoms
+  - Bleed
+  - Box
+  - BoxRenderer
+  - Columns
+  - Disclosure
+  - Inline
+  - List
+  - MenuRenderer
+  - Stack
+  - Tabs
+  - Tiles
+  - useSpace
+  - vars
+---
+
+Add `xxxsmall` and `xxxlarge` to the space scale
+
+Extends the range of the space scale in both directions to include `xxxsmall` and `xxxlarge`.
+This addition is to support an upcoming design uplift that requires greater fidelity in the scale.
+Note, the new values are also available as responsive properties.
+
+**EXAMPLE USAGE:**
+```jsx
+<Stack space="xxxlarge">...</Stack>
+
+{/* Or responsively: */}
+<Stack space={{ mobile: 'large', tablet: 'xxxlarge' }}>...</Stack>
+```
+
+```ts
+import { atoms } from 'braid-design-system/css';
+
+atoms({ padding: 'xxxsmall' })
+```
+
+```ts
+import { vars } from 'braid-design-system/css';
+
+const space = vars.space.xxxlarge;
+```

--- a/.changeset/heavy-foxes-dress.md
+++ b/.changeset/heavy-foxes-dress.md
@@ -20,9 +20,9 @@ updated:
   - vars
 ---
 
-Add `xxxsmall` and `xxxlarge` to the space scale
+Add `xxxlarge` to the space scale
 
-Extends the range of the space scale in both directions to include `xxxsmall` and `xxxlarge`.
+Extends the range of the space scale to include `xxxlarge`.
 This addition is to support an upcoming design uplift that requires greater fidelity in the scale.
 Note, the new values are also available as responsive properties.
 
@@ -37,7 +37,7 @@ Note, the new values are also available as responsive properties.
 ```ts
 import { atoms } from 'braid-design-system/css';
 
-atoms({ padding: 'xxxsmall' })
+atoms({ paddingY: 'xxxlarge' })
 ```
 
 ```ts

--- a/.changeset/heavy-foxes-dress.md
+++ b/.changeset/heavy-foxes-dress.md
@@ -24,7 +24,7 @@ Add `xxxlarge` to the space scale
 
 Extends the range of the space scale to include `xxxlarge`.
 This addition is to support an upcoming design uplift that requires greater fidelity in the scale.
-Note, the new values are also available as responsive properties.
+Note, the new value is also available as a responsive property.
 
 **EXAMPLE USAGE:**
 ```jsx

--- a/packages/braid-design-system/src/lib/themes/baseTokens/apac.ts
+++ b/packages/braid-design-system/src/lib/themes/baseTokens/apac.ts
@@ -151,6 +151,7 @@ export const makeTokens = ({
     touchableSize: 11,
     space: {
       gutter: 6,
+      xxxsmall: 0.5,
       xxsmall: 1,
       xsmall: 2,
       small: 3,
@@ -158,6 +159,7 @@ export const makeTokens = ({
       large: 8,
       xlarge: 12,
       xxlarge: 24,
+      xxxlarge: 30,
     },
     transforms: {
       touchable: 'scale(0.95)',

--- a/packages/braid-design-system/src/lib/themes/baseTokens/apac.ts
+++ b/packages/braid-design-system/src/lib/themes/baseTokens/apac.ts
@@ -151,7 +151,6 @@ export const makeTokens = ({
     touchableSize: 11,
     space: {
       gutter: 6,
-      xxxsmall: 0.5,
       xxsmall: 1,
       xsmall: 2,
       small: 3,

--- a/packages/braid-design-system/src/lib/themes/docs/tokens.ts
+++ b/packages/braid-design-system/src/lib/themes/docs/tokens.ts
@@ -127,6 +127,7 @@ const tokens: BraidTokens = {
   touchableSize: 12,
   space: {
     gutter: 6,
+    xxxsmall: 0.5,
     xxsmall: 1,
     xsmall: 2,
     small: 3,
@@ -134,6 +135,7 @@ const tokens: BraidTokens = {
     large: 8,
     xlarge: 11,
     xxlarge: 15,
+    xxxlarge: 20,
   },
   transforms: {
     touchable: 'scale(0.97)',

--- a/packages/braid-design-system/src/lib/themes/docs/tokens.ts
+++ b/packages/braid-design-system/src/lib/themes/docs/tokens.ts
@@ -127,7 +127,6 @@ const tokens: BraidTokens = {
   touchableSize: 12,
   space: {
     gutter: 6,
-    xxxsmall: 0.5,
     xxsmall: 1,
     xsmall: 2,
     small: 3,

--- a/packages/braid-design-system/src/lib/themes/tokenType.ts
+++ b/packages/braid-design-system/src/lib/themes/tokenType.ts
@@ -66,7 +66,6 @@ export interface BraidTokens {
   touchableSize: number;
   space: {
     gutter: number;
-    xxxsmall: number;
     xxsmall: number;
     xsmall: number;
     small: number;

--- a/packages/braid-design-system/src/lib/themes/tokenType.ts
+++ b/packages/braid-design-system/src/lib/themes/tokenType.ts
@@ -66,6 +66,7 @@ export interface BraidTokens {
   touchableSize: number;
   space: {
     gutter: number;
+    xxxsmall: number;
     xxsmall: number;
     xsmall: number;
     small: number;
@@ -73,6 +74,7 @@ export interface BraidTokens {
     large: number;
     xlarge: number;
     xxlarge: number;
+    xxxlarge: number;
   };
   transforms: {
     touchable: string;

--- a/packages/braid-design-system/src/lib/themes/wireframe/tokens.ts
+++ b/packages/braid-design-system/src/lib/themes/wireframe/tokens.ts
@@ -160,6 +160,7 @@ const tokens: BraidTokens = {
   touchableSize: 12,
   space: {
     gutter: 6,
+    xxxsmall: 0.5,
     xxsmall: 1,
     xsmall: 2,
     small: 3,
@@ -167,6 +168,7 @@ const tokens: BraidTokens = {
     large: 8,
     xlarge: 12,
     xxlarge: 24,
+    xxxlarge: 30,
   },
   transforms: {
     touchable: 'scale(0.97)',

--- a/packages/braid-design-system/src/lib/themes/wireframe/tokens.ts
+++ b/packages/braid-design-system/src/lib/themes/wireframe/tokens.ts
@@ -160,7 +160,6 @@ const tokens: BraidTokens = {
   touchableSize: 12,
   space: {
     gutter: 6,
-    xxxsmall: 0.5,
     xxsmall: 1,
     xsmall: 2,
     small: 3,

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -192,7 +192,6 @@ exports[`Bleed 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     children: ReactNode
@@ -211,7 +210,6 @@ exports[`Bleed 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     left?: 
@@ -225,7 +223,6 @@ exports[`Bleed 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     right?: 
@@ -239,7 +236,6 @@ exports[`Bleed 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     space?: 
@@ -253,7 +249,6 @@ exports[`Bleed 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     top?: 
@@ -267,7 +262,6 @@ exports[`Bleed 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     vertical?: 
@@ -281,7 +275,6 @@ exports[`Bleed 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
 },
@@ -884,9 +877,8 @@ exports[`Box 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     marginBottom?: 
         | "gutter"
         | "large"
@@ -898,9 +890,8 @@ exports[`Box 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     marginHeight?: number
     marginLeft?: 
         | "gutter"
@@ -913,9 +904,8 @@ exports[`Box 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     marginRight?: 
         | "gutter"
         | "large"
@@ -927,9 +917,8 @@ exports[`Box 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     marginTop?: 
         | "gutter"
         | "large"
@@ -941,9 +930,8 @@ exports[`Box 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     marginWidth?: number
     marginX?: 
         | "gutter"
@@ -956,9 +944,8 @@ exports[`Box 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     marginY?: 
         | "gutter"
         | "large"
@@ -970,9 +957,8 @@ exports[`Box 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     max?: 
         | number
         | string
@@ -1177,9 +1163,8 @@ exports[`Box 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     paddingBottom?: 
         | "gutter"
         | "large"
@@ -1191,9 +1176,8 @@ exports[`Box 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     paddingLeft?: 
         | "gutter"
         | "large"
@@ -1205,9 +1189,8 @@ exports[`Box 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     paddingRight?: 
         | "gutter"
         | "large"
@@ -1219,9 +1202,8 @@ exports[`Box 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     paddingTop?: 
         | "gutter"
         | "large"
@@ -1233,9 +1215,8 @@ exports[`Box 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     paddingX?: 
         | "gutter"
         | "large"
@@ -1247,9 +1228,8 @@ exports[`Box 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     paddingY?: 
         | "gutter"
         | "large"
@@ -1261,9 +1241,8 @@ exports[`Box 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     pattern?: string
     placeholder?: string
     playsInline?: boolean
@@ -1762,9 +1741,8 @@ exports[`BoxRenderer 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     marginBottom?: 
         | "gutter"
         | "large"
@@ -1776,9 +1754,8 @@ exports[`BoxRenderer 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     marginLeft?: 
         | "gutter"
         | "large"
@@ -1790,9 +1767,8 @@ exports[`BoxRenderer 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     marginRight?: 
         | "gutter"
         | "large"
@@ -1804,9 +1780,8 @@ exports[`BoxRenderer 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     marginTop?: 
         | "gutter"
         | "large"
@@ -1818,9 +1793,8 @@ exports[`BoxRenderer 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     marginX?: 
         | "gutter"
         | "large"
@@ -1832,9 +1806,8 @@ exports[`BoxRenderer 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     marginY?: 
         | "gutter"
         | "large"
@@ -1846,9 +1819,8 @@ exports[`BoxRenderer 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     maxWidth?: 
         | "large"
         | "medium"
@@ -1873,9 +1845,8 @@ exports[`BoxRenderer 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     paddingBottom?: 
         | "gutter"
         | "large"
@@ -1887,9 +1858,8 @@ exports[`BoxRenderer 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     paddingLeft?: 
         | "gutter"
         | "large"
@@ -1901,9 +1871,8 @@ exports[`BoxRenderer 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     paddingRight?: 
         | "gutter"
         | "large"
@@ -1915,9 +1884,8 @@ exports[`BoxRenderer 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     paddingTop?: 
         | "gutter"
         | "large"
@@ -1929,9 +1897,8 @@ exports[`BoxRenderer 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     paddingX?: 
         | "gutter"
         | "large"
@@ -1943,9 +1910,8 @@ exports[`BoxRenderer 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     paddingY?: 
         | "gutter"
         | "large"
@@ -1957,9 +1923,8 @@ exports[`BoxRenderer 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | ... 6 more ... | undefined; desktop?: "gutter" | ... 9 more ... | undefined; wide?: "gutter" | ... 9 more ... | undefined; }
     pointerEvents?: "none"
     position?: 
         | "absolute"
@@ -2017,7 +1982,7 @@ exports[`BraidProvider 1`] = `
         | FunctionComponent<LinkComponentProps>
         | { readonly __forwardRef__: ForwardRefExoticComponent<LinkComponentProps & RefAttributes<HTMLAnchorElement>>; }
     styleBody?: boolean
-    theme: { vanillaTheme: string; name: string; displayName: string; background: { lightMode: string; darkMode: string; }; webFonts: { linkTag: string; }[]; space: { grid: number; space: { gutter: number; xxxsmall: number; ... 7 more ...; xxxlarge: number; }; }; color: { ...; }; backgroundLightness: { ...; }; }
+    theme: { vanillaTheme: string; name: string; displayName: string; background: { lightMode: string; darkMode: string; }; webFonts: { linkTag: string; }[]; space: { grid: number; space: { gutter: number; xxsmall: number; ... 6 more ...; xxxlarge: number; }; }; color: { ...; }; backgroundLightness: { ...; }; }
 },
 }
 `;
@@ -2829,7 +2794,6 @@ exports[`Columns 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
 },
@@ -2896,7 +2860,6 @@ exports[`Disclosure 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     weight?: 
@@ -6044,7 +6007,6 @@ exports[`Inline 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
 },
@@ -6580,7 +6542,6 @@ exports[`List 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     start?: number
@@ -6698,7 +6659,6 @@ exports[`MenuRenderer 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     onClose?: (closeReason: CloseReason) => void
@@ -7001,7 +6961,6 @@ exports[`Stack 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
 },
@@ -7114,7 +7073,6 @@ exports[`Tabs 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     label: string
@@ -8072,7 +8030,6 @@ exports[`Tiles 1`] = `
         | "xxlarge"
         | "xxsmall"
         | "xxxlarge"
-        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
 },
@@ -8209,7 +8166,7 @@ exports[`useSpace 1`] = `
 {
   exportType: hook,
   params: [],
-  returnType: { grid: number; space: { gutter: number; xxxsmall: number; xxsmall: number; xsmall: number; small: number; medium: number; large: number; xlarge: number; xxlarge: number; xxxlarge: number; }; },
+  returnType: { grid: number; space: { gutter: number; xxsmall: number; xsmall: number; small: number; medium: number; large: number; xlarge: number; xxlarge: number; xxxlarge: number; }; },
 }
 `;
 

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -191,6 +191,8 @@ exports[`Bleed 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
+        | "xxxlarge"
+        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     children: ReactNode
@@ -208,6 +210,8 @@ exports[`Bleed 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
+        | "xxxlarge"
+        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     left?: 
@@ -220,6 +224,8 @@ exports[`Bleed 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
+        | "xxxlarge"
+        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     right?: 
@@ -232,6 +238,8 @@ exports[`Bleed 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
+        | "xxxlarge"
+        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     space?: 
@@ -244,6 +252,8 @@ exports[`Bleed 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
+        | "xxxlarge"
+        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     top?: 
@@ -256,6 +266,8 @@ exports[`Bleed 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
+        | "xxxlarge"
+        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     vertical?: 
@@ -268,6 +280,8 @@ exports[`Bleed 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
+        | "xxxlarge"
+        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
 },
@@ -869,8 +883,10 @@ exports[`Box 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     marginBottom?: 
         | "gutter"
         | "large"
@@ -881,8 +897,10 @@ exports[`Box 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     marginHeight?: number
     marginLeft?: 
         | "gutter"
@@ -894,8 +912,10 @@ exports[`Box 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     marginRight?: 
         | "gutter"
         | "large"
@@ -906,8 +926,10 @@ exports[`Box 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     marginTop?: 
         | "gutter"
         | "large"
@@ -918,8 +940,10 @@ exports[`Box 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     marginWidth?: number
     marginX?: 
         | "gutter"
@@ -931,8 +955,10 @@ exports[`Box 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     marginY?: 
         | "gutter"
         | "large"
@@ -943,8 +969,10 @@ exports[`Box 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     max?: 
         | number
         | string
@@ -1148,8 +1176,10 @@ exports[`Box 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     paddingBottom?: 
         | "gutter"
         | "large"
@@ -1160,8 +1190,10 @@ exports[`Box 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     paddingLeft?: 
         | "gutter"
         | "large"
@@ -1172,8 +1204,10 @@ exports[`Box 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     paddingRight?: 
         | "gutter"
         | "large"
@@ -1184,8 +1218,10 @@ exports[`Box 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     paddingTop?: 
         | "gutter"
         | "large"
@@ -1196,8 +1232,10 @@ exports[`Box 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     paddingX?: 
         | "gutter"
         | "large"
@@ -1208,8 +1246,10 @@ exports[`Box 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     paddingY?: 
         | "gutter"
         | "large"
@@ -1220,8 +1260,10 @@ exports[`Box 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     pattern?: string
     placeholder?: string
     playsInline?: boolean
@@ -1719,8 +1761,10 @@ exports[`BoxRenderer 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     marginBottom?: 
         | "gutter"
         | "large"
@@ -1731,8 +1775,10 @@ exports[`BoxRenderer 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     marginLeft?: 
         | "gutter"
         | "large"
@@ -1743,8 +1789,10 @@ exports[`BoxRenderer 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     marginRight?: 
         | "gutter"
         | "large"
@@ -1755,8 +1803,10 @@ exports[`BoxRenderer 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     marginTop?: 
         | "gutter"
         | "large"
@@ -1767,8 +1817,10 @@ exports[`BoxRenderer 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     marginX?: 
         | "gutter"
         | "large"
@@ -1779,8 +1831,10 @@ exports[`BoxRenderer 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     marginY?: 
         | "gutter"
         | "large"
@@ -1791,8 +1845,10 @@ exports[`BoxRenderer 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     maxWidth?: 
         | "large"
         | "medium"
@@ -1816,8 +1872,10 @@ exports[`BoxRenderer 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     paddingBottom?: 
         | "gutter"
         | "large"
@@ -1828,8 +1886,10 @@ exports[`BoxRenderer 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     paddingLeft?: 
         | "gutter"
         | "large"
@@ -1840,8 +1900,10 @@ exports[`BoxRenderer 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     paddingRight?: 
         | "gutter"
         | "large"
@@ -1852,8 +1914,10 @@ exports[`BoxRenderer 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     paddingTop?: 
         | "gutter"
         | "large"
@@ -1864,8 +1928,10 @@ exports[`BoxRenderer 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     paddingX?: 
         | "gutter"
         | "large"
@@ -1876,8 +1942,10 @@ exports[`BoxRenderer 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     paddingY?: 
         | "gutter"
         | "large"
@@ -1888,8 +1956,10 @@ exports[`BoxRenderer 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
-        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | null>
-        | { mobile?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "none" | undefined; tablet?: "gutter" | "xxsmall" | "xsmall" | "small" | "medium" | ... 4 more ... | undefined; desktop?: "gutter" | ... 8 more ... | undefined; wide?: "gutter" | ... 8 more ... | undefined; }
+        | "xxxlarge"
+        | "xxxsmall"
+        | ResponsiveArray<1 | 2 | 3 | 4, "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | null>
+        | { mobile?: "gutter" | "xxxsmall" | "xxsmall" | "xsmall" | "small" | "medium" | "large" | "xlarge" | "xxlarge" | "xxxlarge" | "none" | undefined; tablet?: "gutter" | "xxxsmall" | "xxsmall" | ... 8 more ... | undefined; desktop?: "gutter" | ... 10 more ... | undefined; wide?: "gutter" | ... 10 more ... | undefined; }
     pointerEvents?: "none"
     position?: 
         | "absolute"
@@ -1947,7 +2017,7 @@ exports[`BraidProvider 1`] = `
         | FunctionComponent<LinkComponentProps>
         | { readonly __forwardRef__: ForwardRefExoticComponent<LinkComponentProps & RefAttributes<HTMLAnchorElement>>; }
     styleBody?: boolean
-    theme: { vanillaTheme: string; name: string; displayName: string; background: { lightMode: string; darkMode: string; }; webFonts: { linkTag: string; }[]; space: { grid: number; space: { gutter: number; xxsmall: number; ... 5 more ...; xxlarge: number; }; }; color: { ...; }; backgroundLightness: { ...; }; }
+    theme: { vanillaTheme: string; name: string; displayName: string; background: { lightMode: string; darkMode: string; }; webFonts: { linkTag: string; }[]; space: { grid: number; space: { gutter: number; xxxsmall: number; ... 7 more ...; xxxlarge: number; }; }; color: { ...; }; backgroundLightness: { ...; }; }
 },
 }
 `;
@@ -2758,6 +2828,8 @@ exports[`Columns 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
+        | "xxxlarge"
+        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
 },
@@ -2823,6 +2895,8 @@ exports[`Disclosure 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
+        | "xxxlarge"
+        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     weight?: 
@@ -5969,6 +6043,8 @@ exports[`Inline 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
+        | "xxxlarge"
+        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
 },
@@ -6503,6 +6579,8 @@ exports[`List 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
+        | "xxxlarge"
+        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     start?: number
@@ -6619,6 +6697,8 @@ exports[`MenuRenderer 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
+        | "xxxlarge"
+        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     onClose?: (closeReason: CloseReason) => void
@@ -6920,6 +7000,8 @@ exports[`Stack 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
+        | "xxxlarge"
+        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
 },
@@ -7031,6 +7113,8 @@ exports[`Tabs 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
+        | "xxxlarge"
+        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
     label: string
@@ -7987,6 +8071,8 @@ exports[`Tiles 1`] = `
         | "xsmall"
         | "xxlarge"
         | "xxsmall"
+        | "xxxlarge"
+        | "xxxsmall"
         | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
         | RequiredResponsiveArray<1 | 2 | 3 | 4, Space | null>
 },
@@ -8123,7 +8209,7 @@ exports[`useSpace 1`] = `
 {
   exportType: hook,
   params: [],
-  returnType: { grid: number; space: { gutter: number; xxsmall: number; xsmall: number; small: number; medium: number; large: number; xlarge: number; xxlarge: number; }; },
+  returnType: { grid: number; space: { gutter: number; xxxsmall: number; xxsmall: number; xsmall: number; small: number; medium: number; large: number; xlarge: number; xxlarge: number; xxxlarge: number; }; },
 }
 `;
 


### PR DESCRIPTION
Extends the range of the space scale to include `xxxlarge`.
This addition is to support an upcoming design uplift that requires greater fidelity in the scale.
Note, the new value is also available as a responsive property.

**EXAMPLE USAGE:**
```jsx
<Stack space="xxxlarge">...</Stack>

{/* Or responsively: */}
<Stack space={{ mobile: 'large', tablet: 'xxxlarge' }}>...</Stack>
```

```ts
import { atoms } from 'braid-design-system/css';

atoms({ paddingY: 'xxxlarge' })
```

```ts
import { vars } from 'braid-design-system/css';

const space = vars.space.xxxlarge;
```