### PR TITLE
TabPanel: Align focus outline radius to scale

### DIFF
--- a/.changeset/few-wasps-applaud.md
+++ b/.changeset/few-wasps-applaud.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - TabPanel
+---
+
+**TabPanel:** Align focus outline radius to scale
+
+Increase the radius of the focus outline to better align to the scale. A `TabPanel` is typically a "large" element containing entire sections of UI, so using the `large` radius to better align to the radius scale.

--- a/packages/braid-design-system/src/lib/components/Tabs/TabPanel.tsx
+++ b/packages/braid-design-system/src/lib/components/Tabs/TabPanel.tsx
@@ -56,7 +56,7 @@ export const TabPanel = ({
       <Overlay
         zIndex={1}
         boxShadow="outlineFocus"
-        borderRadius="standard"
+        borderRadius="large"
         className={styles.tabPanelFocusRing}
         onlyVisibleForKeyboardNavigation
       />


### PR DESCRIPTION
Increase the radius of the focus outline to better align to the scale. A `TabPanel` is typically a "large" element containing entire sections of UI, so using the `large` radius to better align to the radius scale.

## Screenshots

Example of before and after with the tab panel focused:

<img src="https://github.com/seek-oss/braid-design-system/assets/912060/a422cb28-5a16-4d7a-b354-f4d0ecaae48e" width="45%" align="left" />
<img src="https://github.com/seek-oss/braid-design-system/assets/912060/6a0c9f38-bd48-4118-b12f-27235ea3b6e3" width="45%" />
