### PR TITLE
Drawer: Prevent close button protruding in left position

### DIFF
--- a/.changeset/chilly-mugs-tickle.md
+++ b/.changeset/chilly-mugs-tickle.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Drawer
+---
+
+**Drawer:** Prevent close button protruding in left position
+
+Fixes an issue where the close button could protrude from a `Drawer`.
+This was only visible when setting `position` to `left` and between a small range of screen widths — above 660px (`small` content width) and below 768px (`tablet` breakpoint).

--- a/packages/braid-design-system/src/lib/components/Dialog/Dialog.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Dialog/Dialog.screenshots.tsx
@@ -4,6 +4,7 @@ import { Inline, Stack, Box } from '../';
 import { Placeholder } from '../../playroom/components';
 import { DialogContent } from './Dialog';
 import * as styles from '../private/Modal/Modal.css';
+import { externalGutter } from '../private/Modal/ModalExternalGutter';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <Box position="relative">
@@ -16,7 +17,7 @@ const Container = ({ children }: { children: ReactNode }) => (
       width="full"
       className={styles.backdrop}
     />
-    <Box position="relative" zIndex="modal">
+    <Box position="relative" zIndex="modal" padding={externalGutter}>
       {children}
     </Box>
   </Box>

--- a/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
@@ -115,6 +115,7 @@ export const ModalContent = ({
   const justifyContent = (
     { left: 'flexStart', center: 'center', right: 'flexEnd' } as const
   )[position];
+  const modalRadius = position === 'center' ? 'xlarge' : undefined;
 
   return (
     <Box
@@ -140,6 +141,8 @@ export const ModalContent = ({
           position === 'right' || position === 'left' ? 'full' : undefined
         }
         overflow={position !== 'center' ? 'hidden' : undefined}
+        boxShadow="large"
+        borderRadius={modalRadius}
         width={width !== 'content' ? 'full' : undefined}
         maxWidth={width !== 'content' ? width : undefined}
       >
@@ -147,10 +150,9 @@ export const ModalContent = ({
         <RemoveScroll ref={modalRef} forwardProps enabled={scrollLock}>
           <Box
             background="surface"
-            borderRadius={position === 'center' ? 'xlarge' : undefined}
+            borderRadius={modalRadius}
             overflow="auto"
             position="relative"
-            boxShadow="large"
             width={width !== 'content' ? 'full' : undefined}
             height={
               position === 'right' || position === 'left' ? 'full' : undefined

--- a/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
@@ -139,6 +139,7 @@ export const ModalContent = ({
         height={
           position === 'right' || position === 'left' ? 'full' : undefined
         }
+        overflow={position !== 'center' ? 'hidden' : undefined}
         width={width !== 'content' ? 'full' : undefined}
         maxWidth={width !== 'content' ? width : undefined}
       >


### PR DESCRIPTION
Fixes an issue where the close button could protrude from a `Drawer`.
This was only visible when setting `position` to `left` and between a small range of screen widths — above 660px (`small` content width) and below 768px (`tablet` breakpoint).


![image](https://github.com/seek-oss/braid-design-system/assets/912060/1af6757b-8072-4127-bfc7-5cad34efe4ff)
