### PR TITLE
Drawer, Dialog: Support validation blocking closure of modal

### DIFF
--- a/.changeset/spotty-wasps-poke.md
+++ b/.changeset/spotty-wasps-poke.md
@@ -1,0 +1,27 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Drawer
+  - Dialog
+---
+
+**Drawer, Dialog:** Support validation blocking closure of modal
+
+To prevent a `Dialog` or `Drawer` from closing, e.g. due to validation, the `onClose` function can now return **false**.
+
+**EXAMPLE USAGE:**
+```jsx
+<Drawer
+  onClose={() => {
+    const valid = runValidation();
+    if (!valid) {
+      return false;
+    }
+
+    closeDrawer();
+  }}
+/>
+```

--- a/.changeset/spotty-wasps-poke.md
+++ b/.changeset/spotty-wasps-poke.md
@@ -15,13 +15,14 @@ To prevent a `Dialog` or `Drawer` from closing, e.g. due to validation, the `onC
 **EXAMPLE USAGE:**
 ```jsx
 <Drawer
+  open={open}
   onClose={() => {
     const valid = runValidation();
     if (!valid) {
       return false;
     }
 
-    closeDrawer();
+    setOpen(false);
   }}
 />
 ```

--- a/packages/braid-design-system/src/lib/components/Dialog/Dialog.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Dialog/Dialog.docs.tsx
@@ -12,6 +12,7 @@ import {
   Box,
   Strong,
   IconLanguage,
+  Checkbox,
 } from '../';
 import { Placeholder } from '../../playroom/components';
 
@@ -230,6 +231,61 @@ const docs: ComponentDocs = {
               closeLabel="Close Dialog"
             >
               <Placeholder height={100} width="100%" />
+            </Dialog>
+          </>,
+        ),
+    },
+
+    {
+      description: (
+        <Text>
+          To prevent the Dialog from closing, e.g. due to validation, this
+          function should return <Strong>false</Strong>.
+        </Text>
+      ),
+      Example: ({ id, getState, toggleState, setState, setDefaultState }) =>
+        source(
+          <>
+            {setDefaultState('valid', false)}
+            {setDefaultState('showError', false)}
+
+            <Box padding="medium">
+              <Inline
+                space="small"
+                align={{ mobile: 'center', tablet: 'left' }}
+              >
+                <Button onClick={() => toggleState('dialog')}>
+                  Open validated dialog
+                </Button>
+              </Inline>
+            </Box>
+
+            <Dialog
+              id={id}
+              title="Dialog Title"
+              open={getState('dialog')}
+              onClose={() => {
+                if (getState('valid') === false) {
+                  setState('showError', true);
+                  return false;
+                }
+
+                setState('showError', false);
+                toggleState('dialog');
+              }}
+              closeLabel="Close Dialog"
+            >
+              <Checkbox
+                id="valid"
+                label="Can this Dialog be closed?"
+                checked={getState('valid')}
+                onChange={() => {
+                  setState('showError', false);
+                  toggleState('valid');
+                }}
+                tone={getState('showError') ? 'critical' : undefined}
+                message={getState('showError') ? 'Required field' : undefined}
+              />
             </Dialog>
           </>,
         ),

--- a/packages/braid-design-system/src/lib/components/Drawer/Drawer.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Drawer/Drawer.docs.tsx
@@ -10,6 +10,7 @@ import {
   Box,
   Strong,
   IconLanguage,
+  Checkbox,
 } from '../';
 import { Placeholder } from '../../playroom/components';
 
@@ -221,8 +222,8 @@ const docs: ComponentDocs = {
                 space="small"
                 align={{ mobile: 'center', tablet: 'left' }}
               >
-                <Button onClick={() => toggleState('dialog')}>
-                  Open dialog
+                <Button onClick={() => toggleState('drawer')}>
+                  Open drawer
                 </Button>
               </Inline>
             </Box>
@@ -230,12 +231,65 @@ const docs: ComponentDocs = {
             <Drawer
               id={id}
               title="Drawer Title"
-              description={<Text tone="secondary">Optional description</Text>}
-              open={getState('dialog')}
-              onClose={() => toggleState('dialog')}
+              open={getState('drawer')}
+              onClose={() => toggleState('drawer')}
               closeLabel="Close Drawer"
             >
               <Placeholder height={100} label="Drawer Content" />
+            </Drawer>
+          </>,
+        ),
+    },
+    {
+      description: (
+        <Text>
+          To prevent the Drawer from closing, e.g. due to validation, this
+          function should return <Strong>false</Strong>.
+        </Text>
+      ),
+      Example: ({ id, getState, toggleState, setState, setDefaultState }) =>
+        source(
+          <>
+            {setDefaultState('valid', false)}
+            {setDefaultState('showError', false)}
+
+            <Box padding="medium">
+              <Inline
+                space="small"
+                align={{ mobile: 'center', tablet: 'left' }}
+              >
+                <Button onClick={() => toggleState('drawer')}>
+                  Open validated drawer
+                </Button>
+              </Inline>
+            </Box>
+
+            <Drawer
+              id={id}
+              title="Drawer Title"
+              open={getState('drawer')}
+              onClose={() => {
+                if (getState('valid') === false) {
+                  setState('showError', true);
+                  return false;
+                }
+
+                setState('showError', false);
+                toggleState('drawer');
+              }}
+              closeLabel="Close Drawer"
+            >
+              <Checkbox
+                id="valid"
+                label="Can this Drawer be closed?"
+                checked={getState('valid')}
+                onChange={() => {
+                  setState('showError', false);
+                  toggleState('valid');
+                }}
+                tone={getState('showError') ? 'critical' : undefined}
+                message={getState('showError') ? 'Required field' : undefined}
+              />
             </Drawer>
           </>,
         ),

--- a/packages/braid-design-system/src/lib/components/private/Modal/Modal.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Modal/Modal.tsx
@@ -22,7 +22,7 @@ export interface ModalProps
     'onClose' | 'scrollLock' | 'headingRef' | 'modalRef'
   > {
   open: boolean;
-  onClose: (openState: false) => void;
+  onClose: (openState: false) => void | false;
 }
 
 export const AllowCloseContext = createContext(true);
@@ -146,7 +146,14 @@ export const Modal = ({
 
   const initiateClose = () => {
     if (allowClose) {
-      dispatch(CLOSE_MODAL);
+      const result = closeHandlerRef.current(false);
+      if (result === false) {
+        return result;
+      }
+
+      if (openRef.current) {
+        dispatch(CLOSE_MODAL);
+      }
     }
   };
 
@@ -155,19 +162,16 @@ export const Modal = ({
     dispatch(open ? OPEN_MODAL : CLOSE_MODAL);
   }, [open]);
 
+  const closing = state === CLOSING;
   useEffect(() => {
-    if (state === CLOSING) {
+    if (closing) {
       const timer = setTimeout(() => {
         dispatch(ANIMATION_COMPLETE);
       }, ANIMATION_DURATION);
 
       return () => clearTimeout(timer);
     }
-
-    if (state === CLOSED && openRef.current) {
-      closeHandlerRef.current(false);
-    }
-  }, [state]);
+  }, [closing]);
 
   const shouldAriaHideOthers = state === OPEN || state === CLOSING;
   useEffect(() => {

--- a/packages/braid-design-system/src/lib/playroom/playroomState.tsx
+++ b/packages/braid-design-system/src/lib/playroom/playroomState.tsx
@@ -124,7 +124,7 @@ export function useFallbackState<Value, Handler extends Callback>(
         );
       }
 
-      (handler || noop)(...args);
+      return (handler || noop)(...args);
     };
 
   const handleChange = wrapChangeHandler(onChange || noop);

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -2835,7 +2835,7 @@ exports[`Dialog 1`] = `
     description?: ReactNodeNoStrings
     id: string
     illustration?: ReactNodeNoStrings
-    onClose: (openState: false) => void
+    onClose: (openState: false) => false | void
     open: boolean
     title: string
     width?: 
@@ -2899,7 +2899,7 @@ exports[`Drawer 1`] = `
     data?: DataAttributeMap
     description?: ReactNodeNoStrings
     id: string
-    onClose: (openState: false) => void
+    onClose: (openState: false) => false | void
     open: boolean
     position?: 
         | "left"


### PR DESCRIPTION
To prevent a `Dialog` or `Drawer` from closing, e.g. due to validation, the `onClose` function can now return **false**.

**EXAMPLE USAGE:**
```jsx
<Drawer
  onClose={() => {
    const valid = runValidation();
    if (!valid) {
      return false;
    }

    closeDrawer();
  }}
/>
```