### PR TITLE
RadioGroup: Ensure `reserveMessageSpace` prevents layout shift correctly

### DIFF
--- a/.changeset/few-mayflies-lick.md
+++ b/.changeset/few-mayflies-lick.md
@@ -9,4 +9,4 @@ updated:
 
 **RadioGroup:** Ensure `reserveMessageSpace` prevents layout shift correctly
 
-Consider the `removeMessageSpace` prop as well as `message` when conditionally applying internal padding between radio list and field message.
+Consider the `reserveMessageSpace` prop as well as `message` when conditionally applying internal padding between radio list and field message.

--- a/.changeset/few-mayflies-lick.md
+++ b/.changeset/few-mayflies-lick.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - RadioGroup
+---
+
+**RadioGroup:** Ensure `reserveMessageSpace` prevents layout shift correctly
+
+Consider the `removeMessageSpace` prop as well as `message` when conditionally applying internal padding between radio list and field message.

--- a/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.tsx
+++ b/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.tsx
@@ -79,7 +79,9 @@ const RadioGroup = ({
         >
           <Box
             paddingTop={'label' in props ? labelSpace : undefined}
-            paddingBottom={props.message ? 'xsmall' : undefined}
+            paddingBottom={
+              props.message || props.reserveMessageSpace ? 'xsmall' : undefined
+            }
           >
             <Stack space={stackSpaceForSize[size || 'standard']}>
               {items.map((item, i) => (


### PR DESCRIPTION
Consider the `reserveMessageSpace` prop as well as `message` when conditionally applying internal padding between radio list and field message.