### PR TITLE
Remove all the bits added to test the icons page

### DIFF
--- a/packages/braid-design-system/src/lib/components/index.ts
+++ b/packages/braid-design-system/src/lib/components/index.ts
@@ -86,8 +86,4 @@ export { Toggle } from './Toggle/Toggle';
 export { ToastProvider, useToast } from './useToast/ToastContext';
 export { TooltipRenderer } from './TooltipRenderer/TooltipRenderer';
 
-import * as Icons from './icons';
-// eslint-disable-next-line no-console
-console.log('Icons: ', Icons);
-
 export * from './icons';

--- a/site/src/App/DocNavigation/DocProps.tsx
+++ b/site/src/App/DocNavigation/DocProps.tsx
@@ -176,15 +176,9 @@ export const DocProps = () => {
   const { docsName = '', docs } = useContext(DocsContext);
   const { sourceUrlPrefix } = useConfig();
 
-  // This is temporary while we find the source of the missing props page issue
-  /* eslint-disable no-console */
-
   if (!docs || !isValidComponentName(docsName)) {
-    console.log('Returning null for props page of', docsName);
     return null;
   }
-
-  /* eslint-enable no-console */
 
   const subfolder = /^Icon/.test(docsName) ? 'icons' : undefined;
   const componentFolder = `packages/braid-design-system/src/lib/components/${


### PR DESCRIPTION
I think the icon props page is fixed (#1466), so we can get rid of all the testing logs that were added to solve the problem.

NX task orchestration strikes again.