### PR TITLE
Solve some task dependency issues

### DIFF
--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -51,7 +51,9 @@ jobs:
         run: pnpm lint
 
       - name: Test
-        run: pnpm test
+        run: |
+          pnpm test
+          pnpm test:fixtures
 
       - name: Chromatic
         run: pnpm storybook:chromatic

--- a/fixtures/jest.config.js
+++ b/fixtures/jest.config.js
@@ -1,0 +1,12 @@
+const {
+  setupFilesAfterEnv,
+  testPathIgnorePatterns,
+  ...rootJestConfig
+} = require('../jest.config');
+
+/** @type {import('jest').Config} */
+module.exports = {
+  ...rootJestConfig,
+  displayName: 'fixtures',
+  rootDir: __dirname,
+};

--- a/jest.config.js
+++ b/jest.config.js
@@ -25,6 +25,7 @@ module.exports = {
   ],
   testPathIgnorePatterns: [
     `<rootDir>${slash}(.*${slash})?(dist|node_modules)${slash}`,
+    `<rootDir>/fixtures`, // these have a separate Jest config
   ],
   moduleFileExtensions: ['js', 'json', 'ts', 'tsx'],
   moduleNameMapper: {

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "version": "1.0.0",
   "scripts": {
     "test": "pnpm run generate --skip-nx-cache && jest",
+    "test:fixtures": "jest --config fixtures/jest.config.js",
     "start": "nx run site:start",
     "start:playroom": "nx run site:start:playroom",
     "build": "nx run braid-design-system:build",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "scripts": {
-    "test": "pnpm run generate && jest",
+    "test": "pnpm run generate --skip-nx-cache && jest",
     "start": "nx run site:start",
     "start:playroom": "nx run site:start:playroom",
     "build": "nx run braid-design-system:build",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "scripts": {
-    "test": "pnpm run generate --skip-nx-cache && jest",
+    "test": "pnpm run generate && jest",
     "test:fixtures": "jest --config fixtures/jest.config.js",
     "start": "nx run site:start",
     "start:playroom": "nx run site:start:playroom",

--- a/packages/braid-design-system/project.json
+++ b/packages/braid-design-system/project.json
@@ -49,10 +49,17 @@
     },
     "lint": {},
     "lint:eslint": {
-      "dependsOn": ["prelint:eslint"],
+      "dependsOn": ["prelint:eslint", "generate"],
       "executor": "nx:run-script",
       "options": {
         "script": "lint:eslint"
+      }
+    },
+    "lint:prettier": {
+      "dependsOn": ["generate"],
+      "executor": "nx:run-script",
+      "options": {
+        "script": "lint:prettier"
       }
     },
     "lint:tsc": {


### PR DESCRIPTION
Sometimes the build mysteriously fails in CI when icons are added, e.g. #1390 has been failing on every commit.

There are two issues that have been intermittently observed since we moved to a monorepo with Nx:

1. Linting fails because Prettier expects but doesn't find the generated icon files. This is caused by a race condition where the linting task runs before the icon generation task ([example][lint]).
2. Tests fail because the generated icon files are missing ([example][test]). This is because an integration test runs the `build` script which wipes out all icon component files.

[lint]: https://github.com/seek-oss/braid-design-system/actions/runs/6856814056/job/18644723861#step:7:361
[test]: https://github.com/seek-oss/braid-design-system/actions/runs/6857128352/job/18645633637#step:8:421

This PR

- fixes the task dependency for 1. so that the generated icon files are always available for linting
- ~~skips the Nx cache for 2. so that the generated icon files are always generated when tests run~~
- runs fixture/integration tests separately so they don't interfere with the other tests

### Before

See how `lint:prettier` and `lint:eslint` can run at the same time as `generate`

<img width="1062" alt="braid tasks before" src="https://github.com/seek-oss/braid-design-system/assets/3297808/125a354c-4340-4e84-bca4-3b243b0d07d8">

### After

<img width="1062" alt="braid tasks after" src="https://github.com/seek-oss/braid-design-system/assets/3297808/323232fb-f85f-431b-84a7-49b177d95e24">
