### PR TITLE
Use Icon prop on Text component in all docs examples

### DIFF
--- a/site/src/App/Code/Code.tsx
+++ b/site/src/App/Code/Code.tsx
@@ -107,8 +107,13 @@ export const CodeButton = ({
       userSelect="none"
       pointerEvents="none"
     >
-      <Text size="xsmall" baseline={false} tone="positive">
-        <IconPositive /> {successLabel}
+      <Text
+        size="xsmall"
+        baseline={false}
+        tone="positive"
+        icon={<IconPositive />}
+      >
+        {successLabel}
       </Text>
     </Box>
   ) : (

--- a/site/src/App/routes/examples/job-summary/job-summary.tsx
+++ b/site/src/App/routes/examples/job-summary/job-summary.tsx
@@ -79,14 +79,14 @@ const page: Page = {
             </Columns>
 
             <Stack space="small">
-              <Text size="small" tone="secondary">
-                <IconLocation /> Melbourne
+              <Text size="small" tone="secondary" icon={<IconLocation />}>
+                Melbourne
               </Text>
-              <Text size="small" tone="secondary">
-                <IconTag /> Information Technology
+              <Text size="small" tone="secondary" icon={<IconTag />}>
+                Information Technology
               </Text>
-              <Text size="small" tone="secondary">
-                <IconMoney /> 150k+
+              <Text size="small" tone="secondary" icon={<IconMoney />}>
+                150k+
               </Text>
             </Stack>
             <Text>

--- a/site/src/App/routes/examples/job-summary/job-summary.tsx
+++ b/site/src/App/routes/examples/job-summary/job-summary.tsx
@@ -273,14 +273,14 @@ const page: Page = {
               </Stack>
 
               <Stack space="xsmall">
-                <Text tone="secondary" size="small">
-                  <IconLocation /> Melbourne
+                <Text tone="secondary" size="small" icon={<IconLocation />}>
+                  Melbourne
                 </Text>
-                <Text tone="secondary" size="small">
-                  <IconTag /> Information Technology
+                <Text tone="secondary" size="small" icon={<IconTag />}>
+                  Information Technology
                 </Text>
-                <Text tone="secondary" size="small">
-                  <IconMoney /> 150k+
+                <Text tone="secondary" size="small" icon={<IconMoney />}>
+                  150k+
                 </Text>
               </Stack>
 
@@ -315,14 +315,14 @@ const page: Page = {
               </Stack>
 
               <Stack space="xsmall">
-                <Text tone="secondary" size="small">
-                  <IconLocation /> Melbourne
+                <Text tone="secondary" size="small" icon={<IconLocation />}>
+                  Melbourne
                 </Text>
-                <Text tone="secondary" size="small">
-                  <IconTag /> Information Technology
+                <Text tone="secondary" size="small" icon={<IconTag />}>
+                  Information Technology
                 </Text>
-                <Text tone="secondary" size="small">
-                  <IconMoney /> 150k+
+                <Text tone="secondary" size="small" icon={<IconMoney />}>
+                  150k+
                 </Text>
               </Stack>
 
@@ -367,14 +367,14 @@ const page: Page = {
               </Stack>
 
               <Stack space="xsmall">
-                <Text tone="secondary" size="small">
-                  <IconLocation /> Melbourne
+                <Text tone="secondary" size="small" icon={<IconLocation />}>
+                  Melbourne
                 </Text>
-                <Text tone="secondary" size="small">
-                  <IconTag /> Information Technology
+                <Text tone="secondary" size="small" icon={<IconTag />}>
+                  Information Technology
                 </Text>
-                <Text tone="secondary" size="small">
-                  <IconMoney /> 150k+
+                <Text tone="secondary" size="small" icon={<IconMoney />}>
+                  150k+
                 </Text>
               </Stack>
 
@@ -472,14 +472,14 @@ const page: Page = {
                   </Stack>
 
                   <Stack space="xsmall">
-                    <Text tone="secondary" size="small">
-                      <IconLocation /> Melbourne
+                    <Text tone="secondary" size="small" icon={<IconLocation />}>
+                      Melbourne
                     </Text>
-                    <Text tone="secondary" size="small">
-                      <IconTag /> Information Technology
+                    <Text tone="secondary" size="small" icon={<IconTag />}>
+                      Information Technology
                     </Text>
-                    <Text tone="secondary" size="small">
-                      <IconMoney /> 150k+
+                    <Text tone="secondary" size="small" icon={<IconMoney />}>
+                      150k+
                     </Text>
                   </Stack>
 
@@ -546,14 +546,14 @@ const page: Page = {
               </Columns>
 
               <Stack space="small">
-                <Text size="small" tone="secondary">
-                  <IconLocation /> Melbourne
+                <Text size="small" tone="secondary" icon={<IconLocation />}>
+                  Melbourne
                 </Text>
-                <Text size="small" tone="secondary">
-                  <IconTag /> Information Technology
+                <Text size="small" tone="secondary" icon={<IconTag />}>
+                  Information Technology
                 </Text>
-                <Text size="small" tone="secondary">
-                  <IconMoney /> 150k+
+                <Text size="small" tone="secondary" icon={<IconMoney />}>
+                  150k+
                 </Text>
               </Stack>
               <Text>

--- a/site/src/App/routes/foundations/iconography/IconsDetails.tsx
+++ b/site/src/App/routes/foundations/iconography/IconsDetails.tsx
@@ -92,17 +92,17 @@ export const IconsDetails = () => (
                   <Text size="xsmall" tone="secondary">
                     DECORATIVE (i.e. hidden, will not be read)
                   </Text>
-                  <Text size="large">
-                    <IconTag />
-                  </Text>
+                  <IconTag size="large" />
                 </Stack>
                 <Stack space="medium">
                   <Text size="xsmall" tone="secondary">
                     IMAGE (i.e. Read as “Classification”)
                   </Text>
-                  <Text size="large">
-                    <IconTag title="Classification" titleId="iconId" />
-                  </Text>
+                  <IconTag
+                    title="Classification"
+                    titleId="iconId"
+                    size="large"
+                  />
                 </Stack>
               </Tiles>,
             )


### PR DESCRIPTION
In docs site (mainly docs code snippet examples) migrate to using the `Icon` prop in `Text` components, rather than including an `Icon` component as a child of `Text`.