### PR TITLE
Text, Heading: Only show truncate deprecation message when true

### DIFF
--- a/.changeset/curly-poets-obey.md
+++ b/.changeset/curly-poets-obey.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Text
+  - Heading
+---
+
+**Text, Heading:** Only show truncate deprecation message when true
+
+Only show the truncate deprecation message when `truncate` is provided and set to `true`

--- a/packages/braid-design-system/src/lib/components/private/Typography/Typography.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Typography/Typography.tsx
@@ -43,7 +43,7 @@ export const Typography = ({
     );
 
   if (process.env.NODE_ENV !== 'production') {
-    if (typeof truncate !== 'undefined' && truncate) {
+    if (truncate) {
       // eslint-disable-next-line no-console
       console.warn(
         dedent`

--- a/packages/braid-design-system/src/lib/components/private/Typography/Typography.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Typography/Typography.tsx
@@ -43,7 +43,7 @@ export const Typography = ({
     );
 
   if (process.env.NODE_ENV !== 'production') {
-    if (typeof truncate !== 'undefined') {
+    if (typeof truncate !== 'undefined' && truncate) {
       // eslint-disable-next-line no-console
       console.warn(
         dedent`


### PR DESCRIPTION
Only show the truncate deprecation message when `truncate` is provided and set to `true`

Given we default it to `false` in the Typography component, we are currently showing the message a few too many times 🤦‍♂️ 