### PR TITLE
Add a testing log for the missing icon props page

### DIFF
--- a/site/src/App/DocNavigation/DocProps.tsx
+++ b/site/src/App/DocNavigation/DocProps.tsx
@@ -176,6 +176,10 @@ export const DocProps = () => {
   const { docsName = '', docs } = useContext(DocsContext);
   const { sourceUrlPrefix } = useConfig();
 
+  // This is temporary while we find the source of the missing props page issue
+  // eslint-disable-next-line no-console
+  console.table({ docsName, docs });
+
   if (!docs || !isValidComponentName(docsName)) {
     return null;
   }


### PR DESCRIPTION
For reasons that defy explanation, the Props pages for Icons in the Braid docs are blank.

This can't be replicated locally, and it also works fine on surge.

To test this, we need to run it in a master build.

I'm temporarily adding a console log to see some of the details in the props page, as I suspect we're somehow triggering the null just after this line.