### PR TITLE
TextLink, TextLinkButton: Ensure consistent underline thickness

### DIFF
--- a/.changeset/smooth-comics-call.md
+++ b/.changeset/smooth-comics-call.md
@@ -1,0 +1,14 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - TextLink
+  - TextLinkButton
+---
+
+**TextLink, TextLinkButton:** Ensure consistent underline thickness on weak links
+
+A subtle bug affecting weak links was resulting in a change in underline thickness on hover.
+This bug has been fixed such that weak links now always have the same underline thickness regardless of hover state.

--- a/packages/braid-design-system/src/lib/components/TextLink/TextLink.css.ts
+++ b/packages/braid-design-system/src/lib/components/TextLink/TextLink.css.ts
@@ -27,16 +27,18 @@ const weakLinkVars = assignVars(textLinkVars, {
   colorHover: 'inherit',
 });
 
+const textDecorationThickness = '0.08em';
+
 export const base = style({
   color: textLinkVars.color,
   textDecoration: vars.linkDecoration,
-  textDecorationThickness: '0.08em',
+  textDecorationThickness,
   textUnderlineOffset: 3,
   ':hover': {
     color: textLinkVars.colorHover,
     textDecoration: 'underline',
     /*
-      Duplicating the thickness rule due to inconsistent support
+      Duplicating the thickness property due to inconsistent support
       for shorthand properties of `text-decoration`. Without this,
       applying the above decoration rule resets the thickness in
       browsers that do support shorthands.
@@ -44,7 +46,7 @@ export const base = style({
       We also cannot use the long-form `text-decoration-line` due
       to browser support policy of Edge 16+.
     */
-    textDecorationThickness: '0.08em',
+    textDecorationThickness,
   },
   ':focus-visible': {
     color: textLinkVars.colorHover,
@@ -57,6 +59,14 @@ export const base = style({
 export const weakLink = style({
   vars: weakLinkVars,
   textDecoration: 'underline',
+  /*
+    Duplicating the thickness property again as the `textDecoration`
+    property above overrides the `textDecorationThickness` property
+    in the `base` style due to CSS rule ordering. Without this property,
+    weak links were receiving `auto` thickness instead of the desired
+    value.
+  */
+  textDecorationThickness,
 });
 
 export const regularLinkLightMode = styleVariants({


### PR DESCRIPTION
A subtle bug affecting `TextLink` and `TextLinkButton` was causing underline thickness to change on hover. I believe this was unintentional since the base style contains an explicit `textDecorationThickness` property.

The bug is not visible at 100% zoom on Chrome, but becomes visible at larger zoom levels. The bug is pretty much always visible on Firefox. Safari is not affected by the bug.

The cause of the bug is the fact that the `weakLink` style is declared after the `base` style, so its `textDecoration` value ends up applying a default `textDecorationThickness` value of `auto` in [browsers that include `textDecorationThickness` in the shorthand](https://developer.mozilla.org/en-US/docs/Web/CSS/text-decoration#browser_compatibility) (i.e. not Safari), overriding the `base` style's explicit value. This then gets overridden again to the correct value once the hover style is applied.

The following videos were recorded in Firefox.

Before ([playroom](https://braid-design-system--77097d6f421e56fb92f854407b481a7d5f832771.surge.sh/playroom/#?code=N4Igxg9gJgpiBcIA8AhCAPABABwIZSgEsA7AcwF4AdEAWxiIFcbrMiBnbAG1wE8qQAZpxjoWAKwZsALoQE8AwhGJSYy-mFUqATtQB8lYpkxIAKiKn7DR42fRSAMiQDWmAO4xCpABZT%2B73E56AIIARmAAjABMAMxIAPS2Ds6WRvGJlvFo6JYgADQgUl4wdGwIANogbDAwTgBSECGlALr5roRQhaXwZdGRAAxNAL5AA)):

https://github.com/seek-oss/braid-design-system/assets/5663042/2a2aebe5-29ed-4d42-af14-2e16a3f5febd

After ([playroom](https://braid-design-system--f94b059c14855f68f28bb649ba6d145a6b01e742.surge.sh/playroom/#?code=N4Igxg9gJgpiBcIA8AhCAPABABwIZSgEsA7AcwF4AdEAWxiIFcbrMiBnbAG1wE8qQAZpxjoWAKwZsALoQE8AwhGJSYy-mFUqATtQB8lYpkxIAKiKn7DR42fRSAMiQDWmAO4xCpABZT%2B73E56AIIARmAAjABMAMxIAPS2Ds6WRvGJlvFo6JYgADQgUl4wdGwIANogbDAwTgBSECGlALr5roRQhaXwZdGRAAxNAL5AA)):

https://github.com/seek-oss/braid-design-system/assets/5663042/db77e222-228b-4b02-a795-f9dc3f8bfa26

