### PR TITLE
Textarea: Add support for `caution` highlightRanges

### DIFF
--- a/.changeset/loud-birds-scream.md
+++ b/.changeset/loud-birds-scream.md
@@ -1,0 +1,19 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Textarea
+---
+
+**Textarea:** Add support for disabling built-in spell checker
+
+Provide support for disabling the built-in browser spell checker using the native HTML attribute `spellCheck`.
+
+When highlighting ranges you may choose to turn spell check off to prevent colliding highlights. This can be done be setting `spellCheck` to `false`.
+
+**EXAMPLE USAGE:**
+```jsx
+<Textarea spellCheck={false} />
+```

--- a/.changeset/popular-kangaroos-walk.md
+++ b/.changeset/popular-kangaroos-walk.md
@@ -1,0 +1,22 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Textarea
+---
+
+**Textarea:** Add support for `caution` highlightRanges
+
+Providing a `tone` of `caution` along with a set of `highlightRanges` will now apply the `caution` tone to the text being highlighted.
+To complement this feature, the design has been uplifted to work consistently across both the `critical` and `caution` tones.
+
+**EXAMPLE USAGE:**
+```jsx
+<Textarea
+  tone="caution"
+  message="Caution message"
+  highlightRanges={...}
+/>
+```

--- a/packages/braid-design-system/src/lib/components/Textarea/Highlight/Highlight.css.ts
+++ b/packages/braid-design-system/src/lib/components/Textarea/Highlight/Highlight.css.ts
@@ -1,8 +1,33 @@
 import { style } from '@vanilla-extract/css';
+import { colorModeStyle } from '../../../css/colorModeStyle';
+import { vars } from '../../../themes/vars.css';
 
 const space = 2;
+const lineThickness = 2;
 
 export const root = style({
   padding: space,
   margin: -space,
+  textDecoration: 'underline',
+  textDecorationStyle: 'wavy',
+  textDecorationSkipInk: 'none',
+  textDecorationThickness: lineThickness,
+  textUnderlineOffset: 2,
+  paddingBottom: lineThickness / 2,
+  marginBottom: -(lineThickness / 2),
+});
+
+export const critical = style(
+  colorModeStyle({
+    lightMode: {
+      textDecorationColor: vars.borderColor.critical,
+    },
+    darkMode: {
+      textDecorationColor: vars.borderColor.criticalLight,
+    },
+  }),
+);
+
+export const caution = style({
+  textDecorationColor: vars.borderColor.caution,
 });

--- a/packages/braid-design-system/src/lib/components/Textarea/Highlight/Highlight.css.ts
+++ b/packages/braid-design-system/src/lib/components/Textarea/Highlight/Highlight.css.ts
@@ -1,26 +1,31 @@
 import { style } from '@vanilla-extract/css';
+import { atoms } from '../../../css/atoms/atoms';
 import { colorModeStyle } from '../../../css/colorModeStyle';
 import { vars } from '../../../themes/vars.css';
 
 const space = 2;
 const lineThickness = 2;
 
-export const root = style({
-  padding: space,
-  margin: -space,
-  textDecoration: 'underline',
-  textDecorationStyle: 'wavy',
-  textDecorationSkipInk: 'none',
-  textDecorationThickness: lineThickness,
-  textUnderlineOffset: 2,
-  paddingBottom: lineThickness / 2,
-  marginBottom: -(lineThickness / 2),
-});
+export const root = style([
+  atoms({ borderRadius: 'small' }),
+  {
+    padding: space,
+    margin: -space,
+    textDecoration: 'underline',
+    textDecorationStyle: 'wavy',
+    textDecorationSkipInk: 'none',
+    textDecorationThickness: lineThickness,
+    textUnderlineOffset: 2,
+    paddingBottom: lineThickness / 2,
+    marginBottom: -(lineThickness / 2),
+  },
+]);
 
 export const critical = style(
   colorModeStyle({
     lightMode: {
       textDecorationColor: vars.borderColor.critical,
+      background: vars.backgroundColor.criticalLight,
     },
     darkMode: {
       textDecorationColor: vars.borderColor.criticalLight,
@@ -28,6 +33,13 @@ export const critical = style(
   }),
 );
 
-export const caution = style({
-  textDecorationColor: vars.borderColor.caution,
-});
+export const caution = style([
+  {
+    textDecorationColor: vars.borderColor.caution,
+  },
+  colorModeStyle({
+    lightMode: {
+      background: vars.backgroundColor.cautionLight,
+    },
+  }),
+]);

--- a/packages/braid-design-system/src/lib/components/Textarea/Highlight/Highlight.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Highlight/Highlight.tsx
@@ -10,14 +10,7 @@ export interface HighlightProps {
 const styleForTone = { caution, critical };
 
 export const Highlight = ({ children, tone }: HighlightProps) => (
-  <Box
-    component="mark"
-    borderRadius="small"
-    background={{
-      lightMode: tone === 'caution' ? 'cautionLight' : 'criticalLight',
-    }}
-    className={[root, styleForTone[tone]]}
-  >
+  <Box component="mark" className={[root, styleForTone[tone]]}>
     {children}
   </Box>
 );

--- a/packages/braid-design-system/src/lib/components/Textarea/Highlight/Highlight.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Highlight/Highlight.tsx
@@ -1,17 +1,20 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import * as styles from './Highlight.css';
+import { root, critical, caution } from './Highlight.css';
 
 export interface HighlightProps {
   children: string;
+  tone: 'critical' | 'caution';
 }
 
-export const Highlight = ({ children }: HighlightProps) => (
+export const Highlight = ({ children, tone }: HighlightProps) => (
   <Box
     component="mark"
     borderRadius="small"
-    background={{ lightMode: 'criticalLight', darkMode: 'critical' }}
-    className={styles.root}
+    background={{
+      lightMode: tone === 'caution' ? 'cautionLight' : 'criticalLight',
+    }}
+    className={[root, tone === 'caution' ? caution : critical]}
   >
     {children}
   </Box>

--- a/packages/braid-design-system/src/lib/components/Textarea/Highlight/Highlight.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Highlight/Highlight.tsx
@@ -7,6 +7,8 @@ export interface HighlightProps {
   tone: 'critical' | 'caution';
 }
 
+const styleForTone = { caution, critical };
+
 export const Highlight = ({ children, tone }: HighlightProps) => (
   <Box
     component="mark"
@@ -14,7 +16,7 @@ export const Highlight = ({ children, tone }: HighlightProps) => (
     background={{
       lightMode: tone === 'caution' ? 'cautionLight' : 'criticalLight',
     }}
-    className={[root, tone === 'caution' ? caution : critical]}
+    className={[root, styleForTone[tone]]}
   >
     {children}
   </Box>

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.docs.tsx
@@ -218,7 +218,8 @@ const docs: ComponentDocs = {
           </Text>
           <Text>
             To prevent loss of information, exceeding the limit is permitted,
-            however the count will be presented in a critical tone.
+            however the count will be presented in a <Strong>critical</Strong>{' '}
+            tone.
           </Text>
         </>
       ),
@@ -244,12 +245,19 @@ const docs: ComponentDocs = {
     {
       label: 'Highlighting ranges',
       description: (
-        <Text>
-          To support targeted validations, specific character ranges can be
-          highlighted as critical. The <Strong>highlightRanges</Strong> prop
-          accepts and array of <Strong>start</Strong> and <Strong>end</Strong>{' '}
-          character positions.
-        </Text>
+        <>
+          <Text>
+            To support targeted validations, specific character ranges can be
+            highlighted. The <Strong>highlightRanges</Strong> prop accepts and
+            array of <Strong>start</Strong> and <Strong>end</Strong> character
+            positions.
+          </Text>
+          <Text>
+            Supported highlight tones are <Strong>critical</Strong> and{' '}
+            <Strong>caution</Strong> and follow the <Strong>tone</Strong> set on
+            the field.
+          </Text>
+        </>
       ),
       Example: ({ id, getState, setState, setDefaultState }) =>
         source(
@@ -259,16 +267,29 @@ const docs: ComponentDocs = {
               'A long piece of text with a highlighted range',
             )}
 
-            <Textarea
-              label="Label"
-              id={id}
-              onChange={setState('textarea')}
-              value={getState('textarea')}
-              tone="critical"
-              message="Critical message"
-              description="Characters 7-20 are highlighted"
-              highlightRanges={[{ start: 7, end: 20 }]}
-            />
+            <Stack space="large">
+              <Textarea
+                label="Label"
+                id={id}
+                onChange={setState('textarea')}
+                value={getState('textarea')}
+                tone="critical"
+                message="Critical message"
+                description="Characters 7-20 are highlighted"
+                highlightRanges={[{ start: 7, end: 20 }]}
+              />
+
+              <Textarea
+                label="Label"
+                id={`${id}_2`}
+                onChange={setState('textarea')}
+                value={getState('textarea')}
+                tone="caution"
+                message="Caution message"
+                description="Characters 7-20 are highlighted"
+                highlightRanges={[{ start: 7, end: 20 }]}
+              />
+            </Stack>
           </>,
         ),
     },

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.docs.tsx
@@ -255,8 +255,14 @@ const docs: ComponentDocs = {
           </Text>
           <Text>
             Supported highlight tones are <Strong>critical</Strong> and{' '}
-            <Strong>caution</Strong> and follow the <Strong>tone</Strong> set on
-            the field.
+            <Strong>caution</Strong>. Highlights follow the{' '}
+            <Strong>tone</Strong> set on the field.
+          </Text>
+          <Text>
+            Additionally, when highlighting ranges you may choose to disable the
+            built-in spell check to prevent colliding highlights. This can be
+            done be setting <Strong>spellCheck</Strong> to{' '}
+            <Strong>false</Strong>.
           </Text>
           <Alert>
             <Stack space="large">

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.docs.tsx
@@ -249,7 +249,7 @@ const docs: ComponentDocs = {
         <>
           <Text>
             To support targeted validations, specific character ranges can be
-            highlighted. The <Strong>highlightRanges</Strong> prop accepts and
+            highlighted. The <Strong>highlightRanges</Strong> prop accepts an
             array of <Strong>start</Strong> and <Strong>end</Strong> character
             positions.
           </Text>
@@ -269,11 +269,11 @@ const docs: ComponentDocs = {
               <Text>
                 When combining <Strong>characterLimit</Strong> and{' '}
                 <Strong>highlightRanges</Strong>, if the number of characters
-                exceeds the limit only the exceeding characters will be
+                exceeds the limit, only the exceeding characters will be
                 highlighted (using <Strong>critical</Strong> tone).
               </Text>
               <Text>
-                Once resolved, the provided highlightRanges will then be shown.
+                Once resolved, the provided <Strong>highlightRanges</Strong> will then be shown.
               </Text>
             </Stack>
           </Alert>

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.docs.tsx
@@ -9,6 +9,7 @@ import {
   Strong,
   Stack,
   Heading,
+  Alert,
 } from '../';
 import source from '../../utils/source.macro';
 
@@ -257,6 +258,19 @@ const docs: ComponentDocs = {
             <Strong>caution</Strong> and follow the <Strong>tone</Strong> set on
             the field.
           </Text>
+          <Alert>
+            <Stack space="large">
+              <Text>
+                When combining <Strong>characterLimit</Strong> and{' '}
+                <Strong>highlightRanges</Strong>, if the number of characters
+                exceeds the limit only the exceeding characters will be
+                highlighted (using <Strong>critical</Strong> tone).
+              </Text>
+              <Text>
+                Once resolved, the provided highlightRanges will then be shown.
+              </Text>
+            </Stack>
+          </Alert>
         </>
       ),
       Example: ({ id, getState, setState, setDefaultState }) =>

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.docs.tsx
@@ -273,7 +273,8 @@ const docs: ComponentDocs = {
                 highlighted (using <Strong>critical</Strong> tone).
               </Text>
               <Text>
-                Once resolved, the provided <Strong>highlightRanges</Strong> will then be shown.
+                Once resolved, the provided <Strong>highlightRanges</Strong>{' '}
+                will then be shown.
               </Text>
             </Stack>
           </Alert>

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.screenshots.tsx
@@ -250,7 +250,95 @@ export const screenshots: ComponentScreenshot = {
       },
     },
     {
-      label: 'Textarea highlighting a while range exceeding character limit',
+      label: 'Textarea highlighting a range in caution',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState(
+          'The long piece of text highlighting a range',
+        );
+
+        return (
+          <Textarea
+            id={id}
+            value={value}
+            onChange={(e) => setValue(e.currentTarget.value)}
+            label="Label"
+            tone="caution"
+            description="Characters 9-22 are invalid"
+            highlightRanges={[{ start: 9, end: 22 }]}
+          />
+        );
+      },
+    },
+    {
+      label: 'Within character limit with with highlight range and no tone',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState(
+          'The long piece of text within the limit',
+        );
+
+        return (
+          <Textarea
+            id={id}
+            value={value}
+            onChange={(e) => setValue(e.currentTarget.value)}
+            label="Label"
+            description="Should show highlighted range"
+            characterLimit={50}
+            highlightRanges={[{ start: 9, end: 22 }]}
+          />
+        );
+      },
+    },
+    {
+      label:
+        'Within character limit with with highlight range and explicit critical tone',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState(
+          'The long piece of text within the limit',
+        );
+
+        return (
+          <Textarea
+            id={id}
+            value={value}
+            onChange={(e) => setValue(e.currentTarget.value)}
+            label="Label"
+            tone="critical"
+            description="Should show highlighted range"
+            characterLimit={50}
+            highlightRanges={[{ start: 9, end: 22 }]}
+          />
+        );
+      },
+    },
+    {
+      label:
+        'Within character limit with with highlight range and caution tone',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState(
+          'The long piece of text within the limit',
+        );
+
+        return (
+          <Textarea
+            id={id}
+            value={value}
+            onChange={(e) => setValue(e.currentTarget.value)}
+            label="Label"
+            tone="caution"
+            description="Should show highlighted range"
+            characterLimit={50}
+            highlightRanges={[{ start: 9, end: 22 }]}
+          />
+        );
+      },
+    },
+    {
+      label: 'Exceeding character limit with with highlight range and no tone',
       Container,
       Example: ({ id }) => {
         const [value, setValue] = useState(
@@ -263,7 +351,53 @@ export const screenshots: ComponentScreenshot = {
             value={value}
             onChange={(e) => setValue(e.currentTarget.value)}
             label="Label"
-            description="Characters 9-22 are invalid"
+            description="Should only highlight exceeding characters"
+            characterLimit={50}
+            highlightRanges={[{ start: 9, end: 22 }]}
+          />
+        );
+      },
+    },
+    {
+      label:
+        'Exceeding character limit with with highlight range and explicit critical tone',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState(
+          'The long piece of text exceeding the specified 50 character limit',
+        );
+
+        return (
+          <Textarea
+            id={id}
+            value={value}
+            onChange={(e) => setValue(e.currentTarget.value)}
+            label="Label"
+            tone="critical"
+            description="Should only highlight exceeding characters"
+            characterLimit={50}
+            highlightRanges={[{ start: 9, end: 22 }]}
+          />
+        );
+      },
+    },
+    {
+      label:
+        'Exceeding character limit with with highlight range and caution tone',
+      Container,
+      Example: ({ id }) => {
+        const [value, setValue] = useState(
+          'The long piece of text exceeding the specified 50 character limit',
+        );
+
+        return (
+          <Textarea
+            id={id}
+            value={value}
+            onChange={(e) => setValue(e.currentTarget.value)}
+            label="Label"
+            tone="caution"
+            description="Should only highlight exceeding characters"
             characterLimit={50}
             highlightRanges={[{ start: 9, end: 22 }]}
           />

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.screenshots.tsx
@@ -315,8 +315,7 @@ export const screenshots: ComponentScreenshot = {
       },
     },
     {
-      label:
-        'Within character limit with highlight range and caution tone',
+      label: 'Within character limit with highlight range and caution tone',
       Container,
       Example: ({ id }) => {
         const [value, setValue] = useState(
@@ -382,8 +381,7 @@ export const screenshots: ComponentScreenshot = {
       },
     },
     {
-      label:
-        'Exceeding character limit with highlight range and caution tone',
+      label: 'Exceeding character limit with highlight range and caution tone',
       Container,
       Example: ({ id }) => {
         const [value, setValue] = useState(

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.screenshots.tsx
@@ -271,7 +271,7 @@ export const screenshots: ComponentScreenshot = {
       },
     },
     {
-      label: 'Within character limit with with highlight range and no tone',
+      label: 'Within character limit with highlight range and no tone',
       Container,
       Example: ({ id }) => {
         const [value, setValue] = useState(
@@ -293,7 +293,7 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label:
-        'Within character limit with with highlight range and explicit critical tone',
+        'Within character limit with highlight range and explicit critical tone',
       Container,
       Example: ({ id }) => {
         const [value, setValue] = useState(
@@ -316,7 +316,7 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label:
-        'Within character limit with with highlight range and caution tone',
+        'Within character limit with highlight range and caution tone',
       Container,
       Example: ({ id }) => {
         const [value, setValue] = useState(
@@ -338,7 +338,7 @@ export const screenshots: ComponentScreenshot = {
       },
     },
     {
-      label: 'Exceeding character limit with with highlight range and no tone',
+      label: 'Exceeding character limit with highlight range and no tone',
       Container,
       Example: ({ id }) => {
         const [value, setValue] = useState(
@@ -360,7 +360,7 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label:
-        'Exceeding character limit with with highlight range and explicit critical tone',
+        'Exceeding character limit with highlight range and explicit critical tone',
       Container,
       Example: ({ id }) => {
         const [value, setValue] = useState(
@@ -383,7 +383,7 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label:
-        'Exceeding character limit with with highlight range and caution tone',
+        'Exceeding character limit with highlight range and caution tone',
       Container,
       Example: ({ id }) => {
         const [value, setValue] = useState(

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.tsx
@@ -91,14 +91,16 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       },
       [highlightsRef],
     );
-
     const inputLength = String(value).length;
-    const excessCharactersRange =
-      characterLimit && inputLength > characterLimit
-        ? [{ start: characterLimit }]
-        : [];
-
-    const highlightRanges = [...excessCharactersRange, ...highlightRangesProp];
+    const hasExceededCharacterLimit =
+      characterLimit && inputLength > characterLimit;
+    const highlightTone =
+      !hasExceededCharacterLimit && (tone === 'critical' || tone === 'caution')
+        ? tone
+        : 'critical';
+    const highlightRanges = hasExceededCharacterLimit
+      ? [{ start: characterLimit }]
+      : highlightRangesProp;
     const hasHighlights = highlightRanges.length > 0;
 
     return (
@@ -139,11 +141,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
                 className={[styles.highlights, className]}
                 {...fieldProps}
               >
-                {formatRanges(
-                  String(value),
-                  highlightRanges,
-                  tone === 'critical' || tone === 'caution' ? tone : undefined,
-                )}
+                {formatRanges(String(value), highlightRanges, highlightTone)}
               </Box>
             ) : null}
             <Box

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.tsx
@@ -76,6 +76,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       lines = 3,
       lineLimit,
       grow = true,
+      tone,
       ...restProps
     },
     ref,
@@ -103,6 +104,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
     return (
       <Field
         {...restProps}
+        tone={tone}
         value={value}
         icon={undefined}
         prefix={undefined}
@@ -137,7 +139,11 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
                 className={[styles.highlights, className]}
                 {...fieldProps}
               >
-                {formatRanges(String(value), highlightRanges)}
+                {formatRanges(
+                  String(value),
+                  highlightRanges,
+                  tone === 'critical' || tone === 'caution' ? tone : undefined,
+                )}
               </Box>
             ) : null}
             <Box

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.tsx
@@ -19,6 +19,7 @@ export type TextareaBaseProps = Omit<
   onFocus?: NativeTextareaProps['onFocus'];
   onPaste?: NativeTextareaProps['onPaste'];
   placeholder?: NativeTextareaProps['placeholder'];
+  spellCheck?: NativeTextareaProps['spellCheck'];
   highlightRanges?: Array<{
     start: number;
     end?: number;
@@ -77,6 +78,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
       lineLimit,
       grow = true,
       tone,
+      spellCheck,
       ...restProps
     },
     ref,
@@ -171,6 +173,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
                   : undefined
               }
               placeholder={!restProps.disabled ? placeholder : undefined}
+              spellCheck={spellCheck}
               className={[styles.field, className]}
               {...fieldProps}
               ref={ref}

--- a/packages/braid-design-system/src/lib/components/Textarea/formatRanges.test.ts
+++ b/packages/braid-design-system/src/lib/components/Textarea/formatRanges.test.ts
@@ -271,45 +271,4 @@ describe('formatRanges', () => {
       ]
     `);
   });
-
-  it('should highlight ranges with critical when tone is explicitly critical', () => {
-    const value = 'my longer text';
-    const ranges = [
-      {
-        start: 3,
-        end: 6,
-      },
-      {
-        start: 7,
-        end: 8,
-      },
-      {
-        start: 12,
-        end: 13,
-      },
-    ];
-    expect(formatRanges(value, ranges, 'critical')).toMatchInlineSnapshot(`
-      [
-        "my ",
-        <Highlight
-          tone="critical"
-        >
-          lon
-        </Highlight>,
-        "g",
-        <Highlight
-          tone="critical"
-        >
-          e
-        </Highlight>,
-        "r te",
-        <Highlight
-          tone="critical"
-        >
-          x
-        </Highlight>,
-        "t",
-      ]
-    `);
-  });
 });

--- a/packages/braid-design-system/src/lib/components/Textarea/formatRanges.test.ts
+++ b/packages/braid-design-system/src/lib/components/Textarea/formatRanges.test.ts
@@ -21,7 +21,9 @@ describe('formatRanges', () => {
     expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
       [
         "my str",
-        <Highlight>
+        <Highlight
+          tone="critical"
+        >
           ing of text
         </Highlight>,
       ]
@@ -39,7 +41,9 @@ describe('formatRanges', () => {
     expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
       [
         "my ",
-        <Highlight>
+        <Highlight
+          tone="critical"
+        >
           longer
         </Highlight>,
         " text",
@@ -66,15 +70,21 @@ describe('formatRanges', () => {
     expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
       [
         "my ",
-        <Highlight>
+        <Highlight
+          tone="critical"
+        >
           lon
         </Highlight>,
         "g",
-        <Highlight>
+        <Highlight
+          tone="critical"
+        >
           e
         </Highlight>,
         "r te",
-        <Highlight>
+        <Highlight
+          tone="critical"
+        >
           x
         </Highlight>,
         "t",
@@ -97,7 +107,9 @@ describe('formatRanges', () => {
     expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
       [
         "aaaaaaaaaa",
-        <Highlight>
+        <Highlight
+          tone="critical"
+        >
           bbb
         </Highlight>,
       ]
@@ -134,7 +146,9 @@ describe('formatRanges', () => {
     expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
       [
         "aaaaaaaaaa",
-        <Highlight>
+        <Highlight
+          tone="critical"
+        >
           bbb
         </Highlight>,
       ]
@@ -151,19 +165,27 @@ describe('formatRanges', () => {
     ];
     expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
       [
-        <Highlight>
+        <Highlight
+          tone="critical"
+        >
           some
         </Highlight>,
         " text ",
-        <Highlight>
+        <Highlight
+          tone="critical"
+        >
           some
         </Highlight>,
         " text ",
-        <Highlight>
+        <Highlight
+          tone="critical"
+        >
           some
         </Highlight>,
         " text ",
-        <Highlight>
+        <Highlight
+          tone="critical"
+        >
           some
         </Highlight>,
         " text",
@@ -182,21 +204,111 @@ describe('formatRanges', () => {
     ];
     expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
       [
-        <Highlight>
+        <Highlight
+          tone="critical"
+        >
           some
         </Highlight>,
         " text ",
-        <Highlight>
+        <Highlight
+          tone="critical"
+        >
           some text some text so
         </Highlight>,
-        <Highlight>
+        <Highlight
+          tone="critical"
+        >
           me
         </Highlight>,
         " text ",
-        <Highlight>
+        <Highlight
+          tone="critical"
+        >
           some
         </Highlight>,
         " text",
+      ]
+    `);
+  });
+
+  it('should highlight ranges with caution when tone is caution', () => {
+    const value = 'my longer text';
+    const ranges = [
+      {
+        start: 3,
+        end: 6,
+      },
+      {
+        start: 7,
+        end: 8,
+      },
+      {
+        start: 12,
+        end: 13,
+      },
+    ];
+    expect(formatRanges(value, ranges, 'caution')).toMatchInlineSnapshot(`
+      [
+        "my ",
+        <Highlight
+          tone="caution"
+        >
+          lon
+        </Highlight>,
+        "g",
+        <Highlight
+          tone="caution"
+        >
+          e
+        </Highlight>,
+        "r te",
+        <Highlight
+          tone="caution"
+        >
+          x
+        </Highlight>,
+        "t",
+      ]
+    `);
+  });
+
+  it('should highlight ranges with critical when tone is explicitly critical', () => {
+    const value = 'my longer text';
+    const ranges = [
+      {
+        start: 3,
+        end: 6,
+      },
+      {
+        start: 7,
+        end: 8,
+      },
+      {
+        start: 12,
+        end: 13,
+      },
+    ];
+    expect(formatRanges(value, ranges, 'critical')).toMatchInlineSnapshot(`
+      [
+        "my ",
+        <Highlight
+          tone="critical"
+        >
+          lon
+        </Highlight>,
+        "g",
+        <Highlight
+          tone="critical"
+        >
+          e
+        </Highlight>,
+        "r te",
+        <Highlight
+          tone="critical"
+        >
+          x
+        </Highlight>,
+        "t",
       ]
     `);
   });

--- a/packages/braid-design-system/src/lib/components/Textarea/formatRanges.test.ts
+++ b/packages/braid-design-system/src/lib/components/Textarea/formatRanges.test.ts
@@ -4,7 +4,7 @@ describe('formatRanges', () => {
   it('should return the unformatted text if no highlighting is required', () => {
     const value = 'aaaaaaaaa bbbbbbbbbb';
     const ranges = [{ start: 30 }];
-    expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
+    expect(formatRanges(value, ranges, 'critical')).toMatchInlineSnapshot(`
       [
         "aaaaaaaaa bbbbbbbbbb",
       ]
@@ -18,7 +18,7 @@ describe('formatRanges', () => {
         start: 6,
       },
     ];
-    expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
+    expect(formatRanges(value, ranges, 'critical')).toMatchInlineSnapshot(`
       [
         "my str",
         <Highlight
@@ -38,7 +38,7 @@ describe('formatRanges', () => {
         end: 9,
       },
     ];
-    expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
+    expect(formatRanges(value, ranges, 'critical')).toMatchInlineSnapshot(`
       [
         "my ",
         <Highlight
@@ -67,7 +67,7 @@ describe('formatRanges', () => {
         end: 13,
       },
     ];
-    expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
+    expect(formatRanges(value, ranges, 'critical')).toMatchInlineSnapshot(`
       [
         "my ",
         <Highlight
@@ -104,7 +104,7 @@ describe('formatRanges', () => {
         end: 40,
       },
     ];
-    expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
+    expect(formatRanges(value, ranges, 'critical')).toMatchInlineSnapshot(`
       [
         "aaaaaaaaaa",
         <Highlight
@@ -124,7 +124,7 @@ describe('formatRanges', () => {
         end: 5,
       },
     ];
-    expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
+    expect(formatRanges(value, ranges, 'critical')).toMatchInlineSnapshot(`
       [
         "my longer text",
       ]
@@ -143,7 +143,7 @@ describe('formatRanges', () => {
         end: 4,
       },
     ];
-    expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
+    expect(formatRanges(value, ranges, 'critical')).toMatchInlineSnapshot(`
       [
         "aaaaaaaaaa",
         <Highlight
@@ -163,7 +163,7 @@ describe('formatRanges', () => {
       { start: 30, end: 34 },
       { start: 10, end: 14 },
     ];
-    expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
+    expect(formatRanges(value, ranges, 'critical')).toMatchInlineSnapshot(`
       [
         <Highlight
           tone="critical"
@@ -202,7 +202,7 @@ describe('formatRanges', () => {
       { start: 30, end: 34 },
       { start: 40, end: 44 },
     ];
-    expect(formatRanges(value, ranges)).toMatchInlineSnapshot(`
+    expect(formatRanges(value, ranges, 'critical')).toMatchInlineSnapshot(`
       [
         <Highlight
           tone="critical"

--- a/packages/braid-design-system/src/lib/components/Textarea/formatRanges.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/formatRanges.tsx
@@ -9,7 +9,7 @@ type ReactChild = ReactElement | string | number;
 export const formatRanges = (
   value: string,
   highlightRanges: TextareaProps['highlightRanges'],
-  tone: 'critical' | 'caution' = 'critical',
+  tone: 'critical' | 'caution',
 ): ReactChild[] => {
   if (highlightRanges && value) {
     let lastEnd = 0;

--- a/packages/braid-design-system/src/lib/components/Textarea/formatRanges.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/formatRanges.tsx
@@ -1,12 +1,15 @@
-import type { ReactChild } from 'react';
+import type { ReactElement } from 'react';
 import React from 'react';
 import parseHighlights from 'autosuggest-highlight/parse';
 import type { TextareaProps } from './Textarea';
 import { Highlight } from './Highlight/Highlight';
 
+type ReactChild = ReactElement | string | number;
+
 export const formatRanges = (
   value: string,
   highlightRanges: TextareaProps['highlightRanges'],
+  tone: 'critical' | 'caution' = 'critical',
 ): ReactChild[] => {
   if (highlightRanges && value) {
     let lastEnd = 0;
@@ -47,7 +50,15 @@ export const formatRanges = (
       ]),
     ).reduce((acc, { text, highlight }, i) => {
       if (text) {
-        acc.push(highlight ? <Highlight key={i}>{text}</Highlight> : text);
+        acc.push(
+          highlight ? (
+            <Highlight key={i} tone={tone}>
+              {text}
+            </Highlight>
+          ) : (
+            text
+          ),
+        );
       }
       return acc;
     }, [] as ReactChild[]);

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -7983,6 +7983,11 @@ exports[`Textarea 1`] = `
     required?: boolean
     reserveMessageSpace?: boolean
     secondaryLabel?: ReactNode
+    spellCheck?: 
+        | "false"
+        | "true"
+        | false
+        | true
     tertiaryLabel?: ReactNode
     tone?: 
         | "caution"


### PR DESCRIPTION
Providing a `tone` of `caution` along with a set of `highlightRanges` will now apply the `caution` tone to the text being highlighted.
To complement this feature, the design has been uplifted to work consistently across both the `critical` and `caution` tones.

**EXAMPLE USAGE:**
```jsx
<Textarea
  tone="caution"
  message="Caution message"
  highlightRanges={...}
/>
```

![Preview of new design](https://user-images.githubusercontent.com/912060/229693621-5ca46d9f-f213-4227-9519-ee1bc69b62b1.png)
