### PR TITLE
Alert, useToast: Design update

### DIFF
--- a/.changeset/honest-ants-sneeze.md
+++ b/.changeset/honest-ants-sneeze.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - useToast
+---
+
+**useToast:** Design uplift with increased page contrast
+
+As a means to increase constrast against page content, the design has been updated to be presented on inverted backgrounds based on the color mode.
+The design has also be refined to remove the sidebar/keyline (consistent with `Alert`), while also applying the `tone` to the provided `message`.

--- a/.changeset/tall-trees-smash.md
+++ b/.changeset/tall-trees-smash.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Alert
+---
+
+**Alert:** Design uplift
+
+Refine the design to use consistent horizontal container inset, aligning content with elements like `Card`, as well as simplifying the design by removing the sidebar/keyline (consistent with `useToast`).
+

--- a/packages/braid-design-system/src/lib/components/Alert/Alert.tsx
+++ b/packages/braid-design-system/src/lib/components/Alert/Alert.tsx
@@ -19,7 +19,6 @@ import { textAlignedToIcon } from '../../css/textAlignedToIcon.css';
 import type { DataAttributeMap } from '../private/buildDataAttributes';
 import buildDataAttributes from '../private/buildDataAttributes';
 import type { BoxShadow } from '../../css/atoms/atomicProperties';
-import { Keyline } from '../private/Keyline/Keyline';
 import { virtualTouchable } from '../private/touchable/virtualTouchable';
 import { iconContainerSize } from '../../hooks/useIcon';
 import * as styles from './Alert.css';
@@ -77,7 +76,8 @@ export const Alert = ({
     <Box
       id={id}
       background={backgroundForTone[tone]}
-      padding="medium"
+      paddingY="medium"
+      paddingX="gutter"
       borderRadius={borderRadius}
       position="relative"
       overflow="hidden"
@@ -147,7 +147,6 @@ export const Alert = ({
           visible
         />
       )}
-      <Keyline tone={tone} borderRadius={borderRadius} />
     </Box>
   );
 };

--- a/packages/braid-design-system/src/lib/components/useToast/Toast.tsx
+++ b/packages/braid-design-system/src/lib/components/useToast/Toast.tsx
@@ -12,7 +12,6 @@ import { IconPositive, IconCritical, IconClear } from '../icons';
 import { ButtonIcon } from '../ButtonIcon/ButtonIcon';
 import { useTimeout } from './useTimeout';
 import type { InternalToast, ToastAction } from './ToastTypes';
-import { Keyline } from '../private/Keyline/Keyline';
 import { lineHeightContainer } from '../../css/lineHeightContainer.css';
 import buildDataAttributes from '../private/buildDataAttributes';
 import * as styles from './Toast.css';
@@ -37,13 +36,27 @@ const Action = ({ label, onClick, removeToast }: ActionProps) => {
 
   return (
     <Text baseline={false}>
-      <Box component="span" paddingRight="xsmall" aria-hidden>
+      <Box component="span" aria-hidden>
         <TextLinkButton onClick={handleClick} hitArea="large">
           {label}
         </TextLinkButton>
       </Box>
     </Text>
   );
+};
+
+const ToastIcon = ({ tone, icon }: Pick<InternalToast, 'tone' | 'icon'>) => {
+  if (tone !== 'neutral') {
+    const Icon = toneToIcon[tone];
+
+    return <Icon tone={tone} />;
+  }
+
+  if (icon) {
+    return cloneElement(icon, { tone });
+  }
+
+  return null;
 };
 
 interface ToastProps extends InternalToast {
@@ -84,8 +97,6 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
       }
     }, [shouldRemove, remove, stopTimeout]);
 
-    const Icon = tone !== 'neutral' ? toneToIcon[tone] : undefined;
-
     assert(
       !icon || (icon.props.size === undefined && icon.props.tone === undefined),
       "Icons cannot set the 'size' or 'tone' prop when passed to a Toast component",
@@ -98,7 +109,7 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
 
     const content = description ? (
       <Stack space="xxsmall">
-        <Text weight="strong" baseline={false}>
+        <Text weight="medium" tone={tone} baseline={false}>
           {message}
         </Text>
         {description ? (
@@ -113,7 +124,7 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
     ) : (
       <Inline space="xxsmall">
         <Box paddingRight="medium">
-          <Text weight="strong" baseline={false}>
+          <Text weight="medium" tone={tone} baseline={false}>
             {message}
           </Text>
         </Box>
@@ -137,34 +148,28 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
         <Box boxShadow="large" borderRadius={borderRadius}>
           <ContentBlock width="xsmall">
             <Box
-              background="surface"
+              background={{ lightMode: 'surfaceDark', darkMode: 'surface' }}
               position="relative"
-              boxShadow="borderNeutralLight"
               borderRadius={borderRadius}
               paddingY="medium"
-              paddingLeft="medium"
+              paddingX="gutter"
               overflow="hidden"
               className={styles.toast}
             >
               <Columns space="none">
-                <Column width="content">
-                  {Icon ? (
+                {tone !== 'neutral' || (tone === 'neutral' && icon) ? (
+                  <Column width="content">
                     <Box paddingRight="small">
-                      <Icon tone={tone} />
+                      <ToastIcon tone={tone} icon={icon} />
                     </Box>
-                  ) : null}
-                  {tone === 'neutral' && icon ? (
-                    <Box paddingRight="small">
-                      {cloneElement(icon, { tone: 'secondary' })}
-                    </Box>
-                  ) : null}
-                </Column>
+                  </Column>
+                ) : null}
                 <Column>{content}</Column>
                 <Column width="content">
                   <Box
                     width="touchable"
                     display="flex"
-                    justifyContent="center"
+                    justifyContent="flexEnd"
                     alignItems="center"
                     className={lineHeightContainer.standard}
                     aria-hidden
@@ -185,9 +190,6 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
                   </Box>
                 </Column>
               </Columns>
-              {tone !== 'neutral' ? (
-                <Keyline tone={tone} borderRadius={borderRadius} />
-              ) : null}
             </Box>
           </ContentBlock>
         </Box>

--- a/packages/braid-design-system/src/lib/components/useToast/useToast.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/useToast/useToast.docs.tsx
@@ -367,6 +367,65 @@ const docs: ComponentDocs = {
       },
     },
     {
+      description: (
+        <Text>
+          When an <Strong>action</Strong> is provided in addition to a{' '}
+          <Strong>description</Strong>, the layout will stack vertically to
+          better accommodate all the content.
+        </Text>
+      ),
+      Example: ({ id, showToast }) => {
+        const { theme } = useThemeSettings();
+
+        /* eslint-disable no-alert */
+        const { code } = source(
+          <Inline space="small" align="center">
+            <Button
+              onClick={() =>
+                showToast({
+                  tone: 'positive',
+                  message: 'Positive message',
+                  description:
+                    'Longer description providing more context for the user.',
+                  action: {
+                    label: 'Undo',
+                    onClick: () => alert('Undo!'),
+                  },
+                })
+              }
+            >
+              Show animation <IconPromote alignY="lowercase" />
+            </Button>
+          </Inline>,
+        );
+
+        const { value } = source(
+          <Stack space="large" align="center">
+            <Toast
+              id={id}
+              dedupeKey={id}
+              shouldRemove={false}
+              vanillaTheme={theme.vanillaTheme}
+              onClose={() => {}}
+              message="Positive message"
+              description="Longer description providing more context for the user."
+              tone="positive"
+              action={{
+                label: 'Undo',
+                onClick: () => alert('Undo!'),
+              }}
+            />
+          </Stack>,
+        );
+        /* eslint-enable no-alert */
+
+        return {
+          code,
+          value,
+        };
+      },
+    },
+    {
       label: 'Dismissing messages',
       description: (
         <>


### PR DESCRIPTION
### `Alert`
Refine the design to use consistent horizontal container inset, aligning content with elements like `Card`, as well as simplifying the design by removing the sidebar/keyline (consistent with `useToast`).

<img src="https://user-images.githubusercontent.com/912060/229416291-854fe888-9402-4759-b351-894a7fc607cb.png" alt="Before" align="left" width="48%" />

<img src="https://user-images.githubusercontent.com/912060/229416295-3844eca1-09d6-4f65-b7ed-dddde57e947d.png" alt="After" width="48%" />

### `useToast`
As a means to increase constrast against page content, the design has been updated to be presented on inverted backgrounds based on the color mode.
The design has also be refined to remove the sidebar/keyline (consistent with `Alert`), while also applying the `tone` to the provided `message`.


<img src="https://user-images.githubusercontent.com/912060/229417217-f5439459-319f-4a74-8410-559578340f44.png"  alt="Before" align="left" width="48%" />

<img src="https://user-images.githubusercontent.com/912060/229416958-85518784-b0fd-4dd7-a332-4d56738e8787.png" alt="After" width="48%" />



<img src="https://user-images.githubusercontent.com/912060/229417470-958b23c3-da7d-4a2f-a0a5-51ff6e785e61.png"  alt="Before" align="left" width="48%" />

<img src="https://user-images.githubusercontent.com/912060/229417475-7a62dc73-3a84-4858-b5e5-e2deb36e35cf.png" alt="After" width="48%" />

