### PR TITLE
Add some additional logging for missing props

### DIFF
--- a/site/src/App/DocNavigation/DocProps.tsx
+++ b/site/src/App/DocNavigation/DocProps.tsx
@@ -176,9 +176,19 @@ export const DocProps = () => {
   const { docsName = '', docs } = useContext(DocsContext);
   const { sourceUrlPrefix } = useConfig();
 
+  // This is temporary while we find the source of the missing props page issue
+  /* eslint-disable no-console */
+  console.table({ docsName, docs });
+
+  // @ts-expect-error docsName hasn't been narrowed
+  console.log('Component Docs Entry:', componentDocs[docsName]);
+
   if (!docs || !isValidComponentName(docsName)) {
+    console.log('Returning null for props page of', docsName);
     return null;
   }
+
+  /* eslint-enable no-console */
 
   const subfolder = /^Icon/.test(docsName) ? 'icons' : undefined;
   const componentFolder = `packages/braid-design-system/src/lib/components/${

--- a/site/src/App/DocNavigation/DocProps.tsx
+++ b/site/src/App/DocNavigation/DocProps.tsx
@@ -182,7 +182,7 @@ export const DocProps = () => {
 
   // @ts-expect-error docsName hasn't been narrowed
   console.log('Component Docs Entry:', componentDocs[docsName]);
-        
+
   if (!docs || !isValidComponentName(docsName)) {
     console.log('Returning null for props page of', docsName);
     return null;


### PR DESCRIPTION
The last test (#1461 ) revealed that the logs _were_ being triggered for the icon components, and they were as I expected them to be.

Next step is to check whether they're missing from the componentDocs json.

Have added a log to see the contents of componentDocs, as well as one to check if we are indeed hitting that null.