### PR TITLE
PageBlock: Add `small` and `full` width options

### DIFF
--- a/.changeset/brown-seahorses-notice.md
+++ b/.changeset/brown-seahorses-notice.md
@@ -1,0 +1,21 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - PageBlock
+---
+
+**PageBlock:** Add `small` and `full` width options
+
+Add `small` to available `width` options of `PageBlock` to support narrower max width for page content.
+
+Also introducing `full` as a `width` option to enable full width content, while still maintaining consistent screen gutters.
+
+**EXAMPLE USAGE:**
+```jsx
+<PageBlock width="small">
+  ...
+</PageBlock>
+```

--- a/packages/braid-design-system/src/lib/components/PageBlock/PageBlock.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/PageBlock/PageBlock.docs.tsx
@@ -32,11 +32,18 @@ const docs: ComponentDocs = {
     {
       label: 'Maximum width',
       description: (
-        <Text>
-          Use the <Strong>width</Strong> prop to adjust the maximum width of the
-          page container. Choose from either <Strong>medium</Strong> or{' '}
-          <Strong>large</Strong>.
-        </Text>
+        <>
+          <Text>
+            Use the <Strong>width</Strong> prop to adjust the maximum width of
+            the page container. Choose from either <Strong>small</Strong>,{' '}
+            <Strong>medium</Strong> or <Strong>large</Strong>.
+          </Text>
+          <Text>
+            Setting the <Strong>width</Strong> to <Strong>full</Strong> will
+            allow the content to grow to the full width while maintaining
+            consistent screen gutters.
+          </Text>
+        </>
       ),
       Example: () =>
         source(

--- a/packages/braid-design-system/src/lib/components/PageBlock/PageBlock.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/PageBlock/PageBlock.gallery.tsx
@@ -6,6 +6,15 @@ import source from '@braid-design-system/source.macro';
 
 export const galleryItems: ComponentExample[] = [
   {
+    label: 'Small width',
+    Example: () =>
+      source(
+        <PageBlock width="small">
+          <Placeholder height={100} />
+        </PageBlock>,
+      ),
+  },
+  {
     label: 'Medium width',
     Example: () =>
       source(
@@ -19,6 +28,15 @@ export const galleryItems: ComponentExample[] = [
     Example: () =>
       source(
         <PageBlock width="large">
+          <Placeholder height={100} />
+        </PageBlock>,
+      ),
+  },
+  {
+    label: 'Full width',
+    Example: () =>
+      source(
+        <PageBlock width="full">
           <Placeholder height={100} />
         </PageBlock>,
       ),

--- a/packages/braid-design-system/src/lib/components/PageBlock/PageBlock.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/PageBlock/PageBlock.screenshots.tsx
@@ -15,6 +15,14 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
+      label: 'Small',
+      Example: () => (
+        <PageBlock width="small">
+          <Placeholder height={100} />
+        </PageBlock>
+      ),
+    },
+    {
       label: 'Medium',
       Example: () => (
         <PageBlock width="medium">
@@ -26,6 +34,14 @@ export const screenshots: ComponentScreenshot = {
       label: 'Large',
       Example: () => (
         <PageBlock width="large">
+          <Placeholder height={100} />
+        </PageBlock>
+      ),
+    },
+    {
+      label: 'Full',
+      Example: () => (
+        <PageBlock width="full">
           <Placeholder height={100} />
         </PageBlock>
       ),

--- a/packages/braid-design-system/src/lib/components/PageBlock/PageBlock.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/PageBlock/PageBlock.snippets.tsx
@@ -5,6 +5,14 @@ import source from '@braid-design-system/source.macro';
 
 export const snippets: Snippets = [
   {
+    name: 'Small',
+    code: source(
+      <PageBlock width="small">
+        <Placeholder height={100} />
+      </PageBlock>,
+    ),
+  },
+  {
     name: 'Medium',
     code: source(
       <PageBlock width="medium">
@@ -16,6 +24,14 @@ export const snippets: Snippets = [
     name: 'Large',
     code: source(
       <PageBlock width="large">
+        <Placeholder height={100} />
+      </PageBlock>,
+    ),
+  },
+  {
+    name: 'Full',
+    code: source(
+      <PageBlock width="full">
         <Placeholder height={100} />
       </PageBlock>,
     ),

--- a/packages/braid-design-system/src/lib/components/PageBlock/PageBlock.tsx
+++ b/packages/braid-design-system/src/lib/components/PageBlock/PageBlock.tsx
@@ -21,7 +21,9 @@ export const gutters = { mobile: 'xsmall', tablet: 'gutter' } as const;
 
 interface Props {
   children: ReactNode;
-  width?: Extract<ContentBlockProps['width'], 'medium' | 'large'>;
+  width?:
+    | Extract<ContentBlockProps['width'], 'small' | 'medium' | 'large'>
+    | 'full';
   component?: (typeof validPageBlockComponents)[number];
   data?: DataAttributeMap;
 }
@@ -44,7 +46,11 @@ export const PageBlock = ({
       paddingX={gutters}
       {...buildDataAttributes({ data, validateRestProps: restProps })}
     >
-      <ContentBlock width={width}>{children}</ContentBlock>
+      {width === 'full' ? (
+        children
+      ) : (
+        <ContentBlock width={width}>{children}</ContentBlock>
+      )}
     </Box>
   );
 };

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -7212,8 +7212,10 @@ exports[`PageBlock 1`] = `
         | "section"
     data?: DataAttributeMap
     width?: 
+        | "full"
         | "large"
         | "medium"
+        | "small"
 },
 }
 `;


### PR DESCRIPTION
Add `small` to available `width` options of `PageBlock` to support narrower max width for page content.

Also introducing `full` as a `width` option to enable full width content, while still maintaining consistent screen gutters.

**EXAMPLE USAGE:**
```jsx
<PageBlock width="small">
  ...
</PageBlock>
```