### PR TITLE
Checkbox, RadioItem: Fix alignment with updated `Badge` layout

### DIFF
--- a/.changeset/wild-buttons-march.md
+++ b/.changeset/wild-buttons-march.md
@@ -1,0 +1,14 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Checkbox
+  - RadioItem
+  - Radio
+---
+
+**Checkbox, RadioItem:** Fix alignment with updated Badge layout
+
+Improve layout to work with updated Badge layout which is no longer driven by line height.

--- a/packages/braid-design-system/src/lib/components/private/InlineField/InlineField.css.ts
+++ b/packages/braid-design-system/src/lib/components/private/InlineField/InlineField.css.ts
@@ -1,8 +1,9 @@
-import { style, styleVariants } from '@vanilla-extract/css';
+import { createVar, style, styleVariants } from '@vanilla-extract/css';
 import { calc } from '@vanilla-extract/css-utils';
 import { vars } from '../../../themes/vars.css';
 import { hitArea } from '../touchable/hitArea';
 import { debugTouchable } from '../touchable/debugTouchable';
+import { responsiveStyle } from '../../../css/responsiveStyle';
 
 const sizes = {
   standard: 'standard',
@@ -19,52 +20,47 @@ export const root = style({
   },
 });
 
+const fieldSize = createVar();
+const labelCapHeight = createVar();
+export const sizeVars = styleVariants(sizes, (size) =>
+  responsiveStyle({
+    mobile: {
+      vars: {
+        [fieldSize]: vars.inlineFieldSize[size],
+        [labelCapHeight]: vars.textSize[size].mobile.capHeight,
+      },
+    },
+    tablet: {
+      vars: {
+        [labelCapHeight]: vars.textSize[size].tablet.capHeight,
+      },
+    },
+  }),
+);
+
+const hitAreaOffset = calc(hitArea)
+  .subtract(fieldSize)
+  .divide(2)
+  .negate()
+  .toString();
 export const realField = style([
   {
     width: hitArea,
     height: hitArea,
+    top: hitAreaOffset,
+    left: hitAreaOffset,
   },
   debugTouchable(),
 ]);
 
-export const realFieldPosition = styleVariants(sizes, (size: Size) => {
-  const offset = calc(hitArea)
-    .subtract(vars.inlineFieldSize[size])
-    .divide(2)
-    .negate()
-    .toString();
-
-  return {
-    top: offset,
-    left: offset,
-  };
+export const fakeField = style({
+  height: fieldSize,
+  width: fieldSize,
 });
 
-export const fakeField = style({});
-export const fakeFieldSize = styleVariants(sizes, (size) => ({
-  height: vars.inlineFieldSize[size],
-  width: vars.inlineFieldSize[size],
-}));
-
-export const badgeOffset = styleVariants(sizes, (size: Size) => {
-  const offset = calc(vars.inlineFieldSize[size])
-    .subtract(vars.textSize.xsmall.mobile.lineHeight)
-    .divide(2)
-    .toString();
-
-  return {
-    paddingTop: offset,
-    paddingBottom: offset,
-  };
+export const labelOffset = style({
+  paddingTop: calc(fieldSize).subtract(labelCapHeight).divide(2).toString(),
 });
-
-export const labelOffset = styleVariants(sizes, (size: Size) => ({
-  paddingTop: calc(vars.inlineFieldSize[size])
-    .subtract(vars.textSize[size].mobile.capHeight)
-    .divide(2)
-    .toString(),
-}));
-
 export const isMixed = style({});
 
 export const children = style({

--- a/packages/braid-design-system/src/lib/components/private/InlineField/InlineField.tsx
+++ b/packages/braid-design-system/src/lib/components/private/InlineField/InlineField.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode, ReactElement } from 'react';
-import React, { forwardRef } from 'react';
+import React, { cloneElement, forwardRef } from 'react';
 import { Box } from '../../Box/Box';
 import type { FieldLabelProps } from '../../FieldLabel/FieldLabel';
 import type { FieldMessageProps } from '../../FieldMessage/FieldMessage';
@@ -67,6 +67,17 @@ export const InlineField = forwardRef<
     const descriptionId = `${id}-description`;
     const hasMessage = message || reserveMessageSpace;
 
+    if (process.env.NODE_ENV !== 'production') {
+      if (badge && badge.props.bleedY !== undefined) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          `Badge elements cannot set the \`bleedY\` prop when passed to a ${type
+            .charAt(0)
+            .toUpperCase()}${type.slice(1)} component`,
+        );
+      }
+    }
+
     return (
       <Box position="relative" zIndex={0} className={styles.root}>
         <Box display="flex">
@@ -93,27 +104,27 @@ export const InlineField = forwardRef<
           />
 
           <Box paddingLeft="small" flexGrow={1}>
-            <Inline space="small">
-              <Box
-                component="label"
-                htmlFor={id}
-                userSelect="none"
-                display="block"
-                cursor={!disabled ? 'pointer' : undefined}
-                className={[styles.labelOffset[size], virtualTouchable()]}
-              >
-                <Text
-                  weight={checked && !inList ? 'strong' : undefined}
-                  tone={disabled ? 'secondary' : undefined}
-                  size={size}
+            <Box className={[styles.sizeVars[size], styles.labelOffset]}>
+              <Inline space="small" alignY="center">
+                <Box
+                  component="label"
+                  htmlFor={id}
+                  userSelect="none"
+                  display="block"
+                  cursor={!disabled ? 'pointer' : undefined}
+                  className={virtualTouchable()}
                 >
-                  {label}
-                </Text>
-              </Box>
-              {badge ? (
-                <Box className={styles.badgeOffset[size]}>{badge}</Box>
-              ) : null}
-            </Inline>
+                  <Text
+                    weight={checked && !inList ? 'strong' : undefined}
+                    tone={disabled ? 'secondary' : undefined}
+                    size={size}
+                  >
+                    {label}
+                  </Text>
+                </Box>
+                {badge ? cloneElement(badge, { bleedY: true }) : null}
+              </Inline>
+            </Box>
 
             {description ? (
               <Box paddingTop="small">

--- a/packages/braid-design-system/src/lib/components/private/InlineField/StyledInput.tsx
+++ b/packages/braid-design-system/src/lib/components/private/InlineField/StyledInput.tsx
@@ -184,7 +184,7 @@ export const StyledInput = forwardRef<
           zIndex={1}
           className={[
             styles.realField,
-            styles.realFieldPosition[size],
+            styles.sizeVars[size],
             isMixed ? styles.isMixed : undefined,
           ]}
           cursor={!disabled ? 'pointer' : undefined}
@@ -202,7 +202,7 @@ export const StyledInput = forwardRef<
         <Box
           flexShrink={0}
           position="relative"
-          className={[styles.fakeField, styles.fakeFieldSize[size]]}
+          className={[styles.fakeField, styles.sizeVars[size]]}
           background={fieldBackground}
           borderRadius={fieldBorderRadius}
         >


### PR DESCRIPTION
Improve layout to work with updated `Badge` layout which is no longer driven by line height.