### PR TITLE
Hide field borders in dark containers

### DIFF
--- a/.changeset/eight-clouds-hammer.md
+++ b/.changeset/eight-clouds-hammer.md
@@ -1,0 +1,23 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Autosuggest
+  - Checkbox
+  - CheckboxStandalone
+  - Dropdown
+  - MonthPicker
+  - PasswordField
+  - Radio
+  - RadioItem
+  - Textarea
+  - TextField
+  - Toggle
+---
+
+Hide field borders in dark containers
+
+Reduce visual noise when a form field is displayed in a dark container by hiding the default border.
+As fields are light on light backgrounds, the border is used to delineate its bounds against the container, which is not relevant in a dark container.

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.screenshots.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import React, { useState } from 'react';
 import type { ComponentScreenshot } from 'site/types';
 import { Autosuggest, filterSuggestions, IconSearch, Stack } from '../';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -232,6 +233,23 @@ export const screenshots: ComponentScreenshot = {
           />
         );
       },
+    },
+    {
+      label: 'Contrast',
+      Container,
+      Example: ({ id, handler }) => (
+        <BackgroundContrastTest>
+          <Autosuggest
+            label="I like to eat"
+            id={id}
+            value={{ text: '' }}
+            onChange={handler}
+            suggestions={filterSuggestions(
+              makeSuggestions(['Apples', 'Bananas', 'Broccoli', 'Carrots']),
+            )}
+          />
+        </BackgroundContrastTest>
+      ),
     },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/Button/Button.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.screenshots.tsx
@@ -1,6 +1,7 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
 import {
+  Box,
   Button,
   IconSend,
   Stack,
@@ -10,12 +11,9 @@ import {
   IconArrow,
   IconWorkExperience,
 } from '../';
-// TODO: COLORMODE RELEASE
-// Use public import
-import { Box } from '../Box/Box';
-import { backgrounds } from '../../utils/docsHelpers';
 
 import type { ButtonProps } from './Button';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [768],
@@ -301,87 +299,71 @@ export const screenshots: ComponentScreenshot = {
     {
       label: 'Contrast',
       Example: () => (
-        <Fragment>
-          {backgrounds.map((background) => (
-            <Box key={background} background={background} padding="small">
-              <Inline space="small">
-                <Button>Solid</Button>
-                <Button variant="ghost">Ghost</Button>
-                <Button variant="soft">Soft</Button>
-                <Button variant="transparent">Transparent</Button>
-              </Inline>
-            </Box>
-          ))}
-        </Fragment>
+        <BackgroundContrastTest>
+          <Inline space="small">
+            <Button>Solid</Button>
+            <Button variant="ghost">Ghost</Button>
+            <Button variant="soft">Soft</Button>
+            <Button variant="transparent">Transparent</Button>
+          </Inline>
+        </BackgroundContrastTest>
       ),
     },
     {
       label: 'Contrast - critical',
       Example: () => (
-        <Fragment>
-          {backgrounds.map((background) => (
-            <Box key={background} background={background} padding="small">
-              <Inline space="small">
-                <Button tone="critical">Solid</Button>
-                <Button tone="critical" variant="ghost">
-                  Ghost
-                </Button>
-                <Button tone="critical" variant="soft">
-                  Soft
-                </Button>
-                <Button tone="critical" variant="transparent">
-                  Transparent
-                </Button>
-              </Inline>
-            </Box>
-          ))}
-        </Fragment>
+        <BackgroundContrastTest>
+          <Inline space="small">
+            <Button tone="critical">Solid</Button>
+            <Button tone="critical" variant="ghost">
+              Ghost
+            </Button>
+            <Button tone="critical" variant="soft">
+              Soft
+            </Button>
+            <Button tone="critical" variant="transparent">
+              Transparent
+            </Button>
+          </Inline>
+        </BackgroundContrastTest>
       ),
     },
     {
       label: 'Contrast - brandAccent',
       Example: () => (
-        <Fragment>
-          {backgrounds.map((background) => (
-            <Box key={background} background={background} padding="small">
-              <Inline space="small">
-                <Button tone="brandAccent">Solid</Button>
-                <Button tone="brandAccent" variant="ghost">
-                  Ghost
-                </Button>
-                <Button tone="brandAccent" variant="soft">
-                  Soft
-                </Button>
-                <Button tone="brandAccent" variant="transparent">
-                  Transparent
-                </Button>
-              </Inline>
-            </Box>
-          ))}
-        </Fragment>
+        <BackgroundContrastTest>
+          <Inline space="small">
+            <Button tone="brandAccent">Solid</Button>
+            <Button tone="brandAccent" variant="ghost">
+              Ghost
+            </Button>
+            <Button tone="brandAccent" variant="soft">
+              Soft
+            </Button>
+            <Button tone="brandAccent" variant="transparent">
+              Transparent
+            </Button>
+          </Inline>
+        </BackgroundContrastTest>
       ),
     },
     {
       label: 'Contrast - neutral',
       Example: () => (
-        <Fragment>
-          {backgrounds.map((background) => (
-            <Box key={background} background={background} padding="small">
-              <Inline space="small">
-                <Button tone="neutral">Solid</Button>
-                <Button tone="neutral" variant="ghost">
-                  Ghost
-                </Button>
-                <Button tone="neutral" variant="soft">
-                  Soft
-                </Button>
-                <Button tone="neutral" variant="transparent">
-                  Transparent
-                </Button>
-              </Inline>
-            </Box>
-          ))}
-        </Fragment>
+        <BackgroundContrastTest>
+          <Inline space="small">
+            <Button tone="neutral">Solid</Button>
+            <Button tone="neutral" variant="ghost">
+              Ghost
+            </Button>
+            <Button tone="neutral" variant="soft">
+              Soft
+            </Button>
+            <Button tone="neutral" variant="transparent">
+              Transparent
+            </Button>
+          </Inline>
+        </BackgroundContrastTest>
       ),
     },
     {

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.screenshots.tsx
@@ -1,10 +1,7 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { ButtonIcon, Inline, Heading, IconBookmark } from '../';
-// TODO: COLORMODE RELEASE
-// Use public import
-import { Box } from '../Box/Box';
-import { backgrounds } from '../../utils/docsHelpers';
+import { Box, ButtonIcon, Inline, Heading, IconBookmark } from '../';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],
@@ -183,22 +180,18 @@ export const screenshots: ComponentScreenshot = {
     {
       label: 'Contrast',
       Example: () => (
-        <Fragment>
-          {backgrounds.map((background) => (
-            <Box key={background} background={background} padding="small">
-              <Inline space="medium">
-                <ButtonIcon icon={<IconBookmark />} label="Bookmark" id="1" />
-                <ButtonIcon
-                  variant="transparent"
-                  bleed={false}
-                  icon={<IconBookmark />}
-                  label="Bookmark"
-                  id="1"
-                />
-              </Inline>
-            </Box>
-          ))}
-        </Fragment>
+        <BackgroundContrastTest>
+          <Inline space="medium">
+            <ButtonIcon icon={<IconBookmark />} label="Bookmark" id="1" />
+            <ButtonIcon
+              variant="transparent"
+              bleed={false}
+              icon={<IconBookmark />}
+              label="Bookmark"
+              id="1"
+            />
+          </Inline>
+        </BackgroundContrastTest>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/Checkbox/Checkbox.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Checkbox/Checkbox.screenshots.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { Badge, Checkbox, Stack, Text } from '../';
+import { Badge, Box, Checkbox, Stack, Text, Tiles } from '../';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],
@@ -183,6 +184,29 @@ export const screenshots: ComponentScreenshot = {
         >
           <Text>This text is visible when the button is checked.</Text>
         </Checkbox>
+      ),
+    },
+    {
+      label: 'Contrast',
+      Example: ({ id, handler }) => (
+        <Box maxWidth="xsmall">
+          <BackgroundContrastTest>
+            <Tiles space="small" columns={2}>
+              <Checkbox
+                id={id}
+                checked={false}
+                onChange={handler}
+                label="Label"
+              />
+              <Checkbox
+                id={id}
+                checked={true}
+                onChange={handler}
+                label="Label"
+              />
+            </Tiles>
+          </BackgroundContrastTest>
+        </Box>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/Checkbox/CheckboxStandalone.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Checkbox/CheckboxStandalone.screenshots.tsx
@@ -1,7 +1,16 @@
 import React, { useState } from 'react';
 import type { ComponentProps } from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { Box, CheckboxStandalone, Column, Columns, Stack, Text } from '../';
+import {
+  Box,
+  CheckboxStandalone,
+  Column,
+  Columns,
+  Stack,
+  Text,
+  Tiles,
+} from '../';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 type CheckboxProps = ComponentProps<typeof CheckboxStandalone>;
 const checkboxSizes: CheckboxProps['size'][] = ['small', 'standard'];
@@ -148,6 +157,29 @@ export const screenshots: ComponentScreenshot = {
               </Box>
             ))}
           </Stack>
+        </Box>
+      ),
+    },
+    {
+      label: 'Contrast',
+      Example: ({ id, handler }) => (
+        <Box maxWidth="xsmall">
+          <BackgroundContrastTest>
+            <Tiles space="small" columns={2}>
+              <CheckboxStandalone
+                id={id}
+                checked={false}
+                onChange={handler}
+                aria-label="Label"
+              />
+              <CheckboxStandalone
+                id={id}
+                checked={true}
+                onChange={handler}
+                aria-label="Label"
+              />
+            </Tiles>
+          </BackgroundContrastTest>
         </Box>
       ),
     },

--- a/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.screenshots.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
 import { Dropdown, IconLocation, Stack } from '../';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -157,23 +158,6 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Dropdown on Brand Background',
-      background: 'brand',
-      Container,
-      Example: ({ id, handler }) => (
-        <Dropdown
-          label="Job Title"
-          id={id}
-          onChange={handler}
-          value=""
-          placeholder="Please select a role title"
-        >
-          <option value="1">Developer</option>
-          <option value="2">Designer</option>
-        </Dropdown>
-      ),
-    },
-    {
       label: 'Dropdown with no visual label',
       Container,
       Example: ({ id, handler }) => (
@@ -187,6 +171,24 @@ export const screenshots: ComponentScreenshot = {
           <option value="1">Developer</option>
           <option value="2">Designer</option>
         </Dropdown>
+      ),
+    },
+    {
+      label: 'Contrast',
+      Container,
+      Example: ({ id, handler }) => (
+        <BackgroundContrastTest>
+          <Dropdown
+            label="Job Title"
+            id={id}
+            onChange={handler}
+            value=""
+            placeholder="Please select a role title"
+          >
+            <option value="1">Developer</option>
+            <option value="2">Designer</option>
+          </Dropdown>
+        </BackgroundContrastTest>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/Heading/Heading.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Heading/Heading.screenshots.tsx
@@ -1,12 +1,10 @@
 import type { ReactNode } from 'react';
-import React, { Fragment } from 'react';
+import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
 import { heading } from '../../css/typography.css';
-import { Heading, IconPositive, IconPromote, Stack, Text } from '../';
-// TODO: COLORMODE RELEASE
-// Use public import
-import { Box } from '../Box/Box';
-import { backgrounds, textAlignments } from '../../utils/docsHelpers';
+import { Box, Heading, IconPositive, IconPromote, Stack, Text } from '../';
+import { textAlignments } from '../../utils/docsHelpers';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -191,15 +189,13 @@ export const screenshots: ComponentScreenshot = {
       label: 'Contrast',
       Container,
       Example: () => (
-        <Fragment>
-          {backgrounds.map((background) => (
-            <Box key={background} background={background} paddingY="xsmall">
-              <Heading level="4">
-                {background} <IconPositive />
-              </Heading>
-            </Box>
-          ))}
-        </Fragment>
+        <BackgroundContrastTest>
+          {(background) => (
+            <Heading level="4">
+              {background} <IconPositive />
+            </Heading>
+          )}
+        </BackgroundContrastTest>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/Loader/Loader.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Loader/Loader.screenshots.tsx
@@ -1,10 +1,7 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
 import { Loader } from '../';
-// TODO: COLORMODE RELEASE
-// Use public import
-import { Box } from '../Box/Box';
-import { backgrounds } from '../../utils/docsHelpers';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],
@@ -36,13 +33,9 @@ export const screenshots: ComponentScreenshot = {
     {
       label: 'Loader Contrast',
       Example: () => (
-        <Fragment>
-          {backgrounds.map((background) => (
-            <Box key={background} background={background} padding="xsmall">
-              <Loader />
-            </Box>
-          ))}
-        </Fragment>
+        <BackgroundContrastTest>
+          <Loader />
+        </BackgroundContrastTest>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.screenshots.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
 import { MonthPicker, Stack } from '../';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -148,6 +149,20 @@ export const screenshots: ComponentScreenshot = {
             '12',
           ]}
         />
+      ),
+    },
+    {
+      label: 'Contrast',
+      Container,
+      Example: ({ id, handler }) => (
+        <BackgroundContrastTest>
+          <MonthPicker
+            id={id}
+            label="Started"
+            value={{ month: undefined, year: undefined }}
+            onChange={handler}
+          />
+        </BackgroundContrastTest>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.screenshots.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import React, { useState } from 'react';
 import type { ComponentScreenshot } from 'site/types';
 import { PasswordField, Stack, TextLink } from '../';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -210,20 +211,18 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'PasswordField on Brand Background',
-      background: 'brand',
+      label: 'Contrast',
       Container,
-      Example: ({ id }) => {
-        const [value, setValue] = useState('qwerty');
-        return (
+      Example: ({ id, handler }) => (
+        <BackgroundContrastTest>
           <PasswordField
-            label="Password"
+            label="Label"
             id={id}
-            onChange={(ev) => setValue(ev.currentTarget.value)}
-            value={value}
+            onChange={handler}
+            value="Text value"
           />
-        );
-      },
+        </BackgroundContrastTest>
+      ),
     },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/Radio/Radio.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Radio/Radio.screenshots.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { Badge, Radio, Text, Stack } from '../';
+import { Badge, Radio, Text, Stack, Tiles, Box } from '../';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],
@@ -132,6 +133,19 @@ export const screenshots: ComponentScreenshot = {
         >
           <Text>This text is visible when the radio button is checked.</Text>
         </Radio>
+      ),
+    },
+    {
+      label: 'Contrast',
+      Example: ({ id, handler }) => (
+        <Box maxWidth="small">
+          <BackgroundContrastTest>
+            <Tiles space="small" columns={2}>
+              <Radio id={id} checked={false} onChange={handler} label="Label" />
+              <Radio id={id} checked={true} onChange={handler} label="Label" />
+            </Tiles>
+          </BackgroundContrastTest>
+        </Box>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.screenshots.tsx
@@ -1,7 +1,8 @@
 import React, { useState } from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { RadioGroup, RadioItem } from '../';
+import { Box, RadioGroup, RadioItem } from '../';
 import { Placeholder } from '../../playroom/components';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],
@@ -223,6 +224,19 @@ export const screenshots: ComponentScreenshot = {
           <RadioItem label="Two" value="2" />
           <RadioItem label="Three" value="3" />
         </RadioGroup>
+      ),
+    },
+    {
+      label: 'Contrast',
+      Example: ({ id, handler }) => (
+        <Box maxWidth="xsmall">
+          <BackgroundContrastTest>
+            <RadioGroup id={id} value={1} onChange={handler} label="Experience">
+              <RadioItem label="Less than one year" value="0" />
+              <RadioItem label="1 year" value="1" />
+            </RadioGroup>
+          </BackgroundContrastTest>
+        </Box>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/Rating/Rating.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Rating/Rating.screenshots.tsx
@@ -1,10 +1,7 @@
-import React, { Fragment } from 'react';
-import type { ComponentScreenshot } from 'site/types';
+import React from 'react';
 import { Rating, Stack, Text } from '../';
-// TODO: COLORMODE RELEASE
-// Use public import
-import { Box } from '../Box/Box';
-import { backgrounds } from '../../utils/docsHelpers';
+import type { ComponentScreenshot } from 'site/types';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],
@@ -54,13 +51,9 @@ export const screenshots: ComponentScreenshot = {
     {
       label: 'Rating Contrast',
       Example: () => (
-        <Fragment>
-          {backgrounds.map((background) => (
-            <Box key={background} background={background} padding="xsmall">
-              <Rating rating={1.5} size="xsmall" />
-            </Box>
-          ))}
-        </Fragment>
+        <BackgroundContrastTest>
+          <Rating rating={1.5} size="xsmall" />
+        </BackgroundContrastTest>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/Text/Text.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Text/Text.screenshots.tsx
@@ -1,13 +1,19 @@
 import type { ReactNode } from 'react';
-import React, { Fragment } from 'react';
+import React from 'react';
 import { titleCase } from 'title-case';
 import type { ComponentScreenshot } from 'site/types';
-import { Text, Stack, Column, Columns, IconPositive, IconPromote } from '../';
-// TODO: COLORMODE RELEASE
-// Use public import
-import { Box } from '../Box/Box';
+import {
+  Box,
+  Text,
+  Stack,
+  Column,
+  Columns,
+  IconPositive,
+  IconPromote,
+} from '../';
 import { textSizeUntrimmed, fontWeight } from '../../css/typography.css';
-import { backgrounds, textAlignments } from '../../utils/docsHelpers';
+import { textAlignments } from '../../utils/docsHelpers';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -201,24 +207,22 @@ export const screenshots: ComponentScreenshot = {
       label: 'Contrast',
       Container,
       Example: () => (
-        <Fragment>
-          {backgrounds.map((background) => (
-            <Box key={background} background={background} padding="xsmall">
-              <Columns space="medium">
-                <Column>
-                  <Text size="small">
-                    {background} <IconPositive />
-                  </Text>
-                </Column>
-                <Column width="content">
-                  <Text size="small" tone="secondary">
-                    Secondary <IconPositive />
-                  </Text>
-                </Column>
-              </Columns>
-            </Box>
-          ))}
-        </Fragment>
+        <BackgroundContrastTest>
+          {(background) => (
+            <Columns space="medium">
+              <Column>
+                <Text size="small">
+                  {background} <IconPositive />
+                </Text>
+              </Column>
+              <Column width="content">
+                <Text size="small" tone="secondary">
+                  Secondary <IconPositive />
+                </Text>
+              </Column>
+            </Columns>
+          )}
+        </BackgroundContrastTest>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/TextField/TextField.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/TextField/TextField.screenshots.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import React, { useState } from 'react';
 import type { ComponentScreenshot } from 'site/types';
 import { IconSearch, IconPhone, TextField, TextLink, Stack } from '../';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -237,19 +238,6 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'TextField on Brand Background',
-      background: 'brand',
-      Container,
-      Example: ({ id, handler }) => (
-        <TextField
-          label="Label"
-          id={id}
-          onChange={handler}
-          value="Text value"
-        />
-      ),
-    },
-    {
       label: 'TextField with prefix',
       Container,
       Example: ({ id, handler }) => (
@@ -313,6 +301,20 @@ export const screenshots: ComponentScreenshot = {
           label="Label"
           characterLimit={9}
         />
+      ),
+    },
+    {
+      label: 'Contrast',
+      Container,
+      Example: ({ id, handler }) => (
+        <BackgroundContrastTest>
+          <TextField
+            label="Label"
+            id={id}
+            onChange={handler}
+            value="Text value"
+          />
+        </BackgroundContrastTest>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/TextLink/TextLink.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/TextLink/TextLink.screenshots.tsx
@@ -1,6 +1,7 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
 import {
+  Box,
   Heading,
   IconNewWindow,
   IconHome,
@@ -12,11 +13,8 @@ import {
   Strong,
   IconLink,
 } from '../';
-// TODO: COLORMODE RELEASE
-// Use public import
-import { Box } from '../Box/Box';
-import { backgrounds } from '../../utils/docsHelpers';
 import { heading, tone, textSizeTrimmed } from '../../css/typography.css';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 const textSizes = [
   undefined, // test default case
@@ -264,75 +262,71 @@ export const screenshots: ComponentScreenshot = {
     {
       label: 'Text Contrast',
       Example: () => (
-        <Fragment>
-          {backgrounds.map((background, i) => (
-            <Box key={i} background={background} padding="small">
-              <Columns space="xlarge">
-                <Column>
-                  <Text>{background}</Text>
-                </Column>
-                <Column width="content">
-                  <Text>
-                    <TextLink href="#">
-                      Default <IconNewWindow />
-                    </TextLink>
-                  </Text>
-                </Column>
-                <Column width="content">
-                  <Text>
-                    <TextLink href="#" weight="regular">
-                      Regular <IconNewWindow />
-                    </TextLink>
-                  </Text>
-                </Column>
-                <Column>
-                  <Text>
-                    <TextLink href="#" weight="weak">
-                      Weak <IconNewWindow />
-                    </TextLink>
-                  </Text>
-                </Column>
-              </Columns>
-            </Box>
-          ))}
-        </Fragment>
+        <BackgroundContrastTest>
+          {(background) => (
+            <Columns space="xlarge">
+              <Column>
+                <Text>{background}</Text>
+              </Column>
+              <Column width="content">
+                <Text>
+                  <TextLink href="#">
+                    Default <IconNewWindow />
+                  </TextLink>
+                </Text>
+              </Column>
+              <Column width="content">
+                <Text>
+                  <TextLink href="#" weight="regular">
+                    Regular <IconNewWindow />
+                  </TextLink>
+                </Text>
+              </Column>
+              <Column>
+                <Text>
+                  <TextLink href="#" weight="weak">
+                    Weak <IconNewWindow />
+                  </TextLink>
+                </Text>
+              </Column>
+            </Columns>
+          )}
+        </BackgroundContrastTest>
       ),
     },
     {
       label: 'Heading Contrast',
       Example: () => (
-        <Fragment>
-          {backgrounds.map((background, i) => (
-            <Box key={i} background={background} padding="small">
-              <Columns space="xlarge">
-                <Column>
-                  <Heading level="4">{background}</Heading>
-                </Column>
-                <Column width="content">
-                  <Heading level="4">
-                    <TextLink href="#">
-                      Default <IconNewWindow />
-                    </TextLink>
-                  </Heading>
-                </Column>
-                <Column width="content">
-                  <Heading level="4">
-                    <TextLink href="#" weight="regular">
-                      Regular <IconNewWindow />
-                    </TextLink>
-                  </Heading>
-                </Column>
-                <Column>
-                  <Heading level="4">
-                    <TextLink href="#" weight="weak">
-                      Weak <IconNewWindow />
-                    </TextLink>
-                  </Heading>
-                </Column>
-              </Columns>
-            </Box>
-          ))}
-        </Fragment>
+        <BackgroundContrastTest>
+          {(background) => (
+            <Columns space="xlarge">
+              <Column>
+                <Heading level="4">{background}</Heading>
+              </Column>
+              <Column width="content">
+                <Heading level="4">
+                  <TextLink href="#">
+                    Default <IconNewWindow />
+                  </TextLink>
+                </Heading>
+              </Column>
+              <Column width="content">
+                <Heading level="4">
+                  <TextLink href="#" weight="regular">
+                    Regular <IconNewWindow />
+                  </TextLink>
+                </Heading>
+              </Column>
+              <Column>
+                <Heading level="4">
+                  <TextLink href="#" weight="weak">
+                    Weak <IconNewWindow />
+                  </TextLink>
+                </Heading>
+              </Column>
+            </Columns>
+          )}
+        </BackgroundContrastTest>
       ),
     },
     {

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.screenshots.tsx
@@ -2,6 +2,7 @@ import type { ReactNode } from 'react';
 import React, { useState } from 'react';
 import type { ComponentScreenshot } from 'site/types';
 import { Stack, Textarea, TextLink } from '../';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -403,21 +404,18 @@ export const screenshots: ComponentScreenshot = {
       },
     },
     {
-      label: 'Textarea on Brand Background',
-      background: 'brand',
+      label: 'Contrast',
       Container,
-      Example: ({ id }) => {
-        const [value, setValue] = useState('');
-
-        return (
+      Example: ({ id, handler }) => (
+        <BackgroundContrastTest>
           <Textarea
             label="Label"
             id={id}
-            onChange={(e) => setValue(e.currentTarget.value)}
-            value={value}
+            onChange={handler}
+            value="Text value"
           />
-        );
-      },
+        </BackgroundContrastTest>
+      ),
     },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.css.ts
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.css.ts
@@ -147,6 +147,14 @@ export const icon = style({
   },
 });
 
+export const hideBorderOnDarkBackgroundInLightMode = style(
+  colorModeStyle({
+    lightMode: {
+      opacity: 0,
+    },
+  }),
+);
+
 export const focusOverlay = style({
   selectors: {
     [`${realField}:focus + ${slideContainer} &,

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.screenshots.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { Toggle, Box } from '../';
+import { Toggle, Box, Tiles } from '../';
+import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],
@@ -88,6 +89,19 @@ export const screenshots: ComponentScreenshot = {
           id={id}
           onChange={handler}
         />
+      ),
+    },
+    {
+      label: 'Contrast',
+      Example: ({ id, handler }) => (
+        <Box maxWidth="xsmall">
+          <BackgroundContrastTest>
+            <Tiles space="small" columns={2}>
+              <Toggle on={true} label="Label" id={id} onChange={handler} />
+              <Toggle on={false} label="Label" id={id} onChange={handler} />
+            </Tiles>
+          </BackgroundContrastTest>
+        </Box>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -107,7 +107,6 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
           <Box
             position="absolute"
             background="surface"
-            boxShadow={on ? 'borderFormAccent' : 'borderField'}
             transition="fast"
             display="flex"
             alignItems="center"
@@ -115,6 +114,15 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
             borderRadius="full"
             className={styles.slider[size]}
           >
+            <FieldOverlay
+              variant={on ? 'formAccent' : 'default'}
+              borderRadius="full"
+              visible
+              className={{
+                [styles.hideBorderOnDarkBackgroundInLightMode]:
+                  lightness.lightMode === 'dark',
+              }}
+            />
             <FieldOverlay className={styles.icon}>
               <IconTick tone="formAccent" size="fill" />
             </FieldOverlay>

--- a/packages/braid-design-system/src/lib/components/private/Field/Field.css.ts
+++ b/packages/braid-design-system/src/lib/components/private/Field/Field.css.ts
@@ -1,5 +1,6 @@
 import { style } from '@vanilla-extract/css';
 import { calc } from '@vanilla-extract/css-utils';
+import { colorModeStyle } from '../../../css/colorModeStyle';
 import { vars } from '../../../themes/vars.css';
 
 export const field = style({});
@@ -21,6 +22,14 @@ const textLeftOffset = '2px';
 export const iconSpace = style({
   paddingLeft: calc.subtract(vars.touchableSize, textLeftOffset),
 });
+
+export const hideBorderOnDarkBackgroundInLightMode = style(
+  colorModeStyle({
+    lightMode: {
+      opacity: 0,
+    },
+  }),
+);
 
 export const focusOverlay = style({
   selectors: {

--- a/packages/braid-design-system/src/lib/components/private/Field/Field.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Field/Field.tsx
@@ -17,6 +17,7 @@ import { touchableText } from '../../../css/typography.css';
 import { Text } from '../../Text/Text';
 import { mergeIds } from '../mergeIds';
 import * as styles from './Field.css';
+import { useBackgroundLightness } from '../../Box/BackgroundContext';
 
 type FormElementProps = AllHTMLAttributes<HTMLFormElement>;
 
@@ -129,11 +130,16 @@ export const Field = ({
   const showSecondaryIcon =
     alwaysShowSecondaryIcon || (secondaryIcon && hasValue);
 
+  const { lightMode } = useBackgroundLightness();
+
   const overlays = (
     <Fragment>
       <FieldOverlay
         variant={disabled ? 'disabled' : 'default'}
         visible={tone !== 'critical' || disabled}
+        className={{
+          [styles.hideBorderOnDarkBackgroundInLightMode]: lightMode === 'dark',
+        }}
       />
       <FieldOverlay
         variant="critical"

--- a/packages/braid-design-system/src/lib/components/private/InlineField/InlineField.css.ts
+++ b/packages/braid-design-system/src/lib/components/private/InlineField/InlineField.css.ts
@@ -4,6 +4,7 @@ import { vars } from '../../../themes/vars.css';
 import { hitArea } from '../touchable/hitArea';
 import { debugTouchable } from '../touchable/debugTouchable';
 import { responsiveStyle } from '../../../css/responsiveStyle';
+import { colorModeStyle } from '../../../css/colorModeStyle';
 
 const sizes = {
   standard: 'standard',
@@ -48,6 +49,13 @@ export const realField = style([
 export const fakeField = style({
   height: fieldSize,
   width: fieldSize,
+  selectors: {
+    // Overrides `surface` background of checked checkbox
+    // to make `formAccent` edge crisp on dark background
+    [`${realField}[type="checkbox"]:checked ~ &`]: {
+      background: 'transparent',
+    },
+  },
 });
 
 export const labelOffset = style({
@@ -73,6 +81,14 @@ export const selected = style({
     },
   },
 });
+
+export const hideBorderOnDarkBackgroundInLightMode = style(
+  colorModeStyle({
+    lightMode: {
+      opacity: 0,
+    },
+  }),
+);
 
 export const focusOverlay = style({
   selectors: {

--- a/packages/braid-design-system/src/lib/components/private/InlineField/StyledInput.tsx
+++ b/packages/braid-design-system/src/lib/components/private/InlineField/StyledInput.tsx
@@ -9,6 +9,7 @@ import type { BoxProps } from '../../Box/Box';
 import { Box } from '../../Box/Box';
 import * as styles from './InlineField.css';
 import type { Size } from './InlineField.css';
+import { useBackgroundLightness } from '../../Box/BackgroundContext';
 
 const tones = ['neutral', 'critical'] as const;
 export type InlineFieldTone = (typeof tones)[number];
@@ -155,6 +156,8 @@ export const StyledInput = forwardRef<
       }
     }, [ref, isMixed, isCheckbox]);
 
+    const { lightMode } = useBackgroundLightness();
+
     // Internal consumers of this private component must constrain
     // this in a position relative container. This is left as a
     // fragment to support sibling selectors to the input in
@@ -210,6 +213,10 @@ export const StyledInput = forwardRef<
             variant={disabled ? 'disabled' : defaultBorder}
             borderRadius={fieldBorderRadius}
             visible={tone !== 'critical' || disabled}
+            className={{
+              [styles.hideBorderOnDarkBackgroundInLightMode]:
+                lightMode === 'dark',
+            }}
           />
           <FieldOverlay
             variant="critical"

--- a/packages/braid-design-system/src/lib/utils/BackgroundContrastTest.tsx
+++ b/packages/braid-design-system/src/lib/utils/BackgroundContrastTest.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react';
+import React from 'react';
+// TODO: COLORMODE RELEASE
+// Use public import
+import { Box } from '../components/Box/Box';
+import { backgrounds } from './docsHelpers';
+
+export const BackgroundContrastTest = ({
+  children,
+}: {
+  children:
+    | ReactNode
+    | ((background: (typeof backgrounds)[number]) => ReactNode);
+}) => (
+  <>
+    {backgrounds.map((background) => (
+      <Box key={background} background={background} padding="small">
+        {typeof children === 'function' ? children(background) : children}
+      </Box>
+    ))}
+  </>
+);


### PR DESCRIPTION
Reduce visual noise when a form field is displayed in a dark container by hiding the default border.
As fields are light on light backgrounds, the border is used to delineate its bounds against the container, which is not relevant in a dark container.

### Previews

Before:
![Before](https://user-images.githubusercontent.com/912060/234432997-3fe0e712-5008-4b23-aef6-6c7b91e84bc2.png)

After:
![After](https://user-images.githubusercontent.com/912060/234432991-ba16b3ad-d1ab-46f9-b6e2-2a86b24d9e76.png)
