### PR TITLE
Make component docs dependent on sub-`generate`s

### DIFF
--- a/site/project.json
+++ b/site/project.json
@@ -45,11 +45,12 @@
       }
     },
     "generate": {
-      "dependsOn": ["generate:component-docs", "^generate"],
+      "dependsOn": ["generate:component-docs"],
       "executor": "nx:noop"
     },
     "generate:component-docs": {
       "inputs": ["^default"],
+      "dependsOn": ["^generate"],
       "outputs": ["{projectRoot}/componentDocs.json"],
       "executor": "nx:run-script",
       "options": {


### PR DESCRIPTION
We now suspect the issue (#1464) is that there's a race condition between `generate:icons` and `generate:component-docs`. The page is missing because the componentDocs.json gets generated after the icon files in CI.

To test this (and fix), the `generate:component-docs` task is now dependent on `^generate` rather than being a peer.

This should hopefully remove any possible race conditions.