### PR TITLE
RadioItem, Checkbox: Fix stacking context behaviour

### DIFF
--- a/.changeset/big-bats-decide.md
+++ b/.changeset/big-bats-decide.md
@@ -1,0 +1,20 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Checkbox
+  - RadioItem
+  - Radio
+---
+
+**RadioItem, Checkbox:** Fix stacking context behaviour
+
+A `RadioItem` and `Checkbox` previously created a new stacking context with an elevated `z-index` applied on hover, resulting in their labels overlaying other elements in an unpredictable ways — most noticable when [toggling nested content].
+
+For example, toggling nested content containing an `Autosuggest`, would see the list of suggestions list would be overlayed by the next `RadioItem` on hover.
+
+To fix this, the `z-index` is no longer elevated on hover, and additionally the nested content container applies an elevated index when the field is **checked**.
+
+[toggling nested content]: https://seek-oss.github.io/braid-design-system/components/RadioGroup#toggling-nested-content

--- a/packages/braid-design-system/src/lib/components/private/InlineField/InlineField.css.ts
+++ b/packages/braid-design-system/src/lib/components/private/InlineField/InlineField.css.ts
@@ -12,14 +12,6 @@ const sizes = {
 
 export type Size = keyof typeof sizes;
 
-// Reset the z-index at the parent level to scope
-// overrides internally.
-export const root = style({
-  ':hover': {
-    zIndex: 1,
-  },
-});
-
 const fieldSize = createVar();
 const labelCapHeight = createVar();
 export const sizeVars = styleVariants(sizes, (size) =>
@@ -68,6 +60,7 @@ export const children = style({
     [`${realField}:checked ~ * &,
       ${realField}${isMixed} ~ * &`]: {
       display: 'block',
+      zIndex: 1,
     },
   },
 });

--- a/packages/braid-design-system/src/lib/components/private/InlineField/InlineField.tsx
+++ b/packages/braid-design-system/src/lib/components/private/InlineField/InlineField.tsx
@@ -79,7 +79,7 @@ export const InlineField = forwardRef<
     }
 
     return (
-      <Box position="relative" zIndex={0} className={styles.root}>
+      <Box position="relative">
         <Box display="flex">
           <StyledInput
             {...restProps}
@@ -136,6 +136,7 @@ export const InlineField = forwardRef<
 
             {children ? (
               <Box
+                position="relative"
                 display="none"
                 paddingTop="small"
                 className={styles.children}


### PR DESCRIPTION
A `RadioItem` and `Checkbox` previously created a new stacking context with an elevated `z-index` applied on hover, resulting in their labels overlaying other elements in an unpredictable ways — most noticable when [toggling nested content].

For example, toggling nested content containing an `Autosuggest`, would see the list of suggestions list would be overlayed by the next `RadioItem` on hover.

To fix this, the `z-index` is no longer elevated on hover, and additionally the nested content container applies an elevated index when the field is **checked**.

[toggling nested content]: https://seek-oss.github.io/braid-design-system/components/RadioGroup#toggling-nested-content

https://user-images.githubusercontent.com/912060/232358248-4f29e1f9-5440-4493-ba4f-e12f5b69b944.mov

### Playroom Comparison

[Before](https://seek-oss.github.io/braid-design-system/playroom/#?code=N4Igxg9gJgpiBcIA8BhAhgJygPgDoDsACQpAJTSgEsIBxDCAVwAdCAbNAIxlYF5cQAMp279CANzSsGMPiACM-PEWIlyVCAEkALjAC2bYb34AVAO5oAzlFESpM-gGZRAeiUrVFatr0GuRkGYQNpLSsgBMLm4qZJ6aOvrsfrIA8vgwwXayCiBR7kgAggxaEBYMAOZlMBZaBO7ulFCyAGYYDJQ1ILV1xIncsgBire38Xd2lFVVa1PgWPMAA2qPdhMBLy4Q6AB5a8IT8%2BUxMrFX8ADRrdQC%2B58rrq7frGzDbu-wAQmj4n5ZnF%2B7XfxU90eKi2Oz2IHQGHoWgsvwe3QBCJUAF1LhdXEskM41F54lFsbjaPRmASUAALGBgADWHAgm18fRMk1EYEpNJgUEImOUSDeRWK%2BGwligEAAVtj%2BVpBQSiXRGCxev4hH5FFiid4EoYUmkMqF%2BNlctENPhWJQ0oQLEw0GB7CB8BBdTlAUgALIwfAMUge2AYGAYQHECBNJoWGBaADK1ttsgsukkrBGyPcWgwlAmGDmAApU%2BnKhgAAr0JgWU4rQgQJgewiXACUhB42EIWcD0Te9MIDDDGAj3CpWlkDqdhDADAwFggmf4TAg5p0AZAKwAdCvcxmi5WLJcjSCkMZnlodyDCO7PatF-x0cnHkgNJB8BSYGJ6PhW%2BsqH6wFNHXNK9WAPwQswoivCAoqmK%2BIBXseyySOm%2BAAJqyKwECmP6YCWOknTXusPIwcQ2L7tsR7dJK9IkSotbQcsFEEaeDCahWD5mjS2b1o2KyXNuUqCti9GarRJD8fEAjmtShDkn6TSyAAxIoon4NSfEegxIliRRymet6%2BC%2Bv6R7YiaZppPp7YMjOFjtNMsicBOUg6KIHA2tSZQkjpsgcBgnxQPkYC2vgHSENaUBUPgZTIZglSKGRmxGoSsQCeq8XxIy-hmCKep2k4i54dEGrJUqsiBBl4SRF0cXqPKpIENiUI4AQICnCAWiUroVQIPMIBoNGIAoo1pgNM1FjtQA7AAbAAHGiQA) / [After](https://braid-design-system--8284e617f7b880c773f26a022d102d966c4f101c.surge.sh/playroom/#?code=N4Igxg9gJgpiBcIA8BhAhgJygPgDoDsACQpAJTSgEsIBxDCAVwAdCAbNAIxlYF5cQAMp279CANzSsGMPiACM-PEWIlyVCAEkALjAC2bYb34AVAO5oAzlFESpM-gGZRAeiUrVFatr0GuRkGYQNpLSsgBMLm4qZJ6aOvrsfrIA8vgwwXayCiBR7kgAggxaEBYMAOZlMBZaBO7ulFCyAGYYDJQ1ILV1xIncsgBire38Xd2lFVVa1PgWPMAA2qPdhMBLy4Q6AB5a8IT8%2BUxMrFX8ADRrdQC%2B58rrq7frGzDbu-wAQmj4n5ZnF%2B7XfxU90eKi2Oz2IHQGHoWgsvwe3QBCJUAF1LhdXEskM41F54lFsbjaPRmASUAALGBgADWHAgm18fRMk1EYEpNJgUEImOUSDeRWK%2BGwligEAAVtj%2BVpBQSiXRGCxev4hH5FFiid4EoYUmkMqF%2BNlctENPhWJQ0oQLEw0GB7CB8BBdTlAUgALIwfAMUge2AYGAYQHECBNJoWGBaADK1ttsgsukkrBGyPcWgwlAmGDmAApU%2BnKhgAAr0JgWU4rQgQJgewiXACUhB42EIWcD0Te9MIDDDGAj3CpWlkDqdhDADAwFggmf4TAg5p0AZAKwAdCvcxmi5WLJcjSCkMZnlodyDCO7PatF-x0cnHkgNJB8BSYGJ6PhW%2BsqH6wFNHXNK9WAPwQswoivCAoqmK%2BIBXseyySOm%2BAAJqyKwECmP6YCWOknTXusPIwcQ2L7tsR7dJK9IkSotbQcsFEEaeDCahWD5mjS2b1o2KyXNuUqCti9GarRJD8fEAjmtShDkn6TSyAAxIoon4NSfEegxIliRRymet6%2BC%2Bv6R7YiaZppPp7YMjOFjtNMsicBOUg6KIHA2tSZQkjpsgcBgnxQPkYC2vgHSENaUBUPgZTIZglSKGRmxGoSsQCeq8XxIy-hmCKep2k4i54dEGrJUqsiBBl4SRF0cXqPKpIENiUI4AQICnCAWiUroVQIPMIBoNGIAoo1pgNM1FjtQA7AAbAAHGiQA)