### PR TITLE
More accurately capture NX task dependencies

### DIFF
--- a/site/project.json
+++ b/site/project.json
@@ -45,12 +45,12 @@
       }
     },
     "generate": {
-      "dependsOn": ["generate:component-docs"],
+      "dependsOn": ["generate:component-docs", "^generate"],
       "executor": "nx:noop"
     },
     "generate:component-docs": {
       "inputs": ["^default"],
-      "dependsOn": ["^generate"],
+      "dependsOn": ["^generate:icons"],
       "outputs": ["{projectRoot}/componentDocs.json"],
       "executor": "nx:run-script",
       "options": {


### PR DESCRIPTION
We solved the missing props page issue by making `generate:icons` a dependency of `generate:component-docs`, which would force it to run first, thus preventing race conditions.

However, we did that by making `generate:component-docs` depend on `^generate`, which isn't the whole story.

This update should have much the same effect, but now more accurately captures that we need specifically icons to run before generating the component docs.