### PR TITLE
Update renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,12 +3,12 @@
   "commitMessagePrefix": null,
   "packageRules": [
     {
-      "packageNames": ["playroom", "@capsizecss/*", "@crackle/*"],
+      "matchPackagePrefixes": ["playroom", "@capsizecss/", "@crackle/"],
       "enabled": true
     },
     {
       "groupName": "@testing-library packages",
-      "packageNames": ["@testing-library"],
+      "matchPackagePrefixes": ["@testing-library/"],
       "enabled": true,
       "schedule": ["before 9am on Monday"]
     }


### PR DESCRIPTION
I was looking through [the logs](https://developer.mend.io/github/seek-oss/braid-design-system/-/job/01886460-371c-7418-99bf-c90590adb035) trying to figure out why `@crackle/cli` wasn't picked up by Renovate and I noticed that the config was using an old format.
[`matchPackagePatterns`](https://docs.renovatebot.com/configuration-options/#matchpackagepatterns) is a regex, which is probably why it wasn't picking up `@crackle/*`, so I replaced `packageNames` with [`matchPackagePrefixes`](https://docs.renovatebot.com/configuration-options/#matchpackageprefixes) 🤞 