### PR TITLE
TooltipRenderer: Remove custom background

### DIFF
--- a/.changeset/quiet-comics-sin.md
+++ b/.changeset/quiet-comics-sin.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - TooltipRenderer
+---
+
+**TooltipRenderer:** Remove custom background
+
+Use the correct semantic token for the background of tooltips.
+While there is no visual change, this is just a clean up to ensure the palette usage remains consistent.

--- a/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.css.ts
+++ b/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.css.ts
@@ -7,10 +7,6 @@ export const constants = {
   arrowSize: '12px',
 };
 
-export const background = style({
-  background: vars.foregroundColor.neutral,
-});
-
 export const maxWidth = style({
   maxWidth: constants.maxWidth,
 });

--- a/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.tsx
@@ -72,10 +72,10 @@ export const TooltipContent = ({
   >
     <Box
       boxShadow="large"
-      background="customDark"
+      background="neutral"
       borderRadius={borderRadius}
       padding="small"
-      className={[styles.background, styles.maxWidth, styles.translateZ0]}
+      className={[styles.maxWidth, styles.translateZ0]}
     >
       <TooltipTextDefaultsProvider>
         <Box position="relative" zIndex={1}>
@@ -84,7 +84,8 @@ export const TooltipContent = ({
         <Box
           {...arrowProps}
           borderRadius={borderRadius}
-          className={[styles.arrow, styles.background]}
+          background="neutral"
+          className={styles.arrow}
         />
       </TooltipTextDefaultsProvider>
     </Box>


### PR DESCRIPTION
Use the correct semantic token for the background of tooltips.
While there is no visual change, this is just a clean up to ensure the palette usage remains consistent.