### PR TITLE
Fix routing for Icon page tabs

### DIFF
--- a/site/sku.routes.js
+++ b/site/sku.routes.js
@@ -1,6 +1,5 @@
 const fs = require('fs');
 const path = require('path');
-const flatten = require('lodash/flatten');
 
 const extractExports = require('./extractExports');
 const undocumentedExports = require('./src/undocumentedExports.json');
@@ -40,32 +39,27 @@ module.exports = [
   { route: '/', name: 'home' },
   { route: '/releases', name: 'releases' },
   { route: '/gallery', name: 'gallery' },
-  ...guideRoutes.map((route) => ({ route })),
-  ...foundationRoutes.map((route) => ({ route })),
+  guideRoutes.map((route) => ({ route })),
+  foundationRoutes.map((route) => ({ route })),
   { route: '/foundations/iconography/browse', name: 'browseIcons' },
-  ...exampleRoutes.map((route) => ({ route })),
+  exampleRoutes.map((route) => ({ route })),
   { route: '/components', name: 'components' }, // Pre-rendering this route for url backwards compatibility.
-  ...flatten(
-    [...componentNames, ...testNames].map((name) =>
-      [
-        { route: `/components/${name}` },
-        { route: `/components/${name}/releases` },
-        { route: `/components/${name}/snippets` },
-        !name.startsWith('use') ? { route: `/components/${name}/props` } : null,
-      ].filter(Boolean),
-    ),
-  ),
-  ...flatten(
-    cssNames.map((name) => [
-      { route: `/css/${name}` },
-      { route: `/css/${name}/releases` },
-    ]),
-  ),
-  ...flatten(
-    iconNames.map((name) => [
-      { route: `/components/${name}`, name },
-      { route: `/components/${name}/props` },
+  [...componentNames, ...testNames].flatMap((name) =>
+    [
+      { route: `/components/${name}` },
       { route: `/components/${name}/releases` },
-    ]),
+      { route: `/components/${name}/snippets` },
+      !name.startsWith('use') ? { route: `/components/${name}/props` } : null,
+    ].filter(Boolean),
   ),
-];
+  cssNames.flatMap((name) => [
+    { route: `/css/${name}` },
+    { route: `/css/${name}/releases` },
+  ]),
+
+  iconNames.flatMap((name) => [
+    { route: `/components/${name}`, name },
+    { route: `/components/${name}/props` },
+    { route: `/components/${name}/releases` },
+  ]),
+].flat();

--- a/site/sku.routes.js
+++ b/site/sku.routes.js
@@ -61,5 +61,11 @@ module.exports = [
       { route: `/css/${name}/releases` },
     ]),
   ),
-  ...iconNames.map((name) => ({ route: `/components/${name}`, name })),
+  ...flatten(
+    iconNames.map((name) => [
+      { route: `/components/${name}`, name },
+      { route: `/components/${name}/props` },
+      { route: `/components/${name}/releases` },
+    ]),
+  ),
 ];

--- a/site/src/App/Updates/index.ts
+++ b/site/src/App/Updates/index.ts
@@ -1,5 +1,3 @@
-import flatten from 'lodash/flatten';
-
 import { differenceInMonths, format } from 'date-fns';
 
 import releases from '../../componentUpdates.json';
@@ -137,40 +135,39 @@ export const getHistory = memo((...names: string[]) => {
     return [];
   }
 
-  return flatten(
-    allReleases
-      .filter(({ version }) => releventReleases.has(version))
-      .map(({ version, updates }) =>
-        updates
-          .filter((update) =>
-            'new' in update
-              ? hasIntersection(update.new, names)
-              : hasIntersection(update.updated, names),
-          )
-          .map((update) => {
-            const versionReleaseDate = versionMap[version]
-              ? new Date(versionMap[version])
-              : undefined;
+  return allReleases
+    .filter(({ version }) => releventReleases.has(version))
+    .flatMap(({ version, updates }) =>
+      updates
+        .filter((update) =>
+          'new' in update
+            ? hasIntersection(update.new, names)
+            : hasIntersection(update.updated, names),
+        )
+        .map((update) => {
+          const versionReleaseDate = versionMap[version]
+            ? new Date(versionMap[version])
+            : undefined;
 
-            return {
-              version,
-              time: versionReleaseDate
-                ? format(versionReleaseDate, 'PP')
-                : undefined,
-              rawTime: versionReleaseDate?.getTime(),
-              type: 'new' in update ? 'added' : 'updated',
-              summary: update.summary,
-              isRecent: Boolean(
-                versionReleaseDate &&
-                  differenceInMonths(renderDate, versionReleaseDate) < 2,
-              ),
-            };
-          }),
-      ),
-  ).sort((a, b) => {
-    if (b.rawTime && a.rawTime) {
-      return b.rawTime - a.rawTime;
-    }
-    return 0;
-  });
+          return {
+            version,
+            time: versionReleaseDate
+              ? format(versionReleaseDate, 'PP')
+              : undefined,
+            rawTime: versionReleaseDate?.getTime(),
+            type: 'new' in update ? 'added' : 'updated',
+            summary: update.summary,
+            isRecent: Boolean(
+              versionReleaseDate &&
+                differenceInMonths(renderDate, versionReleaseDate) < 2,
+            ),
+          };
+        }),
+    )
+    .sort((a, b) => {
+      if (b.rawTime && a.rawTime) {
+        return b.rawTime - a.rawTime;
+      }
+      return 0;
+    });
 });


### PR DESCRIPTION
Props are release paths were not included in the static render for icons, causing links such as https://seek-oss.github.io/braid-design-system/components/IconDownload/props to return a 404.
This change includes the correct paths in the static render.

Also, retire usage of `flatten` in favour of `.flat()` and `.flatMap`.