### PR TITLE
Add support for defining line heights with lineGap

### DIFF
--- a/.changeset/curvy-bottles-listen.md
+++ b/.changeset/curvy-bottles-listen.md
@@ -1,0 +1,17 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - theme
+---
+
+**theme:** Add support for defining line heights with lineGap
+
+Provide support for themes to define their typographic line heights via `lineGap`.
+This allows us to reason about the white space between wrapping lines of text in the same way we think about `Stack` spacing.
+
+For a visual preview of this mental model head over to the [Capsize website].
+
+[Capsize website]: https://seek-oss.github.io/capsize/

--- a/packages/braid-design-system/src/lib/themes/makeVanillaTheme.ts
+++ b/packages/braid-design-system/src/lib/themes/makeVanillaTheme.ts
@@ -23,13 +23,33 @@ const fontSizeToCapHeight = (
     fontMetrics,
   });
 
+  const mobileConfig =
+    'lineGap' in mobile
+      ? {
+          fontSize: mobile.fontSize,
+          lineGap: mobile.lineGap,
+        }
+      : {
+          fontSize: mobile.fontSize,
+          leading: mobile.rows * grid,
+        };
+  const tabletConfig =
+    'lineGap' in tablet
+      ? {
+          fontSize: tablet.fontSize,
+          lineGap: tablet.lineGap,
+        }
+      : {
+          fontSize: tablet.fontSize,
+          leading: tablet.rows * grid,
+        };
+
   const {
     fontSize: mobileFontSize,
     lineHeight: mobileLineHeight,
     ...mobileTrims
   } = precomputeValues({
-    fontSize: mobile.fontSize,
-    leading: mobile.rows * grid,
+    ...mobileConfig,
     fontMetrics,
   });
 
@@ -38,8 +58,7 @@ const fontSizeToCapHeight = (
     lineHeight: tabletLineHeight,
     ...tabletTrims
   } = precomputeValues({
-    fontSize: tablet.fontSize,
-    leading: tablet.rows * grid,
+    ...tabletConfig,
     fontMetrics,
   });
 
@@ -67,9 +86,12 @@ export const makeVanillaTheme = (braidTokens: BraidTokens) => {
   const { name, displayName, ...tokens } = braidTokens;
   const { webFont, ...typography } = tokens.typography;
   const { foreground, background } = tokens.color;
+  const textSize = mapValues(tokens.typography.text, (definition) =>
+    fontSizeToCapHeight(tokens.grid, definition, typography.fontMetrics),
+  );
 
   const getInlineFieldSize = (size: 'standard' | 'small') => {
-    const scale = (typography.text[size].mobile.rows * tokens.grid) / 42;
+    const scale = parseInt(textSize[size].mobile.lineHeight, 10) / 42;
     return px(tokens.grid * Math.round(tokens.touchableSize * scale));
   };
 
@@ -86,9 +108,7 @@ export const makeVanillaTheme = (braidTokens: BraidTokens) => {
     backgroundColor: background,
     fontFamily: typography.fontFamily,
     fontMetrics: mapValues(typography.fontMetrics, String),
-    textSize: mapValues(tokens.typography.text, (definition) =>
-      fontSizeToCapHeight(tokens.grid, definition, typography.fontMetrics),
-    ),
+    textSize,
     textWeight: mapValues(typography.fontWeight, String),
     headingLevel: mapValues(tokens.typography.heading.level, (definition) =>
       fontSizeToCapHeight(tokens.grid, definition, typography.fontMetrics),

--- a/packages/braid-design-system/src/lib/themes/tokenType.ts
+++ b/packages/braid-design-system/src/lib/themes/tokenType.ts
@@ -21,10 +21,15 @@ export const extractFontMetricsForTheme = ({
 
 export type TextBreakpoint = Exclude<Breakpoint, 'desktop' | 'wide'>;
 
-type FontSizeText = {
-  fontSize: number;
-  rows: number;
-};
+type FontSizeText =
+  | {
+      fontSize: number;
+      rows: number;
+    }
+  | {
+      fontSize: number;
+      lineGap: number;
+    };
 
 export type TextDefinition = Record<TextBreakpoint, FontSizeText>;
 type FontWeight = 'regular' | 'medium' | 'strong';

--- a/packages/braid-design-system/src/lib/themes/wireframe/tokens.ts
+++ b/packages/braid-design-system/src/lib/themes/wireframe/tokens.ts
@@ -68,41 +68,41 @@ const tokens: BraidTokens = {
         '1': {
           mobile: {
             fontSize: 28,
-            rows: 9,
+            lineGap: 22,
           },
           tablet: {
             fontSize: 42,
-            rows: 11,
+            lineGap: 22,
           },
         },
         '2': {
           mobile: {
             fontSize: 21,
-            rows: 8,
+            lineGap: 20,
           },
           tablet: {
             fontSize: 28,
-            rows: 9,
+            lineGap: 20,
           },
         },
         '3': {
           mobile: {
             fontSize: 21,
-            rows: 7,
+            lineGap: 18,
           },
           tablet: {
             fontSize: 21,
-            rows: 7,
+            lineGap: 18,
           },
         },
         '4': {
           mobile: {
             fontSize: 18,
-            rows: 7,
+            lineGap: 16,
           },
           tablet: {
             fontSize: 18,
-            rows: 7,
+            lineGap: 16,
           },
         },
       },
@@ -111,41 +111,41 @@ const tokens: BraidTokens = {
       xsmall: {
         mobile: {
           fontSize: 12,
-          rows: 5,
+          lineGap: 11,
         },
         tablet: {
           fontSize: 12,
-          rows: 5,
+          lineGap: 11,
         },
       },
       small: {
         mobile: {
           fontSize: 14,
-          rows: 5,
+          lineGap: 12,
         },
         tablet: {
           fontSize: 14,
-          rows: 5,
+          lineGap: 12,
         },
       },
       standard: {
         mobile: {
           fontSize: 16,
-          rows: 7,
+          lineGap: 14,
         },
         tablet: {
           fontSize: 16,
-          rows: 7,
+          lineGap: 14,
         },
       },
       large: {
         mobile: {
           fontSize: 18,
-          rows: 8,
+          lineGap: 16,
         },
         tablet: {
           fontSize: 18,
-          rows: 8,
+          lineGap: 16,
         },
       },
     },


### PR DESCRIPTION
Provide support for themes to define their typographic line heights via `lineGap`.
This allows us to reason about the white space between wrapping lines of text in the same way we think about `Stack` spacing.

For a visual preview of this mental model head over to the [Capsize website].

[Capsize website]: https://seek-oss.github.io/capsize/

---

Note: Migrated the `wireframe` theme as a test/validation, but this will be leveraged in a production sense with the new theme coming soon.