### PR TITLE
TextLink, TextLinkButton: Improve underline position for wrapping text

### DIFF
--- a/.changeset/sour-goats-glow.md
+++ b/.changeset/sour-goats-glow.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - TextLink
+  - TextLinkButton
+---
+
+**TextLink, TextLinkButton:** Improve underline position for wrapping text
+
+Refine the underline position to be consistent across the whole typographic hierarchy, ensuring it does not interfere with wrapping lines of text.

--- a/packages/braid-design-system/src/lib/components/TextLink/TextLink.css.ts
+++ b/packages/braid-design-system/src/lib/components/TextLink/TextLink.css.ts
@@ -39,7 +39,7 @@ export const base = style({
   color: textLinkVars.color,
   textDecoration: textLinkVars.textDecoration,
   textDecorationThickness: '0.1em',
-  textUnderlineOffset: '0.32em',
+  textUnderlineOffset: 3,
   ':hover': {
     color: textLinkVars.colorHover,
     textDecoration: textLinkVars.textDecorationHover,

--- a/packages/braid-design-system/src/lib/components/TextLink/TextLink.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/TextLink/TextLink.screenshots.tsx
@@ -335,5 +335,63 @@ export const screenshots: ComponentScreenshot = {
         </Fragment>
       ),
     },
+    {
+      label: 'Underline position wrap test',
+      Example: () => (
+        <Box style={{ maxWidth: 200 }}>
+          <Stack space="large">
+            <Text size="xsmall">
+              xsmall{' '}
+              <TextLink href="#" weight="weak">
+                Abcing wrap wrap wrap wrap wrap Wrap
+              </TextLink>
+            </Text>
+            <Text size="small">
+              small{' '}
+              <TextLink href="#" weight="weak">
+                Abcing wrap wrap wrap wrap wrap Wrap
+              </TextLink>
+            </Text>
+            <Text size="standard">
+              standard{' '}
+              <TextLink href="#" weight="weak">
+                Abcing wrap wrap wrap wr Wrap
+              </TextLink>
+            </Text>
+            <Text size="large">
+              large{' '}
+              <TextLink href="#" weight="weak">
+                Abcing wrap wrap wrap wr Wrap
+              </TextLink>
+            </Text>
+
+            <Heading level="4">
+              Heading4{' '}
+              <TextLink href="#" weight="weak">
+                Abcing wrap wrap Wrap Wrap
+              </TextLink>
+            </Heading>
+            <Heading level="3">
+              Heading3{' '}
+              <TextLink href="#" weight="weak">
+                Abcing wrap wrap Wrap
+              </TextLink>
+            </Heading>
+            <Heading level="2">
+              H2{' '}
+              <TextLink href="#" weight="weak">
+                Abcing wrap wrap Wrap
+              </TextLink>
+            </Heading>
+            <Heading level="1">
+              H1{' '}
+              <TextLink href="#" weight="weak">
+                Abing wrap Wrap Wrap
+              </TextLink>
+            </Heading>
+          </Stack>
+        </Box>
+      ),
+    },
   ],
 };


### PR DESCRIPTION
Refine the underline position to be consistent across the whole typographic hierarchy, ensuring it does not interfere with wrapping lines of text.

Previews across `apac` and the upcoming `seekjobs` theme:

Before:
![Preview before](https://user-images.githubusercontent.com/912060/233508438-3969b940-cc69-4991-a0ea-a13da4ba30f3.png)

After:
![Preview after](https://user-images.githubusercontent.com/912060/233508426-70cb2354-b3d7-4463-8488-95566cdf33dc.png)