### PR TITLE
playroom: Fix responsive array space values

### DIFF
--- a/packages/braid-design-system/src/lib/playroom/cleanSpaceValue.ts
+++ b/packages/braid-design-system/src/lib/playroom/cleanSpaceValue.ts
@@ -12,8 +12,10 @@ export const cleanSpaceValue = (space?: ResponsiveSpace) => {
         breakpointNames.includes(bp as (typeof breakpointNames)[number]) &&
         validSpaceValues.includes(space[bp as keyof typeof space]),
     );
+  const validArray =
+    Array.isArray(space) && space.some((s) => validSpaceValues.includes(s));
   const validSpace =
     typeof space === 'string' && validSpaceValues.includes(space);
 
-  return validSpace || validResponsiveObject ? space : undefined;
+  return validSpace || validResponsiveObject || validArray ? space : undefined;
 };


### PR DESCRIPTION
Fixes responsive array space values in Playroom. A "[previous fix]" accidentally broke support for the array syntax, this PR extends the helper to support it.

[previous fix]: https://github.com/seek-oss/braid-design-system/pull/1305