### PR TITLE
MenuRenderer: Hide overflow on menu

### DIFF
--- a/.changeset/chilly-fishes-fail.md
+++ b/.changeset/chilly-fishes-fail.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - MenuRenderer
+---
+
+**MenuRenderer:** Hide overflow on menu
+
+Fixes a bug where the selection/highlight for a `MenuItem` could extend outside of the menu itself.

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
@@ -370,6 +370,7 @@ export function Menu({
         transition="fast"
         right={align === 'right' ? 0 : undefined}
         opacity={!open ? 0 : undefined}
+        overflow="hidden"
         className={[
           !open && styles.menuIsClosed,
           width !== 'content' && styles.width[width],


### PR DESCRIPTION
Fixes a bug where the selection/highlight for a `MenuItem` could extend outside of the menu itself.