### PR TITLE
Rating: Add `weight` support

### DIFF
--- a/.changeset/ninety-moose-share.md
+++ b/.changeset/ninety-moose-share.md
@@ -1,0 +1,17 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Rating
+---
+
+**Rating:** Add `weight` support
+
+Provide a `weight` prop to customise the weight of the text rating alongside the stars.
+
+**EXAMPLE USAGE:**
+```jsx
+<Rating rating={3} weight="strong" />
+```

--- a/packages/braid-design-system/src/lib/components/Rating/Rating.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Rating/Rating.docs.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
-import { Rating, Stack, Inline, Text, Strong, TextLink } from '../';
+import { Rating, Stack, Inline, Text, Strong, TextLink, Notice } from '../';
 import { IconLanguage } from '../icons';
 
 const docs: ComponentDocs = {
@@ -24,6 +24,39 @@ const docs: ComponentDocs = {
   ),
   alternatives: [],
   additional: [
+    {
+      label: 'Variants',
+      description: (
+        <Text>
+          The appearance can be customised via the <Strong>variant</Strong>{' '}
+          prop, choosing from <Strong>full</Strong> (default),{' '}
+          <Strong>starsOnly</Strong> or <Strong>minimal</Strong>.
+        </Text>
+      ),
+      Example: () =>
+        source(
+          <Stack space="large">
+            <Stack space="small">
+              <Text tone="secondary" weight="strong">
+                Default
+              </Text>
+              <Rating size="large" rating={4.2} />
+            </Stack>
+            <Stack space="small">
+              <Text tone="secondary" weight="strong">
+                Stars only
+              </Text>
+              <Rating size="large" rating={4.2} variant="starsOnly" />
+            </Stack>
+            <Stack space="small">
+              <Text tone="secondary" weight="strong">
+                Minimal
+              </Text>
+              <Rating size="large" rating={4.2} variant="minimal" />
+            </Stack>
+          </Stack>,
+        ),
+    },
     {
       label: 'Sizing',
       description: (
@@ -63,35 +96,42 @@ const docs: ComponentDocs = {
         ),
     },
     {
-      label: 'Variants',
+      label: 'Weight',
       description: (
-        <Text>
-          The appearance can be customised via the <Strong>variant</Strong>{' '}
-          prop, choosing from <Strong>full</Strong> (default),{' '}
-          <Strong>starsOnly</Strong> or <Strong>minimal</Strong>.
-        </Text>
+        <>
+          <Text>
+            Supports the same weight scale available on the{' '}
+            <TextLink href="/components/Text">Text</TextLink> component.
+          </Text>
+          <Notice>
+            <Text>
+              Note: Setting the <Strong>weight</Strong> prop is only valid when
+              using a <Strong>variant</Strong> that displays the text rating.
+            </Text>
+          </Notice>
+        </>
       ),
       Example: () =>
         source(
-          <Stack space="large">
-            <Stack space="small">
-              <Text tone="secondary" weight="strong">
-                Default
+          <Stack space="gutter">
+            <Inline space="small">
+              <Rating weight="regular" rating={3} />
+              <Text tone="secondary" weight="regular">
+                regular
               </Text>
-              <Rating size="large" rating={4.2} />
-            </Stack>
-            <Stack space="small">
-              <Text tone="secondary" weight="strong">
-                Stars only
+            </Inline>
+            <Inline space="small">
+              <Rating weight="medium" rating={3} />
+              <Text tone="secondary" weight="medium">
+                medium
               </Text>
-              <Rating size="large" rating={4.2} variant="starsOnly" />
-            </Stack>
-            <Stack space="small">
+            </Inline>
+            <Inline space="small">
+              <Rating weight="strong" rating={3} />
               <Text tone="secondary" weight="strong">
-                Minimal
+                strong
               </Text>
-              <Rating size="large" rating={4.2} variant="minimal" />
-            </Stack>
+            </Inline>
           </Stack>,
         ),
     },

--- a/packages/braid-design-system/src/lib/components/Rating/Rating.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Rating/Rating.screenshots.tsx
@@ -19,16 +19,28 @@ export const screenshots: ComponentScreenshot = {
       Example: () => <Rating rating={3.7} variant="minimal" />,
     },
     {
-      label: 'large',
+      label: 'Size: large',
       Example: () => <Rating rating={3} size="large" />,
     },
     {
-      label: 'small',
+      label: 'Size: small',
       Example: () => <Rating rating={2} size="small" />,
     },
     {
-      label: 'xsmall',
+      label: 'Size: xsmall',
       Example: () => <Rating rating={1.5} size="xsmall" />,
+    },
+    {
+      label: 'Weight: regular',
+      Example: () => <Rating rating={3} weight="regular" />,
+    },
+    {
+      label: 'Weight: medium',
+      Example: () => <Rating rating={2} weight="medium" />,
+    },
+    {
+      label: 'Weight: strong',
+      Example: () => <Rating rating={1.5} weight="strong" />,
     },
     {
       label: 'Fill test',

--- a/packages/braid-design-system/src/lib/components/Rating/Rating.tsx
+++ b/packages/braid-design-system/src/lib/components/Rating/Rating.tsx
@@ -50,19 +50,29 @@ const RatingStar = ({ percent, ...restProps }: RatingStar) => {
 };
 
 const ratingArr = [...Array(5)];
-export interface RatingProps {
+interface RatingBaseProps {
   rating: number;
   size?: TextProps['size'];
   /** @deprecated Use `variant="starsOnly"` instead */
   showTextRating?: boolean;
-  variant?: 'full' | 'starsOnly' | 'minimal';
   'aria-label'?: string;
   data?: TextProps['data'];
 }
+type RatingVariants = 'full' | 'starsOnly' | 'minimal';
+
+export type RatingProps = RatingBaseProps &
+  (
+    | { weight?: never; variant?: RatingVariants }
+    | {
+        weight: TextProps['weight'];
+        variant?: Exclude<RatingVariants, 'starsOnly'>;
+      }
+  );
 
 export const Rating = ({
   rating,
   size = 'standard',
+  weight,
   showTextRating,
   variant: variantProp,
   'aria-label': ariaLabel,
@@ -72,6 +82,10 @@ export const Rating = ({
     !rating || (rating >= 0 && rating <= 5),
     'Rating must be between 0 and 5',
   );
+
+  const variant = variantProp || 'full';
+  const resolvedVariant =
+    showTextRating === false && !variantProp ? 'starsOnly' : variant;
 
   if (process.env.NODE_ENV !== 'production') {
     if (typeof showTextRating !== 'undefined') {
@@ -89,14 +103,25 @@ export const Rating = ({
         'color: inherit',
       );
     }
+
+    if (typeof weight !== 'undefined' && resolvedVariant === 'starsOnly') {
+      // eslint-disable-next-line no-console
+      console.warn(
+        dedent`
+          The "weight" prop is not valid with the "starsOnly" variant as there is no visible text. Either remove the \`weight\` prop or choose an alternative \`variant\`.
+             <Rating
+            %c-  weight="strong"
+            %c   variant="starsOnly"
+             />
+        `,
+        'color: red',
+        'color: inherit',
+      );
+    }
   }
 
-  const variant = variantProp || 'full';
-  const resolvedVariant =
-    showTextRating === false && !variantProp ? 'starsOnly' : variant;
-
   return (
-    <Text size={size} data={data}>
+    <Text size={size} data={data} weight={weight}>
       <Box
         display="inlineBlock"
         aria-label={

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -7030,6 +7030,10 @@ exports[`Rating 1`] = `
         | "full"
         | "minimal"
         | "starsOnly"
+    weight?: 
+        | "medium"
+        | "regular"
+        | "strong"
 },
 }
 `;


### PR DESCRIPTION
Provide a `weight` prop to customise the weight of the text rating alongside the stars.

**EXAMPLE USAGE:**
```jsx
<Rating rating={3} weight="strong" />
```