### PR TITLE
Alert, Card, useToast: Decouple keyline width from space scale

### DIFF
--- a/.changeset/real-cooks-mate.md
+++ b/.changeset/real-cooks-mate.md
@@ -1,0 +1,15 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Alert
+  - Card
+  - useToast
+---
+
+**Alert, Card, useToast:** Decouple keyline width from space scale
+
+Previously the keyline width on the left determined its width using the space scale.
+Re-aligning this to use the grid unit to enable themes with larger space scales.

--- a/packages/braid-design-system/src/lib/components/private/Keyline/Keyline.css.ts
+++ b/packages/braid-design-system/src/lib/components/private/Keyline/Keyline.css.ts
@@ -68,3 +68,7 @@ export const noRadiusOnRight = style({
 export const largestWidth = style({
   width: vars.borderRadius.xlarge,
 });
+
+export const width = style({
+  width: vars.grid,
+});

--- a/packages/braid-design-system/src/lib/components/private/Keyline/Keyline.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Keyline/Keyline.tsx
@@ -27,8 +27,8 @@ export const Keyline = ({ tone, borderRadius }: KeylineProps) => {
         component="span"
         height="full"
         display="inlineBlock"
-        paddingLeft="xxsmall"
         className={[
+          styles.width,
           styles.tone[tone],
           styles.lightMode[backgroundLightness.lightMode],
           styles.darkMode[backgroundLightness.darkMode],


### PR DESCRIPTION
Previously the keyline width on the left determined its width using the space scale.
Re-aligning this to use the grid unit to enable themes with larger space scales.