### PR TITLE
Log the icons that are generated in the build

### DIFF
--- a/packages/braid-design-system/src/lib/components/index.ts
+++ b/packages/braid-design-system/src/lib/components/index.ts
@@ -87,6 +87,7 @@ export { ToastProvider, useToast } from './useToast/ToastContext';
 export { TooltipRenderer } from './TooltipRenderer/TooltipRenderer';
 
 import * as Icons from './icons';
+// eslint-disable-next-line no-console
 console.log('Icons: ', Icons);
 
 export * from './icons';

--- a/packages/braid-design-system/src/lib/components/index.ts
+++ b/packages/braid-design-system/src/lib/components/index.ts
@@ -86,4 +86,7 @@ export { Toggle } from './Toggle/Toggle';
 export { ToastProvider, useToast } from './useToast/ToastContext';
 export { TooltipRenderer } from './TooltipRenderer/TooltipRenderer';
 
+import * as Icons from './icons';
+console.log('Icons: ', Icons);
+
 export * from './icons';

--- a/site/src/App/DocNavigation/DocProps.tsx
+++ b/site/src/App/DocNavigation/DocProps.tsx
@@ -178,7 +178,6 @@ export const DocProps = () => {
 
   // This is temporary while we find the source of the missing props page issue
   /* eslint-disable no-console */
-  console.table({ docsName, docs });
 
   if (!docs || !isValidComponentName(docsName)) {
     console.log('Returning null for props page of', docsName);


### PR DESCRIPTION
Continuing the investigation from (#1463), we've narrowed the problem down to the Icons sometimes not being present in the `componentDocs.json` file.

Next step is to work out why that is.

I'd like to see the contents of the star export for Icons, in case they're going missing in the master builds.