### PR TITLE
Add missing Stack

### DIFF
--- a/site/src/App/routes/examples/basic-form/basic-form.tsx
+++ b/site/src/App/routes/examples/basic-form/basic-form.tsx
@@ -136,15 +136,17 @@ const page: Page = {
           {() =>
             source(
               <Card>
-                <Heading level="3">Add role</Heading>
-                <Autosuggest
-                  label="Job title"
-                  suggestions={filterSuggestions([
-                    { text: 'Developer' },
-                    { text: 'Designer' },
-                    { text: 'Product Manager' },
-                  ])}
-                />
+                <Stack space="large">
+                  <Heading level="3">Add role</Heading>
+                  <Autosuggest
+                    label="Job title"
+                    suggestions={filterSuggestions([
+                      { text: 'Developer' },
+                      { text: 'Designer' },
+                      { text: 'Product Manager' },
+                    ])}
+                  />
+                </Stack>
               </Card>,
             )
           }


### PR DESCRIPTION
This PR adds the missing stack component in the examples/Basic Form example, specifically in step 2. The addition of the stack component ensures proper spacing between form elements.

<hr/>
<img width="1429" alt="Screenshot 2023-04-04 at 10 26 53" src="https://user-images.githubusercontent.com/78202674/229734534-90071d25-dff3-4005-bac7-f9ef4542e410.png">
