### PR TITLE
Button, ButtonLink: Provide `formAccent` as the name for `undefined` tone

### DIFF
--- a/.changeset/curvy-ads-shake.md
+++ b/.changeset/curvy-ads-shake.md
@@ -1,0 +1,22 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Button
+  - ButtonLink
+---
+
+**Button, ButtonLink:** Provide `formAccent` as the name for undefined tone
+
+Formalise the name of the `undefined` tone as `formAccent`, making it more discoverable as an accent available for increased prominence.
+
+Note: Consumers should only apply this tone where an action should be emphasized explicitly. The `undefined` value is still valid for buttons that should follow the default button style of the theme.
+
+**EXAMPLE USAGE:**
+```jsx
+<Button tone="formAccent">
+  ...
+</Button>
+```

--- a/packages/braid-design-system/src/lib/components/Button/Button.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.docs.tsx
@@ -25,7 +25,7 @@ const docs: ComponentDocs = {
     source(
       <Card rounded>
         <Inline space="small" collapseBelow="desktop">
-          <Button>Solid</Button>
+          <Button variant="solid">Solid</Button>
           <Button variant="ghost">Ghost</Button>
           <Button variant="soft">Soft</Button>
           <Button variant="transparent">Transparent</Button>
@@ -78,6 +78,125 @@ const docs: ComponentDocs = {
         ),
     },
     {
+      label: 'Branding',
+      background: 'surface',
+      description: (
+        <Text>
+          For hero actions that want to leverage the brand colour, you can set
+          the button’s <Strong>tone</Strong> to <Strong>brandAccent.</Strong>
+        </Text>
+      ),
+      Example: () =>
+        source(
+          <Inline space="small">
+            <Button tone="brandAccent" variant="solid">
+              Search
+            </Button>
+            <Button tone="brandAccent" variant="ghost">
+              Search
+            </Button>
+            <Button tone="brandAccent" variant="soft">
+              Search
+            </Button>
+            <Button tone="brandAccent" variant="transparent">
+              Search
+            </Button>
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Destructive actions',
+      background: 'surface',
+      description: (
+        <Text>
+          For destructive actions like “Delete” you can set the button’s{' '}
+          <Strong>tone</Strong> to <Strong>critical.</Strong>
+        </Text>
+      ),
+      Example: () =>
+        source(
+          <Inline space="small">
+            <Button tone="critical" icon={<IconDelete />} variant="solid">
+              Delete
+            </Button>
+            <Button tone="critical" icon={<IconDelete />} variant="ghost">
+              Delete
+            </Button>
+            <Button tone="critical" icon={<IconDelete />} variant="soft">
+              Delete
+            </Button>
+            <Button tone="critical" icon={<IconDelete />} variant="transparent">
+              Delete
+            </Button>
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Emphasizing actions',
+      background: 'surface',
+      description: (
+        <>
+          <Text>
+            For cases where actions need to be emphasized, the{' '}
+            <Strong>tone</Strong> can be set to <Strong>formAccent</Strong>.
+          </Text>
+        </>
+      ),
+      Example: () =>
+        source(
+          <Inline space="small">
+            <Button tone="formAccent" variant="solid">
+              Solid
+            </Button>
+            <Button tone="formAccent" variant="ghost">
+              Ghost
+            </Button>
+            <Button tone="formAccent" variant="soft">
+              Soft
+            </Button>
+            <Button tone="formAccent" variant="transparent">
+              Transparent
+            </Button>
+          </Inline>,
+        ),
+    },
+    {
+      label: 'De-emphasized actions',
+      background: 'surface',
+      description: (
+        <>
+          <Text>
+            For cases where actions need to be de-emphasized, the{' '}
+            <Strong>tone</Strong> can be set to <Strong>neutral</Strong>.
+          </Text>
+          <Text>
+            This makes the button follow the default text colour, including{' '}
+            <TextLink href="#contextual-design">
+              inverting on dark surfaces
+            </TextLink>{' '}
+            to improve contrast.
+          </Text>
+        </>
+      ),
+      Example: () =>
+        source(
+          <Inline space="small">
+            <Button tone="neutral" variant="solid">
+              Solid
+            </Button>
+            <Button tone="neutral" variant="ghost">
+              Ghost
+            </Button>
+            <Button tone="neutral" variant="soft">
+              Soft
+            </Button>
+            <Button tone="neutral" variant="transparent">
+              Transparent
+            </Button>
+          </Inline>,
+        ),
+    },
+    {
       label: 'Sizes',
       background: 'surface',
       description: (
@@ -95,7 +214,7 @@ const docs: ComponentDocs = {
                 Standard size
               </Text>
               <Inline space="small" collapseBelow="desktop">
-                <Button>Solid</Button>
+                <Button variant="solid">Solid</Button>
                 <Button variant="ghost">Ghost</Button>
                 <Button variant="soft">Soft</Button>
                 <Button variant="transparent">Transparent</Button>
@@ -106,7 +225,9 @@ const docs: ComponentDocs = {
                 Small size
               </Text>
               <Inline space="small" collapseBelow="desktop">
-                <Button size="small">Solid</Button>
+                <Button variant="solid" size="small">
+                  Solid
+                </Button>
                 <Button variant="ghost" size="small">
                   Ghost
                 </Button>
@@ -191,92 +312,6 @@ const docs: ComponentDocs = {
         ),
     },
     {
-      label: 'Branding',
-      background: 'surface',
-      description: (
-        <Text>
-          For hero actions that want to leverage the brand colour, you can set
-          the button’s <Strong>tone</Strong> to <Strong>brandAccent.</Strong>
-        </Text>
-      ),
-      Example: () =>
-        source(
-          <Inline space="small">
-            <Button tone="brandAccent">Search</Button>
-            <Button tone="brandAccent" variant="ghost">
-              Search
-            </Button>
-            <Button tone="brandAccent" variant="soft">
-              Search
-            </Button>
-            <Button tone="brandAccent" variant="transparent">
-              Search
-            </Button>
-          </Inline>,
-        ),
-    },
-    {
-      label: 'Destructive actions',
-      background: 'surface',
-      description: (
-        <Text>
-          For destructive actions like “Delete” you can set the button’s{' '}
-          <Strong>tone</Strong> to <Strong>critical.</Strong>
-        </Text>
-      ),
-      Example: () =>
-        source(
-          <Inline space="small">
-            <Button tone="critical" icon={<IconDelete />}>
-              Delete
-            </Button>
-            <Button tone="critical" icon={<IconDelete />} variant="ghost">
-              Delete
-            </Button>
-            <Button tone="critical" icon={<IconDelete />} variant="soft">
-              Delete
-            </Button>
-            <Button tone="critical" icon={<IconDelete />} variant="transparent">
-              Delete
-            </Button>
-          </Inline>,
-        ),
-    },
-    {
-      label: 'De-emphasized actions',
-      background: 'surface',
-      description: (
-        <>
-          <Text>
-            For cases where actions need to be de-emphasized, the{' '}
-            <Strong>tone</Strong> can be set to <Strong>neutral.</Strong>
-          </Text>
-          <Text>
-            This makes the button follow the default text colour, including{' '}
-            <TextLink href="#contextual-design">
-              inverting on dark surfaces
-            </TextLink>{' '}
-            to improve contrast.
-          </Text>
-        </>
-      ),
-      Example: () =>
-        source(
-          <Inline space="small">
-            <Button tone="neutral">Solid</Button>
-            <Button tone="neutral" variant="ghost">
-              Ghost
-            </Button>
-            <Button tone="neutral" variant="soft">
-              Soft
-            </Button>
-            <Button tone="neutral" variant="transparent">
-              Transparent
-            </Button>
-          </Inline>,
-        ),
-    },
-    {
       label: 'Contextual design',
       description: (
         <>
@@ -289,8 +324,8 @@ const docs: ComponentDocs = {
           </Text>
           <Notice>
             <Text>
-              A <Strong>solid</Strong> button with a <Strong>neutral</Strong>{' '}
-              tone will also be inverted to improve contrast.
+              Buttons with a <Strong>neutral</Strong> tone are inverted to
+              improve contrast.
             </Text>
           </Notice>
           <Text>
@@ -308,13 +343,23 @@ const docs: ComponentDocs = {
           <Box background="neutral">
             <Stack space="small">
               <Inline space="small">
-                <Button>Solid</Button>
-                <Button variant="ghost">Ghost</Button>
-                <Button variant="soft">Soft</Button>
-                <Button variant="transparent">Transparent</Button>
+                <Button tone="formAccent" variant="solid">
+                  Solid
+                </Button>
+                <Button tone="formAccent" variant="ghost">
+                  Ghost
+                </Button>
+                <Button tone="formAccent" variant="soft">
+                  Soft
+                </Button>
+                <Button tone="formAccent" variant="transparent">
+                  Transparent
+                </Button>
               </Inline>
               <Inline space="small">
-                <Button tone="brandAccent">Solid</Button>
+                <Button tone="brandAccent" variant="solid">
+                  Solid
+                </Button>
                 <Button tone="brandAccent" variant="ghost">
                   Ghost
                 </Button>
@@ -326,7 +371,9 @@ const docs: ComponentDocs = {
                 </Button>
               </Inline>
               <Inline space="small">
-                <Button tone="critical">Solid</Button>
+                <Button tone="critical" variant="solid">
+                  Solid
+                </Button>
                 <Button tone="critical" variant="ghost">
                   Ghost
                 </Button>
@@ -338,7 +385,9 @@ const docs: ComponentDocs = {
                 </Button>
               </Inline>
               <Inline space="small">
-                <Button tone="neutral">Solid</Button>
+                <Button tone="neutral" variant="solid">
+                  Solid
+                </Button>
                 <Button tone="neutral" variant="ghost">
                   Ghost
                 </Button>
@@ -406,7 +455,13 @@ const docs: ComponentDocs = {
                   <Box background="surface" boxShadow="borderCriticalLight">
                     <Inline space="xsmall" alignY="center">
                       <Heading level="2">Heading</Heading>
-                      <Button bleed={getState('bleed')}>Solid</Button>
+                      <Button
+                        bleed={getState('bleed')}
+                        tone="formAccent"
+                        variant="solid"
+                      >
+                        Button
+                      </Button>
                     </Inline>
                   </Box>
                 </Box>
@@ -424,8 +479,13 @@ const docs: ComponentDocs = {
                   <Box background="surface" boxShadow="borderCriticalLight">
                     <Inline space="xsmall" alignY="center">
                       <Heading level="2">Heading</Heading>
-                      <Button bleed={getState('bleed')} size="small">
-                        Solid
+                      <Button
+                        bleed={getState('bleed')}
+                        size="small"
+                        tone="formAccent"
+                        variant="solid"
+                      >
+                        Button
                       </Button>
                     </Inline>
                   </Box>
@@ -445,8 +505,12 @@ const docs: ComponentDocs = {
                     <Stack space="gutter">
                       <Heading level="2">Heading</Heading>
                       <Inline space="none">
-                        <Button bleed={getState('bleed')} variant="transparent">
-                          Solid
+                        <Button
+                          bleed={getState('bleed')}
+                          variant="transparent"
+                          tone="formAccent"
+                        >
+                          Button
                         </Button>
                       </Inline>
                     </Stack>

--- a/packages/braid-design-system/src/lib/components/Button/Button.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.gallery.tsx
@@ -5,33 +5,22 @@ import { Button, Heading, Inline, IconSend } from '../';
 
 export const galleryItems: ComponentExample[] = [
   {
-    label: 'Default',
-    background: 'surface',
-    Example: () =>
-      source(
-        <Inline space="small">
-          <Button>Submit</Button>
-          <Button variant="ghost">Submit</Button>
-          <Button variant="soft">Submit</Button>
-          <Button variant="transparent">Submit</Button>
-        </Inline>,
-      ),
-  },
-  {
     label: 'Critical',
     background: 'surface',
     Example: () =>
       source(
         <Inline space="small">
-          <Button tone="critical">Delete</Button>
+          <Button tone="critical" variant="solid">
+            Solid
+          </Button>
           <Button tone="critical" variant="ghost">
-            Delete
+            Ghost
           </Button>
           <Button tone="critical" variant="soft">
-            Delete
+            Soft
           </Button>
           <Button tone="critical" variant="transparent">
-            Delete
+            Transparent
           </Button>
         </Inline>,
       ),
@@ -42,15 +31,38 @@ export const galleryItems: ComponentExample[] = [
     Example: () =>
       source(
         <Inline space="small">
-          <Button tone="brandAccent">Search</Button>
+          <Button tone="brandAccent" variant="solid">
+            Solid
+          </Button>
           <Button tone="brandAccent" variant="ghost">
-            Search
+            Ghost
           </Button>
           <Button tone="brandAccent" variant="soft">
-            Search
+            Soft
           </Button>
           <Button tone="brandAccent" variant="transparent">
-            Search
+            Transparent
+          </Button>
+        </Inline>,
+      ),
+  },
+  {
+    label: 'FormAccent',
+    background: 'surface',
+    Example: () =>
+      source(
+        <Inline space="small">
+          <Button tone="formAccent" variant="solid">
+            Solid
+          </Button>
+          <Button tone="formAccent" variant="ghost">
+            Ghost
+          </Button>
+          <Button tone="formAccent" variant="soft">
+            Soft
+          </Button>
+          <Button tone="formAccent" variant="transparent">
+            Transparent
           </Button>
         </Inline>,
       ),
@@ -61,15 +73,17 @@ export const galleryItems: ComponentExample[] = [
     Example: () =>
       source(
         <Inline space="small">
-          <Button tone="neutral">Search</Button>
+          <Button tone="neutral" variant="solid">
+            Solid
+          </Button>
           <Button tone="neutral" variant="ghost">
-            Search
+            Ghost
           </Button>
           <Button tone="neutral" variant="soft">
-            Search
+            Soft
           </Button>
           <Button tone="neutral" variant="transparent">
-            Search
+            Transparent
           </Button>
         </Inline>,
       ),

--- a/packages/braid-design-system/src/lib/components/Button/Button.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.screenshots.tsx
@@ -19,13 +19,14 @@ export const screenshots: ComponentScreenshot = {
   screenshotWidths: [768],
   examples: [
     {
-      label: 'Default',
+      label: 'Default variant for tone',
       Example: () => (
         <Inline space="small">
-          <Button>Solid</Button>
-          <Button variant="ghost">Ghost</Button>
-          <Button variant="soft">Soft</Button>
-          <Button variant="transparent">Transparent</Button>
+          <Button>No tone</Button>
+          <Button tone="brandAccent">brandAccent</Button>
+          <Button tone="critical">critical</Button>
+          <Button tone="formAccent">formAccent</Button>
+          <Button tone="neutral">neutral</Button>
         </Inline>
       ),
     },
@@ -33,7 +34,9 @@ export const screenshots: ComponentScreenshot = {
       label: 'Critical',
       Example: () => (
         <Inline space="small">
-          <Button tone="critical">Solid</Button>
+          <Button tone="critical" variant="solid">
+            Solid
+          </Button>
           <Button tone="critical" variant="ghost">
             Ghost
           </Button>
@@ -50,7 +53,9 @@ export const screenshots: ComponentScreenshot = {
       label: 'BrandAccent',
       Example: () => (
         <Inline space="small">
-          <Button tone="brandAccent">Solid</Button>
+          <Button tone="brandAccent" variant="solid">
+            Solid
+          </Button>
           <Button tone="brandAccent" variant="ghost">
             Ghost
           </Button>
@@ -64,10 +69,31 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
+      label: 'FormAccent',
+      Example: () => (
+        <Inline space="small">
+          <Button tone="formAccent" variant="solid">
+            Solid
+          </Button>
+          <Button tone="formAccent" variant="ghost">
+            Ghost
+          </Button>
+          <Button tone="formAccent" variant="soft">
+            Soft
+          </Button>
+          <Button tone="formAccent" variant="transparent">
+            Transparent
+          </Button>
+        </Inline>
+      ),
+    },
+    {
       label: 'Neutral',
       Example: () => (
         <Inline space="small">
-          <Button tone="neutral">Solid</Button>
+          <Button tone="neutral" variant="solid">
+            Solid
+          </Button>
           <Button tone="neutral" variant="ghost">
             Ghost
           </Button>
@@ -84,7 +110,9 @@ export const screenshots: ComponentScreenshot = {
       label: 'Small size',
       Example: () => (
         <Inline space="small">
-          <Button size="small">Solid</Button>
+          <Button size="small" variant="solid">
+            Solid
+          </Button>
           <Button size="small" variant="ghost">
             Ghost
           </Button>
@@ -164,7 +192,9 @@ export const screenshots: ComponentScreenshot = {
       Example: () => (
         <Stack space="small">
           <Inline space="small">
-            <Button icon={<IconSend />}>Solid</Button>
+            <Button icon={<IconSend />} variant="solid">
+              Solid
+            </Button>
             <Button icon={<IconSend />} variant="ghost">
               Ghost
             </Button>
@@ -176,7 +206,7 @@ export const screenshots: ComponentScreenshot = {
             </Button>
           </Inline>
           <Inline space="small">
-            <Button size="small" icon={<IconSend />}>
+            <Button size="small" icon={<IconSend />} variant="solid">
               Solid
             </Button>
             <Button size="small" icon={<IconSend />} variant="ghost">
@@ -200,6 +230,7 @@ export const screenshots: ComponentScreenshot = {
             <Button
               icon={<IconArrow direction="right" />}
               iconPosition="trailing"
+              variant="solid"
             >
               Solid
             </Button>
@@ -230,6 +261,7 @@ export const screenshots: ComponentScreenshot = {
               size="small"
               icon={<IconArrow direction="right" />}
               iconPosition="trailing"
+              variant="solid"
             >
               Solid
             </Button>
@@ -301,7 +333,7 @@ export const screenshots: ComponentScreenshot = {
       Example: () => (
         <BackgroundContrastTest>
           <Inline space="small">
-            <Button>Solid</Button>
+            <Button variant="solid">Solid</Button>
             <Button variant="ghost">Ghost</Button>
             <Button variant="soft">Soft</Button>
             <Button variant="transparent">Transparent</Button>
@@ -314,7 +346,9 @@ export const screenshots: ComponentScreenshot = {
       Example: () => (
         <BackgroundContrastTest>
           <Inline space="small">
-            <Button tone="critical">Solid</Button>
+            <Button tone="critical" variant="solid">
+              Solid
+            </Button>
             <Button tone="critical" variant="ghost">
               Ghost
             </Button>
@@ -333,7 +367,9 @@ export const screenshots: ComponentScreenshot = {
       Example: () => (
         <BackgroundContrastTest>
           <Inline space="small">
-            <Button tone="brandAccent">Solid</Button>
+            <Button tone="brandAccent" variant="solid">
+              Solid
+            </Button>
             <Button tone="brandAccent" variant="ghost">
               Ghost
             </Button>
@@ -352,7 +388,9 @@ export const screenshots: ComponentScreenshot = {
       Example: () => (
         <BackgroundContrastTest>
           <Inline space="small">
-            <Button tone="neutral">Solid</Button>
+            <Button tone="neutral" variant="solid">
+              Solid
+            </Button>
             <Button tone="neutral" variant="ghost">
               Ghost
             </Button>

--- a/packages/braid-design-system/src/lib/components/Button/Button.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.tsx
@@ -36,7 +36,7 @@ export const buttonVariants = [
 ] as const;
 
 type ButtonSize = 'standard' | 'small';
-type ButtonTone = 'brandAccent' | 'critical' | 'neutral';
+type ButtonTone = 'formAccent' | 'brandAccent' | 'critical' | 'neutral';
 type ButtonVariant = (typeof buttonVariants)[number];
 export interface ButtonStyleProps {
   size?: ButtonSize;
@@ -84,12 +84,9 @@ type ButtonStyles = {
   boxShadow: BoxShadow | undefined;
 };
 
-const variants: Record<
-  ButtonVariant,
-  Record<'default' | ButtonTone, ButtonStyles>
-> = {
+const variants: Record<ButtonVariant, Record<ButtonTone, ButtonStyles>> = {
   solid: {
-    default: {
+    formAccent: {
       textTone: undefined,
       background: 'formAccent',
       backgroundHover: 'formAccentHover',
@@ -119,7 +116,7 @@ const variants: Record<
     },
   },
   soft: {
-    default: {
+    formAccent: {
       textTone: 'formAccent',
       background: { light: 'formAccentSoft', dark: 'customDark' },
       backgroundHover: 'formAccentSoftHover',
@@ -149,7 +146,7 @@ const variants: Record<
     },
   },
   transparent: {
-    default: {
+    formAccent: {
       textTone: 'formAccent',
       background: undefined,
       backgroundHover: 'formAccentSoftHover',
@@ -179,7 +176,7 @@ const variants: Record<
     },
   },
   ghost: {
-    default: {
+    formAccent: {
       textTone: 'formAccent',
       background: undefined,
       backgroundHover: 'formAccentSoftHover',
@@ -238,7 +235,7 @@ export const ButtonOverlays = ({
   radius?: 'full' | typeof buttonRadius;
   forceActive?: boolean;
 }) => {
-  const stylesForVariant = variants[variant][tone ?? 'default'];
+  const stylesForVariant = variants[variant][tone ?? 'formAccent'];
   const colorContrast = useColorContrast();
   const lightness = useBackgroundLightness();
 
@@ -317,7 +314,7 @@ export const ButtonText = ({
   const actionsContext = useContext(ActionsContext);
   const isLegacyTheme = useBraidTheme().legacy;
   const size = sizeProp ?? actionsContext?.size ?? 'standard';
-  const stylesForVariant = variants[variant][tone ?? 'default'];
+  const stylesForVariant = variants[variant][tone ?? 'formAccent'];
   const shouldReducePaddingX = size === 'small' || variant === 'transparent';
   const labelPaddingXForTheme = isLegacyTheme ? 'medium' : 'gutter';
   const labelPaddingX = shouldReducePaddingX
@@ -402,7 +399,7 @@ export const useButtonStyles = ({
 }): BoxProps => {
   const actionsContext = useContext(ActionsContext);
   const size = sizeProp ?? actionsContext?.size ?? 'standard';
-  const stylesForVariant = variants[variant][tone ?? 'default'];
+  const stylesForVariant = variants[variant][tone ?? 'formAccent'];
   const colorConstrast = useColorContrast();
   const lightness = useBackgroundLightness();
 

--- a/packages/braid-design-system/src/lib/components/ButtonLink/ButtonLink.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonLink/ButtonLink.docs.tsx
@@ -11,7 +11,9 @@ const docs: ComponentDocs = {
     source(
       <Card rounded>
         <Inline space="small" collapseBelow="desktop">
-          <ButtonLink href="#">Solid</ButtonLink>
+          <ButtonLink href="#" variant="solid">
+            Solid
+          </ButtonLink>
           <ButtonLink href="#" variant="ghost">
             Ghost
           </ButtonLink>

--- a/packages/braid-design-system/src/lib/components/ButtonLink/ButtonLink.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonLink/ButtonLink.screenshots.tsx
@@ -10,19 +10,22 @@ export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],
   examples: [
     {
-      label: 'Default',
+      label: 'Default variants for tone',
       Container,
       Example: () => (
         <Inline space="small" collapseBelow="desktop">
-          <ButtonLink href="#">Solid</ButtonLink>
-          <ButtonLink href="#" variant="ghost">
-            Ghost
+          <ButtonLink href="#">No tone</ButtonLink>
+          <ButtonLink href="#" tone="brandAccent">
+            brandAccent
           </ButtonLink>
-          <ButtonLink href="#" variant="soft">
-            Soft
+          <ButtonLink href="#" tone="critical">
+            critical
           </ButtonLink>
-          <ButtonLink href="#" variant="transparent">
-            Transparent
+          <ButtonLink href="#" tone="formAccent">
+            formAccent
+          </ButtonLink>
+          <ButtonLink href="#" tone="neutral">
+            neutral
           </ButtonLink>
         </Inline>
       ),
@@ -32,7 +35,7 @@ export const screenshots: ComponentScreenshot = {
       Container,
       Example: () => (
         <Inline space="small" collapseBelow="desktop">
-          <ButtonLink href="#" tone="critical">
+          <ButtonLink href="#" tone="critical" variant="solid">
             Solid
           </ButtonLink>
           <ButtonLink href="#" tone="critical" variant="ghost">
@@ -52,7 +55,7 @@ export const screenshots: ComponentScreenshot = {
       Container,
       Example: () => (
         <Inline space="small" collapseBelow="desktop">
-          <ButtonLink href="#" tone="brandAccent">
+          <ButtonLink href="#" tone="brandAccent" variant="solid">
             Solid
           </ButtonLink>
           <ButtonLink href="#" tone="brandAccent" variant="ghost">
@@ -68,11 +71,51 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
+      label: 'FormAccent',
+      Container,
+      Example: () => (
+        <Inline space="small" collapseBelow="desktop">
+          <ButtonLink href="#" tone="formAccent" variant="solid">
+            Solid
+          </ButtonLink>
+          <ButtonLink href="#" tone="formAccent" variant="ghost">
+            Ghost
+          </ButtonLink>
+          <ButtonLink href="#" tone="formAccent" variant="soft">
+            Soft
+          </ButtonLink>
+          <ButtonLink href="#" tone="formAccent" variant="transparent">
+            Transparent
+          </ButtonLink>
+        </Inline>
+      ),
+    },
+    {
+      label: 'Neutral',
+      Container,
+      Example: () => (
+        <Inline space="small" collapseBelow="desktop">
+          <ButtonLink href="#" tone="neutral" variant="solid">
+            Solid
+          </ButtonLink>
+          <ButtonLink href="#" tone="neutral" variant="ghost">
+            Ghost
+          </ButtonLink>
+          <ButtonLink href="#" tone="neutral" variant="soft">
+            Soft
+          </ButtonLink>
+          <ButtonLink href="#" tone="neutral" variant="transparent">
+            Transparent
+          </ButtonLink>
+        </Inline>
+      ),
+    },
+    {
       label: 'With icon',
       Example: () => (
         <Stack space="small">
           <Inline space="small">
-            <ButtonLink href="#" icon={<IconSend />}>
+            <ButtonLink href="#" icon={<IconSend />} variant="solid">
               Solid
             </ButtonLink>
             <ButtonLink href="#" icon={<IconSend />} variant="ghost">
@@ -86,7 +129,12 @@ export const screenshots: ComponentScreenshot = {
             </ButtonLink>
           </Inline>
           <Inline space="small">
-            <ButtonLink href="#" size="small" icon={<IconSend />}>
+            <ButtonLink
+              href="#"
+              size="small"
+              icon={<IconSend />}
+              variant="solid"
+            >
               Solid
             </ButtonLink>
             <ButtonLink
@@ -126,6 +174,7 @@ export const screenshots: ComponentScreenshot = {
               href=""
               icon={<IconArrow direction="right" />}
               iconPosition="trailing"
+              variant="solid"
             >
               Solid
             </ButtonLink>
@@ -160,6 +209,7 @@ export const screenshots: ComponentScreenshot = {
               size="small"
               icon={<IconArrow direction="right" />}
               iconPosition="trailing"
+              variant="solid"
             >
               Solid
             </ButtonLink>

--- a/packages/braid-design-system/src/lib/components/icons/Icons.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/Icons.screenshots.tsx
@@ -146,10 +146,10 @@ export const screenshots: ComponentScreenshot = {
             const IconComponent = icons[icon];
             return (
               <Inline key={icon} space="small">
-                <Button>
+                <Button variant="solid">
                   <IconComponent /> Upper
                 </Button>
-                <Button>
+                <Button variant="solid">
                   Lower <IconComponent alignY="lowercase" />
                 </Button>
               </Inline>

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -2061,6 +2061,7 @@ exports[`Button 1`] = `
     tone?: 
         | "brandAccent"
         | "critical"
+        | "formAccent"
         | "neutral"
     type?: 
         | "button"
@@ -2623,6 +2624,7 @@ exports[`ButtonLink 1`] = `
     tone?: 
         | "brandAccent"
         | "critical"
+        | "formAccent"
         | "neutral"
     translate?: 
         | "no"

--- a/site/src/App/SubNavigation/SubNavigation.tsx
+++ b/site/src/App/SubNavigation/SubNavigation.tsx
@@ -60,6 +60,7 @@ const SubNavItem = ({
       <Bleed horizontal="small">
         <ButtonLink
           variant={active ? 'soft' : 'transparent'}
+          tone="formAccent"
           size="small"
           href={path}
           onClick={onClick}


### PR DESCRIPTION
**Button, ButtonLink:** Provide `formAccent` as the name for undefined tone

Formalise the name of the `undefined` tone as `formAccent`, making it more discoverable as an accent available for increased prominence.

_Note: Consumers should only apply this tone where an action should be emphasized explicitly. The `undefined` value is still valid for buttons that should follow the default button style of the theme._

**EXAMPLE USAGE:**
```jsx
<Button tone="formAccent">
  ...
</Button>
```

![Form accent buttons](https://github.com/seek-oss/braid-design-system/assets/912060/29cbd1c9-23a6-4501-b004-becba579965d)


### PR Notes

Making a few docs changes in preparation for a later PR that changes the default tone/variant based on the `legacy` theme flag. Changes include:
- Be explicit about the `variant` and `tone` in docs, gallery, screenshots etc
- Move `Sizes` documentation below the `tone` documentation sections.