### PR TITLE
Page: Add component

### DIFF
--- a/.changeset/empty-zebras-serve.md
+++ b/.changeset/empty-zebras-serve.md
@@ -9,7 +9,7 @@ new:
 
 **Page:** Add component
 
-The new `Page` component establishes a consistent page-level layout, by managing the relationship between the footer and the main content.
+The new `Page` component establishes a consistent page-level layout by managing the relationship between the footer and the main content.
 
 By default, for pages with limited content the `footer` will at a minimum be placed at the bottom of the screen, pushed beyond as the page content grows.
 

--- a/.changeset/empty-zebras-serve.md
+++ b/.changeset/empty-zebras-serve.md
@@ -1,0 +1,24 @@
+---
+'braid-design-system': minor
+---
+
+---
+new:
+  - Page
+---
+
+**Page:** Add component
+
+The new `Page` component establishes a consistent page-level layout, by managing the relationship between the footer and the main content.
+
+By default, for pages with limited content the `footer` will at a minimum be placed at the bottom of the screen, pushed beyond as the page content grows.
+
+For pages with dynamic content, it is recommended to place the footer out of view by setting the `footerPosition` prop to `belowFold` to prevent the footer from popping in and out of view when the page content changes, e.g. toggling between a loading indicator and content.
+
+**EXAMPLE USAGE:**
+```jsx
+<Page footer={<Footer />}>
+  <Header />
+  {/* page content... */}
+</Page>
+```

--- a/packages/braid-design-system/src/lib/components/Page/Page.css.ts
+++ b/packages/braid-design-system/src/lib/components/Page/Page.css.ts
@@ -1,0 +1,7 @@
+import { createVar, fallbackVar, style } from '@vanilla-extract/css';
+
+export const heightLimit = createVar();
+
+export const fullHeight = style({
+  minHeight: fallbackVar(heightLimit, '100vh'),
+});

--- a/packages/braid-design-system/src/lib/components/Page/Page.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Page/Page.docs.tsx
@@ -57,12 +57,12 @@ const docs: ComponentDocs = {
   alternatives: [],
   additional: [
     {
-      label: 'Establishing a top level layout',
+      label: 'Establishing a top-level layout',
       description: (
         <>
           <Text>
             For pages with a limited amount of content, typically the footer
-            would stack below the content — sitting unexpectedly high within in
+            would stack below the content — sitting unexpectedly high within
             the page.
           </Text>
           <Text>

--- a/packages/braid-design-system/src/lib/components/Page/Page.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Page/Page.docs.tsx
@@ -1,7 +1,9 @@
+import { calc } from '@vanilla-extract/css-utils';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import React, { type ReactNode } from 'react';
 import type { ComponentDocs } from 'site/types';
 import { Box, Notice, Stack, Strong, Text, TextLink, Tiles } from '..';
+import { vars } from '../../themes/vars.css';
 import source from '../../utils/source.macro';
 import { Placeholder } from '../private/Placeholder/Placeholder';
 import { Page } from './Page';
@@ -12,7 +14,7 @@ const screenHeight = 350;
 const ScreenOverlay = () => (
   <Box
     boxShadow="borderNeutralLarge"
-    borderRadius="large"
+    borderRadius="standard"
     position="absolute"
     top={0}
     left={0}
@@ -23,6 +25,7 @@ const ScreenOverlay = () => (
   />
 );
 
+const screenBorderWidth = vars.borderWidth.large;
 export const ContainerForPageDocs = ({ children }: { children: ReactNode }) => (
   <Box display="flex" justifyContent="center">
     <Box
@@ -30,12 +33,17 @@ export const ContainerForPageDocs = ({ children }: { children: ReactNode }) => (
       width="full"
       background="surface"
       style={{
-        ...assignInlineVars({ [heightLimit]: `${screenHeight}px` }),
+        ...assignInlineVars({
+          [heightLimit]: calc(screenHeight)
+            .multiply('1px')
+            .subtract(calc(screenBorderWidth).multiply('2'))
+            .toString(),
+        }),
         maxWidth: screenHeight * 1.6,
       }}
     >
       <ScreenOverlay />
-      {children}
+      <Box style={{ padding: screenBorderWidth }}>{children}</Box>
     </Box>
   </Box>
 );
@@ -62,8 +70,8 @@ const docs: ComponentDocs = {
         <>
           <Text>
             For pages with a limited amount of content, typically the footer
-            would stack below the content — sitting unexpectedly high within
-            the page.
+            would stack below the content — sitting unexpectedly high within the
+            page.
           </Text>
           <Text>
             The <Strong>Page</Strong> component provides a simple way to

--- a/packages/braid-design-system/src/lib/components/Page/Page.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Page/Page.docs.tsx
@@ -1,0 +1,158 @@
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+import React, { type ReactNode } from 'react';
+import type { ComponentDocs } from 'site/types';
+import { Box, Notice, Stack, Strong, Text, TextLink, Tiles } from '..';
+import source from '../../utils/source.macro';
+import { Placeholder } from '../private/Placeholder/Placeholder';
+import { Page } from './Page';
+import { heightLimit } from './Page.css';
+
+const screenHeight = 350;
+
+const ScreenOverlay = () => (
+  <Box
+    boxShadow="borderNeutralLarge"
+    borderRadius="large"
+    position="absolute"
+    top={0}
+    left={0}
+    right={0}
+    style={{
+      height: screenHeight,
+    }}
+  />
+);
+
+export const ContainerForPageDocs = ({ children }: { children: ReactNode }) => (
+  <Box display="flex" justifyContent="center">
+    <Box
+      position="relative"
+      width="full"
+      background="surface"
+      style={{
+        ...assignInlineVars({ [heightLimit]: `${screenHeight}px` }),
+        maxWidth: screenHeight * 1.6,
+      }}
+    >
+      <ScreenOverlay />
+      {children}
+    </Box>
+  </Box>
+);
+
+const docs: ComponentDocs = {
+  category: 'Layout',
+  Example: () => {
+    const { code, value } = source(
+      <Page footer={<Placeholder label="Footer" height={100} />}>
+        <Placeholder label="Header" height={30} />
+        <Placeholder label="Content" height={50} />
+      </Page>,
+    );
+    return {
+      code,
+      value: <ContainerForPageDocs>{value}</ContainerForPageDocs>,
+    };
+  },
+  alternatives: [],
+  additional: [
+    {
+      label: 'Establishing a top level layout',
+      description: (
+        <>
+          <Text>
+            For pages with a limited amount of content, typically the footer
+            would stack below the content — sitting unexpectedly high within in
+            the page.
+          </Text>
+          <Text>
+            The <Strong>Page</Strong> component provides a simple way to
+            establish a more predictable layout — at a minimum placing the
+            footer at the bottom of the screen, pushed beyond as the page
+            content grows.
+          </Text>
+        </>
+      ),
+      code: false,
+      Example: () =>
+        source(
+          <Tiles space={{ mobile: 'medium', tablet: 'xlarge' }} columns={2}>
+            <Stack space="medium">
+              <Text size="small" tone="secondary">
+                WITHOUT <Strong>PAGE</Strong>
+              </Text>
+
+              <ContainerForPageDocs>
+                <Placeholder label="Header" height={50} />
+                <Placeholder label="Content" height={50} />
+                <Box background="criticalLight">
+                  <Placeholder label="Footer" height={100} />
+                </Box>
+              </ContainerForPageDocs>
+            </Stack>
+
+            <Stack space="medium">
+              <Text size="small" tone="secondary">
+                WITH <Strong>PAGE</Strong>
+              </Text>
+              <ContainerForPageDocs>
+                <Page
+                  footer={
+                    <Box background="positiveLight">
+                      <Placeholder label="Footer" height={100} />
+                    </Box>
+                  }
+                >
+                  <Placeholder label="Header" height={50} />
+                  <Placeholder label="Content" height={50} />
+                </Page>
+              </ContainerForPageDocs>
+            </Stack>
+          </Tiles>,
+        ),
+    },
+    {
+      label: 'Controlling the footer position',
+      description: (
+        <>
+          <Text>
+            For pages with dynamic content, it is recommended to place the
+            footer out of view by setting the <Strong>footerPosition</Strong>{' '}
+            prop to <Strong>belowFold</Strong>. This prevents the footer from
+            popping in and out of view when the page content changes, e.g.
+            toggling between a loading indicator and content.
+          </Text>
+          <Notice tone="promote">
+            <Text>
+              Placing the footer below the fold can help optimise{' '}
+              <TextLink href="https://web.dev/vitals/">Web Vital</TextLink>{' '}
+              metrics by stabilising the page throughout a user journey —
+              leading to improved{' '}
+              <TextLink href="https://web.dev/cls/">
+                Cumulative Layout Shift (CLS)
+              </TextLink>{' '}
+              scores.
+            </Text>
+          </Notice>
+        </>
+      ),
+      Container: ContainerForPageDocs,
+      Example: () =>
+        source(
+          <Page
+            footer={
+              <Box background="promoteLight">
+                <Placeholder label="Footer" height={100} />
+              </Box>
+            }
+            footerPosition="belowFold"
+          >
+            <Placeholder label="Header" height={50} />
+            <Placeholder label="Content" height={150} />
+          </Page>,
+        ),
+    },
+  ],
+};
+
+export default docs;

--- a/packages/braid-design-system/src/lib/components/Page/Page.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Page/Page.screenshots.tsx
@@ -1,0 +1,103 @@
+import React, { type ReactNode } from 'react';
+import { assignInlineVars } from '@vanilla-extract/dynamic';
+import type { ComponentScreenshot } from 'site/types';
+import { Box, Page } from '..';
+import { Placeholder } from '../private/Placeholder/Placeholder';
+import { heightLimit } from './Page.css';
+
+const viewportHeight = 300;
+
+const Container = ({ children }: { children: ReactNode }) => (
+  <Box
+    position="relative"
+    style={assignInlineVars({ [heightLimit]: `${viewportHeight}px` })}
+  >
+    <Box
+      boxShadow="borderNeutralLarge"
+      borderRadius="large"
+      position="absolute"
+      top={0}
+      left={0}
+      right={0}
+      height="full"
+      style={{
+        maxHeight: viewportHeight,
+      }}
+    />
+    {children}
+  </Box>
+);
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320],
+  screenshotOnlyInWireframe: true,
+  examples: [
+    {
+      label: 'Default',
+      Container,
+      Example: () => (
+        <Page
+          footer={
+            <Box background="promoteLight">
+              <Placeholder label="Footer above fold" height={50} />
+            </Box>
+          }
+        >
+          <Placeholder label="Header" height={50} />
+          <Placeholder label="Content" height={50} />
+        </Page>
+      ),
+    },
+    {
+      label: 'Below fold',
+      Container,
+      Example: () => (
+        <Page
+          footerPosition="belowFold"
+          footer={
+            <Box background="promoteLight">
+              <Placeholder label="Footer below fold" height={50} />
+            </Box>
+          }
+        >
+          <Placeholder label="Header" height={50} />
+          <Placeholder label="Content" height={50} />
+        </Page>
+      ),
+    },
+    {
+      label: 'Default - long page (should push footer below fold organically)',
+      Container,
+      Example: () => (
+        <Page
+          footer={
+            <Box background="promoteLight">
+              <Placeholder label="Footer above fold" height={50} />
+            </Box>
+          }
+        >
+          <Placeholder label="Header" height={50} />
+          <Placeholder label="Content" height={viewportHeight * 1.2} />
+        </Page>
+      ),
+    },
+    {
+      label:
+        'Below fold - long page (should push footer below fold organically)',
+      Container,
+      Example: () => (
+        <Page
+          footerPosition="belowFold"
+          footer={
+            <Box background="promoteLight">
+              <Placeholder label="Footer" height={50} />
+            </Box>
+          }
+        >
+          <Placeholder label="Header" height={50} />
+          <Placeholder label="Content" height={viewportHeight * 1.2} />
+        </Page>
+      ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Page/Page.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/Page/Page.snippets.tsx
@@ -1,0 +1,26 @@
+import React from 'react';
+import type { Snippets } from '../private/Snippets';
+import { Page, Placeholder } from '../../playroom/components';
+import source from '../../utils/source.macro';
+
+export const snippets: Snippets = [
+  {
+    name: 'Default',
+    code: source(
+      <Page footer={<Placeholder label="Footer" height={100} />}>
+        <Placeholder label="Header" height={60} />
+      </Page>,
+    ),
+  },
+  {
+    name: 'Footer below fold',
+    code: source(
+      <Page
+        footer={<Placeholder label="Footer" height={100} />}
+        footerPosition="belowFold"
+      >
+        <Placeholder label="Header" height={60} />
+      </Page>,
+    ),
+  },
+];

--- a/packages/braid-design-system/src/lib/components/Page/Page.tsx
+++ b/packages/braid-design-system/src/lib/components/Page/Page.tsx
@@ -40,7 +40,7 @@ export const Page = ({
           className={
             footerPosition === 'belowFold' ? styles.fullHeight : undefined
           }
-          paddingBottom="xxlarge"
+          paddingBottom="xxxlarge"
         >
           {children}
         </Box>

--- a/packages/braid-design-system/src/lib/components/Page/Page.tsx
+++ b/packages/braid-design-system/src/lib/components/Page/Page.tsx
@@ -1,9 +1,10 @@
-import type { ReactNode } from 'react';
-import React from 'react';
+import assert from 'assert';
+import React, { type ReactNode, useContext } from 'react';
 import { Box } from '../Box/Box';
 import buildDataAttributes, {
   type DataAttributeMap,
 } from '../private/buildDataAttributes';
+import PageContext from './PageContext';
 
 import * as styles from './Page.css';
 
@@ -20,20 +21,31 @@ export const Page = ({
   footerPosition,
   data,
   ...restProps
-}: PageProps) => (
-  <Box
-    display="flex"
-    flexDirection="column"
-    className={styles.fullHeight}
-    {...buildDataAttributes({ data, validateRestProps: restProps })}
-  >
-    <Box
-      flexGrow={footerPosition !== 'belowFold' ? 1 : undefined}
-      className={footerPosition === 'belowFold' ? styles.fullHeight : undefined}
-      paddingBottom="xxlarge"
-    >
-      {children}
-    </Box>
-    {footer}
-  </Box>
-);
+}: PageProps) => {
+  assert(
+    !useContext(PageContext),
+    'Page components should not be nested within each other',
+  );
+
+  return (
+    <PageContext.Provider value={true}>
+      <Box
+        display="flex"
+        flexDirection="column"
+        className={styles.fullHeight}
+        {...buildDataAttributes({ data, validateRestProps: restProps })}
+      >
+        <Box
+          flexGrow={footerPosition !== 'belowFold' ? 1 : undefined}
+          className={
+            footerPosition === 'belowFold' ? styles.fullHeight : undefined
+          }
+          paddingBottom="xxlarge"
+        >
+          {children}
+        </Box>
+        {footer}
+      </Box>
+    </PageContext.Provider>
+  );
+};

--- a/packages/braid-design-system/src/lib/components/Page/Page.tsx
+++ b/packages/braid-design-system/src/lib/components/Page/Page.tsx
@@ -1,0 +1,39 @@
+import type { ReactNode } from 'react';
+import React from 'react';
+import { Box } from '../Box/Box';
+import buildDataAttributes, {
+  type DataAttributeMap,
+} from '../private/buildDataAttributes';
+
+import * as styles from './Page.css';
+
+interface PageProps {
+  children: ReactNode;
+  footer: ReactNode;
+  footerPosition?: 'belowFold';
+  data?: DataAttributeMap;
+}
+
+export const Page = ({
+  children,
+  footer,
+  footerPosition,
+  data,
+  ...restProps
+}: PageProps) => (
+  <Box
+    display="flex"
+    flexDirection="column"
+    className={styles.fullHeight}
+    {...buildDataAttributes({ data, validateRestProps: restProps })}
+  >
+    <Box
+      flexGrow={footerPosition !== 'belowFold' ? 1 : undefined}
+      className={footerPosition === 'belowFold' ? styles.fullHeight : undefined}
+      paddingBottom="xxlarge"
+    >
+      {children}
+    </Box>
+    {footer}
+  </Box>
+);

--- a/packages/braid-design-system/src/lib/components/Page/PageContext.ts
+++ b/packages/braid-design-system/src/lib/components/Page/PageContext.ts
@@ -1,0 +1,3 @@
+import { createContext } from 'react';
+
+export default createContext(false);

--- a/packages/braid-design-system/src/lib/components/index.ts
+++ b/packages/braid-design-system/src/lib/components/index.ts
@@ -57,6 +57,7 @@ export { OverflowMenu } from './OverflowMenu/OverflowMenu';
 export { MonthPicker } from './MonthPicker/MonthPicker';
 export { Notice } from './Notice/Notice';
 export { PageBlock } from './PageBlock/PageBlock';
+export { Page } from './Page/Page';
 export { Pagination } from './Pagination/Pagination';
 export { PasswordField } from './PasswordField/PasswordField';
 export { Radio } from './Radio/Radio';

--- a/packages/braid-design-system/src/lib/playroom/snippets.ts
+++ b/packages/braid-design-system/src/lib/playroom/snippets.ts
@@ -24,6 +24,7 @@ import { snippets as Loader } from './snippets/Loader';
 import { snippets as MonthPicker } from './snippets/MonthPicker';
 import { snippets as Notice } from './snippets/Notice';
 import { snippets as OverflowMenu } from './snippets/OverflowMenu';
+import { snippets as Page } from './snippets/Page';
 import { snippets as PageBlock } from './snippets/PageBlock';
 import { snippets as Pagination } from './snippets/Pagination';
 import { snippets as PasswordField } from './snippets/PasswordField';
@@ -71,6 +72,7 @@ export default Object.entries({
   MonthPicker,
   Notice,
   OverflowMenu,
+  Page,
   PageBlock,
   Pagination,
   PasswordField,

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -6829,6 +6829,18 @@ exports[`OverflowMenu 1`] = `
 }
 `;
 
+exports[`Page 1`] = `
+{
+  exportType: component,
+  props: {
+    children: ReactNode
+    data?: DataAttributeMap
+    footer: ReactNode
+    footerPosition?: "belowFold"
+},
+}
+`;
+
 exports[`PageBlock 1`] = `
 {
   exportType: component,

--- a/site/src/App/routes/foundations/layout/layout.tsx
+++ b/site/src/App/routes/foundations/layout/layout.tsx
@@ -22,14 +22,16 @@ import {
   Strong,
   Bleed,
   PageBlock,
+  Page,
 } from 'braid-src/lib/components';
 import { TextStack } from '../../../TextStack/TextStack';
 import Code from '../../../Code/Code';
 import tokens from 'braid-src/lib/themes/wireframe/tokens';
-import type { Page } from '../../../../types';
+import type { Page as DocsPage } from '../../../../types';
 import { ThemedExample } from '../../../ThemeSetting';
 import { PageTitle } from '../../../Seo/PageTitle';
 import { LinkableHeading } from '../../../LinkableHeading/LinkableHeading';
+import { ContainerForPageDocs } from 'braid-src/lib/components/Page/Page.docs';
 import source from 'braid-design-system/src/lib/utils/source.macro';
 import { Placeholder } from 'braid-src/lib/playroom/components';
 
@@ -42,7 +44,41 @@ const lipsum1 =
 const lipsum2 =
   'Phasellus ipsum tortor, aliquet dapibus fermentum in, mollis vel metus. Vestibulum malesuada ante eu velit malesuada, nec ultricies sapien finibus. Aenean rutrum in sem a ullamcorper. Integer ut euismod urna. Interdum et malesuada fames ac ante ipsum primis in faucibus.';
 
-const page: Page = {
+const defaultPage = source(
+  <Page
+    footer={
+      <Box background="promoteLight">
+        <Placeholder label="Footer" height={100} />
+      </Box>
+    }
+  >
+    <Placeholder label="Header" height={50} />
+    <Placeholder label="Content" height={50} />
+  </Page>,
+);
+const belowFoldPage = source(
+  <Page
+    footer={
+      <Box background="promoteLight">
+        <Placeholder label="Footer" height={100} />
+      </Box>
+    }
+    footerPosition="belowFold"
+  >
+    <Placeholder label="Header" height={50} />
+    <Placeholder label="Content" height={50} />
+  </Page>,
+);
+const sourceForDefaultPage = {
+  code: defaultPage.code,
+  value: <ContainerForPageDocs>{defaultPage.value}</ContainerForPageDocs>,
+};
+const sourceForBelowFoldPage = {
+  code: belowFoldPage.code,
+  value: <ContainerForPageDocs>{belowFoldPage.value}</ContainerForPageDocs>,
+};
+
+const page: DocsPage = {
   title: 'Layout',
   element: (
     <TextStack>
@@ -88,6 +124,9 @@ const page: Page = {
         </Text>
         <Text>
           <TextLink href="#pageblock">PageBlock</TextLink>
+        </Text>
+        <Text>
+          <TextLink href="#page">Page</TextLink>
         </Text>
         <Text>
           <TextLink href="#bleed">Bleed</TextLink>
@@ -809,6 +848,26 @@ const page: Page = {
           </PageBlock>,
         )}
       </Code>
+
+      <Divider />
+
+      <LinkableHeading>Page</LinkableHeading>
+      <Text>
+        For establishing consistent page-level layout, Braid provides the{' '}
+        <TextLink href="/components/Page">Page</TextLink> component —
+        responsible for managing the relationship between the footer and the
+        main content. This ensures at a minimum the footer is always positioned
+        at the bottom of the screen, pushed beyond as the page content grows.
+      </Text>
+      <Code>{sourceForDefaultPage}</Code>
+      <Text>
+        For pages with dynamic content it is recommended to place the footer out
+        of view by setting the <Strong>footerPosition</Strong> prop to{' '}
+        <Strong>belowFold</Strong>. This prevents the footer from popping in and
+        out of view when the page content changes, e.g. toggling between a
+        loading indicator and content.
+      </Text>
+      <Code>{sourceForBelowFoldPage}</Code>
 
       <Divider />
 


### PR DESCRIPTION
The new `Page` component establishes a consistent page-level layout, by managing the relationship between the footer and the main content.

By default, for pages with limited content the `footer` will at a minimum be placed at the bottom of the screen, pushed beyond as the page content grows.

For pages with dynamic content, it is recommended to place the footer out of view by setting the `footerPosition` prop to `belowFold` to prevent the footer from popping in and out of view when the page content changes, e.g. toggling between a loading indicator and content.

**EXAMPLE USAGE:**
```jsx
<Page footer={<Footer />}>
  <Header />
  {/* page content... */}
</Page>
```
