### PR TITLE
changesets: Only bump peer deps out of range

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -4,5 +4,8 @@
   "commit": false,
   "linked": [],
   "access": "public",
-  "baseBranch": "master"
+  "baseBranch": "master",
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }


### PR DESCRIPTION
Switching changesets over to only bump peer deps internally when out of range. This prevents the `docs-ui` package from getting a major version bump for every release of Braid.