### PR TITLE
docs: Move theme selector to header

### DIFF
--- a/site/src/App/Navigation/Navigation.css.ts
+++ b/site/src/App/Navigation/Navigation.css.ts
@@ -60,6 +60,11 @@ const backgroundVar = createVar();
 const shadowVar = createVar();
 const transparent = 'rgba(0, 0, 0, 0)';
 const scrollShadows = style([
+  {
+    backgroundPosition: 'center top',
+    backgroundRepeat: 'no-repeat',
+    backgroundAttachment: 'local, scroll',
+  },
   colorModeStyle({
     lightMode: {
       vars: {
@@ -70,10 +75,7 @@ const scrollShadows = style([
         `linear-gradient(${backgroundVar} 30%, ${transparent})`,
         `radial-gradient(farthest-side at 50% 0, ${shadowVar}, ${transparent})`,
       ].join(', '),
-      backgroundPosition: 'center top',
-      backgroundRepeat: 'no-repeat',
       backgroundSize: '100% 40px, 100% 18px',
-      backgroundAttachment: 'local, scroll',
     },
     darkMode: {
       vars: {
@@ -84,10 +86,7 @@ const scrollShadows = style([
         `linear-gradient(45deg, ${backgroundVar}, ${backgroundVar})`,
         `linear-gradient(90deg, ${transparent}, ${shadowVar} 15%, ${shadowVar} 85%, ${transparent})`,
       ].join(', '),
-      backgroundPosition: 'center top',
-      backgroundRepeat: 'no-repeat',
       backgroundSize: '100% 2px',
-      backgroundAttachment: 'local, scroll',
     },
   }),
 ]);

--- a/site/src/App/Navigation/Navigation.css.ts
+++ b/site/src/App/Navigation/Navigation.css.ts
@@ -1,20 +1,20 @@
-import { style, globalStyle } from '@vanilla-extract/css';
+import { rgba } from 'polished';
+import { style, globalStyle, createVar } from '@vanilla-extract/css';
 import { calc } from '@vanilla-extract/css-utils';
-import { vars, breakpoints, responsiveStyle } from 'braid-src/entries/css';
+import { vars } from 'braid-src/lib/themes/vars.css';
+import { palette } from 'braid-src/lib/color/palette';
+import {
+  breakpoints,
+  responsiveStyle,
+  colorModeStyle,
+} from 'braid-src/entries/css';
 import { menuWidth, headerHeight, gutterSize } from './navigationSizes';
 
 export const isOpen = style({});
 
-const headerOffset = style(
-  responsiveStyle({
-    mobile: {
-      top: headerHeight,
-    },
-    wide: {
-      top: calc.add(headerHeight, vars.space[gutterSize]),
-    },
-  }),
-);
+const headerOffset = style({
+  top: headerHeight,
+});
 
 const fixedWidthAboveMobile = style(
   responsiveStyle({
@@ -56,10 +56,47 @@ const subNavOffsetAboveMobile = style(
   }),
 );
 
+const backgroundVar = createVar();
+const shadowVar = createVar();
+const transparent = 'rgba(0, 0, 0, 0)';
+const scrollShadows = style([
+  colorModeStyle({
+    lightMode: {
+      vars: {
+        [backgroundVar]: vars.backgroundColor.body,
+        [shadowVar]: rgba(palette.grey['800'], 0.2),
+      },
+      backgroundImage: [
+        `linear-gradient(${backgroundVar} 30%, ${transparent})`,
+        `radial-gradient(farthest-side at 50% 0, ${shadowVar}, ${transparent})`,
+      ].join(', '),
+      backgroundPosition: 'center top',
+      backgroundRepeat: 'no-repeat',
+      backgroundSize: '100% 40px, 100% 18px',
+      backgroundAttachment: 'local, scroll',
+    },
+    darkMode: {
+      vars: {
+        [backgroundVar]: vars.backgroundColor.bodyDark,
+        [shadowVar]: palette.grey['800'],
+      },
+      backgroundImage: [
+        `linear-gradient(45deg, ${backgroundVar}, ${backgroundVar})`,
+        `linear-gradient(90deg, ${transparent}, ${shadowVar} 15%, ${shadowVar} 85%, ${transparent})`,
+      ].join(', '),
+      backgroundPosition: 'center top',
+      backgroundRepeat: 'no-repeat',
+      backgroundSize: '100% 2px',
+      backgroundAttachment: 'local, scroll',
+    },
+  }),
+]);
+
 export const subNavigationContainer = style([
   headerOffset,
   fixedWidthAboveMobile,
   hideOnMobileWhenClosed,
+  scrollShadows,
 ]);
 
 export const pageContent = style([

--- a/site/src/App/Navigation/Navigation.tsx
+++ b/site/src/App/Navigation/Navigation.tsx
@@ -19,6 +19,7 @@ import { MenuButton } from '../MenuButton/MenuButton';
 import { Logo } from '../Logo/Logo';
 import { gutterSize, menuButtonSize, headerSpaceY } from './navigationSizes';
 import * as styles from './Navigation.css';
+import { ThemeToggle } from '../ThemeSetting';
 
 const Header = ({
   menuOpen,
@@ -28,26 +29,29 @@ const Header = ({
   menuClick: () => void;
 }) => (
   <Box paddingY={headerSpaceY} paddingX={gutterSize}>
-    <Text component="div" baseline={false}>
-      <Box display="flex" alignItems="center">
-        <Hidden print>
-          <Box
-            paddingRight="medium"
-            display={{
-              mobile: 'flex',
-              wide: 'none',
-            }}
-            alignItems="center"
-          >
-            <MenuButton open={menuOpen} onClick={menuClick} />
-          </Box>
-        </Hidden>
-        <Link href="/" tabIndex={menuOpen ? -1 : undefined}>
-          <Logo iconOnly height={menuButtonSize} />
-          <HiddenVisually>Braid Logo</HiddenVisually>
-        </Link>
+    <Box display="flex" alignItems="center">
+      <Hidden print>
+        <Box
+          paddingRight="medium"
+          display={{
+            mobile: 'flex',
+            wide: 'none',
+          }}
+          alignItems="center"
+        >
+          <MenuButton open={menuOpen} onClick={menuClick} />
+        </Box>
+      </Hidden>
+      <Box paddingRight="medium">
+        <Text component="div" baseline={false}>
+          <Link href="/" tabIndex={menuOpen ? -1 : undefined}>
+            <Logo iconOnly height={menuButtonSize} />
+            <HiddenVisually>Braid Logo</HiddenVisually>
+          </Link>
+        </Text>
       </Box>
-    </Text>
+      <ThemeToggle />
+    </Box>
   </Box>
 );
 
@@ -97,7 +101,6 @@ export const Navigation = () => {
         <FixedContentBlock
           overflow="auto"
           bottom={0}
-          paddingY="small"
           paddingX={gutterSize}
           paddingBottom="xxlarge"
           width="full"
@@ -106,7 +109,6 @@ export const Navigation = () => {
             wide: 'block',
           }}
           zIndex="sticky"
-          background="body"
           className={[
             styles.subNavigationContainer,
             isMenuOpen ? styles.isOpen : undefined,
@@ -124,10 +126,7 @@ export const Navigation = () => {
           mobile: gutterSize,
           wide: 'xxlarge',
         }}
-        paddingY={{
-          mobile: 'small',
-          tablet: 'xxsmall',
-        }}
+        paddingY="small"
         paddingBottom="xxlarge"
         marginBottom="xxlarge"
         transition="fast"
@@ -143,7 +142,7 @@ export const Navigation = () => {
         top={0}
         left={0}
         right={0}
-        boxShadow="small"
+        boxShadow={!isMenuOpen ? 'small' : undefined}
         display={['block', 'none']}
         pointerEvents={showStickyHeader ? undefined : 'none'}
         zIndex="sticky"

--- a/site/src/App/SubNavigation/SubNavigation.tsx
+++ b/site/src/App/SubNavigation/SubNavigation.tsx
@@ -13,7 +13,6 @@ import {
   Badge,
   Bleed,
 } from 'braid-src/lib/components';
-import { ThemeToggle } from '../ThemeSetting';
 import {
   categorisedComponents,
   documentedComponents,
@@ -128,31 +127,27 @@ export const SubNavigation = ({ onSelect }: SubNavigationProps) => {
 
   return (
     <Stack space="large">
-      <Stack space="medium">
-        <ThemeToggle />
-
-        <SubNavigationGroup
-          items={[
-            {
-              name: 'Releases',
-              path: '/releases',
-              onClick: onSelect,
-            },
-            {
-              name: 'Gallery',
-              path: '/gallery',
-            },
-            {
-              name: 'Playroom',
-              path: playroomUrl,
-            },
-            {
-              name: 'GitHub',
-              path: 'https://github.com/seek-oss/braid-design-system',
-            },
-          ]}
-        />
-      </Stack>
+      <SubNavigationGroup
+        items={[
+          {
+            name: 'Releases',
+            path: '/releases',
+            onClick: onSelect,
+          },
+          {
+            name: 'Gallery',
+            path: '/gallery',
+          },
+          {
+            name: 'Playroom',
+            path: playroomUrl,
+          },
+          {
+            name: 'GitHub',
+            path: 'https://github.com/seek-oss/braid-design-system',
+          },
+        ]}
+      />
 
       <SubNavigationGroup
         title="Guides"


### PR DESCRIPTION
Moving the theme selector into the header on the docs site, so that it its always available regardless of scroll position in the side bar navigation.

Also adding some affordance to the top of the side bar when scrolled to improve affordance of the current scroll position not being at the top of the navigation.

| | Top of page | Scrolled navigation |
| --- | --- | --- |
|  Before | ![Top Before]  | ![Scrolled Before] |
|  After | ![Top After] | ![Scrolled After] |

[Top Before]: https://github.com/seek-oss/braid-design-system/assets/912060/d6937d39-272e-47ca-b99a-3107b31ce655
[Top After]: https://github.com/seek-oss/braid-design-system/assets/912060/a59639ea-52f4-43d4-808b-f7229f0e3634
[Scrolled Before]: https://github.com/seek-oss/braid-design-system/assets/912060/32d8897d-a9db-4453-b61e-8e7d88a95ade
[Scrolled After]: https://github.com/seek-oss/braid-design-system/assets/912060/9b1c6181-4c03-4232-b4e1-9bc14765c8c9
