### PR TITLE
TooltipRenderer: Refine padding to complement radius scale

### DIFF
--- a/.changeset/popular-teachers-care.md
+++ b/.changeset/popular-teachers-care.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - TooltipRenderer
+---
+
+**TooltipRenderer:** Refine padding to complement radius scale
+
+Removes the custom padding on tooltips in favour of using the space scale.
+Previously, a custom value was used to complement the over sized radius which has now be reduced.

--- a/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.css.ts
+++ b/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.css.ts
@@ -29,11 +29,6 @@ export const translateZ0 = style({
   transform: 'translateZ(0)',
 });
 
-// Our space scale didn't have enough fidelity here :(
-export const padding = style({
-  padding: calc.add(vars.space.small, vars.grid),
-});
-
 const borderRadius = vars.borderRadius.small;
 const offset = calc(constants.arrowSize).divide(2).negate().toString();
 export const arrow = style({

--- a/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.tsx
@@ -74,12 +74,8 @@ export const TooltipContent = ({
       boxShadow="large"
       background="customDark"
       borderRadius={borderRadius}
-      className={[
-        styles.background,
-        styles.maxWidth,
-        styles.translateZ0,
-        styles.padding,
-      ]}
+      padding="small"
+      className={[styles.background, styles.maxWidth, styles.translateZ0]}
     >
       <TooltipTextDefaultsProvider>
         <Box position="relative" zIndex={1}>


### PR DESCRIPTION
Removes the custom padding on tooltips in favour of using the space scale.
Previously, a custom value was used to complement the over sized radius which has now be reduced.