### PR TITLE
Ensure Chromatic changes are accepted on unreleased master

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -40,8 +40,3 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
           NPM_TOKEN: ${{ secrets.SEEK_OSS_CI_NPM_TOKEN }}
           IS_GITHUB_PAGES: true
-
-      - name: Chromatic
-        run: pnpm storybook:chromatic
-        env:
-          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_APP_CODE }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -54,7 +54,6 @@ jobs:
         run: pnpm test
 
       - name: Chromatic
-        if: github.ref != 'refs/heads/master'
         run: pnpm storybook:chromatic
         env:
           CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_APP_CODE }}


### PR DESCRIPTION
Updating the Chromatic workflow run to ensure changes are accepted as baselines for all merges to master rather than just on release.

This ensures PRs opened by Changesets do not have to re-accept the delta of changes against the last released version of master.