### PR TITLE
Button, TextLinkButton: Add `aria-label` support

### DIFF
--- a/.changeset/loud-nails-float.md
+++ b/.changeset/loud-nails-float.md
@@ -1,0 +1,18 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Button
+  - TextLinkButton
+---
+
+**Button, TextLinkButton:** Add `aria-label` support
+
+Provide support for `aria-label`, enabling additional context to be given to assistive technologies where context is typically visual.
+
+**EXAMPLE USAGE:**
+```jsx
+<Button aria-label="Save job">Save</Button>
+```

--- a/packages/braid-design-system/src/lib/components/Button/Button.test.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.test.tsx
@@ -4,6 +4,7 @@ import React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { BraidTestProvider } from '../../../entries/test';
 import { Button, IconSend } from '..';
+import { render } from '@testing-library/react';
 
 describe('Button', () => {
   it('should render valid html structure', () => {
@@ -17,5 +18,20 @@ describe('Button', () => {
     ).toHTMLValidate({
       extends: ['html-validate:recommended'],
     });
+  });
+
+  it('should honour aria-label if provided', () => {
+    const { getByLabelText, queryByLabelText } = render(
+      <BraidTestProvider>
+        <Button icon={<IconSend />}>Button</Button>
+        <Button aria-label="Actual Label">Visible Label</Button>
+      </BraidTestProvider>,
+    );
+    const buttonEl = getByLabelText('Actual Label');
+    expect(buttonEl.tagName).toBe('BUTTON');
+    expect(buttonEl.textContent).toBe('Visible Label');
+
+    const button = queryByLabelText('Visible Label');
+    expect(button).toBeNull();
   });
 });

--- a/packages/braid-design-system/src/lib/components/Button/Button.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.tsx
@@ -62,6 +62,7 @@ export interface ButtonProps extends ButtonStyleProps {
   'aria-controls'?: NativeButtonProps['aria-controls'];
   'aria-expanded'?: NativeButtonProps['aria-expanded'];
   'aria-describedby'?: NativeButtonProps['aria-describedby'];
+  'aria-label'?: NativeButtonProps['aria-label'];
   tabIndex?: NativeButtonProps['tabIndex'];
   data?: DataAttributeMap;
 }
@@ -469,6 +470,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       'aria-controls': ariaControls,
       'aria-expanded': ariaExpanded,
       'aria-describedby': ariaDescribedBy,
+      'aria-label': ariaLabel,
       data,
       ...restProps
     },
@@ -506,6 +508,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           aria-controls={ariaControls}
           aria-expanded={ariaExpanded}
           aria-describedby={ariaDescribedBy}
+          aria-label={ariaLabel}
           onClick={onClick}
           disabled={loading}
           {...buildDataAttributes({ data, validateRestProps: restProps })}

--- a/packages/braid-design-system/src/lib/components/TextLinkButton/TextLinkButton.test.tsx
+++ b/packages/braid-design-system/src/lib/components/TextLinkButton/TextLinkButton.test.tsx
@@ -77,6 +77,27 @@ describe('TextLink', () => {
     });
   });
 
+  it('should honour aria-label if provided', () => {
+    const { getByLabelText, queryByLabelText } = render(
+      <BraidTestProvider>
+        <Text>
+          <TextLinkButton
+            onClick={createMockClickHandler()}
+            aria-label="Alternate label"
+          >
+            Link text
+          </TextLinkButton>
+        </Text>
+      </BraidTestProvider>,
+    );
+    const buttonEl = getByLabelText('Alternate label');
+    expect(buttonEl.tagName).toBe('SPAN');
+    expect(buttonEl.textContent).toBe('Link text');
+
+    const button = queryByLabelText('Link text');
+    expect(button).toBeNull();
+  });
+
   describe('in Actions', () => {
     beforeAll(() => {
       jest.spyOn(console, 'warn').mockImplementation();

--- a/packages/braid-design-system/src/lib/components/TextLinkButton/TextLinkButton.tsx
+++ b/packages/braid-design-system/src/lib/components/TextLinkButton/TextLinkButton.tsx
@@ -27,6 +27,7 @@ export interface TextLinkButtonProps
   'aria-controls'?: NativeSpanProps['aria-controls'];
   'aria-expanded'?: NativeSpanProps['aria-expanded'];
   'aria-describedby'?: NativeSpanProps['aria-describedby'];
+  'aria-label'?: NativeSpanProps['aria-label'];
   tabIndex?: NativeSpanProps['tabIndex'];
   icon?: ReactElement<UseIconProps>;
 }
@@ -42,6 +43,7 @@ export const TextLinkButton = ({
   'aria-controls': ariaControls,
   'aria-expanded': ariaExpanded,
   'aria-describedby': ariaDescribedBy,
+  'aria-label': ariaLabel,
   tabIndex,
   icon,
   iconPosition,
@@ -75,6 +77,7 @@ export const TextLinkButton = ({
       aria-controls={ariaControls}
       aria-expanded={ariaExpanded}
       aria-describedby={ariaDescribedBy}
+      aria-label={ariaLabel}
       id={id}
       className={classes}
       {...buildDataAttributes({ data, validateRestProps: restProps })}

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -2037,6 +2037,7 @@ exports[`Button 1`] = `
         | "true"
         | false
         | true
+    aria-label?: string
     bleed?: boolean
     bleedY?: boolean
     children?: ReactNode
@@ -7942,6 +7943,7 @@ exports[`TextLinkButton 1`] = `
         | "true"
         | false
         | true
+    aria-label?: string
     children: ReactNode
     data?: DataAttributeMap
     hitArea?: 


### PR DESCRIPTION
Provide support for `aria-label`, enabling additional context to be given to assistive technologies where context is typically visual.

**EXAMPLE USAGE:**
```jsx
<Button aria-label="Save job">Save</Button>
```