### PR TITLE
playroom: Fix space cleaning helper

### DIFF
--- a/packages/braid-design-system/src/lib/components/Columns/Columns.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/Columns/Columns.playroom.tsx
@@ -11,7 +11,7 @@ export const Columns = ({
   ...restProps
 }: ColumnsProps) => (
   <BraidColumns
-    space={cleanSpaceValue(space)}
+    space={cleanSpaceValue(space) || 'none'}
     align={typeof align !== 'boolean' ? align : undefined}
     alignY={typeof alignY !== 'boolean' ? alignY : undefined}
     component={

--- a/packages/braid-design-system/src/lib/components/Inline/Inline.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/Inline/Inline.playroom.tsx
@@ -14,7 +14,7 @@ export const Inline = ({
   ...restProps
 }: InlineProps) => (
   <BraidInline
-    space={cleanSpaceValue(space)}
+    space={cleanSpaceValue(space) || 'none'}
     align={typeof align !== 'boolean' ? align : undefined}
     alignY={typeof alignY !== 'boolean' ? alignY : undefined}
     component={

--- a/packages/braid-design-system/src/lib/components/Stack/Stack.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/Stack/Stack.playroom.tsx
@@ -13,7 +13,7 @@ export const Stack = ({
   ...restProps
 }: StackProps) => (
   <BraidStack
-    space={cleanSpaceValue(space)}
+    space={cleanSpaceValue(space) || 'none'}
     align={typeof align !== 'boolean' ? align : undefined}
     component={
       component && validStackComponents.indexOf(component) > -1

--- a/packages/braid-design-system/src/lib/components/Tiles/Tiles.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/Tiles/Tiles.playroom.tsx
@@ -4,7 +4,7 @@ import { type TilesProps, Tiles as BraidTiles } from './Tiles';
 
 export const Tiles = ({ space, columns, ...restProps }: TilesProps) => (
   <BraidTiles
-    space={cleanSpaceValue(space)}
+    space={cleanSpaceValue(space) || 'none'}
     columns={typeof columns === 'boolean' || !columns ? 1 : columns}
     {...restProps}
   />

--- a/packages/braid-design-system/src/lib/playroom/cleanSpaceValue.ts
+++ b/packages/braid-design-system/src/lib/playroom/cleanSpaceValue.ts
@@ -1,11 +1,19 @@
+import { breakpointNames } from './../css/breakpoints';
 import type { ResponsiveSpace } from '../css/atoms/atoms';
 import { space as spaceValues } from '../css/atoms/atomicProperties';
 
 const validSpaceValues = Object.keys(spaceValues);
 
-export const cleanSpaceValue = (space?: ResponsiveSpace) =>
-  typeof space === 'undefined' ||
-  typeof space === 'boolean' ||
-  (typeof space === 'string' && !validSpaceValues.includes(space))
-    ? 'none'
-    : space;
+export const cleanSpaceValue = (space?: ResponsiveSpace) => {
+  const validResponsiveObject =
+    typeof space === 'object' &&
+    Object.keys(space).some(
+      (bp) =>
+        breakpointNames.includes(bp as (typeof breakpointNames)[number]) &&
+        validSpaceValues.includes(space[bp as keyof typeof space]),
+    );
+  const validSpace =
+    typeof space === 'string' && validSpaceValues.includes(space);
+
+  return validSpace || validResponsiveObject ? space : undefined;
+};


### PR DESCRIPTION
In order to guard against rendering errors in playroom while typing, we have a helper function for our Playroom wrapper components that ensures the `space` value that is passed is valid and not likely to cause an error trying to access invalid space styles.

This resulted in breaking the default value, seeing components such as `List` render with no space between its items (in Playroom only).