### PR TITLE
Dialog, Drawer: Adapt max height to available viewport space

### DIFF
--- a/.changeset/tough-icons-brush.md
+++ b/.changeset/tough-icons-brush.md
@@ -1,0 +1,18 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Dialog
+  - Drawer
+---
+
+**Dialog, Drawer:** Adapt max height to available viewport space
+
+Make use of the new [dynamic viewport units] for applying a max height to modal elements such as `Dialog` and `Drawer`. These new units take into account dynamic browser toolbars that expand and contract as the user scrolls, ensuring the browser interface never obscures the web site content.
+
+Fix also incorporates fallback for older browsers to use regular viewport units.
+
+
+[Dynamic Viewport units]: https://web.dev/viewport-units/

--- a/packages/braid-design-system/src/lib/components/private/Modal/Modal.css.ts
+++ b/packages/braid-design-system/src/lib/components/private/Modal/Modal.css.ts
@@ -1,4 +1,4 @@
-import { style } from '@vanilla-extract/css';
+import { createVar, style } from '@vanilla-extract/css';
 import { calc } from '@vanilla-extract/css-utils';
 import { externalGutter } from './ModalExternalGutter';
 import { responsiveStyle } from '../../../css/responsiveStyle';
@@ -94,57 +94,62 @@ export const horiztontalTransition = style(
   }),
 );
 
-export const modalContainer = style({
-  maxHeight: '100vh',
-  maxWidth: '100vw',
-});
-
 export const pointerEventsAll = style({
   pointerEvents: 'all',
 });
 
+const gutterSizeVar = createVar();
+const fullHeightVar = createVar();
+const fullWidthVar = createVar();
+
 const viewportHeight = style({
-  maxHeight: '100vh',
+  maxHeight: fullHeightVar,
 });
 
 export const maxSize = {
-  center: style(
+  center: style([
+    {
+      maxHeight: calc.subtract(fullHeightVar, calc.multiply(gutterSizeVar, 2)),
+      maxWidth: calc.subtract(fullWidthVar, calc.multiply(gutterSizeVar, 2)),
+    },
     responsiveStyle({
       mobile: {
-        maxHeight: calc.subtract(
-          '100vh',
-          calc.multiply(vars.space[externalGutter[0]], 2),
-        ),
-        maxWidth: calc.subtract(
-          '100vw',
-          calc.multiply(vars.space[externalGutter[0]], 2),
-        ),
+        vars: {
+          [gutterSizeVar]: vars.space[externalGutter.mobile],
+        },
       },
       tablet: {
-        maxHeight: calc.subtract(
-          '100vh',
-          calc.multiply(vars.space[externalGutter[1]], 2),
-        ),
-        maxWidth: calc.subtract(
-          '100vw',
-          calc.multiply(vars.space[externalGutter[1]], 2),
-        ),
+        vars: {
+          [gutterSizeVar]: vars.space[externalGutter.tablet],
+        },
       },
       desktop: {
-        maxHeight: calc.subtract(
-          '100vh',
-          calc.multiply(vars.space[externalGutter[2]], 2),
-        ),
-        maxWidth: calc.subtract(
-          '100vw',
-          calc.multiply(vars.space[externalGutter[2]], 2),
-        ),
+        vars: {
+          [gutterSizeVar]: vars.space[externalGutter.desktop],
+        },
       },
     }),
-  ),
+  ]),
   right: viewportHeight,
   left: viewportHeight,
 };
+
+export const modalContainer = style({
+  vars: {
+    [fullHeightVar]: '100vh',
+    [fullWidthVar]: '100vw',
+  },
+  '@supports': {
+    '(height: 1dvh)': {
+      vars: {
+        [fullHeightVar]: '100dvh',
+        [fullWidthVar]: '100dvw',
+      },
+    },
+  },
+  maxHeight: fullHeightVar,
+  maxWidth: fullWidthVar,
+});
 
 export const headingRoot = style({
   overflowWrap: 'break-word',

--- a/packages/braid-design-system/src/lib/components/private/Modal/ModalExternalGutter.ts
+++ b/packages/braid-design-system/src/lib/components/private/Modal/ModalExternalGutter.ts
@@ -1,1 +1,5 @@
-export const externalGutter = ['xsmall', 'gutter', 'xlarge'] as const;
+export const externalGutter = {
+  mobile: 'xsmall',
+  tablet: 'gutter',
+  desktop: 'xlarge',
+} as const;


### PR DESCRIPTION
Make use of the new [dynamic viewport units] for applying a max height to modal elements such as `Dialog` and `Drawer`. These new units take into account dynamic browser toolbars that expand and contract as the user scrolls, ensuring the browser interface never obscures the web site content.

Fix also incorporates fallback for older browsers to use regular viewport units.

### Notes

Refactored the `maxSize` style to make better use of CSS vars, as well as refactoring the shared `externalGutter` to use the object syntax over the array syntax for responsive values.

### Preview Links
[Before] / [After]

[Before]: https://braid-design-system--d1c4d3e2aab81e4e658e6d06f84e58cda82c1b0a.surge.sh/playroom/preview/#?code=N4Igxg9gJgpiBcIA8ARAlgQwDYQOYAIAXNQrGAXgB0R1s98AJGDKNAO12vwgAcY3ywQgCcArjAC+APkpt8+JABUYAD0IAxNDCxR8WDACNtVEABlD2rgHoZchQAV9YGAAsIOmMPwB3NFEIuggBMAKwADBL4LjBouC6EggDsYRH4NrJIVrQ4uLYgADQgATAAtnCIAM4wMADWAFIQBhUgEkA
[After]: https://braid-design-system--2da599661b6e7a7b33a8b173e3213bfbe77aca9c.surge.sh/playroom/preview/#?code=N4Igxg9gJgpiBcIA8ARAlgQwDYQOYAIAXNQrGAXgB0R1s98AJGDKNAO12vwgAcY3ywQgCcArjAC+APkpt8+JABUYAD0IAxNDCxR8WDACNtVEABlD2rgHoZchQAV9YGAAsIOmMPwB3NFEIuggBMAKwADBL4LjBouC6EggDsYRH4NrJIVrQ4uLYgADQgATAAtnCIAM4wMADWAFIQBhUgEkA
[Dynamic Viewport units]: https://web.dev/viewport-units/