### PR TITLE
MenuItemCheckbox: Align checkbox size with a `small` Checkbox

### DIFF
--- a/.changeset/shiny-chairs-lay.md
+++ b/.changeset/shiny-chairs-lay.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - MenuItemCheckbox
+---
+
+**MenuItemCheckbox:** Align checkbox size with a `small` Checkbox
+
+Align the size of a `MenuItemCheckbox` with a `small` sized `Checkbox`.

--- a/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.css.ts
+++ b/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.css.ts
@@ -1,0 +1,34 @@
+import { createVar, style } from '@vanilla-extract/css';
+import { calc } from '@vanilla-extract/css-utils';
+import { responsiveStyle } from '../../css/responsiveStyle';
+import { vars } from '../../themes/vars.css';
+
+const checkboxFieldSize = vars.inlineFieldSize.small;
+const menuItemCapHeight = createVar();
+const crop = createVar();
+
+export const checkboxSize = style([
+  responsiveStyle({
+    mobile: {
+      vars: {
+        [menuItemCapHeight]: vars.textSize.standard.mobile.capHeight,
+        [crop]: calc(checkboxFieldSize)
+          .subtract(menuItemCapHeight)
+          .divide(2)
+          .negate()
+          .toString(),
+      },
+    },
+    tablet: {
+      vars: {
+        [menuItemCapHeight]: vars.textSize.standard.tablet.capHeight,
+      },
+    },
+  }),
+  {
+    height: checkboxFieldSize,
+    width: checkboxFieldSize,
+    marginTop: crop,
+    marginBottom: crop,
+  },
+]);

--- a/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.tsx
@@ -4,7 +4,8 @@ import { Box } from '../Box/Box';
 import { IconTick } from '../icons/IconTick/IconTick';
 import type { MenuItemProps } from '../MenuItem/MenuItem';
 import { useMenuItem } from '../MenuItem/useMenuItem';
-import { iconSize } from '../../hooks/useIcon';
+
+import * as styles from './MenuItemCheckbox.css';
 
 export interface MenuItemCheckboxProps
   extends Pick<MenuItemProps, 'data' | 'badge' | 'id'> {
@@ -45,7 +46,7 @@ export const MenuItemCheckbox = ({
         background={{ lightMode: 'surface' }}
         marginRight="small"
         flexShrink={0}
-        className={iconSize()}
+        className={styles.checkboxSize}
       >
         <Box
           component="span"


### PR DESCRIPTION
Align the size of a `MenuItemCheckbox` with a `small` sized `Checkbox`.

Previously the size of the checkbox followed icon sizing, which saw the checkbox size follow the text size of theme — yielding unexpected sizing with different themes. Aligning to the `small` sized `Checkbox` size makes sizing more consistent across themes.