### PR TITLE
TooltipRenderer: Re-evaluate position when trigger or children changes

### DIFF
--- a/.changeset/late-socks-double.md
+++ b/.changeset/late-socks-double.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - TooltipRenderer
+---
+
+**TooltipRenderer:** Re-evaluate position when `trigger` or `children` changes
+
+Fixes an issue where the tooltip would not re-evaluate it's position when the `trigger` or `children` prop changed while the tooltip was already open.

--- a/.changeset/late-socks-double.md
+++ b/.changeset/late-socks-double.md
@@ -9,4 +9,4 @@ updated:
 
 **TooltipRenderer:** Re-evaluate position when `trigger` or `children` changes
 
-Fixes an issue where the tooltip would not re-evaluate it's position when the `trigger` or `children` prop changed while the tooltip was already open.
+Fixes an issue where the tooltip would not re-evaluate its position when the `trigger` or `children` prop changed while the tooltip was already open.

--- a/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.tsx
@@ -5,6 +5,7 @@ import React, {
   useEffect,
   useContext,
   useRef,
+  useLayoutEffect,
 } from 'react';
 import { usePopperTooltip } from 'react-popper-tooltip';
 import isMobile from 'is-mobile';
@@ -205,23 +206,25 @@ export const TooltipRenderer = ({
     },
   );
 
-  // If the tooltip is visible and the size or position of either the trigger
-  // or the tooltip has changed, then update the tooltip size and position.
-  if (
-    controlledVisible &&
-    update &&
-    (doesBoundingBoxNeedUpdating(triggerRef, triggerBoundingBoxRef.current) ||
-      doesBoundingBoxNeedUpdating(tooltipRef, tooltipBoundingRectRef.current))
-  ) {
-    triggerBoundingBoxRef.current = normaliseRect(
-      triggerRef?.getBoundingClientRect(),
-    );
-    tooltipBoundingRectRef.current = normaliseRect(
-      tooltipRef?.getBoundingClientRect(),
-    );
+  useLayoutEffect(() => {
+    // If the tooltip is visible and the size or position of either the trigger
+    // or the tooltip has changed, then update the tooltip size and position.
+    if (
+      controlledVisible &&
+      update &&
+      (doesBoundingBoxNeedUpdating(triggerRef, triggerBoundingBoxRef.current) ||
+        doesBoundingBoxNeedUpdating(tooltipRef, tooltipBoundingRectRef.current))
+    ) {
+      triggerBoundingBoxRef.current = normaliseRect(
+        triggerRef?.getBoundingClientRect(),
+      );
+      tooltipBoundingRectRef.current = normaliseRect(
+        tooltipRef?.getBoundingClientRect(),
+      );
 
-    update();
-  }
+      update();
+    }
+  });
 
   useEffect(() => {
     if (visible) {

--- a/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.tsx
@@ -115,6 +115,7 @@ const normaliseRect = (domRect?: DOMRect) => ({
   height: Math.round(domRect?.height || 0),
   width: Math.round(domRect?.width || 0),
 });
+const defaultRect = normaliseRect();
 
 const doesBoundingBoxNeedUpdating = (
   element: HTMLElement | null,
@@ -141,12 +142,10 @@ export const TooltipRenderer = ({
   const [controlledVisible, setControlledVisible] = useState(false);
   const [opacity, setOpacity] = useState<0 | 100>(0);
   const { grid, space } = useSpace();
-  const triggerBoundingBoxRef = useRef<ReturnType<typeof normaliseRect>>(
-    normaliseRect(),
-  );
-  const tooltipBoundingRectRef = useRef<ReturnType<typeof normaliseRect>>(
-    normaliseRect(),
-  );
+  const triggerBoundingBoxRef =
+    useRef<ReturnType<typeof normaliseRect>>(defaultRect);
+  const tooltipBoundingRectRef =
+    useRef<ReturnType<typeof normaliseRect>>(defaultRect);
 
   const {
     visible,
@@ -163,13 +162,13 @@ export const TooltipRenderer = ({
       trigger: [isMobile() ? 'click' : 'hover', 'focus'],
       visible: isStatic || controlledVisible,
       onVisibleChange: (newState) => {
-        setControlledVisible(newState);
         triggerBoundingBoxRef.current = normaliseRect(
           triggerRef?.getBoundingClientRect(),
         );
         tooltipBoundingRectRef.current = normaliseRect(
           tooltipRef?.getBoundingClientRect(),
         );
+        setControlledVisible(newState);
       },
     },
     {


### PR DESCRIPTION
Fixes an issue where the tooltip would not re-evaluate it's position when the `trigger` or `children` prop changed while the tooltip was already open.

https://github.com/seek-oss/braid-design-system/assets/912060/72080336-719d-47fc-bb53-5582d81d83c9

### Playrooms
[Before] / [After]

[Before]: https://braid-design-system--bb744806600c5337caa6b8ba2e99d26b01139dab.surge.sh/playroom/#?code=N4Igxg9gJgpiBcIA8AhCAPABABwIZSgEsA7AcwF4AdEAWxiIFcbqA%2BS4zTJAYQmIBcYAlABsIYANaYA7oSj8AFlRDoAzjVwiRrdpyQBlfrkmZVeMDGXp0I3ACdSMHR05dDxqWeOXq6zdpA2F1cuABUYdH4WAHlsIUxFQlVMPhgZQkVMCRgATwAjCHsoJAB6cMigkM5gR353QQAKahoIADcnEABKTAB%2BTCbgqqRy-gTU5TA7DMIwTVZQqdJHO0wW9qgAGjGIEX5CbEwoCBhVAUx4BtKRyqru%2BExiBi0AX10hlAZ%2Bfj4ASUhiN5VUyEABePhAtgcHUBVRmfHIwCQfz4AEE7HYINJDoQ7DAwHt4dQjtIASBMCUWK9BiFbHkYCJlABZNrQ6muOTKVS4drUGEhPjcEQzCQIhrdcgsMZLEQweowJq0FnUTpUoEUmGldySIIarWeczguiMZhkzSEUjEZSLBT8ZxA4YRKKC4VjKWkGWYWn0q6Om4hVCfb7EZEAtmcVSg8GQxy8sOYOGWxEhtAQCQaOxSYx7doI2pyhVc9bK57kyl81xehk1GB1IyNXzc%2BjK3qYaj6RtQajnVsgAByEFGORrpg7WzAQpM3xHPJAqqB8agnMbsfnKWIzskovFku%2B0tldflDaLXTnIXVoaB1druHrIELTa6mAAhORyJgGMRYAAzEj0FsDVcHUiMZiHBSZplmAJMDNC0rXNG1WAAGVwOkREwMAFFwMgTi2bAIAjAkOCOE4zguH0KnLO4HieERTy4Eo9RuTUjG1UpeAEIR%2BFEcQJCCUo0HQIIQA2EBFBgOhVAQABtO8YBgCQACkIDySSAF0RNkeQFEk%2BApIAdgANgADlU54gA
[After]: https://braid-design-system--f25c0d9ba991feeb5b94027016d0d4d4553c1b13.surge.sh/playroom/#?code=N4Igxg9gJgpiBcIA8AhCAPABABwIZSgEsA7AcwF4AdEAWxiIFcbqA%2BS4zTJAYQmIBcYAlABsIYANaYA7oSj8AFlRDoAzjVwiRrdp05IAyv1yTMqvGBjL06EbgBOpGDo579Rk1PMmr1dZu0QNlc3fQAVGHR%2BFgB5bCFMRUJVTD4YGUJFTAkYAE8AIwgHKCQAegio4NC9YCd%2BD0EACmoaCAA3ZxAASkwAfi4K6LD7QlIne0xWjqgAQjLBlkx4TGIGLQBfXWquFAZ%2Bfj4ASUhiLe2zQgAvXxA7R06z7cIT8mAkY74AQXt7CGlMIj2GBgfiEPjKKB-U4gTClFibELbOz5GAiZQAWXaD0R1TkylUuA61Ee1T43BEzwkr0aPXIiwOYxEMAaMGatCx1C6CPOcJJNTqLLZU06PX6zRxoSQg0SaWU2AgqkyhCJQQMEABckSCnSBwgIlB2Dm5Ui0T5nB6y1WGz5ZQ8kmCNrtXgsNzojGYMM0o2IyhGpAU-Bc5ylJpY5MpMpljPSyNR81DZp2ewOxA%2BpwlbkV12UdycxIzeme4LeabQEAkGnsUhMoI6rwFxiafkJ9E561h8MTnFjaNqMHqjdZzemnL6mGoBhbUGoS3HIAAchB%2BJhcv2zFOADSYMAU0wHdcq7nnTB44fY4%2BpYjhyTU2n0iDRwVn6fdI-VXnp859ge4JsgAkjt0mAzOQ5CYAwxCwAAZiQ9BjuKF4hlEMrEDc8qKrWnSYF6pA%2BtQfoBkGF6YAAMrgKIiNuCi4GQMCqFu6FKnw4HYFAv50TMXZcMalSJhaKxrCIb56Laxj2o8omeFU3G8AIQj8KI4gSMEZRoOgwQgBuICKDAdCqAgADa-4wDAEgAFIQPk%2BkALpabI8gKPp8AGQA7AAbAAHNZ6xAA