### PR TITLE
Fix navigator check for BraidProvider

### DIFF
--- a/.changeset/calm-poets-float.md
+++ b/.changeset/calm-poets-float.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+The Braid Provider contains some code to check that it's running in a browser context (otherwise a BraidTestProvider should be used).
+
+Part of this check was looking to see if there was a `navigator` object, which was not available in Node.
+If there were, it would check the `userAgent` to determine if it was inside jsdom.
+
+Node 21 has a `navigator` object, but it doesn't have a `userAgent` property, so this check was failing (cannot read property 'indexOf' of undefined).
+
+The userAgent check now includes an optional chaining operator to prevent this error.

--- a/.changeset/calm-poets-float.md
+++ b/.changeset/calm-poets-float.md
@@ -9,4 +9,4 @@ If there were, it would check the `userAgent` to determine if it was inside jsdo
 
 Node 21 has a `navigator` object, but it doesn't have a `userAgent` property, so this check was failing (cannot read property 'indexOf' of undefined).
 
-The userAgent check now includes an optional chaining operator to prevent this error.
+The "are we in JSDom" check in the BraidProvider has now been reworked slightly to account for the potentially existing but empty `navigator` object.

--- a/packages/braid-design-system/src/lib/components/BraidProvider/BraidProvider.tsx
+++ b/packages/braid-design-system/src/lib/components/BraidProvider/BraidProvider.tsx
@@ -70,6 +70,8 @@ export interface BraidProviderProps {
   children: ReactNode;
 }
 
+// Node 21 introduces an empty navigator object, so checks need a little more logic to them
+
 export const BraidProvider = ({
   theme,
   styleBody = true,
@@ -82,10 +84,12 @@ export const BraidProvider = ({
 
   useHideFocusRings(!(alreadyInBraidProvider || inTestProvider));
 
+  // Node 21 introduces an empty navigator object, so checks need a little more logic to them
   assert(
-    typeof navigator !== 'object' ||
-      navigator.userAgent.indexOf('jsdom') === -1 ||
-      inTestProvider,
+    inTestProvider ||
+      typeof navigator === 'undefined' ||
+      typeof navigator.userAgent === 'undefined' ||
+      navigator.userAgent.indexOf('jsdom') === -1,
     `Rendering 'BraidProvider' in Jest is not supported as it expects a browser environment. Please switch to 'BraidTestProvider'. See the docs for more info: https://seek-oss.github.io/braid-design-system/components/BraidTestProvider`,
   );
 

--- a/packages/braid-design-system/src/lib/components/BraidProvider/BraidProvider.tsx
+++ b/packages/braid-design-system/src/lib/components/BraidProvider/BraidProvider.tsx
@@ -70,8 +70,6 @@ export interface BraidProviderProps {
   children: ReactNode;
 }
 
-// Node 21 introduces an empty navigator object, so checks need a little more logic to them
-
 export const BraidProvider = ({
   theme,
   styleBody = true,

--- a/packages/braid-design-system/src/lib/components/BraidProvider/BraidProvider.tsx
+++ b/packages/braid-design-system/src/lib/components/BraidProvider/BraidProvider.tsx
@@ -86,7 +86,7 @@ export const BraidProvider = ({
   assert(
     inTestProvider ||
       typeof navigator === 'undefined' ||
-      typeof navigator.userAgent === 'undefined' ||
+      navigator.userAgent === undefined ||
       navigator.userAgent.indexOf('jsdom') === -1,
     `Rendering 'BraidProvider' in Jest is not supported as it expects a browser environment. Please switch to 'BraidTestProvider'. See the docs for more info: https://seek-oss.github.io/braid-design-system/components/BraidTestProvider`,
   );


### PR DESCRIPTION
Node 21 has introduced a `navigator` object, where we could previously rely on there not being one in a Node environment.

This fixes that issue (which has been reported internally already). See changeset for full detail.