### PR TITLE
Card, Column: Add support for full height

### DIFF
--- a/.changeset/healthy-mugs-sip.md
+++ b/.changeset/healthy-mugs-sip.md
@@ -1,0 +1,20 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Card
+---
+
+**Card:** Add full height support
+
+Provide support for making a `Card` use all available vertical space.
+This is useful when laying out rows of `Card` elements and having them all be equal height.
+
+**EXAMPLE USAGE:**
+```jsx
+<Card height="full">
+  ...
+</Card>
+```

--- a/.changeset/warm-terms-film.md
+++ b/.changeset/warm-terms-film.md
@@ -1,0 +1,15 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Columns
+  - Column
+---
+
+**Column:** Support full height content
+
+Provides support for full height content by growing the all `Column` elements to be uniform in height.
+
+This will have no effect on the content itself, but enables consumers to create designs of uniform content, such as rows of `Card` elements.

--- a/.changeset/warm-terms-film.md
+++ b/.changeset/warm-terms-film.md
@@ -10,6 +10,6 @@ updated:
 
 **Column:** Support full height content
 
-Provides support for full height content by growing the all `Column` elements to be uniform in height.
+Provide support for full height content by growing all `Column` elements to be uniform in height.
 
 This will have no effect on the content itself, but enables consumers to create designs of uniform content, such as rows of `Card` elements.

--- a/packages/braid-design-system/src/lib/components/Card/Card.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Card/Card.docs.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import type { ComponentDocs } from 'site/types';
-import { Box, Stack, Card, Text, Tiles, Strong } from '../';
+import { Box, Stack, Card, Text, Tiles, Strong, Columns, Column } from '../';
 import { Placeholder } from '../../playroom/components';
 import source from '../../utils/source.macro';
 import { validCardComponents } from './Card';
@@ -21,6 +21,42 @@ const docs: ComponentDocs = {
     },
   ],
   additional: [
+    {
+      label: 'Controlling the height',
+      description: (
+        <>
+          <Text>
+            By default, <Strong>height</Strong> will be set to{' '}
+            <Strong>content</Strong> — growing to accomodate what is inside it.
+          </Text>
+          <Text>
+            Alternatively, choose a height of <Strong>full</Strong> to use all
+            available vertical space. This is useful when composing rows of Card
+            components that should all be equal height.
+          </Text>
+        </>
+      ),
+      Example: () =>
+        source(
+          <Columns space={{ mobile: 'xsmall', tablet: 'gutter' }}>
+            <Column>
+              <Card height="full">
+                <Placeholder height={60} />
+              </Card>
+            </Column>
+            <Column>
+              <Card height="full">
+                <Placeholder height={200} />
+              </Card>
+            </Column>
+            <Column>
+              <Card height="full">
+                <Placeholder height={100} />
+              </Card>
+            </Column>
+          </Columns>,
+        ),
+    },
     {
       label: 'Tones',
       description: (

--- a/packages/braid-design-system/src/lib/components/Card/Card.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Card/Card.screenshots.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { Card } from '../';
+import { Box, Card } from '../';
 import { Placeholder } from '../../playroom/components';
 
 export const screenshots: ComponentScreenshot = {
@@ -76,6 +76,26 @@ export const screenshots: ComponentScreenshot = {
         <Card tone="formAccent" rounded>
           <Placeholder height={100} />
         </Card>
+      ),
+    },
+    {
+      label: 'Height full',
+      Example: () => (
+        <Box style={{ height: 300 }}>
+          <Card height="full">
+            <Placeholder height={60} />
+          </Card>
+        </Box>
+      ),
+    },
+    {
+      label: 'Height content (default)',
+      Example: () => (
+        <Box style={{ height: 300 }}>
+          <Card height="content">
+            <Placeholder height={60} />
+          </Card>
+        </Box>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/Card/Card.tsx
+++ b/packages/braid-design-system/src/lib/components/Card/Card.tsx
@@ -35,6 +35,7 @@ export type CardProps = {
   children: ReactNode;
   tone?: 'promote' | 'formAccent';
   component?: (typeof validCardComponents)[number];
+  height?: Extract<BoxProps['height'], 'full'> | 'content';
   data?: DataAttributeMap;
 } & (SimpleCardRounding | ResponsiveCardRounding);
 
@@ -43,6 +44,7 @@ export const Card = ({
   component = 'div',
   tone,
   data,
+  height,
   ...restProps
 }: CardProps) => {
   assert(
@@ -75,6 +77,7 @@ export const Card = ({
       background="surface"
       padding="gutter"
       borderRadius={resolvedRounding}
+      height={height === 'full' ? height : undefined}
       {...buildDataAttributes({ data, validateRestProps: restProps })}
     >
       {tone ? <Keyline tone={tone} borderRadius={resolvedRounding} /> : null}

--- a/packages/braid-design-system/src/lib/components/Column/Column.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Column/Column.screenshots.tsx
@@ -122,5 +122,49 @@ export const screenshots: ComponentScreenshot = {
         </Fragment>
       ),
     },
+    {
+      label:
+        'Full height column, where column with shorter content has specified width',
+      Example: () => (
+        <Stack space="medium">
+          {widths.map((width) => (
+            <Columns space="small" key={width}>
+              <Column width={width}>
+                <Box height="full" background="brandAccent">
+                  <Placeholder height={40} label={width} />
+                </Box>
+              </Column>
+              <Column>
+                <Box height="full">
+                  <Placeholder height={100} label="Fluid" />
+                </Box>
+              </Column>
+            </Columns>
+          ))}
+        </Stack>
+      ),
+    },
+    {
+      label:
+        'Full height column, where column with shorter content has specified width',
+      Example: () => (
+        <Stack space="medium">
+          {widths.map((width) => (
+            <Columns space="small" key={width}>
+              <Column width={width}>
+                <Box height="full">
+                  <Placeholder height={100} label={width} />
+                </Box>
+              </Column>
+              <Column>
+                <Box height="full" background="brandAccent">
+                  <Placeholder height={40} label="Fluid" />
+                </Box>
+              </Column>
+            </Columns>
+          ))}
+        </Stack>
+      ),
+    },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/Column/Column.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Column/Column.screenshots.tsx
@@ -146,7 +146,7 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label:
-        'Full height column, where column with shorter content has specified width',
+        'Full height column, where column with taller content has specified width',
       Example: () => (
         <Stack space="medium">
           {widths.map((width) => (

--- a/packages/braid-design-system/src/lib/components/Column/Column.tsx
+++ b/packages/braid-design-system/src/lib/components/Column/Column.tsx
@@ -38,6 +38,7 @@ export const Column = ({
       minWidth={0}
       width={width !== 'content' ? 'full' : undefined}
       flexShrink={width === 'content' ? 0 : undefined}
+      flexGrow={1}
       className={[
         styles.column,
         width !== 'content' ? styles.width[width!] : null,

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -2653,6 +2653,9 @@ exports[`Card 1`] = `
         | "main"
         | "section"
     data?: DataAttributeMap
+    height?: 
+        | "content"
+        | "full"
     rounded?: boolean
     roundedAbove?: 
         | "desktop"


### PR DESCRIPTION
### `Card`
Provide support for making a `Card` use all available vertical space. This is useful when laying out rows of `Card` elements and having them all be equal height.

**EXAMPLE USAGE:**
```jsx
<Card height="full">
  ...
</Card>
```

---
 
### `Column`
Provides support for full height content by growing the all `Column` elements to be uniform in height.

This will have no effect on the content itself, but enables consumers to create designs of uniform content, such as rows of `Card` elements.