### PR TITLE
Tab: Remove cropping of the icon slot

### DIFF
--- a/.changeset/cool-tomatoes-attend.md
+++ b/.changeset/cool-tomatoes-attend.md
@@ -1,0 +1,15 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Tab
+---
+
+**Tab:** Remove cropping of the icon slot
+
+Previously the `icon` slot on a `Tab` was cropped on the left to improve alignment with the active tab indicator.
+For most icons in a `Tab`, this was subtle polish, but for others it had the undesirable side effect of clipping the side of the icon.
+
+Removing the cropping until we have a better solution for trimming whitespace around icons.

--- a/packages/braid-design-system/src/lib/components/Tabs/Tab.tsx
+++ b/packages/braid-design-system/src/lib/components/Tabs/Tab.tsx
@@ -243,7 +243,6 @@ export const Tab = ({
         aria-hidden
         transition="fast"
         opacity={isSelected ? 0 : undefined}
-        className={icon ? styles.cropToIconX : undefined}
       >
         <Text tone="secondary" icon={icon}>
           {children}
@@ -258,10 +257,7 @@ export const Tab = ({
         aria-hidden
         transition="fast"
         opacity={0}
-        className={[
-          !isSelected ? styles.hoveredTab : undefined,
-          icon ? styles.cropToIconX : undefined,
-        ]}
+        className={!isSelected ? styles.hoveredTab : undefined}
       >
         <Text icon={icon}>{children}</Text>
       </Box>
@@ -272,7 +268,6 @@ export const Tab = ({
         display="block"
         transition="fast"
         opacity={!isSelected ? 0 : undefined}
-        className={icon ? styles.cropToIconX : undefined}
       >
         <Text
           {...a11y.tabLabelProps({ tabIndex: tabListItemIndex })}

--- a/packages/braid-design-system/src/lib/components/Tabs/Tabs.css.ts
+++ b/packages/braid-design-system/src/lib/components/Tabs/Tabs.css.ts
@@ -11,10 +11,6 @@ export const tab = style({
   },
 });
 
-export const cropToIconX = style({
-  marginLeft: -2,
-});
-
 export const hoveredTab = style({
   selectors: {
     [`${tab}:hover &`]: {


### PR DESCRIPTION
Previously the `icon` slot on a `Tab` was cropped on the left to improve alignment with the active tab indicator.
For most icons in a `Tab`, this was subtle polish, but for others it had the undesirable side effect of clipping the side of the icon.

Removing the cropping until we have a better solution for trimming whitespace around icons.

![Before](https://github.com/seek-oss/braid-design-system/assets/912060/110e952a-f573-4307-a3b6-f611dfd5f898)
