### PR TITLE
Support `Placeholder` in tooltip content inside Text

### DIFF
--- a/packages/braid-design-system/src/lib/components/private/Placeholder/Placeholder.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Placeholder/Placeholder.tsx
@@ -1,6 +1,7 @@
 import React, { type ReactNode } from 'react';
 import { Box, Text } from '../../';
 import { useBackgroundLightness } from '../../Box/BackgroundContext';
+import { TextContext } from '../../Text/TextContext';
 import { atoms } from '../../../css/atoms/atoms';
 import wireframe from '../../../themes/wireframe';
 import * as styles from './Placeholder.css';
@@ -82,7 +83,9 @@ export const Placeholder = ({
         backgroundSize: imageSize,
       }}
     >
-      <PlaceholderContent label={label} image={image} />
+      <TextContext.Provider value={null}>
+        <PlaceholderContent label={label} image={image} />
+      </TextContext.Provider>
     </Box>
   );
 };


### PR DESCRIPTION
Due to `Text` components containing validation that prevents nesting typography components, the `Placeholder` cannot be used in certain contexts due to using a `Text` component internally for its label.

The `Placeholder` should not be part of the nesting typography validation, so resetting the context.
