### PR TITLE
Document tooltip alternatives

### DIFF
--- a/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.docs.tsx
@@ -70,7 +70,18 @@ const docs: ComponentDocs = {
         </TooltipRenderer>
       </Inline>,
     ),
-  alternatives: [],
+  alternatives: [
+    {
+      name: 'Dialog',
+      description:
+        'For exposing additional content in a modal with richer formatting.',
+    },
+    {
+      name: 'Disclosure',
+      description:
+        'For revealing content inline with a light visual treatment.',
+    },
+  ],
   accessibility: (
     <Stack space="large">
       <Text>


### PR DESCRIPTION
Adding some alternatives to the Tooltip documentation to guide consumers to other system elements when considering richer content.