### PR TITLE
Fix Loader clipping

### DIFF
--- a/.changeset/stupid-trees-remain.md
+++ b/.changeset/stupid-trees-remain.md
@@ -1,0 +1,12 @@
+---
+"braid-design-system": patch
+---
+
+---
+updated:
+  - Loader
+---
+
+When animating an SVG circle, it seems that the width changes slightly, which on Loader was causing the right-most one to push off the boundaries of the SVG View Box.
+
+This has been fixed so clipping should no longer occur.

--- a/packages/braid-design-system/src/lib/components/Loader/Loader.tsx
+++ b/packages/braid-design-system/src/lib/components/Loader/Loader.tsx
@@ -41,7 +41,7 @@ export const Loader = ({
         styles.currentColor,
         typographyStyles.tone.neutral,
       ].join(' ')}
-      viewBox="0 0 300 134"
+      viewBox="0 0 302 134"
       aria-hidden
     >
       <circle className={styles.circle} cy="67" cx="40" r="40" />


### PR DESCRIPTION
Animating the dots in the Loader seems to affect their width, which pushes them outside of the viewbox resulting in clipping.

Easy fix here is to just make the viewbox slightly wider.

| Before | After |
| ------ | ------ |
| <img width="280" alt="Screenshot 2023-10-10 at 9 50 11 am" src="https://github.com/seek-oss/braid-design-system/assets/36141055/c6dbae0a-1e55-41ef-a847-4a193616296f"> | <img width="280" alt="Screenshot 2023-10-10 at 9 50 27 am" src="https://github.com/seek-oss/braid-design-system/assets/36141055/0ff2ef68-471c-46bf-95c3-43c9692b3bd0"> |