### PR TITLE
Add `togglePosition` prop to `Toggle` component

### DIFF
--- a/.changeset/few-planets-invite.md
+++ b/.changeset/few-planets-invite.md
@@ -1,0 +1,20 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Toggle
+---
+
+**Toggle:** Add `togglePosition` prop
+
+Introductions the `togglePosition` prop, enabling the toggle to be positioned either before or after the label text.
+
+- `togglePosition="leading"` -  positions the toggle before the label text.
+- `togglePosition="trailing"` - positions the toggle after the label text.
+
+**EXAMPLE USAGE:**
+```jsx
+<Toggle togglePosition="trailing" label="Label" />
+```

--- a/.changeset/few-planets-invite.md
+++ b/.changeset/few-planets-invite.md
@@ -9,10 +9,7 @@ updated:
 
 **Toggle:** Add `togglePosition` prop
 
-Introductions the `togglePosition` prop, enabling the toggle to be positioned either before or after the label text.
-
-- `togglePosition="leading"` -  positions the toggle before the label text.
-- `togglePosition="trailing"` - positions the toggle after the label text.
+Introduces the `togglePosition` prop, enabling the toggle to either be `leading` or `trailing` its label text.
 
 **EXAMPLE USAGE:**
 ```jsx

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
@@ -59,6 +59,34 @@ const docs: ComponentDocs = {
         ),
     },
     {
+      label: 'Toggle position',
+      description: (
+        <Text>
+          Toggles can be positioned before or after the label via the{' '}
+          <Strong>togglePosition</Strong> prop.
+        </Text>
+      ),
+      Example: ({ id, getState, toggleState }) =>
+        source(
+          <Stack space="large" dividers>
+            <Toggle
+              label="Leading"
+              id={`${id}_leading`}
+              on={getState('toggleLeading')}
+              onChange={() => toggleState('toggleLeading')}
+              togglePosition="leading"
+            />
+            <Toggle
+              label="Trailing"
+              id={`${id}_trailing`}
+              on={getState('toggleTrailing')}
+              onChange={() => toggleState('toggleTrailing')}
+              togglePosition="trailing"
+            />
+          </Stack>,
+        ),
+    },
+    {
       label: 'Sizes',
       description: (
         <Text>

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
@@ -61,10 +61,17 @@ const docs: ComponentDocs = {
     {
       label: 'Toggle position',
       description: (
-        <Text>
-          Toggles can be positioned before or after the label via the{' '}
-          <Strong>togglePosition</Strong> prop.
-        </Text>
+        <>
+          <Text>
+            By default, the position of the toggle relative to the label text
+            will be determined by its <Strong>align</Strong> prop.
+          </Text>
+          <Text>
+            This can be overridden by setting the{' '}
+            <Strong>togglePosition</Strong> prop to either{' '}
+            <Strong>leading</Strong> or <Strong>trailing</Strong>.
+          </Text>
+        </>
       ),
       Example: ({ id, getState, toggleState }) =>
         source(

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.gallery.tsx
@@ -30,6 +30,19 @@ export const galleryItems: ComponentExample[] = [
       ),
   },
   {
+    label: 'Toggle Position: "leading" | "trailing"',
+    Example: ({ id, getState, toggleState }) =>
+      source(
+        <Toggle
+          togglePosition="trailing"
+          label="Trailing toggle"
+          id={id}
+          on={getState('toggle')}
+          onChange={() => toggleState('toggle')}
+        />,
+      ),
+  },
+  {
     label: 'Toggle Alignment: "left" | "justify" | "right"',
     Example: ({ id, getState, toggleState }) =>
       source(

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.screenshots.tsx
@@ -62,6 +62,23 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
+      label: 'Space between the label and toggle preserved',
+      Container: ({ children }) => (
+        <div style={{ maxWidth: '300px' }}>{children}</div>
+      ),
+      Example: ({ id, handler }) => (
+        <Box display="flex">
+          <Toggle
+            on={true}
+            align="justify"
+            label="Justified"
+            id={id}
+            onChange={handler}
+          />
+        </Box>
+      ),
+    },
+    {
       label: 'Left aligned with leading toggle position',
       Container: ({ children }) => (
         <div style={{ maxWidth: '300px' }}>{children}</div>
@@ -155,23 +172,6 @@ export const screenshots: ComponentScreenshot = {
           id={id}
           onChange={handler}
         />
-      ),
-    },
-    {
-      label: 'Space between the label and toggle preserved',
-      Container: ({ children }) => (
-        <div style={{ maxWidth: '300px' }}>{children}</div>
-      ),
-      Example: ({ id, handler }) => (
-        <Box display="flex">
-          <Toggle
-            on={true}
-            align="justify"
-            label="Justified"
-            id={id}
-            onChange={handler}
-          />
-        </Box>
       ),
     },
     {

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.screenshots.tsx
@@ -32,7 +32,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Right aligned',
+      label: 'Right aligned with default toggle position',
       Container: ({ children }) => (
         <div style={{ maxWidth: '300px' }}>{children}</div>
       ),
@@ -47,7 +47,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Justified',
+      label: 'Justified with default toggle position',
       Container: ({ children }) => (
         <div style={{ maxWidth: '300px' }}>{children}</div>
       ),
@@ -56,6 +56,102 @@ export const screenshots: ComponentScreenshot = {
           on={true}
           align="justify"
           label="Justified"
+          id={id}
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'Left aligned with leading toggle position',
+      Container: ({ children }) => (
+        <div style={{ maxWidth: '300px' }}>{children}</div>
+      ),
+      Example: ({ id, handler }) => (
+        <Toggle
+          on={true}
+          align="left"
+          togglePosition="leading"
+          label="Aligned left, leading toggle"
+          id={id}
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'Left aligned with trailing toggle position',
+      Container: ({ children }) => (
+        <div style={{ maxWidth: '300px' }}>{children}</div>
+      ),
+      Example: ({ id, handler }) => (
+        <Toggle
+          on={true}
+          align="left"
+          togglePosition="trailing"
+          label="Aligned left, trailing toggle"
+          id={id}
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'Justified with leading toggle position',
+      Container: ({ children }) => (
+        <div style={{ maxWidth: '300px' }}>{children}</div>
+      ),
+      Example: ({ id, handler }) => (
+        <Toggle
+          on={true}
+          align="justify"
+          togglePosition="leading"
+          label="Justified, leading toggle"
+          id={id}
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'Justified with trailing toggle position',
+      Container: ({ children }) => (
+        <div style={{ maxWidth: '300px' }}>{children}</div>
+      ),
+      Example: ({ id, handler }) => (
+        <Toggle
+          on={true}
+          align="justify"
+          togglePosition="trailing"
+          label="Justified, trailing toggle"
+          id={id}
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'Right aligned with leading toggle position',
+      Container: ({ children }) => (
+        <div style={{ maxWidth: '300px' }}>{children}</div>
+      ),
+      Example: ({ id, handler }) => (
+        <Toggle
+          on={true}
+          align="right"
+          togglePosition="leading"
+          label="Right aligned, leading toggle"
+          id={id}
+          onChange={handler}
+        />
+      ),
+    },
+    {
+      label: 'Right aligned with trailing toggle position',
+      Container: ({ children }) => (
+        <div style={{ maxWidth: '300px' }}>{children}</div>
+      ),
+      Example: ({ id, handler }) => (
+        <Toggle
+          on={true}
+          align="right"
+          togglePosition="trailing"
+          label="Right aligned, trailing toggle"
           id={id}
           onChange={handler}
         />

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.snippets.tsx
@@ -20,4 +20,8 @@ export const snippets: Snippets = [
     name: 'Justified',
     code: source(<Toggle label="Label" align="justify" />),
   },
+  {
+    name: 'Trailing toggle position',
+    code: source(<Toggle label="Label" togglePosition="trailing" />),
+  },
 ];

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -58,8 +58,7 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
 
     const alignToEnd =
       (align === 'left' && appliedTogglePosition === 'trailing') ||
-      (align === 'justify' && appliedTogglePosition === 'leading') ||
-      (align === 'right' && appliedTogglePosition === 'leading');
+      (align !== 'left' && appliedTogglePosition === 'leading');
 
     return (
       <Box

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -53,23 +53,18 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
   ) => {
     const lightness = useBackgroundLightness();
 
-    const flexDirection: 'row' | 'rowReverse' =
-      togglePosition === 'trailing' ? 'rowReverse' : 'row';
-
-    const justifyContent: 'flexEnd' | 'flexStart' =
+    const alignToEnd =
       (align === 'left' && togglePosition === 'trailing') ||
       (align === 'justify' && togglePosition === 'leading') ||
-      (align === 'right' && togglePosition === 'leading')
-        ? 'flexEnd'
-        : 'flexStart';
+      (align === 'right' && togglePosition === 'leading');
 
     return (
       <Box
         position="relative"
         zIndex={0}
         display="flex"
-        flexDirection={flexDirection}
-        justifyContent={justifyContent}
+        flexDirection={togglePosition === 'trailing' ? 'rowReverse' : 'row'}
+        justifyContent={alignToEnd ? 'flexEnd' : undefined}
         className={styles.root}
         {...buildDataAttributes({ data, validateRestProps: restProps })}
       >

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -44,7 +44,7 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
       onChange,
       label,
       align = 'left',
-      togglePosition = 'leading',
+      togglePosition = align === 'left' ? 'leading' : 'trailing',
       size = 'standard',
       data,
       ...restProps
@@ -53,24 +53,15 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
   ) => {
     const lightness = useBackgroundLightness();
 
-    // Todo - fix type. pick from sprinkles?
-    let flexDirection: 'row' | 'rowReverse' | undefined;
-    if (align !== 'left' || togglePosition === 'trailing') {
-      flexDirection = 'rowReverse';
-    }
+    const flexDirection: 'row' | 'rowReverse' =
+      togglePosition === 'trailing' ? 'rowReverse' : 'row';
 
-    // Todo - fix type. pick from sprinkles?
-    let justifyContent: 'spaceBetween' | 'flexEnd' | undefined;
-    if (align === 'justify') {
-      justifyContent = 'spaceBetween';
-    } else if (togglePosition === 'trailing') {
-      justifyContent = 'flexEnd';
-    }
-
-    // Todo - refactor with gap after browser policy change
-    // Todo - come up with exhaustive cases for this
-    const toggleLeftOfLabel: boolean =
-      align === 'left' && togglePosition !== 'trailing';
+    const justifyContent: 'flexEnd' | 'flexStart' =
+      (align === 'left' && togglePosition === 'trailing') ||
+      (align === 'justify' && togglePosition === 'leading') ||
+      (align === 'right' && togglePosition === 'leading')
+        ? 'flexEnd'
+        : 'flexStart';
 
     return (
       <Box
@@ -168,13 +159,28 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
         <Box
           component="label"
           htmlFor={id}
-          paddingLeft={toggleLeftOfLabel ? 'xsmall' : undefined}
-          paddingRight={!toggleLeftOfLabel ? 'xsmall' : undefined}
+          // Todo - Replace paddings with flex-gap after browser policy change
+          /*
+          Apply padding by default to prevent padding disappearing
+          during partial completion of togglePosition prop in Playroom
+          */
+          paddingLeft={togglePosition === 'trailing' ? undefined : 'xsmall'}
+          paddingRight={togglePosition === 'leading' ? undefined : 'xsmall'}
+          flexGrow={align === 'justify' ? 1 : undefined}
           userSelect="none"
           cursor="pointer"
           className={[styles.label[size], virtualTouchable]}
         >
-          <Text baseline={false} weight={on ? 'strong' : undefined} size={size}>
+          <Text
+            baseline={false}
+            weight={on ? 'strong' : undefined}
+            size={size}
+            align={
+              align === 'justify' && togglePosition === 'leading'
+                ? 'right'
+                : undefined
+            }
+          >
             {label}
           </Text>
         </Box>

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -44,7 +44,7 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
       onChange,
       label,
       align = 'left',
-      togglePosition = align === 'left' ? 'leading' : 'trailing',
+      togglePosition,
       size = 'standard',
       data,
       ...restProps
@@ -53,16 +53,21 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
   ) => {
     const lightness = useBackgroundLightness();
 
+    const defaultTogglePosition = align === 'left' ? 'leading' : 'trailing';
+    const appliedTogglePosition = togglePosition || defaultTogglePosition;
+
     const alignToEnd =
-      (align === 'left' && togglePosition === 'trailing') ||
-      (align === 'justify' && togglePosition === 'leading') ||
-      (align === 'right' && togglePosition === 'leading');
+      (align === 'left' && appliedTogglePosition === 'trailing') ||
+      (align === 'justify' && appliedTogglePosition === 'leading') ||
+      (align === 'right' && appliedTogglePosition === 'leading');
 
     return (
       <Box
         zIndex={0}
         display="flex"
-        flexDirection={togglePosition === 'trailing' ? 'rowReverse' : 'row'}
+        flexDirection={
+          appliedTogglePosition === 'trailing' ? 'rowReverse' : 'row'
+        }
         justifyContent={alignToEnd ? 'flexEnd' : undefined}
         className={styles.root}
         {...buildDataAttributes({ data, validateRestProps: restProps })}
@@ -158,10 +163,14 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
           // Todo - Replace paddings with flex-gap after browser policy change
           /*
           Apply padding by default to prevent padding disappearing
-          during partial completion of togglePosition prop in Playroom
+          during partial completion of togglePosition and align props in Playroom
           */
-          paddingLeft={togglePosition === 'trailing' ? undefined : 'xsmall'}
-          paddingRight={togglePosition === 'leading' ? undefined : 'xsmall'}
+          paddingLeft={
+            appliedTogglePosition === 'trailing' ? undefined : 'xsmall'
+          }
+          paddingRight={
+            appliedTogglePosition === 'leading' ? undefined : 'xsmall'
+          }
           flexGrow={align === 'justify' ? 1 : undefined}
           userSelect="none"
           cursor="pointer"
@@ -172,7 +181,7 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
             weight={on ? 'strong' : undefined}
             size={size}
             align={
-              align === 'justify' && togglePosition === 'leading'
+              align === 'justify' && appliedTogglePosition === 'leading'
                 ? 'right'
                 : undefined
             }

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -24,6 +24,7 @@ export interface ToggleProps {
   on: boolean;
   onChange: ChangeHandler;
   align?: 'left' | 'right' | 'justify';
+  togglePosition?: 'leading' | 'trailing';
   size?: Size;
   data?: DataAttributeMap;
 }
@@ -43,6 +44,7 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
       onChange,
       label,
       align = 'left',
+      togglePosition = 'leading',
       size = 'standard',
       data,
       ...restProps
@@ -51,12 +53,32 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
   ) => {
     const lightness = useBackgroundLightness();
 
+    // Todo - fix type. pick from sprinkles?
+    let flexDirection: 'row' | 'rowReverse' | undefined;
+    if (align !== 'left' || togglePosition === 'trailing') {
+      flexDirection = 'rowReverse';
+    }
+
+    // Todo - fix type. pick from sprinkles?
+    let justifyContent: 'spaceBetween' | 'flexEnd' | undefined;
+    if (align === 'justify') {
+      justifyContent = 'spaceBetween';
+    } else if (togglePosition === 'trailing') {
+      justifyContent = 'flexEnd';
+    }
+
+    // Todo - refactor with gap after browser policy change
+    // Todo - come up with exhaustive cases for this
+    const toggleLeftOfLabel: boolean =
+      align === 'left' && togglePosition !== 'trailing';
+
     return (
       <Box
         position="relative"
         zIndex={0}
         display="flex"
-        flexDirection={align === 'left' ? undefined : 'rowReverse'}
+        flexDirection={flexDirection}
+        justifyContent={justifyContent}
         className={styles.root}
         {...buildDataAttributes({ data, validateRestProps: restProps })}
       >
@@ -146,11 +168,8 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
         <Box
           component="label"
           htmlFor={id}
-          paddingLeft={align === 'left' ? 'xsmall' : undefined}
-          paddingRight={
-            align === 'right' || align === 'justify' ? 'xsmall' : undefined
-          }
-          flexGrow={align === 'justify' ? 1 : undefined}
+          paddingLeft={toggleLeftOfLabel ? 'xsmall' : undefined}
+          paddingRight={!toggleLeftOfLabel ? 'xsmall' : undefined}
           userSelect="none"
           cursor="pointer"
           className={[styles.label[size], virtualTouchable]}

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -60,7 +60,6 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
 
     return (
       <Box
-        position="relative"
         zIndex={0}
         display="flex"
         flexDirection={togglePosition === 'trailing' ? 'rowReverse' : 'row'}
@@ -68,87 +67,89 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
         className={styles.root}
         {...buildDataAttributes({ data, validateRestProps: restProps })}
       >
-        <Box
-          component="input"
-          type="checkbox"
-          id={id}
-          checked={on}
-          onChange={handleChange(onChange)}
-          position="absolute"
-          zIndex={1}
-          cursor="pointer"
-          opacity={0}
-          className={[
-            styles.realField,
-            styles.realFieldPosition[size],
-            styles.fieldSize[size],
-          ]}
-          ref={forwardedRef}
-        />
-        <Box
-          position="relative"
-          display="flex"
-          alignItems="center"
-          flexShrink={0}
-          className={[
-            styles.slideContainer,
-            styles.slideContainerSize[size],
-            styles.fieldSize[size],
-          ]}
-        >
+        <Box position="relative">
           <Box
+            component="input"
+            type="checkbox"
+            id={id}
+            checked={on}
+            onChange={handleChange(onChange)}
             position="absolute"
-            width="full"
-            overflow="hidden"
-            borderRadius="full"
+            zIndex={1}
+            cursor="pointer"
+            opacity={0}
             className={[
-              styles.slideTrack[size],
-              styles.slideTrackMask,
-              styles.slideTrackBgLightMode[lightness.lightMode],
-              styles.slideTrackBgDarkMode[lightness.darkMode],
+              styles.realField,
+              styles.realFieldPosition[size],
+              styles.fieldSize[size],
+            ]}
+            ref={forwardedRef}
+          />
+          <Box
+            position="relative"
+            display="flex"
+            alignItems="center"
+            flexShrink={0}
+            className={[
+              styles.slideContainer,
+              styles.slideContainerSize[size],
+              styles.fieldSize[size],
             ]}
           >
             <Box
               position="absolute"
               width="full"
-              height="full"
-              background="formAccent"
+              overflow="hidden"
+              borderRadius="full"
+              className={[
+                styles.slideTrack[size],
+                styles.slideTrackMask,
+                styles.slideTrackBgLightMode[lightness.lightMode],
+                styles.slideTrackBgDarkMode[lightness.darkMode],
+              ]}
+            >
+              <Box
+                position="absolute"
+                width="full"
+                height="full"
+                background="formAccent"
+                transition="fast"
+                className={styles.slideTrackSelected}
+              />
+            </Box>
+            <Box
+              position="absolute"
+              background="surface"
               transition="fast"
-              className={styles.slideTrackSelected}
-            />
-          </Box>
-          <Box
-            position="absolute"
-            background="surface"
-            transition="fast"
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-            borderRadius="full"
-            className={styles.slider[size]}
-          >
-            <FieldOverlay
-              variant={on ? 'formAccent' : 'default'}
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
               borderRadius="full"
-              visible
-              className={{
-                [styles.hideBorderOnDarkBackgroundInLightMode]:
-                  lightness.lightMode === 'dark',
-              }}
-            />
-            <FieldOverlay className={styles.icon}>
-              <IconTick tone="formAccent" size="fill" />
-            </FieldOverlay>
-            <FieldOverlay
-              variant="focus"
-              borderRadius="full"
-              className={styles.focusOverlay}
-            />
-            <FieldOverlay
-              variant="formAccent"
-              borderRadius="full"
-              className={!on ? styles.hoverOverlay : undefined}
-            />
+              className={styles.slider[size]}
+            >
+              <FieldOverlay
+                variant={on ? 'formAccent' : 'default'}
+                borderRadius="full"
+                visible
+                className={{
+                  [styles.hideBorderOnDarkBackgroundInLightMode]:
+                    lightness.lightMode === 'dark',
+                }}
+              />
+              <FieldOverlay className={styles.icon}>
+                <IconTick tone="formAccent" size="fill" />
+              </FieldOverlay>
+              <FieldOverlay
+                variant="focus"
+                borderRadius="full"
+                className={styles.focusOverlay}
+              />
+              <FieldOverlay
+                variant="formAccent"
+                borderRadius="full"
+                className={!on ? styles.hoverOverlay : undefined}
+              />
+            </Box>
           </Box>
         </Box>
         <Box

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -8553,6 +8553,9 @@ exports[`Toggle 1`] = `
     size?: 
         | "small"
         | "standard"
+    togglePosition?: 
+        | "leading"
+        | "trailing"
 },
 }
 `;


### PR DESCRIPTION
Add `togglePosition` prop to `Toggle` component:

* `togglePosition="leading"` - positions the toggle before the label text
* `togglePosition="trailing"` - positions the toggle after the label text

If no `togglePosition` prop is provided:

* If `align` is set to `left`,  `togglePosition` is set to `leading`
* If `align` is not set to `left`, `togglePosition` is set to `trailing`

This is to preserve the current behaviour with `align` to avoid a breaking change

See changeset for more details