### PR TITLE
docs: Fix useResponsiveValue alternative link

### DIFF
--- a/packages/braid-design-system/src/lib/components/useResponsiveValue/useResponsiveValue.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/useResponsiveValue/useResponsiveValue.docs.tsx
@@ -68,7 +68,11 @@ const docs: ComponentDocs = {
   alternatives: [
     { name: 'Box', description: 'For custom layouts.' },
     { name: 'Hidden', description: 'For responsively hiding content.' },
-    { name: 'responsiveStyle', description: 'For custom styles.' },
+    {
+      name: 'responsiveStyle',
+      description: 'For custom styles.',
+      section: 'css',
+    },
   ],
   additional: [
     {

--- a/site/src/App/DocNavigation/DocDetails.tsx
+++ b/site/src/App/DocNavigation/DocDetails.tsx
@@ -44,7 +44,9 @@ export const DocDetails = () => {
             <List space="large">
               {docs.alternatives.map((alt) => (
                 <Text key={`${alt.name}`}>
-                  <TextLink href={`/components/${alt.name}`}>
+                  <TextLink
+                    href={`/${alt.section || 'components'}/${alt.name}`}
+                  >
                     {alt.name}
                   </TextLink>{' '}
                   <Secondary>— {alt.description}</Secondary>

--- a/site/src/App/routes/gallery/Gallery.tsx
+++ b/site/src/App/routes/gallery/Gallery.tsx
@@ -312,7 +312,7 @@ const GalleryItem = ({
                         ) : (
                           <TextLink
                             weight="weak"
-                            href={`/components/${alt.name}`}
+                            href={`/${alt.section || 'components'}/${alt.name}`}
                             hitArea="large"
                             target="_blank"
                           >

--- a/site/src/types.d.ts
+++ b/site/src/types.d.ts
@@ -26,6 +26,14 @@ export type Page = RouteProps & {
   badge?: 'New';
 };
 
+type NavigationSection =
+  | 'guides'
+  | 'foundations'
+  | 'examples'
+  | 'components'
+  | 'css'
+  | 'logic';
+
 export interface ComponentDocs {
   category: 'Logic' | 'Layout' | 'Content' | 'Icon';
   deprecationWarning?: ReactNodeNoStrings;
@@ -36,7 +44,11 @@ export interface ComponentDocs {
   Example?: (
     props: ExampleProps & PlayroomExampleProps,
   ) => Source<ReactElement>;
-  alternatives: Array<{ name: string; description: string }>;
+  alternatives: Array<{
+    name: string;
+    description: string;
+    section?: NavigationSection;
+  }>;
   accessibility?: ReactNodeNoStrings;
   additional?: ComponentExample[];
 }


### PR DESCRIPTION
Fix the `responsiveStyle` link on the `useResponsiveValue` docs page.

Enables the alternatives to be from sub paths other than `components`, e.g. `css`.