### PR TITLE
Textarea: Adjust highlightRange background height

### DIFF
--- a/.changeset/itchy-rabbits-study.md
+++ b/.changeset/itchy-rabbits-study.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Textarea
+---
+
+**Textarea:** Adjust `highlightRange` background to support different line heights
+
+Remove the vertical padding on the highlight element to prevent the background colour overlapping the wavy underline in themes with tighter line heights.

--- a/packages/braid-design-system/src/lib/components/Textarea/Highlight/Highlight.css.ts
+++ b/packages/braid-design-system/src/lib/components/Textarea/Highlight/Highlight.css.ts
@@ -3,21 +3,18 @@ import { atoms } from '../../../css/atoms/atoms';
 import { colorModeStyle } from '../../../css/colorModeStyle';
 import { vars } from '../../../themes/vars.css';
 
-const space = 2;
-const lineThickness = 2;
+const space = '2px';
 
 export const root = style([
   atoms({ borderRadius: 'small' }),
   {
-    padding: space,
-    margin: -space,
+    padding: `0 ${space}`,
+    margin: `0 -${space}`,
     textDecoration: 'underline',
     textDecorationStyle: 'wavy',
     textDecorationSkipInk: 'none',
-    textDecorationThickness: lineThickness,
+    textDecorationThickness: 2,
     textUnderlineOffset: 2,
-    paddingBottom: lineThickness / 2,
-    marginBottom: -(lineThickness / 2),
   },
 ]);
 


### PR DESCRIPTION
Remove the vertical padding on the highlight element to prevent the background colour overlapping the wavy underline in themes with tighter line heights.