### PR TITLE
ContentBlock: Add support for left alignment

### DIFF
--- a/.changeset/flat-coats-flow.md
+++ b/.changeset/flat-coats-flow.md
@@ -1,0 +1,21 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - ContentBlock
+---
+
+**ContentBlock:** Add support for left alignment
+
+Introduces horizontal alignment support for `ContentBlock`, enabling content to be constrained to a max width and aligned to the left.
+
+Useful inside of larger `PageBlock` or `ContentBlock` elements when constraining the content for readability or length of form fields.
+
+**EXAMPLE USAGE:**
+```jsx
+<ContentBlock align="left">
+  ...
+</ContentBlock>
+```

--- a/packages/braid-design-system/src/lib/components/ContentBlock/ContentBlock.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/ContentBlock/ContentBlock.docs.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import type { ComponentDocs } from 'site/types';
 import { Placeholder } from '../private/Placeholder/Placeholder';
-import { ContentBlock } from '../';
+import { ContentBlock, Stack } from '../';
 import source from '@braid-design-system/source.macro';
 import { Strong } from '../Strong/Strong';
 import { Text } from '../Text/Text';
@@ -16,8 +16,8 @@ const docs: ComponentDocs = {
     ),
   description: (
     <Text>
-      Provides a container that both centers and constrains the maximum width of
-      the content it wraps.
+      Provides a container to constrain the maximum width of the content it
+      wraps.
     </Text>
   ),
   alternatives: [
@@ -37,6 +37,26 @@ const docs: ComponentDocs = {
           <ContentBlock width="xsmall">
             <Placeholder height={100} />
           </ContentBlock>,
+        ),
+    },
+    {
+      label: 'Alignment',
+      description: (
+        <Text>
+          By default, the content will be center aligned to its parent, but this
+          can be customised via the <Strong>align</Strong> prop.
+        </Text>
+      ),
+      Example: () =>
+        source(
+          <Stack space="large">
+            <ContentBlock width="xsmall" align="center">
+              <Placeholder height={100} label="Center aligned (default)" />
+            </ContentBlock>
+            <ContentBlock width="xsmall" align="left">
+              <Placeholder height={100} label="Left aligned" />
+            </ContentBlock>
+          </Stack>,
         ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/ContentBlock/ContentBlock.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/ContentBlock/ContentBlock.docs.tsx
@@ -43,7 +43,7 @@ const docs: ComponentDocs = {
       label: 'Alignment',
       description: (
         <Text>
-          By default, the content will be center aligned to its parent, but this
+          By default, the content will be center-aligned to its parent, but this
           can be customised via the <Strong>align</Strong> prop.
         </Text>
       ),

--- a/packages/braid-design-system/src/lib/components/ContentBlock/ContentBlock.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/ContentBlock/ContentBlock.screenshots.tsx
@@ -7,7 +7,7 @@ export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320, 1200],
   examples: [
     {
-      label: 'Default Content Block',
+      label: 'Default width',
       Example: () => (
         <ContentBlock>
           <Placeholder height={100} />
@@ -15,7 +15,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Xsmall Content Block',
+      label: 'Xsmall width',
       Example: () => (
         <ContentBlock width="xsmall">
           <Placeholder height={100} />
@@ -23,7 +23,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Small Content Block',
+      label: 'Small width',
       Example: () => (
         <ContentBlock width="small">
           <Placeholder height={100} />
@@ -31,7 +31,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Medium Content Block',
+      label: 'Medium width',
       Example: () => (
         <ContentBlock width="medium">
           <Placeholder height={100} />
@@ -39,9 +39,17 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Large Content Block',
+      label: 'Large width',
       Example: () => (
         <ContentBlock width="large">
+          <Placeholder height={100} />
+        </ContentBlock>
+      ),
+    },
+    {
+      label: 'Align left',
+      Example: () => (
+        <ContentBlock width="xsmall" align="left">
           <Placeholder height={100} />
         </ContentBlock>
       ),

--- a/packages/braid-design-system/src/lib/components/ContentBlock/ContentBlock.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/ContentBlock/ContentBlock.snippets.tsx
@@ -36,4 +36,12 @@ export const snippets: Snippets = [
       </ContentBlock>,
     ),
   },
+  {
+    name: 'Left aligned',
+    code: source(
+      <ContentBlock width="small" align="left">
+        <Placeholder height={100} />
+      </ContentBlock>,
+    ),
+  },
 ];

--- a/packages/braid-design-system/src/lib/components/ContentBlock/ContentBlock.tsx
+++ b/packages/braid-design-system/src/lib/components/ContentBlock/ContentBlock.tsx
@@ -8,11 +8,13 @@ import * as styles from './ContentBlock.css';
 export interface ContentBlockProps {
   children: ReactNode;
   width?: BoxProps['maxWidth'];
+  align?: 'left' | 'center';
   data?: DataAttributeMap;
 }
 
 export const ContentBlock = ({
   width = 'medium',
+  align = 'center',
   data,
   children,
   ...restProps
@@ -20,7 +22,7 @@ export const ContentBlock = ({
   <Box
     width="full"
     maxWidth={width}
-    className={styles.marginAuto}
+    className={align === 'left' ? undefined : styles.marginAuto}
     {...buildDataAttributes({ data, validateRestProps: restProps })}
   >
     {children}

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -2825,6 +2825,9 @@ exports[`ContentBlock 1`] = `
 {
   exportType: component,
   props: {
+    align?: 
+        | "center"
+        | "left"
     children: ReactNode
     data?: DataAttributeMap
     width?: 

--- a/site/src/App/routes/foundations/layout/layout.tsx
+++ b/site/src/App/routes/foundations/layout/layout.tsx
@@ -801,7 +801,7 @@ const page: DocsPage = {
         )}
       </Code>
       <Text>
-        If you’d like a to increase or decrease the width of the block, you can
+        If you’d like to increase or decrease the width of the block, you can
         optionally provide the{' '}
         <TextLink href="/components/ContentBlock#maximum-width">width</TextLink>{' '}
         prop:

--- a/site/src/App/routes/foundations/layout/layout.tsx
+++ b/site/src/App/routes/foundations/layout/layout.tsx
@@ -788,7 +788,7 @@ const page: DocsPage = {
         applications will want to limit the width of content on the screen. In
         order to address this, Braid provides the{' '}
         <TextLink href="/components/ContentBlock">ContentBlock</TextLink>{' '}
-        component that sets a maximum width and horizontally center aligns the
+        component that sets a maximum width and horizontally center-aligns the
         block by default.
       </Text>
       <Code>
@@ -816,7 +816,7 @@ const page: DocsPage = {
         )}
       </Code>
       <Text>
-        To manage line length or form field sizes you may choose to left align
+        To manage line length or form field sizes you may choose to left-align
         the block. This can be done via the{' '}
         <TextLink href="/components/ContentBlock#alignment">align</TextLink>{' '}
         prop:
@@ -873,7 +873,7 @@ const page: DocsPage = {
         choose a{' '}
         <TextLink href="/components/PageBlock#maximum-width">width</TextLink> of{' '}
         <Strong>full</Strong>. This allows content to extend to the full
-        available width while still maintaining the standardised responsive
+        available width while still maintaining the standard responsive
         gutters.
       </Text>
 

--- a/site/src/App/routes/foundations/layout/layout.tsx
+++ b/site/src/App/routes/foundations/layout/layout.tsx
@@ -788,7 +788,8 @@ const page: DocsPage = {
         applications will want to limit the width of content on the screen. In
         order to address this, Braid provides the{' '}
         <TextLink href="/components/ContentBlock">ContentBlock</TextLink>{' '}
-        component that sets a maximum width and centres content horizontally.
+        component that sets a maximum width and horizontally center aligns the
+        block by default.
       </Text>
       <Code>
         {source(
@@ -800,13 +801,29 @@ const page: DocsPage = {
         )}
       </Code>
       <Text>
-        If you’d like a larger content block, you can optionally provide the{' '}
+        If you’d like a to increase or decrease the width of the block, you can
+        optionally provide the{' '}
         <TextLink href="/components/ContentBlock#maximum-width">width</TextLink>{' '}
         prop:
       </Text>
       <Code>
         {source(
-          <ContentBlock width="large">
+          <ContentBlock width="small">
+            <Card>
+              <Text>Hello World</Text>
+            </Card>
+          </ContentBlock>,
+        )}
+      </Code>
+      <Text>
+        To manage line length or form field sizes you may choose to left align
+        the block. This can be done via the{' '}
+        <TextLink href="/components/ContentBlock#alignment">align</TextLink>{' '}
+        prop:
+      </Text>
+      <Code>
+        {source(
+          <ContentBlock width="small" align="left">
             <Card>
               <Text>Hello World</Text>
             </Card>
@@ -837,7 +854,8 @@ const page: DocsPage = {
       <Text>
         To standardise our page-level block widths, the{' '}
         <TextLink href="/components/PageBlock#maximum-width">width</TextLink>{' '}
-        prop accepts either <Strong>medium</Strong> or <Strong>large</Strong>.
+        prop accepts either <Strong>small</Strong>, <Strong>medium</Strong> or{' '}
+        <Strong>large</Strong>.
       </Text>
       <Code>
         {source(
@@ -848,6 +866,16 @@ const page: DocsPage = {
           </PageBlock>,
         )}
       </Code>
+
+      <Text>
+        Additionally, a{' '}
+        <TextLink href="/components/PageBlock">PageBlock</TextLink> can also
+        choose a{' '}
+        <TextLink href="/components/PageBlock#maximum-width">width</TextLink> of{' '}
+        <Strong>full</Strong>. This allows content to extend to the full
+        available width while still maintaining the standardised responsive
+        gutters.
+      </Text>
 
       <Divider />
 

--- a/site/src/App/routes/foundations/layout/layout.tsx
+++ b/site/src/App/routes/foundations/layout/layout.tsx
@@ -873,8 +873,7 @@ const page: DocsPage = {
         choose a{' '}
         <TextLink href="/components/PageBlock#maximum-width">width</TextLink> of{' '}
         <Strong>full</Strong>. This allows content to extend to the full
-        available width while still maintaining the standard responsive
-        gutters.
+        available width while still maintaining the standard responsive gutters.
       </Text>
 
       <Divider />


### PR DESCRIPTION
Introduces horizontal alignment support for `ContentBlock`, enabling content to be constrained to a max width and aligned to the left.

Useful inside of larger `PageBlock` or `ContentBlock` elements when constraining the content for readability or length of form fields.

**EXAMPLE USAGE:**
```jsx
<ContentBlock align="left">
  ...
</ContentBlock>
```