### PR TITLE
Don't cancel other workflow runs for the same commit

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -15,7 +15,6 @@ jobs:
         id: skip_check
         with:
           concurrent_skipping: same_content_newer
-          cancel_others: true
           # We want to skip only concurrent runs. Subsequent runs/retries should be allowed.
           skip_after_successful_duplicate: false
 


### PR DESCRIPTION
Attempt to fix Chromatic not picking up the latest builds on master (because the workflow had been cancelled)