### PR TITLE
Remove one of the icon prop console logs

### DIFF
--- a/site/src/App/DocNavigation/DocProps.tsx
+++ b/site/src/App/DocNavigation/DocProps.tsx
@@ -180,9 +180,6 @@ export const DocProps = () => {
   /* eslint-disable no-console */
   console.table({ docsName, docs });
 
-  // @ts-expect-error docsName hasn't been narrowed
-  console.log('Component Docs Entry:', componentDocs[docsName]);
-
   if (!docs || !isValidComponentName(docsName)) {
     console.log('Returning null for props page of', docsName);
     return null;


### PR DESCRIPTION
The last test (#1462) fixed it. No idea how though.

We did do two things here, so the next test is to unwind them one thing at a time and see when it goes back to breaking.