### PR TITLE
Drawer, Dialog: Increase gutter around close button

### DIFF
--- a/.changeset/stale-ties-rescue.md
+++ b/.changeset/stale-ties-rescue.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Drawer
+  - Dialog
+---
+
+**Drawer, Dialog:** Increase gutter around close button
+
+Fix for a regression where the gutter around the close button was reduced — resulting in visually clashing with the content when scrolling.

--- a/packages/braid-design-system/src/lib/components/Dialog/Dialog.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Dialog/Dialog.screenshots.tsx
@@ -1,14 +1,34 @@
-import React from 'react';
+import React, { type ReactNode } from 'react';
 import type { ComponentScreenshot } from 'site/types';
 import { Inline, Stack, Box } from '../';
 import { Placeholder } from '../../playroom/components';
 import { DialogContent } from './Dialog';
+import * as styles from '../private/Modal/Modal.css';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <Box position="relative">
+    <Box position="absolute" padding="small">
+      <Placeholder height={100} width="100%" label="Page content" />
+    </Box>
+    <Box
+      position="absolute"
+      height="full"
+      width="full"
+      className={styles.backdrop}
+    />
+    <Box position="relative" zIndex="modal">
+      {children}
+    </Box>
+  </Box>
+);
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320, 1200],
   examples: [
     {
       label: 'Default layout',
+      gutter: false,
+      Container,
       Example: ({ id }) => (
         <DialogContent
           id={id}
@@ -22,6 +42,8 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label: 'Illustration layout',
+      gutter: false,
+      Container,
       Example: ({ id }) => (
         <DialogContent
           id={id}
@@ -49,6 +71,8 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label: 'Layout with a description',
+      gutter: false,
+      Container,
       Example: ({ id }) => (
         <DialogContent
           id={id}
@@ -65,6 +89,8 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label: 'Layout: Content width',
+      gutter: false,
+      Container,
       Example: ({ id }) => (
         <Box display="flex" alignItems="center" justifyContent="center">
           <DialogContent
@@ -81,6 +107,8 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label: 'Layout: Xsmall width',
+      gutter: false,
+      Container,
       Example: ({ id }) => (
         <DialogContent
           id={id}
@@ -95,6 +123,8 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label: 'Layout: Small width',
+      gutter: false,
+      Container,
       Example: ({ id }) => (
         <DialogContent
           id={id}
@@ -109,6 +139,8 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label: 'Layout: Medium width',
+      gutter: false,
+      Container,
       Example: ({ id }) => (
         <DialogContent
           id={id}
@@ -123,6 +155,8 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label: 'Layout: Large width',
+      gutter: false,
+      Container,
       Example: ({ id }) => (
         <DialogContent
           id={id}
@@ -137,6 +171,8 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label: 'Layout: Handle long-unbroken title',
+      gutter: false,
+      Container,
       Example: ({ id }) => (
         <DialogContent
           id={id}
@@ -150,6 +186,34 @@ export const screenshots: ComponentScreenshot = {
             width="100%"
             label="Handle long-unbroken title"
           />
+        </DialogContent>
+      ),
+    },
+    {
+      label: 'Test: Close button layout',
+      gutter: false,
+      Container,
+      Example: ({ id }) => (
+        <DialogContent
+          id={id}
+          title="Default test"
+          onClose={() => {}}
+          width="medium"
+          scrollLock={false}
+        >
+          <Box style={{ height: 100 }} />
+          <Box
+            position="absolute"
+            inset={0}
+            style={{ background: '#4964E9' }}
+            background="customDark"
+          >
+            <Placeholder
+              height="100%"
+              width="100%"
+              label="Close button should be on top of content and have a gutter"
+            />
+          </Box>
         </DialogContent>
       ),
     },

--- a/packages/braid-design-system/src/lib/components/Drawer/Drawer.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Drawer/Drawer.screenshots.tsx
@@ -1,13 +1,34 @@
-import React from 'react';
+import React, { type ReactNode } from 'react';
 import type { ComponentScreenshot } from 'site/types';
+import { Box } from '../Box/Box';
 import { Placeholder } from '../../playroom/components';
 import { DrawerContent } from './Drawer';
+import * as styles from '../private/Modal/Modal.css';
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <Box position="relative">
+    <Box position="absolute" padding="small">
+      <Placeholder height={100} width="100%" label="Page content" />
+    </Box>
+    <Box
+      position="absolute"
+      height="full"
+      width="full"
+      className={styles.backdrop}
+    />
+    <Box position="relative" zIndex="modal">
+      {children}
+    </Box>
+  </Box>
+);
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320, 1200],
   examples: [
     {
       label: 'Default layout',
+      gutter: false,
+      Container,
       Example: ({ id }) => (
         <DrawerContent
           id={id}
@@ -22,6 +43,8 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label: 'Layout with a description',
+      gutter: false,
+      Container,
       Example: ({ id }) => (
         <DrawerContent
           id={id}
@@ -38,6 +61,8 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label: 'Layout: Small width',
+      gutter: false,
+      Container,
       Example: ({ id }) => (
         <DrawerContent
           id={id}
@@ -52,6 +77,8 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label: 'Layout: Medium width',
+      gutter: false,
+      Container,
       Example: ({ id }) => (
         <DrawerContent
           id={id}
@@ -66,6 +93,8 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label: 'Layout: Large width',
+      gutter: false,
+      Container,
       Example: ({ id }) => (
         <DrawerContent
           id={id}
@@ -75,6 +104,34 @@ export const screenshots: ComponentScreenshot = {
           scrollLock={false}
         >
           <Placeholder height={100} width="100%" label="Large Drawer" />
+        </DrawerContent>
+      ),
+    },
+    {
+      label: 'Test: Close button layout',
+      gutter: false,
+      Container,
+      Example: ({ id }) => (
+        <DrawerContent
+          id={id}
+          title="Default test"
+          onClose={() => {}}
+          width="medium"
+          scrollLock={false}
+        >
+          <Box style={{ height: 100 }} />
+          <Box
+            position="absolute"
+            inset={0}
+            style={{ background: '#4964E9' }}
+            background="customDark"
+          >
+            <Placeholder
+              height="100%"
+              width="100%"
+              label="Close button should be on top of content and have a gutter"
+            />
+          </Box>
         </DrawerContent>
       ),
     },

--- a/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
@@ -14,6 +14,7 @@ import { Stack } from '../../Stack/Stack';
 import { Columns } from '../../Columns/Columns';
 import { Column } from '../../Column/Column';
 import { Overlay } from '../Overlay/Overlay';
+import { Bleed } from '../../Bleed/Bleed';
 import { gutters as pageBlockGutters } from '../../PageBlock/PageBlock';
 import type { ReactNodeNoStrings } from '../ReactNodeNoStrings';
 import { IconClear } from '../../icons';
@@ -207,22 +208,25 @@ export const ModalContent = ({
           paddingRight={position !== 'center' ? pageBlockGutters : modalPadding}
           className={position === 'center' && styles.maxSize[position]}
         >
-          <Box
-            position="relative"
-            background="surface"
-            borderRadius="full"
-            className={[styles.closeIconOffset, styles.pointerEventsAll]}
-          >
-            <ButtonIcon
-              id={`${id}-close`}
-              label={closeLabel}
-              icon={<IconClear />}
-              tone="secondary"
-              variant="transparent"
-              size="large"
-              onClick={onClose}
-            />
-          </Box>
+          <Bleed space="xsmall">
+            <Box
+              position="relative"
+              background="surface"
+              borderRadius="full"
+              padding="xsmall"
+              className={[styles.closeIconOffset, styles.pointerEventsAll]}
+            >
+              <ButtonIcon
+                id={`${id}-close`}
+                label={closeLabel}
+                icon={<IconClear />}
+                tone="secondary"
+                variant="transparent"
+                size="large"
+                onClick={onClose}
+              />
+            </Box>
+          </Bleed>
         </Box>
       </Box>
     </Box>

--- a/packages/braid-design-system/src/lib/stories/all.stories.tsx
+++ b/packages/braid-design-system/src/lib/stories/all.stories.tsx
@@ -44,6 +44,7 @@ const RenderExample = ({ example }: RenderExampleProps) => {
     label,
     Container = DefaultContainer,
     background = 'body',
+    gutter = true,
     Example,
   } = example;
   const id = useId();
@@ -68,7 +69,7 @@ const RenderExample = ({ example }: RenderExampleProps) => {
       >
         {label}
       </h4>
-      <Box background={background} style={{ padding: 12 }}>
+      <Box background={background} style={gutter ? { padding: 12 } : undefined}>
         <Container>
           {Example ? <Example id={id} handler={noop} /> : null}
         </Container>

--- a/site/src/types.d.ts
+++ b/site/src/types.d.ts
@@ -73,6 +73,7 @@ export interface ComponentScreenshot {
   examples: {
     label?: string;
     background?: NonNullable<BoxProps['background']>;
+    gutter?: boolean;
     Example?: (props: ExampleProps) => ReactElement;
     Container?: (props: { children: ReactNode }) => ReactElement;
   }[];


### PR DESCRIPTION
Fix for a regression (introduced [here]) where the gutter around the close button was reduced — resulting in visually clashing with the content when scrolling.

(Also adding screenshot tests to prevent future regressions, and applying the modal backdrop to the Dialog and Drawer tests for better affordance)

[here]: https://github.com/seek-oss/braid-design-system/pull/1316/files#diff-d95ad2142ce38ae0fd78738b870d5b1ef50f5891e2f6f09d01ef2adf03d5b8dbR210