### PR TITLE
Fix rendering of GitHub Pages

### DIFF
--- a/site/src/render.tsx
+++ b/site/src/render.tsx
@@ -33,7 +33,8 @@ const skuRender: Render<RenderContext> = {
 
     const playroomUrl = !CI
       ? 'http://127.0.0.1:8082'
-      : `${routerBasename ? `/${routerBasename}` : ''}/playroom`;
+      : `${routerBasename}/playroom`;
+
     const appConfig = {
       playroomUrl,
       sourceUrlPrefix,

--- a/site/src/render.tsx
+++ b/site/src/render.tsx
@@ -17,7 +17,7 @@ import { colorModeQueryParamCheck } from 'braid-src/entries/color-mode/query-par
 const { version } = packageJson;
 
 const skuRender: Render<RenderContext> = {
-  renderApp: async ({ route }) => {
+  renderApp: async ({ route: inputRoute }) => {
     const {
       IS_GITHUB_PAGES: isGithubPages,
       GITHUB_SHA: prSha,
@@ -27,7 +27,10 @@ const skuRender: Render<RenderContext> = {
     const versionMap = await braidVersionToDate();
 
     const sourceUrlPrefix = `${githubUrl}${prSha || 'master'}`;
-    const routerBasename = isGithubPages ? 'braid-design-system' : '';
+
+    const routerBasename = isGithubPages ? '/braid-design-system' : '';
+    const route = `${routerBasename}${inputRoute}`;
+
     const playroomUrl = !CI
       ? 'http://127.0.0.1:8082'
       : `${routerBasename ? `/${routerBasename}` : ''}/playroom`;


### PR DESCRIPTION
The docs site is hosted on GitHub Pages, and has a global `/braid-design-system` prefix for its URL paths. This is achieved in React Router using the `basename` prop on the various routers.

However, when the routers have a basename enabled, and sku requests an un-basenamed path to build, react router doesn't find anything. This causes all of the static renders in `IS_GITHUB_PAGES` mode to be empty.

We can fix this by having sku pass in the route with relevant basename prepended.

There's also a small change here to add the leading slash to the `routerBasename` const. This simplifies the logic required for the `route` and playroom path values, and all the example usage of basename I can find accepts the leading slash.