### PR TITLE
source macro: preserve new lines

### DIFF
--- a/.changeset/red-melons-compete.md
+++ b/.changeset/red-melons-compete.md
@@ -2,4 +2,32 @@
 '@braid-design-system/source.macro': patch
 ---
 
-Preserve newlines in the output code
+Preserve new lines in the output code
+
+Before:
+```ts
+const responsiveValue = useResponsiveValue()
+const isMobile = responsiveValue({
+  mobile: true,
+  tablet: false,
+})
+const isDesktopOrAbove = responsiveValue({
+  mobile: false,
+  desktop: true,
+})
+```
+
+After:
+```ts
+const responsiveValue = useResponsiveValue()
+
+const isMobile = responsiveValue({
+  mobile: true,
+  tablet: false,
+})
+
+const isDesktopOrAbove = responsiveValue({
+  mobile: false,
+  desktop: true,
+})
+```

--- a/.changeset/red-melons-compete.md
+++ b/.changeset/red-melons-compete.md
@@ -1,0 +1,5 @@
+---
+'@braid-design-system/source.macro': patch
+---
+
+Preserve newlines in the output code

--- a/packages/source.macro/__snapshots__/source.macro.test.ts.snap
+++ b/packages/source.macro/__snapshots__/source.macro.test.ts.snap
@@ -56,7 +56,48 @@ const foo = 'bar';
 
 `;
 
-exports[`source.macro 4. code only: 4. code only 1`] = `
+exports[`source.macro 4. with new lines: 4. with new lines 1`] = `
+
+
+import source from './source.macro';
+
+const options = source(() => {
+  sideEffect();
+
+  return [
+    { value: "1", label: "Option 1" },
+    { value: "2", label: "Option 2" },
+    { value: "3", label: "Option 3" },
+  ];
+});
+      
+
+      ↓ ↓ ↓ ↓ ↓ ↓
+
+const options = {
+  code: '() => {\\n  sideEffect();\\n\\n  return [\\n  { value: "1", label: "Option 1" },\\n  { value: "2", label: "Option 2" },\\n  { value: "3", label: "Option 3" }];\\n\\n}',
+  value: () => {
+    sideEffect();
+    return [
+      {
+        value: '1',
+        label: 'Option 1',
+      },
+      {
+        value: '2',
+        label: 'Option 2',
+      },
+      {
+        value: '3',
+        label: 'Option 3',
+      },
+    ];
+  },
+};
+
+`;
+
+exports[`source.macro 5. code only: 5. code only 1`] = `
 
 
 import source from './source.macro';

--- a/packages/source.macro/source.macro.cjs
+++ b/packages/source.macro/source.macro.cjs
@@ -9,7 +9,7 @@ module.exports = createMacro(
 
     references.default.forEach(({ parentPath }) => {
       const value = parentPath.node.arguments[0] || t.identifier('undefined');
-      const code = t.stringLiteral(generate(value).code);
+      const code = t.stringLiteral(generate(value, { retainLines: true }).code);
 
       return parentPath.replaceWith(
         codeOnly

--- a/packages/source.macro/source.macro.cjs
+++ b/packages/source.macro/source.macro.cjs
@@ -9,7 +9,9 @@ module.exports = createMacro(
 
     references.default.forEach(({ parentPath }) => {
       const value = parentPath.node.arguments[0] || t.identifier('undefined');
-      const code = t.stringLiteral(generate(value, { retainLines: true }).code);
+      const code = t.stringLiteral(
+        generate(value, { retainLines: true }).code.replace(/^\n+/, ''),
+      );
 
       return parentPath.replaceWith(
         codeOnly

--- a/packages/source.macro/source.macro.test.ts
+++ b/packages/source.macro/source.macro.test.ts
@@ -39,6 +39,21 @@ pluginTester({
         const foo = 'bar';
       `,
     },
+    'with new lines': {
+      code: /* ts */ `
+        import source from './source.macro';
+
+        const options = source(() => {
+          sideEffect();
+
+          return [
+            { value: "1", label: "Option 1" },
+            { value: "2", label: "Option 2" },
+            { value: "3", label: "Option 3" },
+          ];
+        });
+      `,
+    },
     'code only': {
       pluginOptions: { source: { codeOnly: true } },
       code: /* ts */ `


### PR DESCRIPTION
`@babel/generator`'s default value for `retainLines` is `false`. This means that applying the source macro on a code block with something like this:

```js
const options = [
  { value: "1", label: "Option 1" },
  { value: "2", label: "Option 2" },
  { value: "3", label: "Option 3" },
  { value: "4", label: "Option 4" },
  { value: "5", label: "Option 5" },
];
```

results in this

```js
const options = [
  {
    value: "1",
    label: "Option 1",
  },
  {
    value: "2",
    label: "Option 2",
  },
  {
    value: "3",
    label: "Option 3",
  },
  {
    value: "4",
    label: "Option 4",
  },
  {
    value: "5",
    label: "Option 5",
  },
];
```

Another example:

<details>
<summary>Before</summary>

```js
const responsiveValue = useResponsiveValue()
const isMobile = responsiveValue({
  mobile: true,
  tablet: false,
})
const isDesktopOrAbove = responsiveValue({
  mobile: false,
  desktop: true,
})
```

</details>

<details>
<summary>After</summary>

```js
const responsiveValue = useResponsiveValue()

const isMobile = responsiveValue({
  mobile: true,
  tablet: false,
})

const isDesktopOrAbove = responsiveValue({
  mobile: false,
  desktop: true,
})
```

</details>