### PR TITLE
Align tone headings

### DIFF
--- a/site/src/App/routes/foundations/tones/tones.tsx
+++ b/site/src/App/routes/foundations/tones/tones.tsx
@@ -17,6 +17,7 @@ import type { Page } from '../../../../types';
 import { ThemedExample } from '../../../ThemeSetting';
 import { PageTitle } from '../../../Seo/PageTitle';
 import * as styles from './tones.css';
+import { LinkableHeading } from '@braid-design-system/docs-ui';
 
 const tones = [
   'critical',
@@ -143,7 +144,7 @@ const ToneDefinition = ({ tone }: { tone: Tone }) => {
 
   return (
     <Stack space="small">
-      <Columns space="medium">
+      <Columns space="medium" alignY="center">
         <Column width="content">
           <ThemedExample>
             <Box background={swatch} className={styles.square} />
@@ -151,7 +152,7 @@ const ToneDefinition = ({ tone }: { tone: Tone }) => {
         </Column>
         <Column>
           <Box height="touchable" display="flex" alignItems="center">
-            <Heading level="4">{tone}</Heading>
+            <LinkableHeading level="3">{tone}</LinkableHeading>
           </Box>
         </Column>
       </Columns>


### PR DESCRIPTION
The headings for the tone descriptions looked a little odd in their alignment.

I think it looks more natural to have them centered.

This also makes them linkable.

| Before | After |
| --------------------- | ------------------- |
| ![Screenshot before] | ![Screenshot after] |


[screenshot before]: https://github.com/seek-oss/braid-design-system/assets/36141055/c629e7cc-fd4b-4f13-881f-9eec0c8bc3a1
[screenshot after]: https://github.com/seek-oss/braid-design-system/assets/36141055/7954193f-c639-4224-9655-c23bc65c127c