### PR TITLE
Text: Remove descender crop on truncated text

### DIFF
--- a/.changeset/itchy-mayflies-allow.md
+++ b/.changeset/itchy-mayflies-allow.md
@@ -9,3 +9,5 @@ updated:
 ---
 
 **Text, Heading:** Fix `maxLines` cropping of decending characters
+
+Fixes a bug when using -webkit-box, where the descender on the last line of text could be cropped based on the combination of line height and font size.

--- a/.changeset/itchy-mayflies-allow.md
+++ b/.changeset/itchy-mayflies-allow.md
@@ -1,0 +1,11 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Text
+  - Heading
+---
+
+**Text, Heading:** Fix `maxLines` cropping of decending characters

--- a/packages/braid-design-system/src/lib/components/Heading/Heading.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Heading/Heading.screenshots.tsx
@@ -90,9 +90,11 @@ export const screenshots: ComponentScreenshot = {
       label: 'Truncation (legacy)',
       Example: () => (
         <Box style={{ width: 220 }}>
+          <Box style={{ border: '1px solid red' }} />
           <Heading level="2" truncate>
-            Limited to 1 line that won’t fit in the layout
+            Limiting to 1 line that won’t fit in the layout
           </Heading>
+          <Box style={{ border: '1px solid red' }} />
         </Box>
       ),
     },
@@ -100,9 +102,11 @@ export const screenshots: ComponentScreenshot = {
       label: 'Max lines = 1 (should be same as truncation)',
       Example: () => (
         <Box style={{ width: 220 }}>
+          <Box style={{ border: '1px solid red' }} />
           <Heading level="2" maxLines={1}>
-            Limited to 1 line that won’t fit in the layout
+            Limiting to 1 line that won’t fit in the layout
           </Heading>
+          <Box style={{ border: '1px solid red' }} />
         </Box>
       ),
     },
@@ -110,10 +114,12 @@ export const screenshots: ComponentScreenshot = {
       label: 'Max lines = 3',
       Example: () => (
         <Box style={{ width: 220 }}>
+          <Box style={{ border: '1px solid red' }} />
           <Heading level="2" maxLines={3}>
-            Another example of long text, but limited to 3 lines, and won’t fit
+            Another example of long text, but limiting to 3 lines, and won’t fit
             in the layout.
           </Heading>
+          <Box style={{ border: '1px solid red' }} />
         </Box>
       ),
     },

--- a/packages/braid-design-system/src/lib/components/private/MaxLines/MaxLines.css.ts
+++ b/packages/braid-design-system/src/lib/components/private/MaxLines/MaxLines.css.ts
@@ -22,7 +22,7 @@ export const base = style([
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     selectors: {
-      [`${descenderCropFixForWebkitBox} &`]: {
+      [`${descenderCropFixForWebkitBox} > &`]: {
         paddingBottom: descenderCropFixOffset,
       },
     },

--- a/packages/braid-design-system/src/lib/components/private/MaxLines/MaxLines.css.ts
+++ b/packages/braid-design-system/src/lib/components/private/MaxLines/MaxLines.css.ts
@@ -24,6 +24,7 @@ export const multiLine = style({
       display: '-webkit-box',
       WebkitLineClamp: lineLimit,
       WebkitBoxOrient: 'vertical',
+      paddingBottom: '0.1em',
     },
   },
 });

--- a/packages/braid-design-system/src/lib/components/private/MaxLines/MaxLines.css.ts
+++ b/packages/braid-design-system/src/lib/components/private/MaxLines/MaxLines.css.ts
@@ -1,6 +1,17 @@
 import { createVar, style } from '@vanilla-extract/css';
 import { atoms } from '../../../../entries/css';
 
+/*
+Fixes a bug when using -webkit-box, where the descender of the last line
+of text could be cropped based on the combination of line height and
+font size.
+*/
+const descenderCropFixOffset = '0.1em';
+const negateDescenderCropFixOffset = `-${descenderCropFixOffset}`;
+export const descenderCropFixForWebkitBox = style({
+  marginBottom: negateDescenderCropFixOffset,
+});
+
 export const base = style([
   atoms({
     display: 'block',
@@ -10,6 +21,11 @@ export const base = style([
   {
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
+    selectors: {
+      [`${descenderCropFixForWebkitBox} &`]: {
+        paddingBottom: descenderCropFixOffset,
+      },
+    },
   },
 ]);
 
@@ -24,7 +40,6 @@ export const multiLine = style({
       display: '-webkit-box',
       WebkitLineClamp: lineLimit,
       WebkitBoxOrient: 'vertical',
-      paddingBottom: '0.1em',
     },
   },
 });

--- a/packages/braid-design-system/src/lib/components/private/MaxLines/MaxLines.css.ts
+++ b/packages/braid-design-system/src/lib/components/private/MaxLines/MaxLines.css.ts
@@ -2,7 +2,7 @@ import { createVar, style } from '@vanilla-extract/css';
 import { atoms } from '../../../../entries/css';
 
 /*
-Fixes a bug when using -webkit-box, where the descender of the last line
+Fixes a bug when using -webkit-box, where the descender on the last line
 of text could be cropped based on the combination of line height and
 font size.
 */

--- a/packages/braid-design-system/src/lib/components/private/MaxLines/MaxLines.css.ts
+++ b/packages/braid-design-system/src/lib/components/private/MaxLines/MaxLines.css.ts
@@ -22,7 +22,7 @@ export const base = style([
     textOverflow: 'ellipsis',
     whiteSpace: 'nowrap',
     selectors: {
-      [`${descenderCropFixForWebkitBox} > &`]: {
+      [`${descenderCropFixForWebkitBox} &`]: {
         paddingBottom: descenderCropFixOffset,
       },
     },

--- a/packages/braid-design-system/src/lib/components/private/Typography/Typography.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Typography/Typography.tsx
@@ -7,6 +7,7 @@ import { MaxLines } from '../MaxLines/MaxLines';
 import type { UseIconProps } from '../../../hooks/useIcon';
 import { alignToFlexAlign } from '../../../utils/align';
 import dedent from 'dedent';
+import { descenderCropFixForWebkitBox } from '../MaxLines/MaxLines.css';
 
 export interface TypographyProps extends Pick<BoxProps, 'id' | 'component'> {
   children?: ReactNode;
@@ -34,12 +35,12 @@ export const Typography = ({
   ...restProps
 }: PrivateTypographyProps) => {
   const lines = truncate ? 1 : maxLines;
-  const contents =
-    typeof lines === 'number' ? (
-      <MaxLines lines={lines}>{children}</MaxLines>
-    ) : (
-      children
-    );
+  const isTruncated = typeof lines === 'number';
+  const contents = isTruncated ? (
+    <MaxLines lines={lines}>{children}</MaxLines>
+  ) : (
+    children
+  );
 
   if (process.env.NODE_ENV !== 'production') {
     if (truncate) {
@@ -65,7 +66,10 @@ export const Typography = ({
       display="block"
       component={component}
       textAlign={align}
-      className={className}
+      className={[
+        className,
+        isTruncated ? descenderCropFixForWebkitBox : undefined,
+      ]}
       {...buildDataAttributes({ data, validateRestProps: restProps })}
     >
       {icon ? (


### PR DESCRIPTION
A combination of webkit-box, line-height and font-size can lead to instances where descender in the last line are cropped. 
![Screenshot 2024-02-16 at 10 43 06 am](https://github.com/seek-oss/braid-design-system/assets/9971251/9f59f86e-83b0-4a70-a710-956e7aa84deb)

This change focuses on preventing any potential cropping on text nodes