### PR TITLE
site: Fix nx task dependencies

### DIFF
--- a/packages/braid-design-system/project.json
+++ b/packages/braid-design-system/project.json
@@ -21,6 +21,13 @@
         "script": "codemod"
       }
     },
+    "dev": {
+      "dependsOn": ["generate:icons"],
+      "executor": "nx:run-script",
+      "options": {
+        "script": "dev"
+      }
+    },
     "generate": {
       "dependsOn": ["generate:icons", "generate:snippets"],
       "executor": "nx:noop"


### PR DESCRIPTION
Build is currently failing for the site, as building the dev entries of Braid require the icons to have been generated.

Before:
![before](https://github.com/seek-oss/braid-design-system/assets/912060/e79c7b0c-0b69-4a82-bbc7-9307fdef2bb6)

After:
![after](https://github.com/seek-oss/braid-design-system/assets/912060/a0ecacb7-7804-46e8-a7fa-c6dc92c57ea5)
