### PR TITLE
Always run Chromatic on master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,3 +40,8 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.SEEK_OSS_CI_NPM_TOKEN }}
           IS_GITHUB_PAGES: true
+
+      - name: Chromatic
+        run: pnpm storybook:chromatic
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_APP_CODE }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -16,6 +16,8 @@ jobs:
         with:
           concurrent_skipping: same_content_newer
           cancel_others: true
+          # We want to skip only concurrent runs. Subsequent runs/retries should be allowed.
+          skip_after_successful_duplicate: false
 
   test:
     name: Lint & Test
@@ -53,6 +55,7 @@ jobs:
         run: pnpm test
 
       - name: Chromatic
+        if: github.ref != 'refs/heads/master'
         run: pnpm storybook:chromatic
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_APP_CODE }}


### PR DESCRIPTION
A [recent workflow run](https://github.com/seek-oss/braid-design-system/actions/runs/5107377818) uncovered a situation where Chromatic wasn't run on master because the 'Skip Duplicate Actions' action correctly identified that it did not need to run. However, the **Validate** workflow has a side-effect (running Chromatic on master which updates the baseline), which wasn't executed any more. See https://github.com/seek-oss/braid-design-system/pull/1309#issuecomment-1566368339

This change skips the **Chromatic** workflow step on `push`/`pull_request` but still runs it on `push: master`, ensuring the baseline in Chromatic is updated every time. This also runs Chromatic earlier (without waiting for all the **Lint & Test** steps, so pending pull requests get the updated snapshot baseline sooner.
