### PR TITLE
Add support for `caution` tone to form fields

### DIFF
--- a/.changeset/mighty-apes-grow.md
+++ b/.changeset/mighty-apes-grow.md
@@ -1,0 +1,24 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Autosuggest
+  - Dropdown
+  - FieldMessage
+  - MonthPicker
+  - PasswordField
+  - Textarea
+  - TextField
+---
+
+Add support for `caution` tone to form fields
+
+Provide support for applying a `caution` tone to form fields.
+Specifying this `tone` will provide the `IconCaution` alongside the provided `message`.
+
+**EXAMPLE USAGE:**
+```jsx
+<TextField tone="caution" message="Caution message" />
+```

--- a/.changeset/mighty-apes-grow.md
+++ b/.changeset/mighty-apes-grow.md
@@ -16,7 +16,7 @@ updated:
 Add support for `caution` tone to form fields
 
 Provide support for applying a `caution` tone to form fields.
-Specifying this `tone` will provide the `IconCaution` alongside the provided `message`.
+Specifying this `tone` will show the `IconCaution` alongside the provided `message`.
 
 **EXAMPLE USAGE:**
 ```jsx

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.docs.tsx
@@ -122,7 +122,8 @@ const docs: ComponentDocs = {
           </Text>
           <Text>
             The supported tones are: <Strong>{'"critical"'}</Strong>,{' '}
-            <Strong>{'"positive"'}</Strong>, and <Strong>{'"neutral"'}</Strong>.
+            <Strong>{'"positive"'}</Strong>, <Strong>{'"caution"'}</Strong>, and{' '}
+            <Strong>{'"neutral"'}</Strong>.
           </Text>
         </>
       ),
@@ -170,6 +171,21 @@ const docs: ComponentDocs = {
                 value={getState('value3')}
                 onChange={setState('value3')}
                 onClear={() => resetState('value3')}
+                suggestions={filterSuggestions([
+                  { text: 'Apples', value: 1 },
+                  { text: 'Bananas', value: 2 },
+                  { text: 'Broccoli', value: 3 },
+                  { text: 'Carrots', value: 4 },
+                ])}
+                tone="caution"
+                message="Caution message"
+              />
+              <Autosuggest
+                label="Label"
+                id={`${id}_4`}
+                value={getState('value4')}
+                onChange={setState('value4')}
+                onClear={() => resetState('value4')}
                 suggestions={filterSuggestions([
                   { text: 'Apples', value: 1 },
                   { text: 'Bananas', value: 2 },

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.gallery.tsx
@@ -174,7 +174,51 @@ export const galleryItems: ComponentExample[] = [
             onChange={setState('value')}
             onClear={() => resetState('value')}
             tone="critical"
-            message="You must make a selection"
+            message="Critical message"
+            suggestions={filterSuggestions(
+              makeSuggestions(['Apples', 'Bananas', 'Broccoli', 'Carrots']),
+            )}
+          />
+        </>,
+      ),
+  },
+  {
+    label: 'With a positive message',
+    Example: ({ id, getState, setState, setDefaultState, resetState }) =>
+      source(
+        <>
+          {setDefaultState('value', { text: '' })}
+
+          <Autosuggest
+            label="I like to eat"
+            id={id}
+            value={getState('value')}
+            onChange={setState('value')}
+            onClear={() => resetState('value')}
+            tone="positive"
+            message="Positive message"
+            suggestions={filterSuggestions(
+              makeSuggestions(['Apples', 'Bananas', 'Broccoli', 'Carrots']),
+            )}
+          />
+        </>,
+      ),
+  },
+  {
+    label: 'With a caution message',
+    Example: ({ id, getState, setState, setDefaultState, resetState }) =>
+      source(
+        <>
+          {setDefaultState('value', { text: '' })}
+
+          <Autosuggest
+            label="I like to eat"
+            id={id}
+            value={getState('value')}
+            onChange={setState('value')}
+            onClear={() => resetState('value')}
+            tone="caution"
+            message="Caution message"
             suggestions={filterSuggestions(
               makeSuggestions(['Apples', 'Bananas', 'Broccoli', 'Carrots']),
             )}

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.screenshots.tsx
@@ -128,7 +128,7 @@ export const screenshots: ComponentScreenshot = {
       },
     },
     {
-      label: 'Autosuggest with error',
+      label: 'Critical tone',
       Container,
       Example: ({ id }) => {
         const [value, setValue] = useState<Value>({ text: '' });
@@ -142,6 +142,28 @@ export const screenshots: ComponentScreenshot = {
             onClear={() => setValue({ text: '' })}
             tone="critical"
             message="You must make a selection"
+            suggestions={filterSuggestions(
+              makeSuggestions(['Apples', 'Bananas', 'Broccoli', 'Carrots']),
+            )}
+          />
+        );
+      },
+    },
+    {
+      label: 'Caution tone',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState<Value>({ text: '' });
+
+        return (
+          <Autosuggest
+            label="I like to eat"
+            id={id}
+            value={value}
+            onChange={setValue}
+            onClear={() => setValue({ text: '' })}
+            tone="caution"
+            message="Caution message"
             suggestions={filterSuggestions(
               makeSuggestions(['Apples', 'Bananas', 'Broccoli', 'Carrots']),
             )}

--- a/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.docs.tsx
@@ -124,7 +124,8 @@ const docs: ComponentDocs = {
           </Text>
           <Text>
             The supported tones are: <Strong>{'"critical"'}</Strong>,{' '}
-            <Strong>{'"positive"'}</Strong>, and <Strong>{'"neutral"'}</Strong>.
+            <Strong>{'"positive"'}</Strong>, <Strong>{'"caution"'}</Strong>, and{' '}
+            <Strong>{'"neutral"'}</Strong>.
           </Text>
         </>
       ),
@@ -160,6 +161,18 @@ const docs: ComponentDocs = {
               id={`${id}_3`}
               onChange={setState('dropdown3')}
               value={getState('dropdown3')}
+              tone="caution"
+              message="Caution message"
+              placeholder="Please select"
+            >
+              <option>Option 1</option>
+              <option>Option 2</option>
+            </Dropdown>
+            <Dropdown
+              label="Label"
+              id={`${id}_4`}
+              onChange={setState('dropdown4')}
+              value={getState('dropdown4')}
               tone="neutral"
               message="Neutral message"
               placeholder="Please select"

--- a/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.gallery.tsx
@@ -137,6 +137,24 @@ export const galleryItems: ComponentExample[] = [
       ),
   },
   {
+    label: 'With a caution message',
+    Example: ({ id, getState, setState }) =>
+      source(
+        <Dropdown
+          label="Label"
+          id={id}
+          onChange={setState('dropdown')}
+          value={getState('dropdown')}
+          placeholder="Please select"
+          tone="caution"
+          message="Caution message"
+        >
+          <option>Option 1</option>
+          <option>Option 2</option>
+        </Dropdown>,
+      ),
+  },
+  {
     label: 'Disabled field',
     background: 'surface',
     Example: ({ id, getState, setState }) =>

--- a/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.screenshots.tsx
@@ -73,7 +73,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Dropdown in invalid state',
+      label: 'Dropdown in critical tone',
       Container,
       Example: ({ id, handler }) => (
         <Dropdown
@@ -83,6 +83,23 @@ export const screenshots: ComponentScreenshot = {
           value=""
           tone="critical"
           message="Required field"
+        >
+          <option value="1">Developer</option>
+          <option value="2">Designer</option>
+        </Dropdown>
+      ),
+    },
+    {
+      label: 'Dropdown in caution tone',
+      Container,
+      Example: ({ id, handler }) => (
+        <Dropdown
+          label="Job Title"
+          id={id}
+          onChange={handler}
+          value=""
+          tone="caution"
+          message="Caution message"
         >
           <option value="1">Developer</option>
           <option value="2">Designer</option>

--- a/packages/braid-design-system/src/lib/components/FieldMessage/FieldMessage.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/FieldMessage/FieldMessage.docs.tsx
@@ -32,6 +32,17 @@ const docs: ComponentDocs = {
               message="This is a positive message."
             />
           </Stack>
+
+          <Stack space="small">
+            <Box aria-describedby="message3">
+              <Placeholder height={40} />
+            </Box>
+            <FieldMessage
+              id="message3"
+              tone="caution"
+              message="This is a caution message."
+            />
+          </Stack>
         </Stack>
       </Box>,
     ),

--- a/packages/braid-design-system/src/lib/components/FieldMessage/FieldMessage.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/FieldMessage/FieldMessage.gallery.tsx
@@ -27,6 +27,17 @@ export const galleryItems: ComponentExample[] = [
       ),
   },
   {
+    label: 'Caution',
+    Example: ({ id }) =>
+      source(
+        <FieldMessage
+          id={id}
+          tone="caution"
+          message="This is a caution message."
+        />,
+      ),
+  },
+  {
     label: 'Neutral',
     Example: ({ id }) =>
       source(

--- a/packages/braid-design-system/src/lib/components/FieldMessage/FieldMessage.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/FieldMessage/FieldMessage.screenshots.tsx
@@ -26,6 +26,16 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
+      label: 'Caution Field Message',
+      Example: ({ id }) => (
+        <FieldMessage
+          id={id}
+          tone="caution"
+          message="This is a caution message."
+        />
+      ),
+    },
+    {
       label: 'Neutral Field Message',
       Example: ({ id }) => (
         <FieldMessage id={id} message="This is a neutral message." />

--- a/packages/braid-design-system/src/lib/components/FieldMessage/FieldMessage.tsx
+++ b/packages/braid-design-system/src/lib/components/FieldMessage/FieldMessage.tsx
@@ -3,11 +3,11 @@ import React from 'react';
 import { Box } from '../Box/Box';
 import type { TextProps } from '../Text/Text';
 import { Text } from '../Text/Text';
-import { IconCritical, IconPositive } from '../icons';
+import { IconCaution, IconCritical, IconPositive } from '../icons';
 import type { DataAttributeMap } from '../private/buildDataAttributes';
 import buildDataAttributes from '../private/buildDataAttributes';
 
-export const tones = ['neutral', 'critical', 'positive'] as const;
+export const tones = ['neutral', 'critical', 'positive', 'caution'] as const;
 type FieldTone = (typeof tones)[number];
 
 export interface FieldMessageProps {
@@ -20,9 +20,10 @@ export interface FieldMessageProps {
   data?: DataAttributeMap;
 }
 
-const icon: Record<'critical' | 'positive', TextProps['icon']> = {
+const icon: Record<'critical' | 'positive' | 'caution', TextProps['icon']> = {
   critical: <IconCritical tone="critical" />,
   positive: <IconPositive tone="positive" />,
+  caution: <IconCaution tone="caution" />,
 };
 export const FieldMessage = ({
   id,

--- a/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.docs.tsx
@@ -145,7 +145,8 @@ const docs: ComponentDocs = {
           </Text>
           <Text>
             The supported tones are: <Strong>{'"critical"'}</Strong>,{' '}
-            <Strong>{'"positive"'}</Strong>, and <Strong>{'"neutral"'}</Strong>.
+            <Strong>{'"positive"'}</Strong>, <Strong>{'"caution"'}</Strong>, and{' '}
+            <Strong>{'"neutral"'}</Strong>.
           </Text>
         </>
       ),
@@ -173,6 +174,14 @@ const docs: ComponentDocs = {
               id={`${id}_3`}
               onChange={setState('monthpicker3')}
               value={getState('monthpicker3')}
+              tone="caution"
+              message="Caution message"
+            />
+            <MonthPicker
+              label="Label"
+              id={`${id}_4`}
+              onChange={setState('monthpicker4')}
+              value={getState('monthpicker4')}
               tone="neutral"
               message="Neutral message"
             />

--- a/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.gallery.tsx
@@ -76,6 +76,20 @@ export const galleryItems: ComponentExample[] = [
       ),
   },
   {
+    label: 'With a caution message',
+    Example: ({ id, getState, setState }) =>
+      source(
+        <MonthPicker
+          label="Label"
+          id={id}
+          onChange={setState('monthpicker')}
+          value={getState('monthpicker')}
+          tone="caution"
+          message="Caution message"
+        />,
+      ),
+  },
+  {
     label: 'With a neutral message',
     Example: ({ id, getState, setState }) =>
       source(

--- a/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.screenshots.tsx
@@ -49,6 +49,20 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
+      label: 'Caution message',
+      Container,
+      Example: ({ id, handler }) => (
+        <MonthPicker
+          id={id}
+          label="Started"
+          tone="caution"
+          message="This is a caution message."
+          value={{ month: 1, year: 2019 }}
+          onChange={handler}
+        />
+      ),
+    },
+    {
       label: 'Disabled',
       Container,
       Example: ({ id, handler }) => (

--- a/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.docs.tsx
@@ -74,7 +74,8 @@ const docs: ComponentDocs = {
           </Text>
           <Text>
             The supported tones are: <Strong>{'"critical"'}</Strong>,{' '}
-            <Strong>{'"positive"'}</Strong>, and <Strong>{'"neutral"'}</Strong>.
+            <Strong>{'"positive"'}</Strong>, <Strong>{'"caution"'}</Strong>, and{' '}
+            <Strong>{'"neutral"'}</Strong>.
           </Text>
         </>
       ),
@@ -102,6 +103,14 @@ const docs: ComponentDocs = {
               id={`${id}_3`}
               onChange={setState('passwordfield3')}
               value={getState('passwordfield3')}
+              tone="caution"
+              message="Caution message"
+            />
+            <PasswordField
+              label="Label"
+              id={`${id}_4`}
+              onChange={setState('passwordfield4')}
+              value={getState('passwordfield4')}
               tone="neutral"
               message="Neutral message"
             />

--- a/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.gallery.tsx
@@ -72,6 +72,20 @@ export const galleryItems: ComponentExample[] = [
       ),
   },
   {
+    label: 'With a caution message',
+    Example: ({ id, getState, setState }) =>
+      source(
+        <PasswordField
+          label="Label"
+          id={id}
+          onChange={setState('passwordfield')}
+          value={getState('passwordfield')}
+          tone="caution"
+          message="Caution message"
+        />,
+      ),
+  },
+  {
     label: 'With a neutral message',
     Example: ({ id, getState, setState }) =>
       source(

--- a/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.screenshots.tsx
@@ -155,6 +155,23 @@ export const screenshots: ComponentScreenshot = {
       },
     },
     {
+      label: 'PasswordField with caution message',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState('qwerty');
+        return (
+          <PasswordField
+            label="Password"
+            id={id}
+            value={value}
+            onChange={(ev) => setValue(ev.currentTarget.value)}
+            message="Caution message"
+            tone="caution"
+          />
+        );
+      },
+    },
+    {
       label: 'PasswordField disabled',
       Container,
       Example: ({ id, handler }) => (

--- a/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.docs.tsx
@@ -67,27 +67,43 @@ const docs: ComponentDocs = {
             its purpose.
           </Text>
           <Text>
-            The supported tones are: <Strong>{'"critical"'}</Strong> and{' '}
-            <Strong>{'"neutral"'}</Strong>.
+            The supported tones are: <Strong>{'"critical"'}</Strong>,{' '}
+            <Strong>{'"positive"'}</Strong>, and <Strong>{'"neutral"'}</Strong>.
           </Text>
         </>
       ),
       Example: ({ id, getState, setState }) =>
         source(
-          <RadioGroup
-            id={id}
-            value={getState('radio')}
-            onChange={({ currentTarget: { value } }) =>
-              setState('radio', value)
-            }
-            label="Label"
-            tone="critical"
-            message="Critical message"
-          >
-            <RadioItem label="One" value="1" />
-            <RadioItem label="Two" value="2" />
-            <RadioItem label="Three" value="3" />
-          </RadioGroup>,
+          <Tiles space="large" columns={{ mobile: 1, tablet: 2 }}>
+            <RadioGroup
+              id={id}
+              value={getState('radio')}
+              onChange={({ currentTarget: { value } }) =>
+                setState('radio', value)
+              }
+              label="Label"
+              tone="critical"
+              message="Critical message"
+            >
+              <RadioItem label="One" value="1" />
+              <RadioItem label="Two" value="2" />
+              <RadioItem label="Three" value="3" />
+            </RadioGroup>
+            <RadioGroup
+              id={`${id}_2`}
+              value={getState('radio2')}
+              onChange={({ currentTarget: { value } }) =>
+                setState('radio2', value)
+              }
+              label="Label"
+              tone="positive"
+              message="Positive message"
+            >
+              <RadioItem label="One" value="1" />
+              <RadioItem label="Two" value="2" />
+              <RadioItem label="Three" value="3" />
+            </RadioGroup>
+          </Tiles>,
         ),
     },
     {

--- a/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.tsx
+++ b/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.tsx
@@ -22,7 +22,10 @@ export type RadioGroupBaseProps<Value = NonNullable<string | number>> =
     onChange: (event: FormEvent<HTMLInputElement>) => void;
     name?: string;
     size?: InlineFieldProps['size'];
-    tone?: Exclude<FieldGroupBaseProps['tone'], 'caution'>;
+    tone?: Extract<
+      FieldGroupBaseProps['tone'],
+      'critical' | 'positive' | 'neutral'
+    >;
   };
 export type RadioGroupLabelProps = FieldLabelVariant;
 export type RadioGroupProps<Value = NonNullable<string | number>> =

--- a/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.tsx
+++ b/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.tsx
@@ -22,6 +22,7 @@ export type RadioGroupBaseProps<Value = NonNullable<string | number>> =
     onChange: (event: FormEvent<HTMLInputElement>) => void;
     name?: string;
     size?: InlineFieldProps['size'];
+    tone?: Exclude<FieldGroupBaseProps['tone'], 'caution'>;
   };
 export type RadioGroupLabelProps = FieldLabelVariant;
 export type RadioGroupProps<Value = NonNullable<string | number>> =

--- a/packages/braid-design-system/src/lib/components/TextField/TextField.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/TextField/TextField.docs.tsx
@@ -89,7 +89,8 @@ const docs: ComponentDocs = {
           </Text>
           <Text>
             The supported tones are: <Strong>{'"critical"'}</Strong>,{' '}
-            <Strong>{'"positive"'}</Strong>, and <Strong>{'"neutral"'}</Strong>.
+            <Strong>{'"positive"'}</Strong>, <Strong>{'"caution"'}</Strong>, and{' '}
+            <Strong>{'"neutral"'}</Strong>.
           </Text>
         </>
       ),
@@ -117,6 +118,14 @@ const docs: ComponentDocs = {
               id={`${id}_3`}
               onChange={setState('textfield3')}
               value={getState('textfield3')}
+              tone="caution"
+              message="Caution message"
+            />
+            <TextField
+              label="Label"
+              id={`${id}_4`}
+              onChange={setState('textfield4')}
+              value={getState('textfield4')}
               tone="neutral"
               message="Neutral message"
             />

--- a/packages/braid-design-system/src/lib/components/TextField/TextField.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/TextField/TextField.gallery.tsx
@@ -78,6 +78,20 @@ export const galleryItems: ComponentExample[] = [
       ),
   },
   {
+    label: 'With a caution message',
+    Example: ({ id, getState, setState }) =>
+      source(
+        <TextField
+          label="Label"
+          id={id}
+          onChange={setState('textfield')}
+          value={getState('textfield')}
+          tone="caution"
+          message="Caution message"
+        />,
+      ),
+  },
+  {
     label: 'With a neutral message',
     Example: ({ id, getState, setState }) =>
       source(

--- a/packages/braid-design-system/src/lib/components/TextField/TextField.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/TextField/TextField.screenshots.tsx
@@ -171,7 +171,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'TextField with postive message',
+      label: 'TextField with positive message',
       Container,
       Example: ({ id, handler }) => (
         <TextField
@@ -180,6 +180,20 @@ export const screenshots: ComponentScreenshot = {
           value="Text value"
           message="Positive message"
           tone="positive"
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'TextField with caution message',
+      Container,
+      Example: ({ id, handler }) => (
+        <TextField
+          label="Label"
+          id={id}
+          value="Text value"
+          message="Caution message"
+          tone="caution"
           onChange={handler}
         />
       ),

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.docs.tsx
@@ -78,7 +78,8 @@ const docs: ComponentDocs = {
           </Text>
           <Text>
             The supported tones are: <Strong>{'"critical"'}</Strong>,{' '}
-            <Strong>{'"positive"'}</Strong>, and <Strong>{'"neutral"'}</Strong>.
+            <Strong>{'"positive"'}</Strong>, <Strong>{'"caution"'}</Strong>, and{' '}
+            <Strong>{'"neutral"'}</Strong>.
           </Text>
         </>
       ),
@@ -106,6 +107,14 @@ const docs: ComponentDocs = {
               id={`${id}_3`}
               onChange={setState('textarea3')}
               value={getState('textarea3')}
+              tone="caution"
+              message="Caution message"
+            />
+            <Textarea
+              label="Label"
+              id={`${id}_4`}
+              onChange={setState('textarea4')}
+              value={getState('textarea4')}
               tone="neutral"
               message="Neutral message"
             />

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.gallery.tsx
@@ -76,6 +76,20 @@ export const galleryItems: ComponentExample[] = [
       ),
   },
   {
+    label: 'With a caution message',
+    Example: ({ id, getState, setState }) =>
+      source(
+        <Textarea
+          id={id}
+          label="Label"
+          onChange={setState('textarea')}
+          value={getState('textarea')}
+          tone="caution"
+          message="Caution message"
+        />,
+      ),
+  },
+  {
     label: 'With a neutral message',
     Example: ({ id, getState, setState }) =>
       source(

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.screenshots.tsx
@@ -106,6 +106,20 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
+      label: 'Textarea with caution message',
+      Container,
+      Example: ({ id, handler }) => (
+        <Textarea
+          id={id}
+          value=""
+          onChange={handler}
+          label="Label"
+          message="Caution message"
+          tone="caution"
+        />
+      ),
+    },
+    {
       label: 'Textarea disabled',
       Container,
       Example: ({ id, handler }) => (

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -131,6 +131,7 @@ exports[`Autosuggest 1`] = `
         | Suggestions<Value>
     tertiaryLabel?: ReactNode
     tone?: 
+        | "caution"
         | "critical"
         | "neutral"
         | "positive"
@@ -2935,6 +2936,7 @@ exports[`Dropdown 1`] = `
     secondaryLabel?: ReactNode
     tertiaryLabel?: ReactNode
     tone?: 
+        | "caution"
         | "critical"
         | "neutral"
         | "positive"
@@ -2976,6 +2978,7 @@ exports[`FieldMessage 1`] = `
     reserveMessageSpace?: boolean
     secondaryMessage?: ReactNode
     tone?: 
+        | "caution"
         | "critical"
         | "neutral"
         | "positive"
@@ -6702,6 +6705,7 @@ exports[`MonthPicker 1`] = `
     secondaryLabel?: ReactNode
     tertiaryLabel?: ReactNode
     tone?: 
+        | "caution"
         | "critical"
         | "neutral"
         | "positive"
@@ -6798,6 +6802,7 @@ exports[`PasswordField 1`] = `
     secondaryLabel?: ReactNode
     tertiaryLabel?: ReactNode
     tone?: 
+        | "caution"
         | "critical"
         | "neutral"
         | "positive"
@@ -7386,6 +7391,7 @@ exports[`TextField 1`] = `
         | string
     tertiaryLabel?: ReactNode
     tone?: 
+        | "caution"
         | "critical"
         | "neutral"
         | "positive"
@@ -7979,6 +7985,7 @@ exports[`Textarea 1`] = `
     secondaryLabel?: ReactNode
     tertiaryLabel?: ReactNode
     tone?: 
+        | "caution"
         | "critical"
         | "neutral"
         | "positive"


### PR DESCRIPTION
Add support for `caution` tone to form fields

Provide support for applying a `caution` tone to form fields.
Specifying this `tone` will provide the `IconCaution` alongside the provided `message`.

**EXAMPLE USAGE:**
```jsx
<TextField tone="caution" message="Caution message" />
```