### PR TITLE
Dialog, Drawer: Reduce space between title and description

### DIFF
--- a/.changeset/shiny-penguins-hang.md
+++ b/.changeset/shiny-penguins-hang.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Dialog
+  - Drawer
+---
+
+**Dialog, Drawer:** Reduce space between title and description
+
+Reducing the space between `title` and `description` to `small` to improve association of the header block content

--- a/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
@@ -44,7 +44,7 @@ interface ModalContentHeaderProps
 }
 const ModalContentHeader = forwardRef<HTMLElement, ModalContentHeaderProps>(
   ({ title, headingLevel, description, descriptionId, center }, ref) => (
-    <Stack space="medium">
+    <Stack space="small">
       <Heading level={headingLevel} align={center ? 'center' : undefined}>
         <Box
           ref={ref}


### PR DESCRIPTION
Reducing the space between `title` and `description` to `small` to improve association of the header block content