### PR TITLE
On docs site, add 'wide' width for Gallery Component sections. Use for `PageBlock` and `ContentBlock`

### DIFF
--- a/packages/braid-design-system/src/lib/components/Accordion/Accordion.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Accordion/Accordion.gallery.tsx
@@ -8,82 +8,84 @@ import {
   IconImage,
   Placeholder,
 } from '../../playroom/components';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Large size with dividers',
-    Example: () =>
-      source(
-        <Accordion>
-          <AccordionItem label="Item 1">
-            <Placeholder height={100} />
-          </AccordionItem>
-          <AccordionItem label="Item 2">
-            <Placeholder height={100} />
-          </AccordionItem>
-          <AccordionItem label="Item 3">
-            <Placeholder height={100} />
-          </AccordionItem>
-        </Accordion>,
-      ),
-  },
-  {
-    label: 'Standard size without dividers',
-    Example: () =>
-      source(
-        <Accordion size="standard" dividers={false}>
-          <AccordionItem label="Item 1">
-            <Placeholder height={100} />
-          </AccordionItem>
-          <AccordionItem label="Item 2">
-            <Placeholder height={100} />
-          </AccordionItem>
-          <AccordionItem label="Item 3">
-            <Placeholder height={100} />
-          </AccordionItem>
-        </Accordion>,
-      ),
-  },
-  {
-    label: 'With a Badge',
-    Example: () =>
-      source(
-        <Accordion size="standard" dividers={false}>
-          <AccordionItem label="Item 1">
-            <Placeholder height={100} />
-          </AccordionItem>
-          <AccordionItem
-            label="Item 2"
-            badge={
-              <Badge tone="promote" weight="strong">
-                Badge
-              </Badge>
-            }
-          >
-            <Placeholder height={100} />
-          </AccordionItem>
-          <AccordionItem label="Item 3">
-            <Placeholder height={100} />
-          </AccordionItem>
-        </Accordion>,
-      ),
-  },
-  {
-    label: 'With an icon',
-    Example: () =>
-      source(
-        <Accordion size="standard" dividers={false}>
-          <AccordionItem label="Item 1" icon={<IconImage />}>
-            <Placeholder height={100} />
-          </AccordionItem>
-          <AccordionItem label="Item 2" icon={<IconImage />}>
-            <Placeholder height={100} />
-          </AccordionItem>
-          <AccordionItem label="Item 3" icon={<IconImage />}>
-            <Placeholder height={100} />
-          </AccordionItem>
-        </Accordion>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Large size with dividers',
+      Example: () =>
+        source(
+          <Accordion>
+            <AccordionItem label="Item 1">
+              <Placeholder height={100} />
+            </AccordionItem>
+            <AccordionItem label="Item 2">
+              <Placeholder height={100} />
+            </AccordionItem>
+            <AccordionItem label="Item 3">
+              <Placeholder height={100} />
+            </AccordionItem>
+          </Accordion>,
+        ),
+    },
+    {
+      label: 'Standard size without dividers',
+      Example: () =>
+        source(
+          <Accordion size="standard" dividers={false}>
+            <AccordionItem label="Item 1">
+              <Placeholder height={100} />
+            </AccordionItem>
+            <AccordionItem label="Item 2">
+              <Placeholder height={100} />
+            </AccordionItem>
+            <AccordionItem label="Item 3">
+              <Placeholder height={100} />
+            </AccordionItem>
+          </Accordion>,
+        ),
+    },
+    {
+      label: 'With a Badge',
+      Example: () =>
+        source(
+          <Accordion size="standard" dividers={false}>
+            <AccordionItem label="Item 1">
+              <Placeholder height={100} />
+            </AccordionItem>
+            <AccordionItem
+              label="Item 2"
+              badge={
+                <Badge tone="promote" weight="strong">
+                  Badge
+                </Badge>
+              }
+            >
+              <Placeholder height={100} />
+            </AccordionItem>
+            <AccordionItem label="Item 3">
+              <Placeholder height={100} />
+            </AccordionItem>
+          </Accordion>,
+        ),
+    },
+    {
+      label: 'With an icon',
+      Example: () =>
+        source(
+          <Accordion size="standard" dividers={false}>
+            <AccordionItem label="Item 1" icon={<IconImage />}>
+              <Placeholder height={100} />
+            </AccordionItem>
+            <AccordionItem label="Item 2" icon={<IconImage />}>
+              <Placeholder height={100} />
+            </AccordionItem>
+            <AccordionItem label="Item 3" icon={<IconImage />}>
+              <Placeholder height={100} />
+            </AccordionItem>
+          </Accordion>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Actions/Actions.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Actions/Actions.gallery.tsx
@@ -1,51 +1,53 @@
 import React from 'react';
 import source from '@braid-design-system/source.macro';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Actions, Button, IconDelete } from '../';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'With multiple buttons',
-    Example: () =>
-      source(
-        <Actions>
-          <Button>Button 1</Button>
-          <Button>Button 2</Button>
-          <Button variant="transparent">Button 3</Button>
-        </Actions>,
-      ),
-  },
-  {
-    label: 'With a branded action',
-    Example: () =>
-      source(
-        <Actions>
-          <Button tone="brandAccent">Button 1</Button>
-          <Button variant="transparent">Button 2</Button>
-        </Actions>,
-      ),
-  },
-  {
-    label: 'With a destructive action',
-    Example: () =>
-      source(
-        <Actions>
-          <Button tone="critical" icon={<IconDelete />}>
-            Delete
-          </Button>
-          <Button variant="transparent">Cancel</Button>
-        </Actions>,
-      ),
-  },
-  {
-    label: 'Small size',
-    Example: () =>
-      source(
-        <Actions size="small">
-          <Button>Button 1</Button>
-          <Button>Button 2</Button>
-          <Button variant="transparent">Button 3</Button>
-        </Actions>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'With multiple buttons',
+      Example: () =>
+        source(
+          <Actions>
+            <Button>Button 1</Button>
+            <Button>Button 2</Button>
+            <Button variant="transparent">Button 3</Button>
+          </Actions>,
+        ),
+    },
+    {
+      label: 'With a branded action',
+      Example: () =>
+        source(
+          <Actions>
+            <Button tone="brandAccent">Button 1</Button>
+            <Button variant="transparent">Button 2</Button>
+          </Actions>,
+        ),
+    },
+    {
+      label: 'With a destructive action',
+      Example: () =>
+        source(
+          <Actions>
+            <Button tone="critical" icon={<IconDelete />}>
+              Delete
+            </Button>
+            <Button variant="transparent">Cancel</Button>
+          </Actions>,
+        ),
+    },
+    {
+      label: 'Small size',
+      Example: () =>
+        source(
+          <Actions size="small">
+            <Button>Button 1</Button>
+            <Button>Button 2</Button>
+            <Button variant="transparent">Button 3</Button>
+          </Actions>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Alert/Alert.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Alert/Alert.gallery.tsx
@@ -1,80 +1,82 @@
 import React from 'react';
 import source from '@braid-design-system/source.macro';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Alert, Text, Stack, TextLink, List } from '../';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Promote',
-    Example: () =>
-      source(
-        <Alert tone="promote">
-          <Text>This is a promoted message.</Text>
-        </Alert>,
-      ),
-  },
-  {
-    label: 'Info',
-    Example: () =>
-      source(
-        <Alert tone="info">
-          <Text>This is an informative message.</Text>
-        </Alert>,
-      ),
-  },
-  {
-    label: 'Positive',
-    Example: () =>
-      source(
-        <Alert tone="positive">
-          <Text>This is a positive message.</Text>
-        </Alert>,
-      ),
-  },
-  {
-    label: 'Caution',
-    Example: () =>
-      source(
-        <Alert tone="caution">
-          <Text>This is a cautionary message.</Text>
-        </Alert>,
-      ),
-  },
-  {
-    label: 'Critical',
-    Example: () =>
-      source(
-        <Alert tone="critical">
-          <Text>This is a critical message.</Text>
-        </Alert>,
-      ),
-  },
-  {
-    label: 'Dismissible',
-    Example: () =>
-      source(
-        <Alert tone="info" onClose={() => {}} closeLabel="Close info alert">
-          <Text>This is an informative message.</Text>
-        </Alert>,
-      ),
-  },
-  {
-    label: 'With rich content',
-    Example: () =>
-      source(
-        <Alert tone="info">
-          <Stack space="large">
-            <Text>
-              This is an informative message with a{' '}
-              <TextLink href="#">TextLink.</TextLink>
-            </Text>
-            <List space="medium">
-              <Text>Bullet 1</Text>
-              <Text>Bullet 2</Text>
-              <Text>Bullet 3</Text>
-            </List>
-          </Stack>
-        </Alert>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Promote',
+      Example: () =>
+        source(
+          <Alert tone="promote">
+            <Text>This is a promoted message.</Text>
+          </Alert>,
+        ),
+    },
+    {
+      label: 'Info',
+      Example: () =>
+        source(
+          <Alert tone="info">
+            <Text>This is an informative message.</Text>
+          </Alert>,
+        ),
+    },
+    {
+      label: 'Positive',
+      Example: () =>
+        source(
+          <Alert tone="positive">
+            <Text>This is a positive message.</Text>
+          </Alert>,
+        ),
+    },
+    {
+      label: 'Caution',
+      Example: () =>
+        source(
+          <Alert tone="caution">
+            <Text>This is a cautionary message.</Text>
+          </Alert>,
+        ),
+    },
+    {
+      label: 'Critical',
+      Example: () =>
+        source(
+          <Alert tone="critical">
+            <Text>This is a critical message.</Text>
+          </Alert>,
+        ),
+    },
+    {
+      label: 'Dismissible',
+      Example: () =>
+        source(
+          <Alert tone="info" onClose={() => {}} closeLabel="Close info alert">
+            <Text>This is an informative message.</Text>
+          </Alert>,
+        ),
+    },
+    {
+      label: 'With rich content',
+      Example: () =>
+        source(
+          <Alert tone="info">
+            <Stack space="large">
+              <Text>
+                This is an informative message with a{' '}
+                <TextLink href="#">TextLink.</TextLink>
+              </Text>
+              <List space="medium">
+                <Text>Bullet 1</Text>
+                <Text>Bullet 2</Text>
+                <Text>Bullet 3</Text>
+              </List>
+            </Stack>
+          </Alert>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.gallery.tsx
@@ -1,229 +1,231 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Autosuggest, filterSuggestions, IconSearch } from '../';
 import { makeSuggestions } from './Autosuggest.docs';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Standard suggestions',
-    Example: ({ id, setDefaultState, getState, setState, resetState }) =>
-      source(
-        <>
-          {setDefaultState('value', { text: '' })}
-          {setDefaultState('showRecent', true)}
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Standard suggestions',
+      Example: ({ id, setDefaultState, getState, setState, resetState }) =>
+        source(
+          <>
+            {setDefaultState('value', { text: '' })}
+            {setDefaultState('showRecent', true)}
 
-          <Autosuggest
-            label="I like to eat"
-            id={id}
-            value={getState('value')}
-            onChange={setState('value')}
-            onClear={() => resetState('value')}
-            suggestions={filterSuggestions([
-              ...(getState('showRecent') && getState('value').text === ''
-                ? [
-                    {
-                      text: 'Apples',
-                      onClear: () => setState('showRecent', false),
-                    },
-                  ]
-                : []),
-              ...makeSuggestions([
-                ...(getState('value').text !== '' ? ['Apples'] : []),
-                'Bananas',
-                'Broccoli',
-                'Carrots',
-              ]),
-            ])}
-          />
-        </>,
-      ),
-  },
-  {
-    label: 'Grouped suggestions',
-    Example: ({ id, getState, setState, setDefaultState, resetState }) =>
-      source(
-        <>
-          {setDefaultState('value', { text: '' })}
-
-          <Autosuggest
-            label="I like to eat"
-            id={id}
-            value={getState('value')}
-            onChange={setState('value')}
-            onClear={() => resetState('value')}
-            suggestions={filterSuggestions([
-              {
-                label: 'Fruit',
-                suggestions: makeSuggestions(['Apples', 'Bananas']),
-              },
-              {
-                label: 'Vegetables',
-                suggestions: makeSuggestions(['Broccoli', 'Carrots'], 2),
-              },
-            ])}
-          />
-        </>,
-      ),
-  },
-  {
-    label: 'Standard suggestions with descriptions',
-    Example: ({ id, setDefaultState, getState, setState, resetState }) =>
-      source(
-        <>
-          {setDefaultState('value', { text: '' })}
-          {setDefaultState('showRecent', true)}
-
-          <Autosuggest
-            label="I like to eat"
-            id={id}
-            value={getState('value')}
-            onChange={setState('value')}
-            onClear={() => resetState('value')}
-            suggestions={filterSuggestions([
-              ...(getState('showRecent') && getState('value').text === ''
-                ? [
-                    {
-                      text: 'Apples',
-                      description: 'Juicy and delicious',
-                      onClear: () => setState('showRecent', false),
-                    },
-                  ]
-                : []),
-              ...makeSuggestions([
-                ...(getState('value').text !== ''
-                  ? [{ text: 'Apples', description: 'Juicy and delicious' }]
+            <Autosuggest
+              label="I like to eat"
+              id={id}
+              value={getState('value')}
+              onChange={setState('value')}
+              onClear={() => resetState('value')}
+              suggestions={filterSuggestions([
+                ...(getState('showRecent') && getState('value').text === ''
+                  ? [
+                      {
+                        text: 'Apples',
+                        onClear: () => setState('showRecent', false),
+                      },
+                    ]
                   : []),
-                { text: 'Bananas', description: 'High in potassium' },
-                { text: 'Broccoli', description: 'Looks like a tree' },
-                { text: 'Carrots', description: 'Orange and crunchy' },
-              ]),
-            ])}
-          />
-        </>,
-      ),
-  },
-  {
-    label: 'Grouped suggestions with descriptions',
-    Example: ({ id, getState, setState, setDefaultState, resetState }) =>
-      source(
-        <>
-          {setDefaultState('value', { text: '' })}
-
-          <Autosuggest
-            label="I like to eat"
-            id={id}
-            value={getState('value')}
-            onChange={setState('value')}
-            onClear={() => resetState('value')}
-            suggestions={filterSuggestions([
-              {
-                label: 'Fruit',
-                suggestions: makeSuggestions([
-                  { text: 'Apples', description: 'Juicy and delicious' },
-                  { text: 'Bananas', description: 'High in potassium' },
+                ...makeSuggestions([
+                  ...(getState('value').text !== '' ? ['Apples'] : []),
+                  'Bananas',
+                  'Broccoli',
+                  'Carrots',
                 ]),
-              },
-              {
-                label: 'Vegetables',
-                suggestions: makeSuggestions(
-                  [
-                    { text: 'Broccoli', description: 'Looks like a tree' },
-                    { text: 'Carrots', description: 'Orange and crunchy' },
-                  ],
-                  2,
-                ),
-              },
-            ])}
-          />
-        </>,
-      ),
-  },
-  {
-    label: 'Standard suggestions with an icon',
-    Example: ({ id, getState, setState, setDefaultState, resetState }) =>
-      source(
-        <>
-          {setDefaultState('value', { text: '' })}
+              ])}
+            />
+          </>,
+        ),
+    },
+    {
+      label: 'Grouped suggestions',
+      Example: ({ id, getState, setState, setDefaultState, resetState }) =>
+        source(
+          <>
+            {setDefaultState('value', { text: '' })}
 
-          <Autosuggest
-            label="I like to eat"
-            icon={<IconSearch />}
-            id={id}
-            value={getState('value')}
-            onChange={setState('value')}
-            onClear={() => resetState('value')}
-            suggestions={filterSuggestions(
-              makeSuggestions(['Apples', 'Bananas', 'Broccoli', 'Carrots']),
-            )}
-          />
-        </>,
-      ),
-  },
-  {
-    label: 'With a critical message',
-    Example: ({ id, getState, setState, setDefaultState, resetState }) =>
-      source(
-        <>
-          {setDefaultState('value', { text: '' })}
+            <Autosuggest
+              label="I like to eat"
+              id={id}
+              value={getState('value')}
+              onChange={setState('value')}
+              onClear={() => resetState('value')}
+              suggestions={filterSuggestions([
+                {
+                  label: 'Fruit',
+                  suggestions: makeSuggestions(['Apples', 'Bananas']),
+                },
+                {
+                  label: 'Vegetables',
+                  suggestions: makeSuggestions(['Broccoli', 'Carrots'], 2),
+                },
+              ])}
+            />
+          </>,
+        ),
+    },
+    {
+      label: 'Standard suggestions with descriptions',
+      Example: ({ id, setDefaultState, getState, setState, resetState }) =>
+        source(
+          <>
+            {setDefaultState('value', { text: '' })}
+            {setDefaultState('showRecent', true)}
 
-          <Autosuggest
-            label="I like to eat"
-            id={id}
-            value={getState('value')}
-            onChange={setState('value')}
-            onClear={() => resetState('value')}
-            tone="critical"
-            message="Critical message"
-            suggestions={filterSuggestions(
-              makeSuggestions(['Apples', 'Bananas', 'Broccoli', 'Carrots']),
-            )}
-          />
-        </>,
-      ),
-  },
-  {
-    label: 'With a positive message',
-    Example: ({ id, getState, setState, setDefaultState, resetState }) =>
-      source(
-        <>
-          {setDefaultState('value', { text: '' })}
+            <Autosuggest
+              label="I like to eat"
+              id={id}
+              value={getState('value')}
+              onChange={setState('value')}
+              onClear={() => resetState('value')}
+              suggestions={filterSuggestions([
+                ...(getState('showRecent') && getState('value').text === ''
+                  ? [
+                      {
+                        text: 'Apples',
+                        description: 'Juicy and delicious',
+                        onClear: () => setState('showRecent', false),
+                      },
+                    ]
+                  : []),
+                ...makeSuggestions([
+                  ...(getState('value').text !== ''
+                    ? [{ text: 'Apples', description: 'Juicy and delicious' }]
+                    : []),
+                  { text: 'Bananas', description: 'High in potassium' },
+                  { text: 'Broccoli', description: 'Looks like a tree' },
+                  { text: 'Carrots', description: 'Orange and crunchy' },
+                ]),
+              ])}
+            />
+          </>,
+        ),
+    },
+    {
+      label: 'Grouped suggestions with descriptions',
+      Example: ({ id, getState, setState, setDefaultState, resetState }) =>
+        source(
+          <>
+            {setDefaultState('value', { text: '' })}
 
-          <Autosuggest
-            label="I like to eat"
-            id={id}
-            value={getState('value')}
-            onChange={setState('value')}
-            onClear={() => resetState('value')}
-            tone="positive"
-            message="Positive message"
-            suggestions={filterSuggestions(
-              makeSuggestions(['Apples', 'Bananas', 'Broccoli', 'Carrots']),
-            )}
-          />
-        </>,
-      ),
-  },
-  {
-    label: 'With a caution message',
-    Example: ({ id, getState, setState, setDefaultState, resetState }) =>
-      source(
-        <>
-          {setDefaultState('value', { text: '' })}
+            <Autosuggest
+              label="I like to eat"
+              id={id}
+              value={getState('value')}
+              onChange={setState('value')}
+              onClear={() => resetState('value')}
+              suggestions={filterSuggestions([
+                {
+                  label: 'Fruit',
+                  suggestions: makeSuggestions([
+                    { text: 'Apples', description: 'Juicy and delicious' },
+                    { text: 'Bananas', description: 'High in potassium' },
+                  ]),
+                },
+                {
+                  label: 'Vegetables',
+                  suggestions: makeSuggestions(
+                    [
+                      { text: 'Broccoli', description: 'Looks like a tree' },
+                      { text: 'Carrots', description: 'Orange and crunchy' },
+                    ],
+                    2,
+                  ),
+                },
+              ])}
+            />
+          </>,
+        ),
+    },
+    {
+      label: 'Standard suggestions with an icon',
+      Example: ({ id, getState, setState, setDefaultState, resetState }) =>
+        source(
+          <>
+            {setDefaultState('value', { text: '' })}
 
-          <Autosuggest
-            label="I like to eat"
-            id={id}
-            value={getState('value')}
-            onChange={setState('value')}
-            onClear={() => resetState('value')}
-            tone="caution"
-            message="Caution message"
-            suggestions={filterSuggestions(
-              makeSuggestions(['Apples', 'Bananas', 'Broccoli', 'Carrots']),
-            )}
-          />
-        </>,
-      ),
-  },
-];
+            <Autosuggest
+              label="I like to eat"
+              icon={<IconSearch />}
+              id={id}
+              value={getState('value')}
+              onChange={setState('value')}
+              onClear={() => resetState('value')}
+              suggestions={filterSuggestions(
+                makeSuggestions(['Apples', 'Bananas', 'Broccoli', 'Carrots']),
+              )}
+            />
+          </>,
+        ),
+    },
+    {
+      label: 'With a critical message',
+      Example: ({ id, getState, setState, setDefaultState, resetState }) =>
+        source(
+          <>
+            {setDefaultState('value', { text: '' })}
+
+            <Autosuggest
+              label="I like to eat"
+              id={id}
+              value={getState('value')}
+              onChange={setState('value')}
+              onClear={() => resetState('value')}
+              tone="critical"
+              message="Critical message"
+              suggestions={filterSuggestions(
+                makeSuggestions(['Apples', 'Bananas', 'Broccoli', 'Carrots']),
+              )}
+            />
+          </>,
+        ),
+    },
+    {
+      label: 'With a positive message',
+      Example: ({ id, getState, setState, setDefaultState, resetState }) =>
+        source(
+          <>
+            {setDefaultState('value', { text: '' })}
+
+            <Autosuggest
+              label="I like to eat"
+              id={id}
+              value={getState('value')}
+              onChange={setState('value')}
+              onClear={() => resetState('value')}
+              tone="positive"
+              message="Positive message"
+              suggestions={filterSuggestions(
+                makeSuggestions(['Apples', 'Bananas', 'Broccoli', 'Carrots']),
+              )}
+            />
+          </>,
+        ),
+    },
+    {
+      label: 'With a caution message',
+      Example: ({ id, getState, setState, setDefaultState, resetState }) =>
+        source(
+          <>
+            {setDefaultState('value', { text: '' })}
+
+            <Autosuggest
+              label="I like to eat"
+              id={id}
+              value={getState('value')}
+              onChange={setState('value')}
+              onClear={() => resetState('value')}
+              tone="caution"
+              message="Caution message"
+              suggestions={filterSuggestions(
+                makeSuggestions(['Apples', 'Bananas', 'Broccoli', 'Carrots']),
+              )}
+            />
+          </>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Badge/Badge.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Badge/Badge.gallery.tsx
@@ -1,91 +1,93 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import source from '@braid-design-system/source.macro';
 import { Badge } from '../';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Positive',
-    background: 'surface',
-    Example: () => source(<Badge tone="positive">Positive</Badge>),
-  },
-  {
-    label: 'Strong Positive',
-    Example: () =>
-      source(
-        <Badge tone="positive" weight="strong">
-          Positive
-        </Badge>,
-      ),
-  },
-  {
-    label: 'Critical',
-    background: 'surface',
-    Example: () => source(<Badge tone="critical">Critical</Badge>),
-  },
-  {
-    label: 'Strong Critical',
-    Example: () =>
-      source(
-        <Badge tone="critical" weight="strong">
-          Critical
-        </Badge>,
-      ),
-  },
-  {
-    label: 'Caution',
-    background: 'surface',
-    Example: () => source(<Badge tone="caution">Caution</Badge>),
-  },
-  {
-    label: 'Strong Caution',
-    Example: () =>
-      source(
-        <Badge tone="caution" weight="strong">
-          Caution
-        </Badge>,
-      ),
-  },
-  {
-    label: 'Info',
-    background: 'surface',
-    Example: () => source(<Badge tone="info">Info</Badge>),
-  },
-  {
-    label: 'Strong Info',
-    Example: () =>
-      source(
-        <Badge tone="info" weight="strong">
-          Info
-        </Badge>,
-      ),
-  },
-  {
-    label: 'Promote',
-    background: 'surface',
-    Example: () => source(<Badge tone="promote">Promote</Badge>),
-  },
-  {
-    label: 'Strong Promote',
-    Example: () =>
-      source(
-        <Badge tone="promote" weight="strong">
-          Promote
-        </Badge>,
-      ),
-  },
-  {
-    label: 'Neutral',
-    background: 'surface',
-    Example: () => source(<Badge tone="neutral">Neutral</Badge>),
-  },
-  {
-    label: 'Strong Neutral',
-    Example: () =>
-      source(
-        <Badge tone="neutral" weight="strong">
-          Neutral
-        </Badge>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Positive',
+      background: 'surface',
+      Example: () => source(<Badge tone="positive">Positive</Badge>),
+    },
+    {
+      label: 'Strong Positive',
+      Example: () =>
+        source(
+          <Badge tone="positive" weight="strong">
+            Positive
+          </Badge>,
+        ),
+    },
+    {
+      label: 'Critical',
+      background: 'surface',
+      Example: () => source(<Badge tone="critical">Critical</Badge>),
+    },
+    {
+      label: 'Strong Critical',
+      Example: () =>
+        source(
+          <Badge tone="critical" weight="strong">
+            Critical
+          </Badge>,
+        ),
+    },
+    {
+      label: 'Caution',
+      background: 'surface',
+      Example: () => source(<Badge tone="caution">Caution</Badge>),
+    },
+    {
+      label: 'Strong Caution',
+      Example: () =>
+        source(
+          <Badge tone="caution" weight="strong">
+            Caution
+          </Badge>,
+        ),
+    },
+    {
+      label: 'Info',
+      background: 'surface',
+      Example: () => source(<Badge tone="info">Info</Badge>),
+    },
+    {
+      label: 'Strong Info',
+      Example: () =>
+        source(
+          <Badge tone="info" weight="strong">
+            Info
+          </Badge>,
+        ),
+    },
+    {
+      label: 'Promote',
+      background: 'surface',
+      Example: () => source(<Badge tone="promote">Promote</Badge>),
+    },
+    {
+      label: 'Strong Promote',
+      Example: () =>
+        source(
+          <Badge tone="promote" weight="strong">
+            Promote
+          </Badge>,
+        ),
+    },
+    {
+      label: 'Neutral',
+      background: 'surface',
+      Example: () => source(<Badge tone="neutral">Neutral</Badge>),
+    },
+    {
+      label: 'Strong Neutral',
+      Example: () =>
+        source(
+          <Badge tone="neutral" weight="strong">
+            Neutral
+          </Badge>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Bleed/Bleed.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Bleed/Bleed.gallery.tsx
@@ -1,5 +1,5 @@
 import React, { type ReactNode } from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Bleed, Box } from '../';
 import source from '@braid-design-system/source.macro';
 import { Placeholder } from '../../playroom/components';
@@ -10,75 +10,77 @@ const Container = ({ children }: { children: ReactNode }) => (
   </Box>
 );
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Horizontally',
-    Container,
-    Example: () =>
-      source(
-        <Bleed horizontal="gutter">
-          <Placeholder height={80} />
-        </Bleed>,
-      ),
-  },
-  {
-    label: 'Vertically',
-    Container,
-    Example: () =>
-      source(
-        <Bleed vertical="gutter">
-          <Placeholder height={80} />
-        </Bleed>,
-      ),
-  },
-  {
-    label: 'To the top',
-    Container,
-    Example: () =>
-      source(
-        <Bleed top="gutter">
-          <Placeholder height={80} />
-        </Bleed>,
-      ),
-  },
-  {
-    label: 'To the bottom',
-    Container,
-    Example: () =>
-      source(
-        <Bleed bottom="gutter">
-          <Placeholder height={80} />
-        </Bleed>,
-      ),
-  },
-  {
-    label: 'To the left',
-    Container,
-    Example: () =>
-      source(
-        <Bleed left="gutter">
-          <Placeholder height={80} />
-        </Bleed>,
-      ),
-  },
-  {
-    label: 'To the right',
-    Container,
-    Example: () =>
-      source(
-        <Bleed right="gutter">
-          <Placeholder height={80} />
-        </Bleed>,
-      ),
-  },
-  {
-    label: 'On all sides',
-    Container,
-    Example: () =>
-      source(
-        <Bleed space="gutter">
-          <Placeholder height={80} />
-        </Bleed>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Horizontally',
+      Container,
+      Example: () =>
+        source(
+          <Bleed horizontal="gutter">
+            <Placeholder height={80} />
+          </Bleed>,
+        ),
+    },
+    {
+      label: 'Vertically',
+      Container,
+      Example: () =>
+        source(
+          <Bleed vertical="gutter">
+            <Placeholder height={80} />
+          </Bleed>,
+        ),
+    },
+    {
+      label: 'To the top',
+      Container,
+      Example: () =>
+        source(
+          <Bleed top="gutter">
+            <Placeholder height={80} />
+          </Bleed>,
+        ),
+    },
+    {
+      label: 'To the bottom',
+      Container,
+      Example: () =>
+        source(
+          <Bleed bottom="gutter">
+            <Placeholder height={80} />
+          </Bleed>,
+        ),
+    },
+    {
+      label: 'To the left',
+      Container,
+      Example: () =>
+        source(
+          <Bleed left="gutter">
+            <Placeholder height={80} />
+          </Bleed>,
+        ),
+    },
+    {
+      label: 'To the right',
+      Container,
+      Example: () =>
+        source(
+          <Bleed right="gutter">
+            <Placeholder height={80} />
+          </Bleed>,
+        ),
+    },
+    {
+      label: 'On all sides',
+      Container,
+      Example: () =>
+        source(
+          <Bleed space="gutter">
+            <Placeholder height={80} />
+          </Bleed>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Button/Button.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.gallery.tsx
@@ -1,131 +1,133 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import source from '@braid-design-system/source.macro';
 import { Button, Heading, Inline, IconSend } from '../';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Critical',
-    background: 'surface',
-    Example: () =>
-      source(
-        <Inline space="small">
-          <Button tone="critical" variant="solid">
-            Solid
-          </Button>
-          <Button tone="critical" variant="ghost">
-            Ghost
-          </Button>
-          <Button tone="critical" variant="soft">
-            Soft
-          </Button>
-          <Button tone="critical" variant="transparent">
-            Transparent
-          </Button>
-        </Inline>,
-      ),
-  },
-  {
-    label: 'BrandAccent',
-    background: 'surface',
-    Example: () =>
-      source(
-        <Inline space="small">
-          <Button tone="brandAccent" variant="solid">
-            Solid
-          </Button>
-          <Button tone="brandAccent" variant="ghost">
-            Ghost
-          </Button>
-          <Button tone="brandAccent" variant="soft">
-            Soft
-          </Button>
-          <Button tone="brandAccent" variant="transparent">
-            Transparent
-          </Button>
-        </Inline>,
-      ),
-  },
-  {
-    label: 'FormAccent',
-    background: 'surface',
-    Example: () =>
-      source(
-        <Inline space="small">
-          <Button tone="formAccent" variant="solid">
-            Solid
-          </Button>
-          <Button tone="formAccent" variant="ghost">
-            Ghost
-          </Button>
-          <Button tone="formAccent" variant="soft">
-            Soft
-          </Button>
-          <Button tone="formAccent" variant="transparent">
-            Transparent
-          </Button>
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Neutral',
-    background: 'surface',
-    Example: () =>
-      source(
-        <Inline space="small">
-          <Button tone="neutral" variant="solid">
-            Solid
-          </Button>
-          <Button tone="neutral" variant="ghost">
-            Ghost
-          </Button>
-          <Button tone="neutral" variant="soft">
-            Soft
-          </Button>
-          <Button tone="neutral" variant="transparent">
-            Transparent
-          </Button>
-        </Inline>,
-      ),
-  },
-  {
-    label: 'With icon',
-    Example: () =>
-      source(
-        <Inline space="small">
-          <Button icon={<IconSend />}>Send</Button>
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Loading state',
-    Example: () =>
-      source(
-        <Inline space="small">
-          <Button loading>Loading</Button>
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Small size',
-    Example: () =>
-      source(
-        <Inline space="small">
-          <Button size="small">Submit</Button>
-        </Inline>,
-      ),
-  },
-  {
-    label: 'With bleed',
-    Example: () =>
-      source(
-        <Inline space="small" alignY="center">
-          <Heading level="4">Heading</Heading>
-          <Button bleed>Button</Button>
-          <Button bleed size="small">
-            Button
-          </Button>
-        </Inline>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Critical',
+      background: 'surface',
+      Example: () =>
+        source(
+          <Inline space="small">
+            <Button tone="critical" variant="solid">
+              Solid
+            </Button>
+            <Button tone="critical" variant="ghost">
+              Ghost
+            </Button>
+            <Button tone="critical" variant="soft">
+              Soft
+            </Button>
+            <Button tone="critical" variant="transparent">
+              Transparent
+            </Button>
+          </Inline>,
+        ),
+    },
+    {
+      label: 'BrandAccent',
+      background: 'surface',
+      Example: () =>
+        source(
+          <Inline space="small">
+            <Button tone="brandAccent" variant="solid">
+              Solid
+            </Button>
+            <Button tone="brandAccent" variant="ghost">
+              Ghost
+            </Button>
+            <Button tone="brandAccent" variant="soft">
+              Soft
+            </Button>
+            <Button tone="brandAccent" variant="transparent">
+              Transparent
+            </Button>
+          </Inline>,
+        ),
+    },
+    {
+      label: 'FormAccent',
+      background: 'surface',
+      Example: () =>
+        source(
+          <Inline space="small">
+            <Button tone="formAccent" variant="solid">
+              Solid
+            </Button>
+            <Button tone="formAccent" variant="ghost">
+              Ghost
+            </Button>
+            <Button tone="formAccent" variant="soft">
+              Soft
+            </Button>
+            <Button tone="formAccent" variant="transparent">
+              Transparent
+            </Button>
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Neutral',
+      background: 'surface',
+      Example: () =>
+        source(
+          <Inline space="small">
+            <Button tone="neutral" variant="solid">
+              Solid
+            </Button>
+            <Button tone="neutral" variant="ghost">
+              Ghost
+            </Button>
+            <Button tone="neutral" variant="soft">
+              Soft
+            </Button>
+            <Button tone="neutral" variant="transparent">
+              Transparent
+            </Button>
+          </Inline>,
+        ),
+    },
+    {
+      label: 'With icon',
+      Example: () =>
+        source(
+          <Inline space="small">
+            <Button icon={<IconSend />}>Send</Button>
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Loading state',
+      Example: () =>
+        source(
+          <Inline space="small">
+            <Button loading>Loading</Button>
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Small size',
+      Example: () =>
+        source(
+          <Inline space="small">
+            <Button size="small">Submit</Button>
+          </Inline>,
+        ),
+    },
+    {
+      label: 'With bleed',
+      Example: () =>
+        source(
+          <Inline space="small" alignY="center">
+            <Heading level="4">Heading</Heading>
+            <Button bleed>Button</Button>
+            <Button bleed size="small">
+              Button
+            </Button>
+          </Inline>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.gallery.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import source from '@braid-design-system/source.macro';
 import {
   ButtonIcon,
@@ -15,175 +15,177 @@ import {
   Text,
 } from '../';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Soft',
-    background: 'surface',
-    Example: () =>
-      source(
-        <Inline space="small">
-          <ButtonIcon
-            icon={<IconBookmark />}
-            label="Bookmark"
-            id="buttonicon-default-1"
-          />
-          <ButtonIcon
-            icon={<IconAdd />}
-            label="Add"
-            id="buttonicon-default-2"
-          />
-          <ButtonIcon
-            icon={<IconShare />}
-            label="Share"
-            id="buttonicon-default-3"
-          />
-          <ButtonIcon
-            icon={<IconOverflow />}
-            label="More"
-            id="buttonicon-default-4"
-          />
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Transparent',
-    background: 'surface',
-    Example: () =>
-      source(
-        <Inline space="medium">
-          <ButtonIcon
-            variant="transparent"
-            icon={<IconBookmark />}
-            label="Bookmark"
-            id="buttonicon-transparent-1"
-          />
-          <ButtonIcon
-            variant="transparent"
-            icon={<IconAdd />}
-            label="Add"
-            id="buttonicon-transparent-2"
-          />
-          <ButtonIcon
-            variant="transparent"
-            icon={<IconShare />}
-            label="Share"
-            id="buttonicon-transparent-3"
-          />
-          <ButtonIcon
-            variant="transparent"
-            icon={<IconOverflow />}
-            label="More"
-            id="buttonicon-transparent-4"
-          />
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Sizes',
-    background: 'surface',
-    Example: () =>
-      source(
-        <Stack space="medium">
-          <Inline space="medium" alignY="center">
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Soft',
+      background: 'surface',
+      Example: () =>
+        source(
+          <Inline space="small">
             <ButtonIcon
-              size="small"
-              icon={<IconAdd />}
-              label="Small size"
-              id="size-0"
+              icon={<IconBookmark />}
+              label="Bookmark"
+              id="buttonicon-default-1"
             />
-            <Text tone="secondary" size="xsmall">
-              SMALL
-            </Text>
-          </Inline>
-          <Inline space="medium" alignY="center">
             <ButtonIcon
-              size="standard"
               icon={<IconAdd />}
-              label="Standard size"
-              id="size-1"
+              label="Add"
+              id="buttonicon-default-2"
             />
-            <Text tone="secondary" size="xsmall">
-              STANDARD
-            </Text>
-          </Inline>
-          <Inline space="medium" alignY="center">
             <ButtonIcon
+              icon={<IconShare />}
+              label="Share"
+              id="buttonicon-default-3"
+            />
+            <ButtonIcon
+              icon={<IconOverflow />}
+              label="More"
+              id="buttonicon-default-4"
+            />
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Transparent',
+      background: 'surface',
+      Example: () =>
+        source(
+          <Inline space="medium">
+            <ButtonIcon
+              variant="transparent"
+              icon={<IconBookmark />}
+              label="Bookmark"
+              id="buttonicon-transparent-1"
+            />
+            <ButtonIcon
+              variant="transparent"
+              icon={<IconAdd />}
+              label="Add"
+              id="buttonicon-transparent-2"
+            />
+            <ButtonIcon
+              variant="transparent"
+              icon={<IconShare />}
+              label="Share"
+              id="buttonicon-transparent-3"
+            />
+            <ButtonIcon
+              variant="transparent"
+              icon={<IconOverflow />}
+              label="More"
+              id="buttonicon-transparent-4"
+            />
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Sizes',
+      background: 'surface',
+      Example: () =>
+        source(
+          <Stack space="medium">
+            <Inline space="medium" alignY="center">
+              <ButtonIcon
+                size="small"
+                icon={<IconAdd />}
+                label="Small size"
+                id="size-0"
+              />
+              <Text tone="secondary" size="xsmall">
+                SMALL
+              </Text>
+            </Inline>
+            <Inline space="medium" alignY="center">
+              <ButtonIcon
+                size="standard"
+                icon={<IconAdd />}
+                label="Standard size"
+                id="size-1"
+              />
+              <Text tone="secondary" size="xsmall">
+                STANDARD
+              </Text>
+            </Inline>
+            <Inline space="medium" alignY="center">
+              <ButtonIcon
+                size="large"
+                icon={<IconAdd />}
+                label="Large size"
+                id="size-2"
+              />
+              <Text tone="secondary" size="xsmall">
+                LARGE
+              </Text>
+            </Inline>
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Tone',
+      background: 'surface',
+      Example: () =>
+        source(
+          <Stack space="medium">
+            <Inline space="small" alignY="center">
+              <ButtonIcon
+                tone="neutral"
+                variant="soft"
+                icon={<IconClear />}
+                label="Close"
+                id="buttonicon-neutral-1"
+              />
+              <ButtonIcon
+                tone="neutral"
+                variant="transparent"
+                bleed={false}
+                icon={<IconClear />}
+                label="Close"
+                id="buttonicon-neutral-2"
+              />
+              <Text tone="secondary" size="xsmall">
+                NEUTRAL
+              </Text>
+            </Inline>
+            <Inline space="small" alignY="center">
+              <ButtonIcon
+                tone="formAccent"
+                variant="soft"
+                icon={<IconAdd />}
+                label="Add"
+                id="buttonicon-formAccent-1"
+              />
+              <ButtonIcon
+                tone="formAccent"
+                variant="transparent"
+                bleed={false}
+                icon={<IconAdd />}
+                label="Add"
+                id="buttonicon-formAccent-2"
+              />
+              <Text tone="secondary" size="xsmall">
+                FORMACCENT
+              </Text>
+            </Inline>
+          </Stack>,
+        ),
+    },
+    {
+      label: 'With bleed',
+      background: 'surface',
+      Example: () =>
+        source(
+          <Inline space="small" alignY="center">
+            <Heading level="2">Heading</Heading>
+            <ButtonIcon
+              bleed={true}
               size="large"
-              icon={<IconAdd />}
-              label="Large size"
-              id="size-2"
+              icon={<IconHelp />}
+              label="Help"
+              id="buttonicon-bleed-1"
             />
-            <Text tone="secondary" size="xsmall">
-              LARGE
-            </Text>
-          </Inline>
-        </Stack>,
-      ),
-  },
-  {
-    label: 'Tone',
-    background: 'surface',
-    Example: () =>
-      source(
-        <Stack space="medium">
-          <Inline space="small" alignY="center">
-            <ButtonIcon
-              tone="neutral"
-              variant="soft"
-              icon={<IconClear />}
-              label="Close"
-              id="buttonicon-neutral-1"
-            />
-            <ButtonIcon
-              tone="neutral"
-              variant="transparent"
-              bleed={false}
-              icon={<IconClear />}
-              label="Close"
-              id="buttonicon-neutral-2"
-            />
-            <Text tone="secondary" size="xsmall">
-              NEUTRAL
-            </Text>
-          </Inline>
-          <Inline space="small" alignY="center">
-            <ButtonIcon
-              tone="formAccent"
-              variant="soft"
-              icon={<IconAdd />}
-              label="Add"
-              id="buttonicon-formAccent-1"
-            />
-            <ButtonIcon
-              tone="formAccent"
-              variant="transparent"
-              bleed={false}
-              icon={<IconAdd />}
-              label="Add"
-              id="buttonicon-formAccent-2"
-            />
-            <Text tone="secondary" size="xsmall">
-              FORMACCENT
-            </Text>
-          </Inline>
-        </Stack>,
-      ),
-  },
-  {
-    label: 'With bleed',
-    background: 'surface',
-    Example: () =>
-      source(
-        <Inline space="small" alignY="center">
-          <Heading level="2">Heading</Heading>
-          <ButtonIcon
-            bleed={true}
-            size="large"
-            icon={<IconHelp />}
-            label="Help"
-            id="buttonicon-bleed-1"
-          />
-        </Inline>,
-      ),
-  },
-];
+          </Inline>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Card/Card.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Card/Card.gallery.tsx
@@ -1,67 +1,69 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Card, Text, Stack, Tiles } from '../';
 import source from '@braid-design-system/source.macro';
 import { Placeholder } from '../../playroom/components';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Standard',
-    Example: () =>
-      source(
-        <Card>
-          <Placeholder height={100} />
-        </Card>,
-      ),
-  },
-  {
-    label: 'Tones',
-    Example: () =>
-      source(
-        <Tiles space="large" columns={{ mobile: 1, tablet: 2 }}>
-          <Stack space="small">
-            <Text size="xsmall" tone="secondary">
-              PROMOTE
-            </Text>
-            <Card tone="promote">
-              <Placeholder height={100} />
-            </Card>
-          </Stack>
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Standard',
+      Example: () =>
+        source(
+          <Card>
+            <Placeholder height={100} />
+          </Card>,
+        ),
+    },
+    {
+      label: 'Tones',
+      Example: () =>
+        source(
+          <Tiles space="large" columns={{ mobile: 1, tablet: 2 }}>
+            <Stack space="small">
+              <Text size="xsmall" tone="secondary">
+                PROMOTE
+              </Text>
+              <Card tone="promote">
+                <Placeholder height={100} />
+              </Card>
+            </Stack>
 
-          <Stack space="small">
-            <Text size="xsmall" tone="secondary">
-              FORMACCENT
-            </Text>
-            <Card tone="formAccent">
-              <Placeholder height={100} />
-            </Card>
-          </Stack>
-        </Tiles>,
-      ),
-  },
-  {
-    label: 'Rounded corners',
-    Example: () =>
-      source(
-        <Tiles space="large" columns={{ mobile: 1, tablet: 2 }}>
-          <Stack space="small">
-            <Text size="xsmall" tone="secondary">
-              DEFAULT
-            </Text>
-            <Card>
-              <Placeholder height={100} />
-            </Card>
-          </Stack>
+            <Stack space="small">
+              <Text size="xsmall" tone="secondary">
+                FORMACCENT
+              </Text>
+              <Card tone="formAccent">
+                <Placeholder height={100} />
+              </Card>
+            </Stack>
+          </Tiles>,
+        ),
+    },
+    {
+      label: 'Rounded corners',
+      Example: () =>
+        source(
+          <Tiles space="large" columns={{ mobile: 1, tablet: 2 }}>
+            <Stack space="small">
+              <Text size="xsmall" tone="secondary">
+                DEFAULT
+              </Text>
+              <Card>
+                <Placeholder height={100} />
+              </Card>
+            </Stack>
 
-          <Stack space="small">
-            <Text size="xsmall" tone="secondary">
-              ROUNDED
-            </Text>
-            <Card rounded>
-              <Placeholder height={100} />
-            </Card>
-          </Stack>
-        </Tiles>,
-      ),
-  },
-];
+            <Stack space="small">
+              <Text size="xsmall" tone="secondary">
+                ROUNDED
+              </Text>
+              <Card rounded>
+                <Placeholder height={100} />
+              </Card>
+            </Stack>
+          </Tiles>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Checkbox/Checkbox.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Checkbox/Checkbox.gallery.tsx
@@ -1,114 +1,116 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Badge, Checkbox, Stack } from '../';
 import source from '@braid-design-system/source.macro';
 import { Placeholder } from '../../playroom/components';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Standard',
-    Example: ({ id, getState, toggleState }) =>
-      source(
-        <Checkbox
-          id={id}
-          checked={getState('checked')}
-          onChange={() => toggleState('checked')}
-          label="Label"
-        />,
-      ),
-  },
-  {
-    label: 'With a description',
-    Example: ({ id, getState, toggleState }) =>
-      source(
-        <Checkbox
-          id={id}
-          checked={getState('checked')}
-          onChange={() => toggleState('checked')}
-          label="Label"
-          description="Extra information about the field"
-        />,
-      ),
-  },
-  {
-    label: 'With a Badge',
-    Example: ({ id, getState, toggleState }) =>
-      source(
-        <Checkbox
-          id={id}
-          checked={getState('checked')}
-          onChange={() => toggleState('checked')}
-          label="Label"
-          badge={
-            <Badge tone="positive" weight="strong">
-              Badge
-            </Badge>
-          }
-        />,
-      ),
-  },
-  {
-    label: 'Toggling nested content',
-    Example: ({ id, getState, toggleState, setDefaultState }) =>
-      source(
-        <>
-          {setDefaultState('checked', true)}
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Standard',
+      Example: ({ id, getState, toggleState }) =>
+        source(
           <Checkbox
             id={id}
             checked={getState('checked')}
             onChange={() => toggleState('checked')}
             label="Label"
-          >
-            <Placeholder height={100} />
-          </Checkbox>
-        </>,
-      ),
-  },
-  {
-    label: 'States',
-    background: 'surface',
-    Example: ({ id, handler }) =>
-      source(
-        <Stack space="medium">
+          />,
+        ),
+    },
+    {
+      label: 'With a description',
+      Example: ({ id, getState, toggleState }) =>
+        source(
           <Checkbox
-            id={`chk_states_${id}_1`}
-            checked={false}
-            label="Unchecked"
-            onChange={handler}
-          />
+            id={id}
+            checked={getState('checked')}
+            onChange={() => toggleState('checked')}
+            label="Label"
+            description="Extra information about the field"
+          />,
+        ),
+    },
+    {
+      label: 'With a Badge',
+      Example: ({ id, getState, toggleState }) =>
+        source(
           <Checkbox
-            id={`chk_states_${id}_2`}
-            checked={true}
-            label="Checked"
-            onChange={handler}
-          />
+            id={id}
+            checked={getState('checked')}
+            onChange={() => toggleState('checked')}
+            label="Label"
+            badge={
+              <Badge tone="positive" weight="strong">
+                Badge
+              </Badge>
+            }
+          />,
+        ),
+    },
+    {
+      label: 'Toggling nested content',
+      Example: ({ id, getState, toggleState, setDefaultState }) =>
+        source(
+          <>
+            {setDefaultState('checked', true)}
+            <Checkbox
+              id={id}
+              checked={getState('checked')}
+              onChange={() => toggleState('checked')}
+              label="Label"
+            >
+              <Placeholder height={100} />
+            </Checkbox>
+          </>,
+        ),
+    },
+    {
+      label: 'States',
+      background: 'surface',
+      Example: ({ id, handler }) =>
+        source(
+          <Stack space="medium">
+            <Checkbox
+              id={`chk_states_${id}_1`}
+              checked={false}
+              label="Unchecked"
+              onChange={handler}
+            />
+            <Checkbox
+              id={`chk_states_${id}_2`}
+              checked={true}
+              label="Checked"
+              onChange={handler}
+            />
+            <Checkbox
+              id={`chk_states_${id}_3`}
+              checked="mixed"
+              label="Mixed"
+              onChange={handler}
+            />
+            <Checkbox
+              id={`chk_states_${id}_4`}
+              disabled={true}
+              checked={false}
+              onChange={handler}
+              label="Disabled"
+            />
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Small',
+      Example: ({ id, getState, toggleState }) =>
+        source(
           <Checkbox
-            id={`chk_states_${id}_3`}
-            checked="mixed"
-            label="Mixed"
-            onChange={handler}
-          />
-          <Checkbox
-            id={`chk_states_${id}_4`}
-            disabled={true}
-            checked={false}
-            onChange={handler}
-            label="Disabled"
-          />
-        </Stack>,
-      ),
-  },
-  {
-    label: 'Small',
-    Example: ({ id, getState, toggleState }) =>
-      source(
-        <Checkbox
-          id={id}
-          checked={getState('checked')}
-          onChange={() => toggleState('checked')}
-          label="Label"
-          size="small"
-        />,
-      ),
-  },
-];
+            id={id}
+            checked={getState('checked')}
+            onChange={() => toggleState('checked')}
+            label="Label"
+            size="small"
+          />,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Columns/Columns.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Columns/Columns.gallery.tsx
@@ -1,218 +1,220 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Placeholder } from '../private/Placeholder/Placeholder';
 import { Columns, Column, Stack } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Spacing',
-    Example: () =>
-      source(
-        <Columns space="large">
-          <Column>
-            <Placeholder height={60} />
-          </Column>
-          <Column>
-            <Placeholder height={60} />
-          </Column>
-        </Columns>,
-      ),
-  },
-  {
-    label: 'Vertical align top',
-    Example: () =>
-      source(
-        <Columns space="small" alignY="top">
-          <Column>
-            <Placeholder height={20} />
-          </Column>
-          <Column>
-            <Placeholder height={80} label="top" />
-          </Column>
-          <Column>
-            <Placeholder height={20} />
-          </Column>
-        </Columns>,
-      ),
-  },
-  {
-    label: 'Vertical align center',
-    Example: () =>
-      source(
-        <Columns space="small" alignY="center">
-          <Column>
-            <Placeholder height={20} />
-          </Column>
-          <Column>
-            <Placeholder height={80} label="center" />
-          </Column>
-          <Column>
-            <Placeholder height={20} />
-          </Column>
-        </Columns>,
-      ),
-  },
-  {
-    label: 'Vertical align bottom',
-    Example: () =>
-      source(
-        <Columns space="small" alignY="bottom">
-          <Column>
-            <Placeholder height={20} />
-          </Column>
-          <Column>
-            <Placeholder height={80} label="bottom" />
-          </Column>
-          <Column>
-            <Placeholder height={20} />
-          </Column>
-        </Columns>,
-      ),
-  },
-  {
-    label: 'Horizontal align left',
-    Example: () =>
-      source(
-        <Columns space="small" align="left">
-          <Column width="1/5">
-            <Placeholder height={20} label="left" />
-          </Column>
-          <Column width="1/5">
-            <Placeholder height={20} />
-          </Column>
-        </Columns>,
-      ),
-  },
-  {
-    label: 'Horizontal align center',
-    Example: () =>
-      source(
-        <Columns space="small" align="center">
-          <Column width="1/5">
-            <Placeholder height={20} label="center" />
-          </Column>
-          <Column width="1/5">
-            <Placeholder height={20} />
-          </Column>
-        </Columns>,
-      ),
-  },
-  {
-    label: 'Horizontal align right',
-    Example: () =>
-      source(
-        <Columns space="small" align="right">
-          <Column width="1/5">
-            <Placeholder height={20} label="right" />
-          </Column>
-          <Column width="1/5">
-            <Placeholder height={20} />
-          </Column>
-        </Columns>,
-      ),
-  },
-
-  {
-    label: 'Reversing the column order',
-    Example: () =>
-      source(
-        <Columns space="small" reverse>
-          <Column width="1/5">
-            <Placeholder height={60} label="First" />
-          </Column>
-          <Column>
-            <Placeholder height={60} label="Second" />
-          </Column>
-        </Columns>,
-      ),
-  },
-  {
-    label: 'Column widths',
-    Example: () =>
-      source(
-        <Stack space="medium">
-          <Columns space="xsmall">
-            <Column width="content">
-              <Placeholder height={30} label="content" />
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Spacing',
+      Example: () =>
+        source(
+          <Columns space="large">
+            <Column>
+              <Placeholder height={60} />
             </Column>
             <Column>
-              <Placeholder height={30} label="fluid" />
+              <Placeholder height={60} />
             </Column>
-          </Columns>
-          <Columns space="xsmall">
+          </Columns>,
+        ),
+    },
+    {
+      label: 'Vertical align top',
+      Example: () =>
+        source(
+          <Columns space="small" alignY="top">
+            <Column>
+              <Placeholder height={20} />
+            </Column>
+            <Column>
+              <Placeholder height={80} label="top" />
+            </Column>
+            <Column>
+              <Placeholder height={20} />
+            </Column>
+          </Columns>,
+        ),
+    },
+    {
+      label: 'Vertical align center',
+      Example: () =>
+        source(
+          <Columns space="small" alignY="center">
+            <Column>
+              <Placeholder height={20} />
+            </Column>
+            <Column>
+              <Placeholder height={80} label="center" />
+            </Column>
+            <Column>
+              <Placeholder height={20} />
+            </Column>
+          </Columns>,
+        ),
+    },
+    {
+      label: 'Vertical align bottom',
+      Example: () =>
+        source(
+          <Columns space="small" alignY="bottom">
+            <Column>
+              <Placeholder height={20} />
+            </Column>
+            <Column>
+              <Placeholder height={80} label="bottom" />
+            </Column>
+            <Column>
+              <Placeholder height={20} />
+            </Column>
+          </Columns>,
+        ),
+    },
+    {
+      label: 'Horizontal align left',
+      Example: () =>
+        source(
+          <Columns space="small" align="left">
             <Column width="1/5">
-              <Placeholder height={30} label="1/5" />
+              <Placeholder height={20} label="left" />
+            </Column>
+            <Column width="1/5">
+              <Placeholder height={20} />
+            </Column>
+          </Columns>,
+        ),
+    },
+    {
+      label: 'Horizontal align center',
+      Example: () =>
+        source(
+          <Columns space="small" align="center">
+            <Column width="1/5">
+              <Placeholder height={20} label="center" />
+            </Column>
+            <Column width="1/5">
+              <Placeholder height={20} />
+            </Column>
+          </Columns>,
+        ),
+    },
+    {
+      label: 'Horizontal align right',
+      Example: () =>
+        source(
+          <Columns space="small" align="right">
+            <Column width="1/5">
+              <Placeholder height={20} label="right" />
+            </Column>
+            <Column width="1/5">
+              <Placeholder height={20} />
+            </Column>
+          </Columns>,
+        ),
+    },
+
+    {
+      label: 'Reversing the column order',
+      Example: () =>
+        source(
+          <Columns space="small" reverse>
+            <Column width="1/5">
+              <Placeholder height={60} label="First" />
             </Column>
             <Column>
-              <Placeholder height={30} label="fluid" />
+              <Placeholder height={60} label="Second" />
             </Column>
-          </Columns>
-          <Columns space="xsmall">
-            <Column width="1/4">
-              <Placeholder height={30} label="1/4" />
-            </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
-          </Columns>
-          <Columns space="xsmall">
-            <Column width="1/3">
-              <Placeholder height={30} label="1/3" />
-            </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
-          </Columns>
-          <Columns space="xsmall">
-            <Column width="2/5">
-              <Placeholder height={30} label="2/5" />
-            </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
-          </Columns>
-          <Columns space="xsmall">
-            <Column width="1/2">
-              <Placeholder height={30} label="1/2" />
-            </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
-          </Columns>
-          <Columns space="xsmall">
-            <Column width="3/5">
-              <Placeholder height={30} label="3/5" />
-            </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
-          </Columns>
-          <Columns space="xsmall">
-            <Column width="2/3">
-              <Placeholder height={30} label="2/3" />
-            </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
-          </Columns>
-          <Columns space="xsmall">
-            <Column width="3/4">
-              <Placeholder height={30} label="3/4" />
-            </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
-          </Columns>
-          <Columns space="xsmall">
-            <Column width="4/5">
-              <Placeholder height={30} label="4/5" />
-            </Column>
-            <Column>
-              <Placeholder height={30} label="fluid" />
-            </Column>
-          </Columns>
-        </Stack>,
-      ),
-  },
-];
+          </Columns>,
+        ),
+    },
+    {
+      label: 'Column widths',
+      Example: () =>
+        source(
+          <Stack space="medium">
+            <Columns space="xsmall">
+              <Column width="content">
+                <Placeholder height={30} label="content" />
+              </Column>
+              <Column>
+                <Placeholder height={30} label="fluid" />
+              </Column>
+            </Columns>
+            <Columns space="xsmall">
+              <Column width="1/5">
+                <Placeholder height={30} label="1/5" />
+              </Column>
+              <Column>
+                <Placeholder height={30} label="fluid" />
+              </Column>
+            </Columns>
+            <Columns space="xsmall">
+              <Column width="1/4">
+                <Placeholder height={30} label="1/4" />
+              </Column>
+              <Column>
+                <Placeholder height={30} label="fluid" />
+              </Column>
+            </Columns>
+            <Columns space="xsmall">
+              <Column width="1/3">
+                <Placeholder height={30} label="1/3" />
+              </Column>
+              <Column>
+                <Placeholder height={30} label="fluid" />
+              </Column>
+            </Columns>
+            <Columns space="xsmall">
+              <Column width="2/5">
+                <Placeholder height={30} label="2/5" />
+              </Column>
+              <Column>
+                <Placeholder height={30} label="fluid" />
+              </Column>
+            </Columns>
+            <Columns space="xsmall">
+              <Column width="1/2">
+                <Placeholder height={30} label="1/2" />
+              </Column>
+              <Column>
+                <Placeholder height={30} label="fluid" />
+              </Column>
+            </Columns>
+            <Columns space="xsmall">
+              <Column width="3/5">
+                <Placeholder height={30} label="3/5" />
+              </Column>
+              <Column>
+                <Placeholder height={30} label="fluid" />
+              </Column>
+            </Columns>
+            <Columns space="xsmall">
+              <Column width="2/3">
+                <Placeholder height={30} label="2/3" />
+              </Column>
+              <Column>
+                <Placeholder height={30} label="fluid" />
+              </Column>
+            </Columns>
+            <Columns space="xsmall">
+              <Column width="3/4">
+                <Placeholder height={30} label="3/4" />
+              </Column>
+              <Column>
+                <Placeholder height={30} label="fluid" />
+              </Column>
+            </Columns>
+            <Columns space="xsmall">
+              <Column width="4/5">
+                <Placeholder height={30} label="4/5" />
+              </Column>
+              <Column>
+                <Placeholder height={30} label="fluid" />
+              </Column>
+            </Columns>
+          </Stack>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/ContentBlock/ContentBlock.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/ContentBlock/ContentBlock.gallery.tsx
@@ -1,53 +1,56 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Placeholder } from '../private/Placeholder/Placeholder';
 import { ContentBlock } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Default width',
-    Example: () =>
-      source(
-        <ContentBlock>
-          <Placeholder height={100} />
-        </ContentBlock>,
-      ),
-  },
-  {
-    label: 'Xsmall width',
-    Example: () =>
-      source(
-        <ContentBlock width="xsmall">
-          <Placeholder height={100} />
-        </ContentBlock>,
-      ),
-  },
-  {
-    label: 'Small width',
-    Example: () =>
-      source(
-        <ContentBlock width="small">
-          <Placeholder height={100} />
-        </ContentBlock>,
-      ),
-  },
-  {
-    label: 'Medium width',
-    Example: () =>
-      source(
-        <ContentBlock width="medium">
-          <Placeholder height={100} />
-        </ContentBlock>,
-      ),
-  },
-  {
-    label: 'Large width',
-    Example: () =>
-      source(
-        <ContentBlock width="large">
-          <Placeholder height={100} />
-        </ContentBlock>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  itemWidth: 'wide',
+  examples: [
+    {
+      label: 'Default width',
+      Example: () =>
+        source(
+          <ContentBlock>
+            <Placeholder height={100} />
+          </ContentBlock>,
+        ),
+    },
+    {
+      label: 'Xsmall width',
+      Example: () =>
+        source(
+          <ContentBlock width="xsmall">
+            <Placeholder height={100} />
+          </ContentBlock>,
+        ),
+    },
+    {
+      label: 'Small width',
+      Example: () =>
+        source(
+          <ContentBlock width="small">
+            <Placeholder height={100} />
+          </ContentBlock>,
+        ),
+    },
+    {
+      label: 'Medium width',
+      Example: () =>
+        source(
+          <ContentBlock width="medium">
+            <Placeholder height={100} />
+          </ContentBlock>,
+        ),
+    },
+    {
+      label: 'Large width',
+      Example: () =>
+        source(
+          <ContentBlock width="large">
+            <Placeholder height={100} />
+          </ContentBlock>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Dialog/Dialog.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Dialog/Dialog.gallery.tsx
@@ -1,100 +1,102 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import source from '@braid-design-system/source.macro';
 import { Dialog, Button, Inline, Stack } from '../';
 import { Placeholder } from '../../playroom/components';
 import { DialogContent } from './Dialog';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Default layout',
-    Example: ({ id }) =>
-      source(
-        <DialogContent
-          id={id}
-          title="Default test"
-          onClose={() => {}}
-          scrollLock={false}
-        >
-          <Placeholder height={100} width="100%" />
-        </DialogContent>,
-      ),
-  },
-  {
-    label: 'Illustration layout',
-    Example: ({ id }) =>
-      source(
-        <DialogContent
-          id={id}
-          title="Illustration test"
-          illustration={
-            <Placeholder
-              height={150}
-              width={150}
-              shape="round"
-              label="Illustration"
-            />
-          }
-          onClose={() => {}}
-          scrollLock={false}
-        >
-          <Stack space="xlarge" align="center">
-            <Placeholder width="100%" height={100} />
-            <Inline space="small">
-              <Placeholder height={44} width={80} label="OK" />
-              <Placeholder height={44} width={80} label="Cancel" />
-            </Inline>
-          </Stack>
-        </DialogContent>,
-      ),
-  },
-  {
-    label: 'Layout with a description',
-    Example: ({ id }) =>
-      source(
-        <DialogContent
-          id={id}
-          title="Description test"
-          description={
-            <Placeholder height="auto" width="100%" label="Description" />
-          }
-          onClose={() => {}}
-          scrollLock={false}
-        >
-          <Placeholder height={100} width="100%" />
-        </DialogContent>,
-      ),
-  },
-  {
-    label: 'Preview animation',
-    Example: ({ getState, setState, resetState }) =>
-      source(
-        <>
-          <Inline space="small" align="center">
-            <Button onClick={() => setState('width', 'xsmall')}>
-              Open xsmall
-            </Button>
-            <Button onClick={() => setState('width', 'small')}>
-              Open small
-            </Button>
-            <Button onClick={() => setState('width', 'medium')}>
-              Open medium
-            </Button>
-            <Button onClick={() => setState('width', 'large')}>
-              Open large
-            </Button>
-          </Inline>
-
-          <Dialog
-            id="dialog-animation-example"
-            title={`A \"${getState('width')}\" dialog`}
-            width={getState('width')}
-            open={getState('width')}
-            onClose={() => resetState('width')}
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Default layout',
+      Example: ({ id }) =>
+        source(
+          <DialogContent
+            id={id}
+            title="Default test"
+            onClose={() => {}}
+            scrollLock={false}
           >
-            <Placeholder height={200} width="100%" />
-          </Dialog>
-        </>,
-      ),
-  },
-];
+            <Placeholder height={100} width="100%" />
+          </DialogContent>,
+        ),
+    },
+    {
+      label: 'Illustration layout',
+      Example: ({ id }) =>
+        source(
+          <DialogContent
+            id={id}
+            title="Illustration test"
+            illustration={
+              <Placeholder
+                height={150}
+                width={150}
+                shape="round"
+                label="Illustration"
+              />
+            }
+            onClose={() => {}}
+            scrollLock={false}
+          >
+            <Stack space="xlarge" align="center">
+              <Placeholder width="100%" height={100} />
+              <Inline space="small">
+                <Placeholder height={44} width={80} label="OK" />
+                <Placeholder height={44} width={80} label="Cancel" />
+              </Inline>
+            </Stack>
+          </DialogContent>,
+        ),
+    },
+    {
+      label: 'Layout with a description',
+      Example: ({ id }) =>
+        source(
+          <DialogContent
+            id={id}
+            title="Description test"
+            description={
+              <Placeholder height="auto" width="100%" label="Description" />
+            }
+            onClose={() => {}}
+            scrollLock={false}
+          >
+            <Placeholder height={100} width="100%" />
+          </DialogContent>,
+        ),
+    },
+    {
+      label: 'Preview animation',
+      Example: ({ getState, setState, resetState }) =>
+        source(
+          <>
+            <Inline space="small" align="center">
+              <Button onClick={() => setState('width', 'xsmall')}>
+                Open xsmall
+              </Button>
+              <Button onClick={() => setState('width', 'small')}>
+                Open small
+              </Button>
+              <Button onClick={() => setState('width', 'medium')}>
+                Open medium
+              </Button>
+              <Button onClick={() => setState('width', 'large')}>
+                Open large
+              </Button>
+            </Inline>
+
+            <Dialog
+              id="dialog-animation-example"
+              title={`A \"${getState('width')}\" dialog`}
+              width={getState('width')}
+              open={getState('width')}
+              onClose={() => resetState('width')}
+            >
+              <Placeholder height={200} width="100%" />
+            </Dialog>
+          </>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.gallery.tsx
@@ -1,20 +1,22 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Disclosure } from '..';
 import source from '@braid-design-system/source.macro';
 import { Placeholder } from '../../playroom/components';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    Example: ({ id }) =>
-      source(
-        <Disclosure
-          id={id}
-          expandLabel="Show content"
-          collapseLabel="Hide content"
-        >
-          <Placeholder height={100} />
-        </Disclosure>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      Example: ({ id }) =>
+        source(
+          <Disclosure
+            id={id}
+            expandLabel="Show content"
+            collapseLabel="Hide content"
+          >
+            <Placeholder height={100} />
+          </Disclosure>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Divider/Divider.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Divider/Divider.gallery.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Divider } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Regular weight',
-    Example: () => source(<Divider />),
-  },
-  {
-    label: 'Strong weight',
-    Example: () => source(<Divider weight="strong" />),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Regular weight',
+      Example: () => source(<Divider />),
+    },
+    {
+      label: 'Strong weight',
+      Example: () => source(<Divider weight="strong" />),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Drawer/Drawer.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Drawer/Drawer.gallery.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import source from '@braid-design-system/source.macro';
 import {
   Drawer,
@@ -13,111 +13,113 @@ import {
 import { Placeholder } from '../../playroom/components';
 import { DrawerContent } from './Drawer';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Default layout',
-    Example: ({ id }) =>
-      source(
-        <DrawerContent
-          id={id}
-          title="Default test"
-          onClose={() => {}}
-          width="medium"
-          scrollLock={false}
-        >
-          <Placeholder height={100} width="100%" />
-        </DrawerContent>,
-      ),
-  },
-  {
-    label: 'Layout with a description',
-    Example: ({ id }) =>
-      source(
-        <DrawerContent
-          id={id}
-          title="Description test"
-          description={
-            <Placeholder height="auto" width="100%" label="Description" />
-          }
-          onClose={() => {}}
-          scrollLock={false}
-        >
-          <Placeholder height={100} width="100%" />
-        </DrawerContent>,
-      ),
-  },
-  {
-    label: 'Preview animation',
-    Example: ({ setDefaultState, getState, setState, toggleState }) =>
-      source(
-        <>
-          {setDefaultState('width', 'medium')}
-          {setDefaultState('position', 'right')}
-          <Inline space="gutter" align="center" alignY="center">
-            <Text>
-              Width:{' '}
-              <Strong>
-                <TextDropdown
-                  id="width"
-                  label="Width"
-                  options={['small', 'medium', 'large']}
-                  value={getState('width')}
-                  onChange={setState('width')}
-                />
-              </Strong>
-            </Text>
-            <Text>
-              Position:{' '}
-              <Strong>
-                <TextDropdown
-                  id="position"
-                  label="Position"
-                  options={['left', 'right']}
-                  value={getState('position')}
-                  onChange={setState('position')}
-                />
-              </Strong>
-            </Text>
-            <Button size="small" onClick={() => toggleState('open')}>
-              Open
-            </Button>
-          </Inline>
-
-          <Drawer
-            id="drawer-animation-example"
-            title={`A \"${getState(
-              'width',
-            )}\" drawer positioned on the \"${getState('position')}\"`}
-            description={
-              <Text tone="secondary">
-                Uses a {getState('width')}{' '}
-                <TextLink href="/components/ContentBlock">
-                  ContentBlock
-                </TextLink>
-              </Text>
-            }
-            width={getState('width')}
-            position={getState('position')}
-            open={getState('open')}
-            onClose={() => toggleState('open')}
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Default layout',
+      Example: ({ id }) =>
+        source(
+          <DrawerContent
+            id={id}
+            title="Default test"
+            onClose={() => {}}
+            width="medium"
+            scrollLock={false}
           >
             <Placeholder height={100} width="100%" />
+          </DrawerContent>,
+        ),
+    },
+    {
+      label: 'Layout with a description',
+      Example: ({ id }) =>
+        source(
+          <DrawerContent
+            id={id}
+            title="Description test"
+            description={
+              <Placeholder height="auto" width="100%" label="Description" />
+            }
+            onClose={() => {}}
+            scrollLock={false}
+          >
             <Placeholder height={100} width="100%" />
-            <Placeholder height={100} width="100%" />
-            <Placeholder height={100} width="100%" />
-            <Placeholder height={100} width="100%" />
-            <Placeholder height={100} width="100%" />
-            <Placeholder height={100} width="100%" />
-            <Placeholder height={100} width="100%" />
-            <Placeholder height={100} width="100%" />
-            <Placeholder height={100} width="100%" />
-            <Placeholder height={100} width="100%" />
-            <Placeholder height={100} width="100%" />
-            <Placeholder height={100} width="100%" />
-            <Placeholder height={100} width="100%" />
-            <Placeholder height={100} width="100%" />
-          </Drawer>
-        </>,
-      ),
-  },
-];
+          </DrawerContent>,
+        ),
+    },
+    {
+      label: 'Preview animation',
+      Example: ({ setDefaultState, getState, setState, toggleState }) =>
+        source(
+          <>
+            {setDefaultState('width', 'medium')}
+            {setDefaultState('position', 'right')}
+            <Inline space="gutter" align="center" alignY="center">
+              <Text>
+                Width:{' '}
+                <Strong>
+                  <TextDropdown
+                    id="width"
+                    label="Width"
+                    options={['small', 'medium', 'large']}
+                    value={getState('width')}
+                    onChange={setState('width')}
+                  />
+                </Strong>
+              </Text>
+              <Text>
+                Position:{' '}
+                <Strong>
+                  <TextDropdown
+                    id="position"
+                    label="Position"
+                    options={['left', 'right']}
+                    value={getState('position')}
+                    onChange={setState('position')}
+                  />
+                </Strong>
+              </Text>
+              <Button size="small" onClick={() => toggleState('open')}>
+                Open
+              </Button>
+            </Inline>
+
+            <Drawer
+              id="drawer-animation-example"
+              title={`A \"${getState(
+                'width',
+              )}\" drawer positioned on the \"${getState('position')}\"`}
+              description={
+                <Text tone="secondary">
+                  Uses a {getState('width')}{' '}
+                  <TextLink href="/components/ContentBlock">
+                    ContentBlock
+                  </TextLink>
+                </Text>
+              }
+              width={getState('width')}
+              position={getState('position')}
+              open={getState('open')}
+              onClose={() => toggleState('open')}
+            >
+              <Placeholder height={100} width="100%" />
+              <Placeholder height={100} width="100%" />
+              <Placeholder height={100} width="100%" />
+              <Placeholder height={100} width="100%" />
+              <Placeholder height={100} width="100%" />
+              <Placeholder height={100} width="100%" />
+              <Placeholder height={100} width="100%" />
+              <Placeholder height={100} width="100%" />
+              <Placeholder height={100} width="100%" />
+              <Placeholder height={100} width="100%" />
+              <Placeholder height={100} width="100%" />
+              <Placeholder height={100} width="100%" />
+              <Placeholder height={100} width="100%" />
+              <Placeholder height={100} width="100%" />
+              <Placeholder height={100} width="100%" />
+            </Drawer>
+          </>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.gallery.tsx
@@ -1,174 +1,176 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Dropdown, IconLocation, IconHelp, TextLink } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Standard',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <Dropdown
-          label="Label"
-          id={id}
-          onChange={setState('dropdown')}
-          value={getState('dropdown')}
-          placeholder="Please select"
-        >
-          <option>Option 1</option>
-          <option>Option 2</option>
-        </Dropdown>,
-      ),
-  },
-  {
-    label: 'With option groups',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <Dropdown
-          label="Label"
-          id={id}
-          onChange={setState('dropdown')}
-          value={getState('dropdown')}
-          placeholder="Please select"
-        >
-          <optgroup label="Group 1">
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Standard',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <Dropdown
+            label="Label"
+            id={id}
+            onChange={setState('dropdown')}
+            value={getState('dropdown')}
+            placeholder="Please select"
+          >
             <option>Option 1</option>
             <option>Option 2</option>
-            <option>Option 3</option>
-          </optgroup>
-          <optgroup label="Group 2">
-            <option>Option A</option>
-            <option>Option B</option>
-            <option>Option C</option>
-          </optgroup>
-        </Dropdown>,
-      ),
-  },
-  {
-    label: 'With additional labels',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <Dropdown
-          label="Label"
-          id={id}
-          onChange={setState('dropdown')}
-          value={getState('dropdown')}
-          placeholder="Please select"
-          secondaryLabel="optional"
-          tertiaryLabel={
-            <TextLink href="#" icon={<IconHelp />}>
-              Help
-            </TextLink>
-          }
-        >
-          <option>Option 1</option>
-          <option>Option 2</option>
-        </Dropdown>,
-      ),
-  },
-  {
-    label: 'With a description',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <Dropdown
-          label="Label"
-          id={id}
-          onChange={setState('dropdown')}
-          value={getState('dropdown')}
-          placeholder="Please select"
-          description="Extra information about the field"
-        >
-          <option>Option 1</option>
-          <option>Option 2</option>
-        </Dropdown>,
-      ),
-  },
-  {
-    label: 'With an icon',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <Dropdown
-          label="Label"
-          id={id}
-          onChange={setState('dropdown')}
-          value={getState('dropdown')}
-          placeholder="Please select"
-          icon={<IconLocation />}
-        >
-          <option>Option 1</option>
-          <option>Option 2</option>
-        </Dropdown>,
-      ),
-  },
-  {
-    label: 'With a critical message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <Dropdown
-          label="Label"
-          id={id}
-          onChange={setState('dropdown')}
-          value={getState('dropdown')}
-          placeholder="Please select"
-          tone="critical"
-          message="Critical message"
-        >
-          <option>Option 1</option>
-          <option>Option 2</option>
-        </Dropdown>,
-      ),
-  },
-  {
-    label: 'With a positive message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <Dropdown
-          label="Label"
-          id={id}
-          onChange={setState('dropdown')}
-          value={getState('dropdown')}
-          placeholder="Please select"
-          tone="positive"
-          message="Positive message"
-        >
-          <option>Option 1</option>
-          <option>Option 2</option>
-        </Dropdown>,
-      ),
-  },
-  {
-    label: 'With a caution message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <Dropdown
-          label="Label"
-          id={id}
-          onChange={setState('dropdown')}
-          value={getState('dropdown')}
-          placeholder="Please select"
-          tone="caution"
-          message="Caution message"
-        >
-          <option>Option 1</option>
-          <option>Option 2</option>
-        </Dropdown>,
-      ),
-  },
-  {
-    label: 'Disabled field',
-    background: 'surface',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <Dropdown
-          label="Label"
-          id={id}
-          onChange={setState('dropdown')}
-          value={getState('dropdown')}
-          disabled={true}
-        >
-          <option>Option 1</option>
-          <option>Option 2</option>
-        </Dropdown>,
-      ),
-  },
-];
+          </Dropdown>,
+        ),
+    },
+    {
+      label: 'With option groups',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <Dropdown
+            label="Label"
+            id={id}
+            onChange={setState('dropdown')}
+            value={getState('dropdown')}
+            placeholder="Please select"
+          >
+            <optgroup label="Group 1">
+              <option>Option 1</option>
+              <option>Option 2</option>
+              <option>Option 3</option>
+            </optgroup>
+            <optgroup label="Group 2">
+              <option>Option A</option>
+              <option>Option B</option>
+              <option>Option C</option>
+            </optgroup>
+          </Dropdown>,
+        ),
+    },
+    {
+      label: 'With additional labels',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <Dropdown
+            label="Label"
+            id={id}
+            onChange={setState('dropdown')}
+            value={getState('dropdown')}
+            placeholder="Please select"
+            secondaryLabel="optional"
+            tertiaryLabel={
+              <TextLink href="#" icon={<IconHelp />}>
+                Help
+              </TextLink>
+            }
+          >
+            <option>Option 1</option>
+            <option>Option 2</option>
+          </Dropdown>,
+        ),
+    },
+    {
+      label: 'With a description',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <Dropdown
+            label="Label"
+            id={id}
+            onChange={setState('dropdown')}
+            value={getState('dropdown')}
+            placeholder="Please select"
+            description="Extra information about the field"
+          >
+            <option>Option 1</option>
+            <option>Option 2</option>
+          </Dropdown>,
+        ),
+    },
+    {
+      label: 'With an icon',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <Dropdown
+            label="Label"
+            id={id}
+            onChange={setState('dropdown')}
+            value={getState('dropdown')}
+            placeholder="Please select"
+            icon={<IconLocation />}
+          >
+            <option>Option 1</option>
+            <option>Option 2</option>
+          </Dropdown>,
+        ),
+    },
+    {
+      label: 'With a critical message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <Dropdown
+            label="Label"
+            id={id}
+            onChange={setState('dropdown')}
+            value={getState('dropdown')}
+            placeholder="Please select"
+            tone="critical"
+            message="Critical message"
+          >
+            <option>Option 1</option>
+            <option>Option 2</option>
+          </Dropdown>,
+        ),
+    },
+    {
+      label: 'With a positive message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <Dropdown
+            label="Label"
+            id={id}
+            onChange={setState('dropdown')}
+            value={getState('dropdown')}
+            placeholder="Please select"
+            tone="positive"
+            message="Positive message"
+          >
+            <option>Option 1</option>
+            <option>Option 2</option>
+          </Dropdown>,
+        ),
+    },
+    {
+      label: 'With a caution message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <Dropdown
+            label="Label"
+            id={id}
+            onChange={setState('dropdown')}
+            value={getState('dropdown')}
+            placeholder="Please select"
+            tone="caution"
+            message="Caution message"
+          >
+            <option>Option 1</option>
+            <option>Option 2</option>
+          </Dropdown>,
+        ),
+    },
+    {
+      label: 'Disabled field',
+      background: 'surface',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <Dropdown
+            label="Label"
+            id={id}
+            onChange={setState('dropdown')}
+            value={getState('dropdown')}
+            disabled={true}
+          >
+            <option>Option 1</option>
+            <option>Option 2</option>
+          </Dropdown>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/FieldLabel/FieldLabel.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/FieldLabel/FieldLabel.gallery.tsx
@@ -1,45 +1,47 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { FieldLabel, TextLink } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Standard',
-    Example: ({ id }) => source(<FieldLabel htmlFor={id} label="Label" />),
-  },
-  {
-    label: 'With secondary label',
-    Example: ({ id }) =>
-      source(
-        <FieldLabel
-          htmlFor={id}
-          label="Label"
-          secondaryLabel="Secondary label"
-        />,
-      ),
-  },
-  {
-    label: 'With tertiary label',
-    Example: ({ id }) =>
-      source(
-        <FieldLabel
-          htmlFor={id}
-          label="Label"
-          tertiaryLabel={<TextLink href="#">Tertiary label</TextLink>}
-        />,
-      ),
-  },
-  {
-    label: 'With all types',
-    Example: ({ id }) =>
-      source(
-        <FieldLabel
-          htmlFor={id}
-          label="Label"
-          secondaryLabel="Secondary label"
-          tertiaryLabel={<TextLink href="#">Tertiary label</TextLink>}
-        />,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Standard',
+      Example: ({ id }) => source(<FieldLabel htmlFor={id} label="Label" />),
+    },
+    {
+      label: 'With secondary label',
+      Example: ({ id }) =>
+        source(
+          <FieldLabel
+            htmlFor={id}
+            label="Label"
+            secondaryLabel="Secondary label"
+          />,
+        ),
+    },
+    {
+      label: 'With tertiary label',
+      Example: ({ id }) =>
+        source(
+          <FieldLabel
+            htmlFor={id}
+            label="Label"
+            tertiaryLabel={<TextLink href="#">Tertiary label</TextLink>}
+          />,
+        ),
+    },
+    {
+      label: 'With all types',
+      Example: ({ id }) =>
+        source(
+          <FieldLabel
+            htmlFor={id}
+            label="Label"
+            secondaryLabel="Secondary label"
+            tertiaryLabel={<TextLink href="#">Tertiary label</TextLink>}
+          />,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/FieldMessage/FieldMessage.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/FieldMessage/FieldMessage.gallery.tsx
@@ -1,51 +1,53 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { FieldMessage } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Critical',
-    Example: ({ id }) =>
-      source(
-        <FieldMessage
-          id={id}
-          tone="critical"
-          message="This is a critical message."
-        />,
-      ),
-  },
-  {
-    label: 'Positive',
-    Example: ({ id }) =>
-      source(
-        <FieldMessage
-          id={id}
-          tone="positive"
-          message="This is a positive message."
-        />,
-      ),
-  },
-  {
-    label: 'Caution',
-    Example: ({ id }) =>
-      source(
-        <FieldMessage
-          id={id}
-          tone="caution"
-          message="This is a caution message."
-        />,
-      ),
-  },
-  {
-    label: 'Neutral',
-    Example: ({ id }) =>
-      source(
-        <FieldMessage
-          id={id}
-          tone="neutral"
-          message="This is a neutral message."
-        />,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Critical',
+      Example: ({ id }) =>
+        source(
+          <FieldMessage
+            id={id}
+            tone="critical"
+            message="This is a critical message."
+          />,
+        ),
+    },
+    {
+      label: 'Positive',
+      Example: ({ id }) =>
+        source(
+          <FieldMessage
+            id={id}
+            tone="positive"
+            message="This is a positive message."
+          />,
+        ),
+    },
+    {
+      label: 'Caution',
+      Example: ({ id }) =>
+        source(
+          <FieldMessage
+            id={id}
+            tone="caution"
+            message="This is a caution message."
+          />,
+        ),
+    },
+    {
+      label: 'Neutral',
+      Example: ({ id }) =>
+        source(
+          <FieldMessage
+            id={id}
+            tone="neutral"
+            message="This is a neutral message."
+          />,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Heading/Heading.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Heading/Heading.gallery.tsx
@@ -1,91 +1,93 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Box, Heading, Stack, IconImage } from '../';
 
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Levels',
-    Example: () =>
-      source(
-        <Stack space="large">
-          <Heading level="1">Level 1</Heading>
-          <Heading level="2">Level 2</Heading>
-          <Heading level="3">Level 3</Heading>
-          <Heading level="4">Level 4</Heading>
-        </Stack>,
-      ),
-  },
-  {
-    label: 'Weight',
-    Example: () =>
-      source(
-        <Stack space="large">
-          <Heading level="1" weight="weak">
-            Level 1 Weak
-          </Heading>
-          <Heading level="2" weight="weak">
-            Level 2 Weak
-          </Heading>
-          <Heading level="3" weight="weak">
-            Level 3 Weak
-          </Heading>
-          <Heading level="4" weight="weak">
-            Level 4 Weak
-          </Heading>
-        </Stack>,
-      ),
-  },
-  {
-    label: 'Alignment',
-    Example: () =>
-      source(
-        <Stack space="large" dividers>
-          <Heading level="2" align="left">
-            Left (default)
-          </Heading>
-          <Heading level="2" align="center">
-            Center
-          </Heading>
-          <Heading level="2" align="right">
-            Right
-          </Heading>
-          <Heading level="2" align={{ mobile: 'center', tablet: 'left' }}>
-            Center on mobile
-          </Heading>
-        </Stack>,
-      ),
-  },
-  {
-    label: 'Truncation',
-    Example: () =>
-      source(
-        <Box style={{ width: 150 }}>
-          <Heading level="2" maxLines={1}>
-            Long heading
-          </Heading>
-        </Box>,
-      ),
-  },
-  {
-    label: 'With an icon',
-    Example: () =>
-      source(
-        <Stack space="large">
-          <Heading level="1" icon={<IconImage />}>
-            Level 1 with icon
-          </Heading>
-          <Heading level="2" icon={<IconImage />}>
-            Level 2 with icon
-          </Heading>
-          <Heading level="3" icon={<IconImage />}>
-            Level 3 with icon
-          </Heading>
-          <Heading level="4" icon={<IconImage />}>
-            Level 4 with icon
-          </Heading>
-        </Stack>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Levels',
+      Example: () =>
+        source(
+          <Stack space="large">
+            <Heading level="1">Level 1</Heading>
+            <Heading level="2">Level 2</Heading>
+            <Heading level="3">Level 3</Heading>
+            <Heading level="4">Level 4</Heading>
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Weight',
+      Example: () =>
+        source(
+          <Stack space="large">
+            <Heading level="1" weight="weak">
+              Level 1 Weak
+            </Heading>
+            <Heading level="2" weight="weak">
+              Level 2 Weak
+            </Heading>
+            <Heading level="3" weight="weak">
+              Level 3 Weak
+            </Heading>
+            <Heading level="4" weight="weak">
+              Level 4 Weak
+            </Heading>
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Alignment',
+      Example: () =>
+        source(
+          <Stack space="large" dividers>
+            <Heading level="2" align="left">
+              Left (default)
+            </Heading>
+            <Heading level="2" align="center">
+              Center
+            </Heading>
+            <Heading level="2" align="right">
+              Right
+            </Heading>
+            <Heading level="2" align={{ mobile: 'center', tablet: 'left' }}>
+              Center on mobile
+            </Heading>
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Truncation',
+      Example: () =>
+        source(
+          <Box style={{ width: 150 }}>
+            <Heading level="2" maxLines={1}>
+              Long heading
+            </Heading>
+          </Box>,
+        ),
+    },
+    {
+      label: 'With an icon',
+      Example: () =>
+        source(
+          <Stack space="large">
+            <Heading level="1" icon={<IconImage />}>
+              Level 1 with icon
+            </Heading>
+            <Heading level="2" icon={<IconImage />}>
+              Level 2 with icon
+            </Heading>
+            <Heading level="3" icon={<IconImage />}>
+              Level 3 with icon
+            </Heading>
+            <Heading level="4" icon={<IconImage />}>
+              Level 4 with icon
+            </Heading>
+          </Stack>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Inline/Inline.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Inline/Inline.gallery.tsx
@@ -1,87 +1,89 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Placeholder } from '../private/Placeholder/Placeholder';
 import { Inline } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Spacing',
-    Example: () =>
-      source(
-        <Inline space="large">
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-          <Placeholder width={48} height={48} />
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Vertical align top',
-    Example: () =>
-      source(
-        <Inline space="small" alignY="top">
-          <Placeholder width={60} height={20} />
-          <Placeholder width={80} height={60} label="top" />
-          <Placeholder width={60} height={20} />
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Vertical align center',
-    Example: () =>
-      source(
-        <Inline space="small" alignY="center">
-          <Placeholder width={60} height={20} />
-          <Placeholder width={80} height={60} label="center" />
-          <Placeholder width={60} height={20} />
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Vertical align bottom',
-    Example: () =>
-      source(
-        <Inline space="small" alignY="bottom">
-          <Placeholder width={60} height={20} />
-          <Placeholder width={80} height={60} label="bottom" />
-          <Placeholder width={60} height={20} />
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Horizontal align left',
-    Example: () =>
-      source(
-        <Inline space="small" align="left">
-          <Placeholder width={80} height={60} label="left" />
-          <Placeholder width={80} height={60} />
-          <Placeholder width={80} height={60} />
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Horizontal align center',
-    Example: () =>
-      source(
-        <Inline space="small" align="center">
-          <Placeholder width={80} height={60} />
-          <Placeholder width={80} height={60} label="center" />
-          <Placeholder width={80} height={60} />
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Horizontal align right',
-    Example: () =>
-      source(
-        <Inline space="small" align="right">
-          <Placeholder width={80} height={60} />
-          <Placeholder width={80} height={60} />
-          <Placeholder width={80} height={60} label="right" />
-        </Inline>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Spacing',
+      Example: () =>
+        source(
+          <Inline space="large">
+            <Placeholder width={48} height={48} />
+            <Placeholder width={48} height={48} />
+            <Placeholder width={48} height={48} />
+            <Placeholder width={48} height={48} />
+            <Placeholder width={48} height={48} />
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Vertical align top',
+      Example: () =>
+        source(
+          <Inline space="small" alignY="top">
+            <Placeholder width={60} height={20} />
+            <Placeholder width={80} height={60} label="top" />
+            <Placeholder width={60} height={20} />
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Vertical align center',
+      Example: () =>
+        source(
+          <Inline space="small" alignY="center">
+            <Placeholder width={60} height={20} />
+            <Placeholder width={80} height={60} label="center" />
+            <Placeholder width={60} height={20} />
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Vertical align bottom',
+      Example: () =>
+        source(
+          <Inline space="small" alignY="bottom">
+            <Placeholder width={60} height={20} />
+            <Placeholder width={80} height={60} label="bottom" />
+            <Placeholder width={60} height={20} />
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Horizontal align left',
+      Example: () =>
+        source(
+          <Inline space="small" align="left">
+            <Placeholder width={80} height={60} label="left" />
+            <Placeholder width={80} height={60} />
+            <Placeholder width={80} height={60} />
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Horizontal align center',
+      Example: () =>
+        source(
+          <Inline space="small" align="center">
+            <Placeholder width={80} height={60} />
+            <Placeholder width={80} height={60} label="center" />
+            <Placeholder width={80} height={60} />
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Horizontal align right',
+      Example: () =>
+        source(
+          <Inline space="small" align="right">
+            <Placeholder width={80} height={60} />
+            <Placeholder width={80} height={60} />
+            <Placeholder width={80} height={60} label="right" />
+          </Inline>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/List/List.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/List/List.gallery.tsx
@@ -1,168 +1,170 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { List, IconTick, Text, Stack } from '..';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Standard',
-    Example: () =>
-      source(
-        <List>
-          <Text>This is a list item.</Text>
-          <Text>This is a list item.</Text>
-          <Text>This is a list item.</Text>
-        </List>,
-      ),
-  },
-  {
-    label: 'Numbered',
-    Example: () =>
-      source(
-        <List type="number">
-          <Text>This is a numbered list item.</Text>
-          <Text>This is a numbered list item.</Text>
-          <Text>This is a numbered list item.</Text>
-        </List>,
-      ),
-  },
-  {
-    label: 'Alpha',
-    Example: () =>
-      source(
-        <List type="alpha">
-          <Text>This is an alpha list item.</Text>
-          <Text>This is an alpha list item.</Text>
-          <Text>This is an alpha list item.</Text>
-        </List>,
-      ),
-  },
-  {
-    label: 'Roman',
-    Example: () =>
-      source(
-        <List type="roman">
-          <Text>This is a Roman list item.</Text>
-          <Text>This is a Roman list item.</Text>
-          <Text>This is a Roman list item.</Text>
-        </List>,
-      ),
-  },
-  {
-    label: 'Icon',
-    Example: () =>
-      source(
-        <List type="icon" icon={<IconTick tone="positive" />}>
-          <Text>This is a list item.</Text>
-          <Text>This is a list item.</Text>
-          <Text>This is a list item.</Text>
-        </List>,
-      ),
-  },
-  {
-    label: 'With paragraphs',
-    Example: () =>
-      source(
-        <List space="large">
-          <Stack space="medium">
-            <Text>This is a paragraph.</Text>
-            <Text>This is another paragraph.</Text>
-          </Stack>
-          <Stack space="medium">
-            <Text>This is a paragraph.</Text>
-            <Text>This is another paragraph.</Text>
-          </Stack>
-        </List>,
-      ),
-  },
-  {
-    label: 'Nested Lists',
-    Example: () =>
-      source(
-        <List space="large" type="number">
-          <Stack space="medium">
-            <Text>This has a nested list.</Text>
-            <List type="alpha">
-              <Text>This is a nested list item.</Text>
-              <Text>This is a nested list item.</Text>
-              <Text>This is a nested list item.</Text>
-            </List>
-          </Stack>
-          <Stack space="medium">
-            <Text>This has a nested list.</Text>
-            <List type="alpha">
-              <Text>This is a nested list item.</Text>
-              <Text>This is a nested list item.</Text>
-              <Text>This is a nested list item.</Text>
-            </List>
-          </Stack>
-        </List>,
-      ),
-  },
-  {
-    label: 'With custom text size',
-    Example: () =>
-      source(
-        <List size="large">
-          <Text>This is a large list item.</Text>
-          <Text>This is a large list item.</Text>
-          <Text>This is a large list item.</Text>
-        </List>,
-      ),
-  },
-  {
-    label: 'With custom space between items',
-    Example: () =>
-      source(
-        <List space="large">
-          <Text>List item with large space.</Text>
-          <Text>List item with large space.</Text>
-          <Text>List item with large space.</Text>
-        </List>,
-      ),
-  },
-  {
-    label: 'With custom tone',
-    Example: () =>
-      source(
-        <List tone="secondary">
-          <Text>List item with secondary tone.</Text>
-          <Text>List item with secondary tone.</Text>
-          <Text>List item with secondary tone.</Text>
-        </List>,
-      ),
-  },
-  {
-    label: 'Numbered with custom start position',
-    Example: () =>
-      source(
-        <List type="number" start={9}>
-          <Text>This is a numbered list item.</Text>
-          <Text>This is a numbered list item.</Text>
-          <Text>This is a numbered list item.</Text>
-        </List>,
-      ),
-  },
-  {
-    label: 'Alpha with custom start position',
-    Example: () =>
-      source(
-        <List type="alpha" start={9}>
-          <Text>This is an alpha list item.</Text>
-          <Text>This is an alpha list item.</Text>
-          <Text>This is an alpha list item.</Text>
-        </List>,
-      ),
-  },
-  {
-    label: 'Roman with custom start position',
-    Example: () =>
-      source(
-        <List type="roman" start={9}>
-          <Text>This is a Roman list item.</Text>
-          <Text>This is a Roman list item.</Text>
-          <Text>This is a Roman list item.</Text>
-        </List>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Standard',
+      Example: () =>
+        source(
+          <List>
+            <Text>This is a list item.</Text>
+            <Text>This is a list item.</Text>
+            <Text>This is a list item.</Text>
+          </List>,
+        ),
+    },
+    {
+      label: 'Numbered',
+      Example: () =>
+        source(
+          <List type="number">
+            <Text>This is a numbered list item.</Text>
+            <Text>This is a numbered list item.</Text>
+            <Text>This is a numbered list item.</Text>
+          </List>,
+        ),
+    },
+    {
+      label: 'Alpha',
+      Example: () =>
+        source(
+          <List type="alpha">
+            <Text>This is an alpha list item.</Text>
+            <Text>This is an alpha list item.</Text>
+            <Text>This is an alpha list item.</Text>
+          </List>,
+        ),
+    },
+    {
+      label: 'Roman',
+      Example: () =>
+        source(
+          <List type="roman">
+            <Text>This is a Roman list item.</Text>
+            <Text>This is a Roman list item.</Text>
+            <Text>This is a Roman list item.</Text>
+          </List>,
+        ),
+    },
+    {
+      label: 'Icon',
+      Example: () =>
+        source(
+          <List type="icon" icon={<IconTick tone="positive" />}>
+            <Text>This is a list item.</Text>
+            <Text>This is a list item.</Text>
+            <Text>This is a list item.</Text>
+          </List>,
+        ),
+    },
+    {
+      label: 'With paragraphs',
+      Example: () =>
+        source(
+          <List space="large">
+            <Stack space="medium">
+              <Text>This is a paragraph.</Text>
+              <Text>This is another paragraph.</Text>
+            </Stack>
+            <Stack space="medium">
+              <Text>This is a paragraph.</Text>
+              <Text>This is another paragraph.</Text>
+            </Stack>
+          </List>,
+        ),
+    },
+    {
+      label: 'Nested Lists',
+      Example: () =>
+        source(
+          <List space="large" type="number">
+            <Stack space="medium">
+              <Text>This has a nested list.</Text>
+              <List type="alpha">
+                <Text>This is a nested list item.</Text>
+                <Text>This is a nested list item.</Text>
+                <Text>This is a nested list item.</Text>
+              </List>
+            </Stack>
+            <Stack space="medium">
+              <Text>This has a nested list.</Text>
+              <List type="alpha">
+                <Text>This is a nested list item.</Text>
+                <Text>This is a nested list item.</Text>
+                <Text>This is a nested list item.</Text>
+              </List>
+            </Stack>
+          </List>,
+        ),
+    },
+    {
+      label: 'With custom text size',
+      Example: () =>
+        source(
+          <List size="large">
+            <Text>This is a large list item.</Text>
+            <Text>This is a large list item.</Text>
+            <Text>This is a large list item.</Text>
+          </List>,
+        ),
+    },
+    {
+      label: 'With custom space between items',
+      Example: () =>
+        source(
+          <List space="large">
+            <Text>List item with large space.</Text>
+            <Text>List item with large space.</Text>
+            <Text>List item with large space.</Text>
+          </List>,
+        ),
+    },
+    {
+      label: 'With custom tone',
+      Example: () =>
+        source(
+          <List tone="secondary">
+            <Text>List item with secondary tone.</Text>
+            <Text>List item with secondary tone.</Text>
+            <Text>List item with secondary tone.</Text>
+          </List>,
+        ),
+    },
+    {
+      label: 'Numbered with custom start position',
+      Example: () =>
+        source(
+          <List type="number" start={9}>
+            <Text>This is a numbered list item.</Text>
+            <Text>This is a numbered list item.</Text>
+            <Text>This is a numbered list item.</Text>
+          </List>,
+        ),
+    },
+    {
+      label: 'Alpha with custom start position',
+      Example: () =>
+        source(
+          <List type="alpha" start={9}>
+            <Text>This is an alpha list item.</Text>
+            <Text>This is an alpha list item.</Text>
+            <Text>This is an alpha list item.</Text>
+          </List>,
+        ),
+    },
+    {
+      label: 'Roman with custom start position',
+      Example: () =>
+        source(
+          <List type="roman" start={9}>
+            <Text>This is a Roman list item.</Text>
+            <Text>This is a Roman list item.</Text>
+            <Text>This is a Roman list item.</Text>
+          </List>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Loader/Loader.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Loader/Loader.gallery.tsx
@@ -1,10 +1,12 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Loader } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    Example: () => source(<Loader />),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      Example: () => source(<Loader />),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/MenuItem/MenuItem.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItem/MenuItem.gallery.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import {
   Box,
   MenuItem,
@@ -15,127 +15,129 @@ import {
 } from '..';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Default',
-    background: 'surface',
-    Example: () =>
-      source(
-        <Inline space="none">
-          <MenuRenderer
-            offsetSpace="small"
-            trigger={(triggerProps, { open }) => (
-              <Box userSelect="none" cursor="pointer" {...triggerProps}>
-                <Text>
-                  Menu{' '}
-                  <IconChevron
-                    direction={open ? 'up' : 'down'}
-                    alignY="lowercase"
-                  />
-                </Text>
-              </Box>
-            )}
-          >
-            <MenuItem onClick={() => {}}>Button</MenuItem>
-            <MenuItemLink href="#">Link</MenuItemLink>
-          </MenuRenderer>
-        </Inline>,
-      ),
-  },
-  {
-    label: 'With an icon',
-    background: 'surface',
-    Example: () =>
-      source(
-        <Inline space="none">
-          <MenuRenderer
-            reserveIconSpace
-            width="small"
-            offsetSpace="small"
-            trigger={(triggerProps, { open }) => (
-              <Box userSelect="none" cursor="pointer" {...triggerProps}>
-                <Text>
-                  Menu{' '}
-                  <IconChevron
-                    direction={open ? 'up' : 'down'}
-                    alignY="lowercase"
-                  />
-                </Text>
-              </Box>
-            )}
-          >
-            <MenuItem onClick={() => {}} icon={<IconProfile />}>
-              Item
-            </MenuItem>
-            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-              Item
-            </MenuItem>
-          </MenuRenderer>
-        </Inline>,
-      ),
-  },
-  {
-    label: 'With a Badge',
-    background: 'surface',
-    Example: () =>
-      source(
-        <Inline space="none">
-          <MenuRenderer
-            width="small"
-            offsetSpace="small"
-            trigger={(triggerProps, { open }) => (
-              <Box userSelect="none" cursor="pointer" {...triggerProps}>
-                <Text>
-                  Menu{' '}
-                  <IconChevron
-                    direction={open ? 'up' : 'down'}
-                    alignY="lowercase"
-                  />
-                </Text>
-              </Box>
-            )}
-          >
-            <MenuItem
-              onClick={() => {}}
-              badge={
-                <Badge tone="promote" weight="strong">
-                  Badge
-                </Badge>
-              }
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Default',
+      background: 'surface',
+      Example: () =>
+        source(
+          <Inline space="none">
+            <MenuRenderer
+              offsetSpace="small"
+              trigger={(triggerProps, { open }) => (
+                <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                  <Text>
+                    Menu{' '}
+                    <IconChevron
+                      direction={open ? 'up' : 'down'}
+                      alignY="lowercase"
+                    />
+                  </Text>
+                </Box>
+              )}
             >
-              Item
-            </MenuItem>
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-          </MenuRenderer>
-        </Inline>,
-      ),
-  },
-  {
-    label: 'With a critical tone',
-    background: 'surface',
-    Example: () =>
-      source(
-        <Inline space="none">
-          <MenuRenderer
-            width="small"
-            offsetSpace="small"
-            trigger={(triggerProps, { open }) => (
-              <Box userSelect="none" cursor="pointer" {...triggerProps}>
-                <Text>
-                  Menu{' '}
-                  <IconChevron
-                    direction={open ? 'up' : 'down'}
-                    alignY="lowercase"
-                  />
-                </Text>
-              </Box>
-            )}
-          >
-            <MenuItem onClick={() => {}} icon={<IconClear />} tone="critical">
-              Critical
-            </MenuItem>
-          </MenuRenderer>
-        </Inline>,
-      ),
-  },
-];
+              <MenuItem onClick={() => {}}>Button</MenuItem>
+              <MenuItemLink href="#">Link</MenuItemLink>
+            </MenuRenderer>
+          </Inline>,
+        ),
+    },
+    {
+      label: 'With an icon',
+      background: 'surface',
+      Example: () =>
+        source(
+          <Inline space="none">
+            <MenuRenderer
+              reserveIconSpace
+              width="small"
+              offsetSpace="small"
+              trigger={(triggerProps, { open }) => (
+                <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                  <Text>
+                    Menu{' '}
+                    <IconChevron
+                      direction={open ? 'up' : 'down'}
+                      alignY="lowercase"
+                    />
+                  </Text>
+                </Box>
+              )}
+            >
+              <MenuItem onClick={() => {}} icon={<IconProfile />}>
+                Item
+              </MenuItem>
+              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+                Item
+              </MenuItem>
+            </MenuRenderer>
+          </Inline>,
+        ),
+    },
+    {
+      label: 'With a Badge',
+      background: 'surface',
+      Example: () =>
+        source(
+          <Inline space="none">
+            <MenuRenderer
+              width="small"
+              offsetSpace="small"
+              trigger={(triggerProps, { open }) => (
+                <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                  <Text>
+                    Menu{' '}
+                    <IconChevron
+                      direction={open ? 'up' : 'down'}
+                      alignY="lowercase"
+                    />
+                  </Text>
+                </Box>
+              )}
+            >
+              <MenuItem
+                onClick={() => {}}
+                badge={
+                  <Badge tone="promote" weight="strong">
+                    Badge
+                  </Badge>
+                }
+              >
+                Item
+              </MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+            </MenuRenderer>
+          </Inline>,
+        ),
+    },
+    {
+      label: 'With a critical tone',
+      background: 'surface',
+      Example: () =>
+        source(
+          <Inline space="none">
+            <MenuRenderer
+              width="small"
+              offsetSpace="small"
+              trigger={(triggerProps, { open }) => (
+                <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                  <Text>
+                    Menu{' '}
+                    <IconChevron
+                      direction={open ? 'up' : 'down'}
+                      alignY="lowercase"
+                    />
+                  </Text>
+                </Box>
+              )}
+            >
+              <MenuItem onClick={() => {}} icon={<IconClear />} tone="critical">
+                Critical
+              </MenuItem>
+            </MenuRenderer>
+          </Inline>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.gallery.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import {
   MenuItemCheckbox,
   Box,
@@ -11,104 +11,106 @@ import {
 } from '..';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Default',
-    background: 'surface',
-    Example: ({ setDefaultState, getState, toggleState }) =>
-      source(
-        <>
-          {setDefaultState('checked1', false)}
-          {setDefaultState('checked2', false)}
-          {setDefaultState('checked3', false)}
-          <Inline space="none">
-            <MenuRenderer
-              offsetSpace="small"
-              trigger={(triggerProps, { open }) => (
-                <Box userSelect="none" cursor="pointer" {...triggerProps}>
-                  <Text>
-                    Menu{' '}
-                    <IconChevron
-                      direction={open ? 'up' : 'down'}
-                      alignY="lowercase"
-                    />
-                  </Text>
-                </Box>
-              )}
-            >
-              <MenuItemCheckbox
-                checked={getState('checked1')}
-                onChange={() => toggleState('checked1')}
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Default',
+      background: 'surface',
+      Example: ({ setDefaultState, getState, toggleState }) =>
+        source(
+          <>
+            {setDefaultState('checked1', false)}
+            {setDefaultState('checked2', false)}
+            {setDefaultState('checked3', false)}
+            <Inline space="none">
+              <MenuRenderer
+                offsetSpace="small"
+                trigger={(triggerProps, { open }) => (
+                  <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                    <Text>
+                      Menu{' '}
+                      <IconChevron
+                        direction={open ? 'up' : 'down'}
+                        alignY="lowercase"
+                      />
+                    </Text>
+                  </Box>
+                )}
               >
-                Checkbox
-              </MenuItemCheckbox>
-              <MenuItemCheckbox
-                checked={getState('checked2')}
-                onChange={() => toggleState('checked2')}
+                <MenuItemCheckbox
+                  checked={getState('checked1')}
+                  onChange={() => toggleState('checked1')}
+                >
+                  Checkbox
+                </MenuItemCheckbox>
+                <MenuItemCheckbox
+                  checked={getState('checked2')}
+                  onChange={() => toggleState('checked2')}
+                >
+                  Checkbox
+                </MenuItemCheckbox>
+                <MenuItemCheckbox
+                  checked={getState('checked3')}
+                  onChange={() => toggleState('checked3')}
+                >
+                  Checkbox
+                </MenuItemCheckbox>
+              </MenuRenderer>
+            </Inline>
+          </>,
+        ),
+    },
+    {
+      label: 'With a Badge',
+      background: 'surface',
+      Example: ({ setDefaultState, getState, toggleState }) =>
+        source(
+          <>
+            {setDefaultState('checked1', false)}
+            {setDefaultState('checked2', false)}
+            {setDefaultState('checked3', false)}
+            <Inline space="none">
+              <MenuRenderer
+                offsetSpace="small"
+                trigger={(triggerProps, { open }) => (
+                  <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                    <Text>
+                      Menu{' '}
+                      <IconChevron
+                        direction={open ? 'up' : 'down'}
+                        alignY="lowercase"
+                      />
+                    </Text>
+                  </Box>
+                )}
               >
-                Checkbox
-              </MenuItemCheckbox>
-              <MenuItemCheckbox
-                checked={getState('checked3')}
-                onChange={() => toggleState('checked3')}
-              >
-                Checkbox
-              </MenuItemCheckbox>
-            </MenuRenderer>
-          </Inline>
-        </>,
-      ),
-  },
-  {
-    label: 'With a Badge',
-    background: 'surface',
-    Example: ({ setDefaultState, getState, toggleState }) =>
-      source(
-        <>
-          {setDefaultState('checked1', false)}
-          {setDefaultState('checked2', false)}
-          {setDefaultState('checked3', false)}
-          <Inline space="none">
-            <MenuRenderer
-              offsetSpace="small"
-              trigger={(triggerProps, { open }) => (
-                <Box userSelect="none" cursor="pointer" {...triggerProps}>
-                  <Text>
-                    Menu{' '}
-                    <IconChevron
-                      direction={open ? 'up' : 'down'}
-                      alignY="lowercase"
-                    />
-                  </Text>
-                </Box>
-              )}
-            >
-              <MenuItemCheckbox
-                checked={getState('checked1')}
-                onChange={() => toggleState('checked1')}
-              >
-                Checkbox
-              </MenuItemCheckbox>
-              <MenuItemCheckbox
-                checked={getState('checked2')}
-                onChange={() => toggleState('checked2')}
-                badge={
-                  <Badge tone="promote" weight="strong">
-                    Badge
-                  </Badge>
-                }
-              >
-                Checkbox
-              </MenuItemCheckbox>
-              <MenuItemCheckbox
-                checked={getState('checked3')}
-                onChange={() => toggleState('checked3')}
-              >
-                Checkbox
-              </MenuItemCheckbox>
-            </MenuRenderer>
-          </Inline>
-        </>,
-      ),
-  },
-];
+                <MenuItemCheckbox
+                  checked={getState('checked1')}
+                  onChange={() => toggleState('checked1')}
+                >
+                  Checkbox
+                </MenuItemCheckbox>
+                <MenuItemCheckbox
+                  checked={getState('checked2')}
+                  onChange={() => toggleState('checked2')}
+                  badge={
+                    <Badge tone="promote" weight="strong">
+                      Badge
+                    </Badge>
+                  }
+                >
+                  Checkbox
+                </MenuItemCheckbox>
+                <MenuItemCheckbox
+                  checked={getState('checked3')}
+                  onChange={() => toggleState('checked3')}
+                >
+                  Checkbox
+                </MenuItemCheckbox>
+              </MenuRenderer>
+            </Inline>
+          </>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/MenuItemDivider/MenuItemDivider.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItemDivider/MenuItemDivider.gallery.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import {
   MenuItemDivider,
   MenuItem,
@@ -13,55 +13,57 @@ import {
 } from '..';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    background: 'surface',
-    Example: ({ setDefaultState, getState, toggleState }) =>
-      source(
-        <>
-          {setDefaultState('checked1', false)}
-          {setDefaultState('checked2', false)}
-          {setDefaultState('checked3', false)}
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      background: 'surface',
+      Example: ({ setDefaultState, getState, toggleState }) =>
+        source(
+          <>
+            {setDefaultState('checked1', false)}
+            {setDefaultState('checked2', false)}
+            {setDefaultState('checked3', false)}
 
-          <Inline space="none">
-            <MenuRenderer
-              offsetSpace="small"
-              trigger={(triggerProps, { open }) => (
-                <Box userSelect="none" cursor="pointer" {...triggerProps}>
-                  <Text>
-                    Menu{' '}
-                    <IconChevron
-                      direction={open ? 'up' : 'down'}
-                      alignY="lowercase"
-                    />
-                  </Text>
-                </Box>
-              )}
-            >
-              <MenuItem onClick={() => {}}>Button</MenuItem>
-              <MenuItemLink href="#">Link</MenuItemLink>
-              <MenuItemDivider />
-              <MenuItemCheckbox
-                checked={getState('checked1')}
-                onChange={() => toggleState('checked1')}
+            <Inline space="none">
+              <MenuRenderer
+                offsetSpace="small"
+                trigger={(triggerProps, { open }) => (
+                  <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                    <Text>
+                      Menu{' '}
+                      <IconChevron
+                        direction={open ? 'up' : 'down'}
+                        alignY="lowercase"
+                      />
+                    </Text>
+                  </Box>
+                )}
               >
-                Checkbox
-              </MenuItemCheckbox>
-              <MenuItemCheckbox
-                checked={getState('checked2')}
-                onChange={() => toggleState('checked2')}
-              >
-                Checkbox
-              </MenuItemCheckbox>
-              <MenuItemCheckbox
-                checked={getState('checked3')}
-                onChange={() => toggleState('checked3')}
-              >
-                Checkbox
-              </MenuItemCheckbox>
-            </MenuRenderer>
-          </Inline>
-        </>,
-      ),
-  },
-];
+                <MenuItem onClick={() => {}}>Button</MenuItem>
+                <MenuItemLink href="#">Link</MenuItemLink>
+                <MenuItemDivider />
+                <MenuItemCheckbox
+                  checked={getState('checked1')}
+                  onChange={() => toggleState('checked1')}
+                >
+                  Checkbox
+                </MenuItemCheckbox>
+                <MenuItemCheckbox
+                  checked={getState('checked2')}
+                  onChange={() => toggleState('checked2')}
+                >
+                  Checkbox
+                </MenuItemCheckbox>
+                <MenuItemCheckbox
+                  checked={getState('checked3')}
+                  onChange={() => toggleState('checked3')}
+                >
+                  Checkbox
+                </MenuItemCheckbox>
+              </MenuRenderer>
+            </Inline>
+          </>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.gallery.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import {
   Box,
   MenuRenderer,
@@ -15,121 +15,18 @@ import {
 } from '..';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Default',
-    Example: () =>
-      source(
-        <Inline space="none">
-          <MenuRenderer
-            trigger={(triggerProps, { open }) => (
-              <Box userSelect="none" cursor="pointer" {...triggerProps}>
-                <Text>
-                  Menu{' '}
-                  <IconChevron
-                    direction={open ? 'up' : 'down'}
-                    alignY="lowercase"
-                  />
-                </Text>
-              </Box>
-            )}
-          >
-            <MenuItem onClick={() => {}}>Button</MenuItem>
-            <MenuItemLink href="#">Link</MenuItemLink>
-          </MenuRenderer>
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Right aligned',
-    Example: () =>
-      source(
-        <Inline space="none">
-          <MenuRenderer
-            align="right"
-            trigger={(triggerProps, { open }) => (
-              <Box userSelect="none" cursor="pointer" {...triggerProps}>
-                <Text>
-                  Right aligned menu{' '}
-                  <IconChevron
-                    direction={open ? 'up' : 'down'}
-                    alignY="lowercase"
-                  />
-                </Text>
-              </Box>
-            )}
-          >
-            <MenuItem onClick={() => {}}>Button</MenuItem>
-            <MenuItemLink href="#">Link</MenuItemLink>
-          </MenuRenderer>
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Placement',
-    Example: () =>
-      source(
-        <Inline space="none">
-          <MenuRenderer
-            placement="top"
-            offsetSpace="small"
-            trigger={(triggerProps, { open }) => (
-              <Box userSelect="none" cursor="pointer" {...triggerProps}>
-                <Text>
-                  Placed on top{' '}
-                  <IconChevron
-                    direction={open ? 'down' : 'up'}
-                    alignY="lowercase"
-                  />
-                </Text>
-              </Box>
-            )}
-          >
-            <MenuItem onClick={() => {}}>Button</MenuItem>
-            <MenuItemLink href="#">Link</MenuItemLink>
-          </MenuRenderer>
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Offset space for menu',
-    Example: () =>
-      source(
-        <Inline space="none">
-          <MenuRenderer
-            offsetSpace={{ mobile: 'none', tablet: 'small' }}
-            trigger={(triggerProps, { open }) => (
-              <Box userSelect="none" cursor="pointer" {...triggerProps}>
-                <Text>
-                  Menu{' '}
-                  <IconChevron
-                    direction={open ? 'up' : 'down'}
-                    alignY="lowercase"
-                  />
-                </Text>
-              </Box>
-            )}
-          >
-            <MenuItem onClick={() => {}}>Button</MenuItem>
-            <MenuItemLink href="#">Link</MenuItemLink>
-          </MenuRenderer>
-        </Inline>,
-      ),
-  },
-  {
-    label: 'Width',
-    Example: ({ setState, getState, setDefaultState }) =>
-      source(
-        <>
-          {setDefaultState('width', 'content')}
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Default',
+      Example: () =>
+        source(
           <Inline space="none">
             <MenuRenderer
-              offsetSpace="small"
-              width={getState('width')}
               trigger={(triggerProps, { open }) => (
                 <Box userSelect="none" cursor="pointer" {...triggerProps}>
                   <Text>
-                    Menu width: <Strong>{getState('width')}</Strong>{' '}
+                    Menu{' '}
                     <IconChevron
                       direction={open ? 'up' : 'down'}
                       alignY="lowercase"
@@ -138,55 +35,160 @@ export const galleryItems: ComponentExample[] = [
                 </Box>
               )}
             >
-              <MenuItem onClick={() => setState('width', 'content')}>
-                Content
-              </MenuItem>
-              <MenuItem onClick={() => setState('width', 'small')}>
-                Small
-              </MenuItem>
-              <MenuItem onClick={() => setState('width', 'medium')}>
-                Medium
-              </MenuItem>
-              <MenuItem onClick={() => setState('width', 'large')}>
-                Large
-              </MenuItem>
+              <MenuItem onClick={() => {}}>Button</MenuItem>
+              <MenuItemLink href="#">Link</MenuItemLink>
             </MenuRenderer>
-          </Inline>
-        </>,
-      ),
-  },
-  {
-    label: 'Reserving icon space',
-    Example: () =>
-      source(
-        <Inline space="none">
-          <MenuRenderer
-            reserveIconSpace
-            offsetSpace="small"
-            width="small"
-            trigger={(triggerProps, { open }) => (
-              <Box userSelect="none" cursor="pointer" {...triggerProps}>
-                <Text>
-                  Reserved icon space{' '}
-                  <IconChevron
-                    direction={open ? 'up' : 'down'}
-                    alignY="lowercase"
-                  />
-                </Text>
-              </Box>
-            )}
-          >
-            <MenuItem onClick={() => {}} icon={<IconProfile />}>
-              Item
-            </MenuItem>
-            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-              Item
-            </MenuItem>
-            <MenuItemDivider />
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-          </MenuRenderer>
-        </Inline>,
-      ),
-  },
-];
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Right aligned',
+      Example: () =>
+        source(
+          <Inline space="none">
+            <MenuRenderer
+              align="right"
+              trigger={(triggerProps, { open }) => (
+                <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                  <Text>
+                    Right aligned menu{' '}
+                    <IconChevron
+                      direction={open ? 'up' : 'down'}
+                      alignY="lowercase"
+                    />
+                  </Text>
+                </Box>
+              )}
+            >
+              <MenuItem onClick={() => {}}>Button</MenuItem>
+              <MenuItemLink href="#">Link</MenuItemLink>
+            </MenuRenderer>
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Placement',
+      Example: () =>
+        source(
+          <Inline space="none">
+            <MenuRenderer
+              placement="top"
+              offsetSpace="small"
+              trigger={(triggerProps, { open }) => (
+                <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                  <Text>
+                    Placed on top{' '}
+                    <IconChevron
+                      direction={open ? 'down' : 'up'}
+                      alignY="lowercase"
+                    />
+                  </Text>
+                </Box>
+              )}
+            >
+              <MenuItem onClick={() => {}}>Button</MenuItem>
+              <MenuItemLink href="#">Link</MenuItemLink>
+            </MenuRenderer>
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Offset space for menu',
+      Example: () =>
+        source(
+          <Inline space="none">
+            <MenuRenderer
+              offsetSpace={{ mobile: 'none', tablet: 'small' }}
+              trigger={(triggerProps, { open }) => (
+                <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                  <Text>
+                    Menu{' '}
+                    <IconChevron
+                      direction={open ? 'up' : 'down'}
+                      alignY="lowercase"
+                    />
+                  </Text>
+                </Box>
+              )}
+            >
+              <MenuItem onClick={() => {}}>Button</MenuItem>
+              <MenuItemLink href="#">Link</MenuItemLink>
+            </MenuRenderer>
+          </Inline>,
+        ),
+    },
+    {
+      label: 'Width',
+      Example: ({ setState, getState, setDefaultState }) =>
+        source(
+          <>
+            {setDefaultState('width', 'content')}
+            <Inline space="none">
+              <MenuRenderer
+                offsetSpace="small"
+                width={getState('width')}
+                trigger={(triggerProps, { open }) => (
+                  <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                    <Text>
+                      Menu width: <Strong>{getState('width')}</Strong>{' '}
+                      <IconChevron
+                        direction={open ? 'up' : 'down'}
+                        alignY="lowercase"
+                      />
+                    </Text>
+                  </Box>
+                )}
+              >
+                <MenuItem onClick={() => setState('width', 'content')}>
+                  Content
+                </MenuItem>
+                <MenuItem onClick={() => setState('width', 'small')}>
+                  Small
+                </MenuItem>
+                <MenuItem onClick={() => setState('width', 'medium')}>
+                  Medium
+                </MenuItem>
+                <MenuItem onClick={() => setState('width', 'large')}>
+                  Large
+                </MenuItem>
+              </MenuRenderer>
+            </Inline>
+          </>,
+        ),
+    },
+    {
+      label: 'Reserving icon space',
+      Example: () =>
+        source(
+          <Inline space="none">
+            <MenuRenderer
+              reserveIconSpace
+              offsetSpace="small"
+              width="small"
+              trigger={(triggerProps, { open }) => (
+                <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                  <Text>
+                    Reserved icon space{' '}
+                    <IconChevron
+                      direction={open ? 'up' : 'down'}
+                      alignY="lowercase"
+                    />
+                  </Text>
+                </Box>
+              )}
+            >
+              <MenuItem onClick={() => {}} icon={<IconProfile />}>
+                Item
+              </MenuItem>
+              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+                Item
+              </MenuItem>
+              <MenuItemDivider />
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+            </MenuRenderer>
+          </Inline>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.gallery.tsx
@@ -1,148 +1,150 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { IconHelp, MonthPicker, TextLink } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Standard',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <MonthPicker
-          label="Label"
-          id={id}
-          onChange={setState('monthpicker')}
-          value={getState('monthpicker')}
-        />,
-      ),
-  },
-  {
-    label: 'With additional labels',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <MonthPicker
-          label="Label"
-          id={id}
-          onChange={setState('monthpicker')}
-          value={getState('monthpicker')}
-          secondaryLabel="optional"
-          tertiaryLabel={
-            <TextLink href="#" icon={<IconHelp />}>
-              Help
-            </TextLink>
-          }
-        />,
-      ),
-  },
-  {
-    label: 'With a description',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <MonthPicker
-          label="Label"
-          id={id}
-          onChange={setState('monthpicker')}
-          value={getState('monthpicker')}
-          description="Longer description of this field"
-        />,
-      ),
-  },
-  {
-    label: 'With a critical message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <MonthPicker
-          label="Label"
-          id={id}
-          onChange={setState('monthpicker')}
-          value={getState('monthpicker')}
-          tone="critical"
-          message="Critical message"
-        />,
-      ),
-  },
-  {
-    label: 'With a positive message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <MonthPicker
-          label="Label"
-          id={id}
-          onChange={setState('monthpicker')}
-          value={getState('monthpicker')}
-          tone="positive"
-          message="Positive message"
-        />,
-      ),
-  },
-  {
-    label: 'With a caution message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <MonthPicker
-          label="Label"
-          id={id}
-          onChange={setState('monthpicker')}
-          value={getState('monthpicker')}
-          tone="caution"
-          message="Caution message"
-        />,
-      ),
-  },
-  {
-    label: 'With a neutral message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <MonthPicker
-          label="Label"
-          id={id}
-          onChange={setState('monthpicker')}
-          value={getState('monthpicker')}
-          tone="neutral"
-          message="Neutral message"
-        />,
-      ),
-  },
-  {
-    label: 'Disabled field',
-    background: 'surface',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <MonthPicker
-          label="Label"
-          id={id}
-          onChange={setState('monthpicker')}
-          value={getState('monthpicker')}
-          disabled={true}
-        />,
-      ),
-  },
-  {
-    label: 'Custom months and years',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <MonthPicker
-          id={id}
-          label="Started"
-          onChange={setState('monthpicker')}
-          value={getState('monthpicker')}
-          monthLabel="MM"
-          yearLabel="YYYY"
-          monthNames={[
-            '01',
-            '02',
-            '03',
-            '04',
-            '05',
-            '06',
-            '07',
-            '08',
-            '09',
-            '10',
-            '11',
-            '12',
-          ]}
-        />,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Standard',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <MonthPicker
+            label="Label"
+            id={id}
+            onChange={setState('monthpicker')}
+            value={getState('monthpicker')}
+          />,
+        ),
+    },
+    {
+      label: 'With additional labels',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <MonthPicker
+            label="Label"
+            id={id}
+            onChange={setState('monthpicker')}
+            value={getState('monthpicker')}
+            secondaryLabel="optional"
+            tertiaryLabel={
+              <TextLink href="#" icon={<IconHelp />}>
+                Help
+              </TextLink>
+            }
+          />,
+        ),
+    },
+    {
+      label: 'With a description',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <MonthPicker
+            label="Label"
+            id={id}
+            onChange={setState('monthpicker')}
+            value={getState('monthpicker')}
+            description="Longer description of this field"
+          />,
+        ),
+    },
+    {
+      label: 'With a critical message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <MonthPicker
+            label="Label"
+            id={id}
+            onChange={setState('monthpicker')}
+            value={getState('monthpicker')}
+            tone="critical"
+            message="Critical message"
+          />,
+        ),
+    },
+    {
+      label: 'With a positive message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <MonthPicker
+            label="Label"
+            id={id}
+            onChange={setState('monthpicker')}
+            value={getState('monthpicker')}
+            tone="positive"
+            message="Positive message"
+          />,
+        ),
+    },
+    {
+      label: 'With a caution message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <MonthPicker
+            label="Label"
+            id={id}
+            onChange={setState('monthpicker')}
+            value={getState('monthpicker')}
+            tone="caution"
+            message="Caution message"
+          />,
+        ),
+    },
+    {
+      label: 'With a neutral message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <MonthPicker
+            label="Label"
+            id={id}
+            onChange={setState('monthpicker')}
+            value={getState('monthpicker')}
+            tone="neutral"
+            message="Neutral message"
+          />,
+        ),
+    },
+    {
+      label: 'Disabled field',
+      background: 'surface',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <MonthPicker
+            label="Label"
+            id={id}
+            onChange={setState('monthpicker')}
+            value={getState('monthpicker')}
+            disabled={true}
+          />,
+        ),
+    },
+    {
+      label: 'Custom months and years',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <MonthPicker
+            id={id}
+            label="Started"
+            onChange={setState('monthpicker')}
+            value={getState('monthpicker')}
+            monthLabel="MM"
+            yearLabel="YYYY"
+            monthNames={[
+              '01',
+              '02',
+              '03',
+              '04',
+              '05',
+              '06',
+              '07',
+              '08',
+              '09',
+              '10',
+              '11',
+              '12',
+            ]}
+          />,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Notice/Notice.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Notice/Notice.gallery.tsx
@@ -1,62 +1,64 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Notice, Text, Stack, TextLink, List } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Promote',
-    Example: () =>
-      source(
-        <Notice tone="promote">
-          <Text>This is a promoted message.</Text>
-        </Notice>,
-      ),
-  },
-  {
-    label: 'Info',
-    Example: () =>
-      source(
-        <Notice tone="info">
-          <Text>This is an informative message.</Text>
-        </Notice>,
-      ),
-  },
-  {
-    label: 'Positive',
-    Example: () =>
-      source(
-        <Notice tone="positive">
-          <Text>This is a positive message.</Text>
-        </Notice>,
-      ),
-  },
-  {
-    label: 'Critical',
-    Example: () =>
-      source(
-        <Notice tone="critical">
-          <Text>This is a critical message.</Text>
-        </Notice>,
-      ),
-  },
-  {
-    label: 'With rich content',
-    Example: () =>
-      source(
-        <Notice tone="info">
-          <Stack space="medium">
-            <Text>
-              This is an informative message with a{' '}
-              <TextLink href="#">TextLink.</TextLink>
-            </Text>
-            <List space="medium">
-              <Text>Bullet 1</Text>
-              <Text>Bullet 2</Text>
-              <Text>Bullet 3</Text>
-            </List>
-          </Stack>
-        </Notice>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Promote',
+      Example: () =>
+        source(
+          <Notice tone="promote">
+            <Text>This is a promoted message.</Text>
+          </Notice>,
+        ),
+    },
+    {
+      label: 'Info',
+      Example: () =>
+        source(
+          <Notice tone="info">
+            <Text>This is an informative message.</Text>
+          </Notice>,
+        ),
+    },
+    {
+      label: 'Positive',
+      Example: () =>
+        source(
+          <Notice tone="positive">
+            <Text>This is a positive message.</Text>
+          </Notice>,
+        ),
+    },
+    {
+      label: 'Critical',
+      Example: () =>
+        source(
+          <Notice tone="critical">
+            <Text>This is a critical message.</Text>
+          </Notice>,
+        ),
+    },
+    {
+      label: 'With rich content',
+      Example: () =>
+        source(
+          <Notice tone="info">
+            <Stack space="medium">
+              <Text>
+                This is an informative message with a{' '}
+                <TextLink href="#">TextLink.</TextLink>
+              </Text>
+              <List space="medium">
+                <Text>Bullet 1</Text>
+                <Text>Bullet 2</Text>
+                <Text>Bullet 3</Text>
+              </List>
+            </Stack>
+          </Notice>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.gallery.tsx
@@ -1,21 +1,23 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Box, OverflowMenu, MenuItem, MenuItemLink } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    background: 'surface',
-    Example: ({ handler }) =>
-      source(
-        <Box style={{ maxWidth: '100px' }}>
-          <OverflowMenu label="Options">
-            <MenuItem onClick={handler}>Button</MenuItem>
-            <MenuItemLink href="#" onClick={handler}>
-              Link
-            </MenuItemLink>
-          </OverflowMenu>
-        </Box>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      background: 'surface',
+      Example: ({ handler }) =>
+        source(
+          <Box style={{ maxWidth: '100px' }}>
+            <OverflowMenu label="Options">
+              <MenuItem onClick={handler}>Button</MenuItem>
+              <MenuItemLink href="#" onClick={handler}>
+                Link
+              </MenuItemLink>
+            </OverflowMenu>
+          </Box>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/PageBlock/PageBlock.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/PageBlock/PageBlock.gallery.tsx
@@ -1,44 +1,47 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Placeholder } from '../private/Placeholder/Placeholder';
 import { PageBlock } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Small width',
-    Example: () =>
-      source(
-        <PageBlock width="small">
-          <Placeholder height={100} />
-        </PageBlock>,
-      ),
-  },
-  {
-    label: 'Medium width',
-    Example: () =>
-      source(
-        <PageBlock width="medium">
-          <Placeholder height={100} />
-        </PageBlock>,
-      ),
-  },
-  {
-    label: 'Large width',
-    Example: () =>
-      source(
-        <PageBlock width="large">
-          <Placeholder height={100} />
-        </PageBlock>,
-      ),
-  },
-  {
-    label: 'Full width',
-    Example: () =>
-      source(
-        <PageBlock width="full">
-          <Placeholder height={100} />
-        </PageBlock>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  itemWidth: 'wide',
+  examples: [
+    {
+      label: 'Small width',
+      Example: () =>
+        source(
+          <PageBlock width="small">
+            <Placeholder height={100} />
+          </PageBlock>,
+        ),
+    },
+    {
+      label: 'Medium width',
+      Example: () =>
+        source(
+          <PageBlock width="medium">
+            <Placeholder height={100} />
+          </PageBlock>,
+        ),
+    },
+    {
+      label: 'Large width',
+      Example: () =>
+        source(
+          <PageBlock width="large">
+            <Placeholder height={100} />
+          </PageBlock>,
+        ),
+    },
+    {
+      label: 'Full width',
+      Example: () =>
+        source(
+          <PageBlock width="full">
+            <Placeholder height={100} />
+          </PageBlock>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Pagination/Pagination.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Pagination/Pagination.gallery.tsx
@@ -1,12 +1,14 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Pagination } from '../../playroom/components';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Standard',
-    background: 'surface',
-    Example: () => source(<Pagination />),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Standard',
+      background: 'surface',
+      Example: () => source(<Pagination />),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.gallery.tsx
@@ -1,116 +1,118 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { PasswordField, TextLink } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Standard',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <PasswordField
-          label="Label"
-          id={id}
-          onChange={setState('passwordfield')}
-          value={getState('passwordfield')}
-        />,
-      ),
-  },
-  {
-    label: 'With additional labels',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <PasswordField
-          label="Label"
-          id={id}
-          onChange={setState('passwordfield')}
-          value={getState('passwordfield')}
-          secondaryLabel="optional"
-          tertiaryLabel={<TextLink href="#">Forgot password?</TextLink>}
-        />,
-      ),
-  },
-  {
-    label: 'With a description',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <PasswordField
-          label="Label"
-          id={id}
-          onChange={setState('passwordfield')}
-          value={getState('passwordfield')}
-          description="Longer description of this field"
-        />,
-      ),
-  },
-  {
-    label: 'With a critical message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <PasswordField
-          label="Label"
-          id={id}
-          onChange={setState('passwordfield')}
-          value={getState('passwordfield')}
-          tone="critical"
-          message="Critical message"
-        />,
-      ),
-  },
-  {
-    label: 'With a positive message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <PasswordField
-          label="Label"
-          id={id}
-          onChange={setState('passwordfield')}
-          value={getState('passwordfield')}
-          tone="positive"
-          message="Positive message"
-        />,
-      ),
-  },
-  {
-    label: 'With a caution message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <PasswordField
-          label="Label"
-          id={id}
-          onChange={setState('passwordfield')}
-          value={getState('passwordfield')}
-          tone="caution"
-          message="Caution message"
-        />,
-      ),
-  },
-  {
-    label: 'With a neutral message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <PasswordField
-          label="Label"
-          id={id}
-          onChange={setState('passwordfield')}
-          value={getState('passwordfield')}
-          tone="neutral"
-          message="Neutral message"
-        />,
-      ),
-  },
-  {
-    label: 'Disabled field',
-    background: 'surface',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <PasswordField
-          label="Label"
-          id={id}
-          onChange={setState('passwordfield')}
-          value={getState('passwordfield')}
-          disabled={true}
-        />,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Standard',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <PasswordField
+            label="Label"
+            id={id}
+            onChange={setState('passwordfield')}
+            value={getState('passwordfield')}
+          />,
+        ),
+    },
+    {
+      label: 'With additional labels',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <PasswordField
+            label="Label"
+            id={id}
+            onChange={setState('passwordfield')}
+            value={getState('passwordfield')}
+            secondaryLabel="optional"
+            tertiaryLabel={<TextLink href="#">Forgot password?</TextLink>}
+          />,
+        ),
+    },
+    {
+      label: 'With a description',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <PasswordField
+            label="Label"
+            id={id}
+            onChange={setState('passwordfield')}
+            value={getState('passwordfield')}
+            description="Longer description of this field"
+          />,
+        ),
+    },
+    {
+      label: 'With a critical message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <PasswordField
+            label="Label"
+            id={id}
+            onChange={setState('passwordfield')}
+            value={getState('passwordfield')}
+            tone="critical"
+            message="Critical message"
+          />,
+        ),
+    },
+    {
+      label: 'With a positive message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <PasswordField
+            label="Label"
+            id={id}
+            onChange={setState('passwordfield')}
+            value={getState('passwordfield')}
+            tone="positive"
+            message="Positive message"
+          />,
+        ),
+    },
+    {
+      label: 'With a caution message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <PasswordField
+            label="Label"
+            id={id}
+            onChange={setState('passwordfield')}
+            value={getState('passwordfield')}
+            tone="caution"
+            message="Caution message"
+          />,
+        ),
+    },
+    {
+      label: 'With a neutral message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <PasswordField
+            label="Label"
+            id={id}
+            onChange={setState('passwordfield')}
+            value={getState('passwordfield')}
+            tone="neutral"
+            message="Neutral message"
+          />,
+        ),
+    },
+    {
+      label: 'Disabled field',
+      background: 'surface',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <PasswordField
+            label="Label"
+            id={id}
+            onChange={setState('passwordfield')}
+            value={getState('passwordfield')}
+            disabled={true}
+          />,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.gallery.tsx
@@ -1,137 +1,15 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { RadioGroup, RadioItem, Badge } from '..';
 import { Placeholder } from '../../playroom/components';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Standard',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <RadioGroup
-          id={id}
-          value={getState('radio')}
-          onChange={({ currentTarget: { value } }) => setState('radio', value)}
-          label="Label"
-        >
-          <RadioItem label="One" value="1" />
-          <RadioItem label="Two" value="2" />
-          <RadioItem label="Three" value="3" />
-        </RadioGroup>,
-      ),
-  },
-  {
-    label: 'With a critical message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <RadioGroup
-          id={id}
-          value={getState('radio')}
-          onChange={({ currentTarget: { value } }) => setState('radio', value)}
-          label="Label"
-          message="Critical message"
-          tone="critical"
-        >
-          <RadioItem label="One" value="1" />
-          <RadioItem label="Two" value="2" />
-          <RadioItem label="Three" value="3" />
-        </RadioGroup>,
-      ),
-  },
-  {
-    label: 'With a description',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <RadioGroup
-          id={id}
-          value={getState('radio')}
-          onChange={({ currentTarget: { value } }) => setState('radio', value)}
-          label="Label"
-          description="Extra information about the field"
-        >
-          <RadioItem label="One" value="1" />
-          <RadioItem label="Two" value="2" />
-          <RadioItem label="Three" value="3" />
-        </RadioGroup>,
-      ),
-  },
-  {
-    label: 'With item-level descriptions',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <RadioGroup
-          id={id}
-          value={getState('radio')}
-          onChange={({ currentTarget: { value } }) => setState('radio', value)}
-          label="Label"
-        >
-          <RadioItem
-            label="One"
-            value="1"
-            description="Description for item 1"
-          />
-          <RadioItem
-            label="Two"
-            value="2"
-            description="Description for item 2"
-          />
-          <RadioItem
-            label="Three"
-            value="3"
-            description="Description for item 3"
-          />
-        </RadioGroup>,
-      ),
-  },
-  {
-    label: 'With a Badge',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <RadioGroup
-          id={id}
-          value={getState('radio')}
-          onChange={({ currentTarget: { value } }) => setState('radio', value)}
-          label="Label"
-        >
-          <RadioItem label="One" value="1" />
-          <RadioItem label="Two" value="2" />
-          <RadioItem
-            label="Three"
-            value="3"
-            badge={
-              <Badge tone="positive" weight="strong">
-                Badge
-              </Badge>
-            }
-          />
-        </RadioGroup>,
-      ),
-  },
-  {
-    label: 'Small',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <RadioGroup
-          id={id}
-          value={getState('radio')}
-          onChange={({ currentTarget: { value } }) => setState('radio', value)}
-          label="Label"
-          size="small"
-        >
-          <RadioItem label="One" value="1" />
-          <RadioItem label="Two" value="2" />
-          <RadioItem label="Three" value="3" />
-        </RadioGroup>,
-      ),
-  },
-  {
-    label: 'Toggling nested content',
-    Example: ({ id, getState, setState, setDefaultState }) =>
-      source(
-        <>
-          {setDefaultState('radio', '2')}
-
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Standard',
+      Example: ({ id, getState, setState }) =>
+        source(
           <RadioGroup
             id={id}
             value={getState('radio')}
@@ -141,12 +19,148 @@ export const galleryItems: ComponentExample[] = [
             label="Label"
           >
             <RadioItem label="One" value="1" />
-            <RadioItem label="Two" value="2">
-              <Placeholder height={100} />
-            </RadioItem>
+            <RadioItem label="Two" value="2" />
             <RadioItem label="Three" value="3" />
-          </RadioGroup>
-        </>,
-      ),
-  },
-];
+          </RadioGroup>,
+        ),
+    },
+    {
+      label: 'With a critical message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <RadioGroup
+            id={id}
+            value={getState('radio')}
+            onChange={({ currentTarget: { value } }) =>
+              setState('radio', value)
+            }
+            label="Label"
+            message="Critical message"
+            tone="critical"
+          >
+            <RadioItem label="One" value="1" />
+            <RadioItem label="Two" value="2" />
+            <RadioItem label="Three" value="3" />
+          </RadioGroup>,
+        ),
+    },
+    {
+      label: 'With a description',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <RadioGroup
+            id={id}
+            value={getState('radio')}
+            onChange={({ currentTarget: { value } }) =>
+              setState('radio', value)
+            }
+            label="Label"
+            description="Extra information about the field"
+          >
+            <RadioItem label="One" value="1" />
+            <RadioItem label="Two" value="2" />
+            <RadioItem label="Three" value="3" />
+          </RadioGroup>,
+        ),
+    },
+    {
+      label: 'With item-level descriptions',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <RadioGroup
+            id={id}
+            value={getState('radio')}
+            onChange={({ currentTarget: { value } }) =>
+              setState('radio', value)
+            }
+            label="Label"
+          >
+            <RadioItem
+              label="One"
+              value="1"
+              description="Description for item 1"
+            />
+            <RadioItem
+              label="Two"
+              value="2"
+              description="Description for item 2"
+            />
+            <RadioItem
+              label="Three"
+              value="3"
+              description="Description for item 3"
+            />
+          </RadioGroup>,
+        ),
+    },
+    {
+      label: 'With a Badge',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <RadioGroup
+            id={id}
+            value={getState('radio')}
+            onChange={({ currentTarget: { value } }) =>
+              setState('radio', value)
+            }
+            label="Label"
+          >
+            <RadioItem label="One" value="1" />
+            <RadioItem label="Two" value="2" />
+            <RadioItem
+              label="Three"
+              value="3"
+              badge={
+                <Badge tone="positive" weight="strong">
+                  Badge
+                </Badge>
+              }
+            />
+          </RadioGroup>,
+        ),
+    },
+    {
+      label: 'Small',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <RadioGroup
+            id={id}
+            value={getState('radio')}
+            onChange={({ currentTarget: { value } }) =>
+              setState('radio', value)
+            }
+            label="Label"
+            size="small"
+          >
+            <RadioItem label="One" value="1" />
+            <RadioItem label="Two" value="2" />
+            <RadioItem label="Three" value="3" />
+          </RadioGroup>,
+        ),
+    },
+    {
+      label: 'Toggling nested content',
+      Example: ({ id, getState, setState, setDefaultState }) =>
+        source(
+          <>
+            {setDefaultState('radio', '2')}
+
+            <RadioGroup
+              id={id}
+              value={getState('radio')}
+              onChange={({ currentTarget: { value } }) =>
+                setState('radio', value)
+              }
+              label="Label"
+            >
+              <RadioItem label="One" value="1" />
+              <RadioItem label="Two" value="2">
+                <Placeholder height={100} />
+              </RadioItem>
+              <RadioItem label="Three" value="3" />
+            </RadioGroup>
+          </>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Rating/Rating.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Rating/Rating.gallery.tsx
@@ -1,31 +1,33 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Rating } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Default',
-    Example: () => source(<Rating rating={3} />),
-  },
-  {
-    label: 'Variant: starsOnly',
-    Example: () => source(<Rating rating={4.2} variant="starsOnly" />),
-  },
-  {
-    label: 'Variant: minimal',
-    Example: () => source(<Rating rating={4.2} variant="minimal" />),
-  },
-  {
-    label: 'large',
-    Example: () => source(<Rating rating={3} size="large" />),
-  },
-  {
-    label: 'small',
-    Example: () => source(<Rating rating={2} size="small" />),
-  },
-  {
-    label: 'xsmall',
-    Example: () => source(<Rating rating={1.5} size="xsmall" />),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Default',
+      Example: () => source(<Rating rating={3} />),
+    },
+    {
+      label: 'Variant: starsOnly',
+      Example: () => source(<Rating rating={4.2} variant="starsOnly" />),
+    },
+    {
+      label: 'Variant: minimal',
+      Example: () => source(<Rating rating={4.2} variant="minimal" />),
+    },
+    {
+      label: 'large',
+      Example: () => source(<Rating rating={3} size="large" />),
+    },
+    {
+      label: 'small',
+      Example: () => source(<Rating rating={2} size="small" />),
+    },
+    {
+      label: 'xsmall',
+      Example: () => source(<Rating rating={1.5} size="xsmall" />),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Secondary/Secondary.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Secondary/Secondary.gallery.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Secondary, Text } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    Example: () =>
-      source(
-        <Text>
-          The word in the <Secondary>middle</Secondary> is secondary text.
-        </Text>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      Example: () =>
+        source(
+          <Text>
+            The word in the <Secondary>middle</Secondary> is secondary text.
+          </Text>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Stack/Stack.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Stack/Stack.gallery.tsx
@@ -1,90 +1,92 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Stack, Hidden } from '../';
 import { Placeholder } from '../private/Placeholder/Placeholder';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Spacing',
-    Example: () =>
-      source(
-        <Stack space="small">
-          <Placeholder height={48} />
-          <Placeholder height={48} />
-          <Placeholder height={48} />
-        </Stack>,
-      ),
-  },
-  {
-    label: 'Horizontal align left',
-    Example: () =>
-      source(
-        <Stack space="small" align="left">
-          <Placeholder width={80} height={40} label="left" />
-          <Placeholder width={80} height={40} />
-          <Placeholder width={80} height={40} />
-        </Stack>,
-      ),
-  },
-  {
-    label: 'Horizontal align center',
-    Example: () =>
-      source(
-        <Stack space="small" align="center">
-          <Placeholder width={80} height={40} />
-          <Placeholder width={80} height={40} label="center" />
-          <Placeholder width={80} height={40} />
-        </Stack>,
-      ),
-  },
-  {
-    label: 'Horizontal align right',
-    Example: () =>
-      source(
-        <Stack space="small" align="right">
-          <Placeholder width={80} height={40} />
-          <Placeholder width={80} height={40} />
-          <Placeholder width={80} height={40} label="right" />
-        </Stack>,
-      ),
-  },
-  {
-    label: 'Dividers',
-    Example: () =>
-      source(
-        <Stack space="gutter" dividers>
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-        </Stack>,
-      ),
-  },
-  {
-    label: 'Strong dividers',
-    Example: () =>
-      source(
-        <Stack space="gutter" dividers="strong">
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-        </Stack>,
-      ),
-  },
-  {
-    label: 'Responsively hiding stack items',
-    Example: () =>
-      source(
-        <Stack space="gutter">
-          <Placeholder height={40} label="1" />
-          <Hidden below="tablet">
-            <Placeholder height={40} label="2" />
-          </Hidden>
-          <Hidden above="mobile">
-            <Placeholder height={40} label="3" />
-          </Hidden>
-          <Placeholder height={40} label="4" />
-        </Stack>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Spacing',
+      Example: () =>
+        source(
+          <Stack space="small">
+            <Placeholder height={48} />
+            <Placeholder height={48} />
+            <Placeholder height={48} />
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Horizontal align left',
+      Example: () =>
+        source(
+          <Stack space="small" align="left">
+            <Placeholder width={80} height={40} label="left" />
+            <Placeholder width={80} height={40} />
+            <Placeholder width={80} height={40} />
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Horizontal align center',
+      Example: () =>
+        source(
+          <Stack space="small" align="center">
+            <Placeholder width={80} height={40} />
+            <Placeholder width={80} height={40} label="center" />
+            <Placeholder width={80} height={40} />
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Horizontal align right',
+      Example: () =>
+        source(
+          <Stack space="small" align="right">
+            <Placeholder width={80} height={40} />
+            <Placeholder width={80} height={40} />
+            <Placeholder width={80} height={40} label="right" />
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Dividers',
+      Example: () =>
+        source(
+          <Stack space="gutter" dividers>
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Strong dividers',
+      Example: () =>
+        source(
+          <Stack space="gutter" dividers="strong">
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Responsively hiding stack items',
+      Example: () =>
+        source(
+          <Stack space="gutter">
+            <Placeholder height={40} label="1" />
+            <Hidden below="tablet">
+              <Placeholder height={40} label="2" />
+            </Hidden>
+            <Hidden above="mobile">
+              <Placeholder height={40} label="3" />
+            </Hidden>
+            <Placeholder height={40} label="4" />
+          </Stack>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Stepper/Stepper.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Stepper/Stepper.gallery.tsx
@@ -1,73 +1,75 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Stepper, Step } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Linear',
-    Example: () =>
-      source(
-        <Stepper label="Linear steps" progress={3}>
-          {[
-            '1. First step',
-            '2. Second step',
-            '3. Third step',
-            '4. Forth step',
-          ].map((step) => (
-            <Step key={step}>{step}</Step>
-          ))}
-        </Stepper>,
-      ),
-  },
-  {
-    label: 'Non-linear',
-    Example: () =>
-      source(
-        <Stepper mode="non-linear" label="Non-linear steps" activeStep={2}>
-          {[
-            '1. First step',
-            '2. Second step',
-            '3. Third step',
-            '4. Forth step',
-          ].map((step, index) => (
-            <Step key={step} complete={index === 3}>
-              {step}
-            </Step>
-          ))}
-        </Stepper>,
-      ),
-  },
-  {
-    label: 'Neutral',
-    Example: () =>
-      source(
-        <Stepper tone="neutral" label="Neutral stepper" progress={3}>
-          {[
-            '1. First step',
-            '2. Second step',
-            '3. Third step',
-            '4. Forth step',
-          ].map((step) => (
-            <Step key={step}>{step}</Step>
-          ))}
-        </Stepper>,
-      ),
-  },
-  {
-    label: 'Left Aligned',
-    Example: () =>
-      source(
-        <Stepper align="left" label="Left aligned stepper" progress={3}>
-          {[
-            '1. First step',
-            '2. Second step',
-            '3. Third step',
-            '4. Forth step',
-          ].map((step) => (
-            <Step key={step}>{step}</Step>
-          ))}
-        </Stepper>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Linear',
+      Example: () =>
+        source(
+          <Stepper label="Linear steps" progress={3}>
+            {[
+              '1. First step',
+              '2. Second step',
+              '3. Third step',
+              '4. Forth step',
+            ].map((step) => (
+              <Step key={step}>{step}</Step>
+            ))}
+          </Stepper>,
+        ),
+    },
+    {
+      label: 'Non-linear',
+      Example: () =>
+        source(
+          <Stepper mode="non-linear" label="Non-linear steps" activeStep={2}>
+            {[
+              '1. First step',
+              '2. Second step',
+              '3. Third step',
+              '4. Forth step',
+            ].map((step, index) => (
+              <Step key={step} complete={index === 3}>
+                {step}
+              </Step>
+            ))}
+          </Stepper>,
+        ),
+    },
+    {
+      label: 'Neutral',
+      Example: () =>
+        source(
+          <Stepper tone="neutral" label="Neutral stepper" progress={3}>
+            {[
+              '1. First step',
+              '2. Second step',
+              '3. Third step',
+              '4. Forth step',
+            ].map((step) => (
+              <Step key={step}>{step}</Step>
+            ))}
+          </Stepper>,
+        ),
+    },
+    {
+      label: 'Left Aligned',
+      Example: () =>
+        source(
+          <Stepper align="left" label="Left aligned stepper" progress={3}>
+            {[
+              '1. First step',
+              '2. Second step',
+              '3. Third step',
+              '4. Forth step',
+            ].map((step) => (
+              <Step key={step}>{step}</Step>
+            ))}
+          </Stepper>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Strong/Strong.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Strong/Strong.gallery.tsx
@@ -1,15 +1,17 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Strong, Text } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    Example: () =>
-      source(
-        <Text>
-          The last word of this sentence is <Strong>strong.</Strong>
-        </Text>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      Example: () =>
+        source(
+          <Text>
+            The last word of this sentence is <Strong>strong.</Strong>
+          </Text>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Tabs/Tabs.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Tabs/Tabs.gallery.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import {
   Stack,
   Tabs,
@@ -16,149 +16,71 @@ import {
 import { Placeholder } from '../../playroom/components';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Left aligned',
-    Example: ({ id }) =>
-      source(
-        <Card>
-          <TabsProvider id={id}>
-            <Stack space="medium">
-              <Tabs label="Test tabs">
-                <Tab>The first tab</Tab>
-                <Tab>The second tab</Tab>
-                <Tab>The third tab</Tab>
-              </Tabs>
-              <TabPanels>
-                <TabPanel>
-                  <Placeholder height={100} label="Panel 1" />
-                </TabPanel>
-                <TabPanel>
-                  <Placeholder height={100} label="Panel 2" />
-                </TabPanel>
-                <TabPanel>
-                  <Placeholder height={100} label="Panel 3" />
-                </TabPanel>
-              </TabPanels>
-            </Stack>
-          </TabsProvider>
-        </Card>,
-      ),
-  },
-  {
-    label: 'Center aligned',
-    Example: ({ id }) =>
-      source(
-        <Card>
-          <TabsProvider id={id}>
-            <Stack space="medium">
-              <Tabs label="Test tabs" align="center">
-                <Tab>The first tab</Tab>
-                <Tab>The second tab</Tab>
-              </Tabs>
-              <TabPanels>
-                <TabPanel>
-                  <Placeholder height={100} label="Panel 1" />
-                </TabPanel>
-                <TabPanel>
-                  <Placeholder height={100} label="Panel 2" />
-                </TabPanel>
-              </TabPanels>
-            </Stack>
-          </TabsProvider>
-        </Card>,
-      ),
-  },
-  {
-    label: 'With gutter',
-    Example: ({ id }) =>
-      source(
-        <TabsProvider id={id}>
-          <Tabs label="Test tabs" gutter="gutter" divider="none">
-            <Tab>The first tab</Tab>
-            <Tab>The second tab</Tab>
-            <Tab>The third tab</Tab>
-          </Tabs>
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Left aligned',
+      Example: ({ id }) =>
+        source(
           <Card>
-            <TabPanels>
-              <TabPanel>
-                <Placeholder height={100} label="Panel 1" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={100} label="Panel 2" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={100} label="Panel 3" />
-              </TabPanel>
-            </TabPanels>
-          </Card>
-        </TabsProvider>,
-      ),
-  },
-  {
-    label: 'Full width divider',
-    Example: ({ id }) =>
-      source(
-        <Card>
-          <TabsProvider id={id}>
-            <Stack space="medium">
-              <Tabs label="Test tabs" divider="full">
-                <Tab>The first tab</Tab>
-                <Tab>The second tab</Tab>
-              </Tabs>
-              <TabPanels>
-                <TabPanel>
-                  <Placeholder height={100} label="Panel 1" />
-                </TabPanel>
-                <TabPanel>
-                  <Placeholder height={100} label="Panel 2" />
-                </TabPanel>
-              </TabPanels>
-            </Stack>
-          </TabsProvider>
-        </Card>,
-      ),
-  },
-  {
-    label: 'No divider',
-    Example: ({ id }) =>
-      source(
-        <TabsProvider id={id}>
-          <Tabs label="Test tabs" divider="none">
-            <Tab>The first tab</Tab>
-            <Tab>The second tab</Tab>
-            <Tab>The third tab</Tab>
-          </Tabs>
+            <TabsProvider id={id}>
+              <Stack space="medium">
+                <Tabs label="Test tabs">
+                  <Tab>The first tab</Tab>
+                  <Tab>The second tab</Tab>
+                  <Tab>The third tab</Tab>
+                </Tabs>
+                <TabPanels>
+                  <TabPanel>
+                    <Placeholder height={100} label="Panel 1" />
+                  </TabPanel>
+                  <TabPanel>
+                    <Placeholder height={100} label="Panel 2" />
+                  </TabPanel>
+                  <TabPanel>
+                    <Placeholder height={100} label="Panel 3" />
+                  </TabPanel>
+                </TabPanels>
+              </Stack>
+            </TabsProvider>
+          </Card>,
+        ),
+    },
+    {
+      label: 'Center aligned',
+      Example: ({ id }) =>
+        source(
           <Card>
-            <TabPanels>
-              <TabPanel>
-                <Placeholder height={100} label="Panel 1" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={100} label="Panel 2" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={100} label="Panel 3" />
-              </TabPanel>
-            </TabPanels>
-          </Card>
-        </TabsProvider>,
-      ),
-  },
-  {
-    label: 'With a badge',
-    Example: ({ id }) =>
-      source(
-        <Card>
+            <TabsProvider id={id}>
+              <Stack space="medium">
+                <Tabs label="Test tabs" align="center">
+                  <Tab>The first tab</Tab>
+                  <Tab>The second tab</Tab>
+                </Tabs>
+                <TabPanels>
+                  <TabPanel>
+                    <Placeholder height={100} label="Panel 1" />
+                  </TabPanel>
+                  <TabPanel>
+                    <Placeholder height={100} label="Panel 2" />
+                  </TabPanel>
+                </TabPanels>
+              </Stack>
+            </TabsProvider>
+          </Card>,
+        ),
+    },
+    {
+      label: 'With gutter',
+      Example: ({ id }) =>
+        source(
           <TabsProvider id={id}>
-            <Stack space="medium">
-              <Tabs label="Test tabs">
-                <Tab>The first tab</Tab>
-                <Tab>The second tab</Tab>
-                <Tab badge={<Badge tone="positive">New</Badge>}>
-                  The third tab
-                </Tab>
-              </Tabs>
+            <Tabs label="Test tabs" gutter="gutter" divider="none">
+              <Tab>The first tab</Tab>
+              <Tab>The second tab</Tab>
+              <Tab>The third tab</Tab>
+            </Tabs>
+            <Card>
               <TabPanels>
                 <TabPanel>
                   <Placeholder height={100} label="Panel 1" />
@@ -170,23 +92,45 @@ export const galleryItems: ComponentExample[] = [
                   <Placeholder height={100} label="Panel 3" />
                 </TabPanel>
               </TabPanels>
-            </Stack>
-          </TabsProvider>
-        </Card>,
-      ),
-  },
-  {
-    label: 'With an icon',
-    Example: ({ id }) =>
-      source(
-        <Card>
+            </Card>
+          </TabsProvider>,
+        ),
+    },
+    {
+      label: 'Full width divider',
+      Example: ({ id }) =>
+        source(
+          <Card>
+            <TabsProvider id={id}>
+              <Stack space="medium">
+                <Tabs label="Test tabs" divider="full">
+                  <Tab>The first tab</Tab>
+                  <Tab>The second tab</Tab>
+                </Tabs>
+                <TabPanels>
+                  <TabPanel>
+                    <Placeholder height={100} label="Panel 1" />
+                  </TabPanel>
+                  <TabPanel>
+                    <Placeholder height={100} label="Panel 2" />
+                  </TabPanel>
+                </TabPanels>
+              </Stack>
+            </TabsProvider>
+          </Card>,
+        ),
+    },
+    {
+      label: 'No divider',
+      Example: ({ id }) =>
+        source(
           <TabsProvider id={id}>
-            <Stack space="medium">
-              <Tabs label="Test tabs">
-                <Tab icon={<IconHome />}>The first tab</Tab>
-                <Tab icon={<IconRecommended />}>The second tab</Tab>
-                <Tab icon={<IconCompany />}>The third tab</Tab>
-              </Tabs>
+            <Tabs label="Test tabs" divider="none">
+              <Tab>The first tab</Tab>
+              <Tab>The second tab</Tab>
+              <Tab>The third tab</Tab>
+            </Tabs>
+            <Card>
               <TabPanels>
                 <TabPanel>
                   <Placeholder height={100} label="Panel 1" />
@@ -198,9 +142,67 @@ export const galleryItems: ComponentExample[] = [
                   <Placeholder height={100} label="Panel 3" />
                 </TabPanel>
               </TabPanels>
-            </Stack>
-          </TabsProvider>
-        </Card>,
-      ),
-  },
-];
+            </Card>
+          </TabsProvider>,
+        ),
+    },
+    {
+      label: 'With a badge',
+      Example: ({ id }) =>
+        source(
+          <Card>
+            <TabsProvider id={id}>
+              <Stack space="medium">
+                <Tabs label="Test tabs">
+                  <Tab>The first tab</Tab>
+                  <Tab>The second tab</Tab>
+                  <Tab badge={<Badge tone="positive">New</Badge>}>
+                    The third tab
+                  </Tab>
+                </Tabs>
+                <TabPanels>
+                  <TabPanel>
+                    <Placeholder height={100} label="Panel 1" />
+                  </TabPanel>
+                  <TabPanel>
+                    <Placeholder height={100} label="Panel 2" />
+                  </TabPanel>
+                  <TabPanel>
+                    <Placeholder height={100} label="Panel 3" />
+                  </TabPanel>
+                </TabPanels>
+              </Stack>
+            </TabsProvider>
+          </Card>,
+        ),
+    },
+    {
+      label: 'With an icon',
+      Example: ({ id }) =>
+        source(
+          <Card>
+            <TabsProvider id={id}>
+              <Stack space="medium">
+                <Tabs label="Test tabs">
+                  <Tab icon={<IconHome />}>The first tab</Tab>
+                  <Tab icon={<IconRecommended />}>The second tab</Tab>
+                  <Tab icon={<IconCompany />}>The third tab</Tab>
+                </Tabs>
+                <TabPanels>
+                  <TabPanel>
+                    <Placeholder height={100} label="Panel 1" />
+                  </TabPanel>
+                  <TabPanel>
+                    <Placeholder height={100} label="Panel 2" />
+                  </TabPanel>
+                  <TabPanel>
+                    <Placeholder height={100} label="Panel 3" />
+                  </TabPanel>
+                </TabPanels>
+              </Stack>
+            </TabsProvider>
+          </Card>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Tag/Tag.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Tag/Tag.gallery.tsx
@@ -1,60 +1,62 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Tag, Inline, Text, TextLinkButton, IconTag } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Standard',
-    background: 'surface',
-    Example: () => source(<Tag>Tag</Tag>),
-  },
-  {
-    label: 'Small',
-    background: 'surface',
-    Example: () => source(<Tag size="small">Tag</Tag>),
-  },
-  {
-    label: 'With an icon',
-    background: 'surface',
-    Example: () => source(<Tag icon={<IconTag />}>Tag</Tag>),
-  },
-  {
-    label: 'Clearable',
-    background: 'surface',
-    Example: ({ getState, setState }) =>
-      source(
-        <Inline space="small" alignY="center">
-          <Tag>One</Tag>
-          {!getState('clearTwo') ? (
-            <Tag
-              onClear={() => setState('clearTwo', true)}
-              clearLabel={'Clear "Two"'}
-            >
-              Two
-            </Tag>
-          ) : null}
-          {!getState('clearThree') ? (
-            <Tag
-              onClear={() => setState('clearThree', true)}
-              clearLabel={'Clear "Three"'}
-            >
-              Three
-            </Tag>
-          ) : null}
-          <Text tone="secondary">
-            <TextLinkButton
-              weight="weak"
-              hitArea="large"
-              onClick={() => {
-                setState('clearTwo', false);
-                setState('clearThree', false);
-              }}
-            >
-              Reset
-            </TextLinkButton>
-          </Text>
-        </Inline>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Standard',
+      background: 'surface',
+      Example: () => source(<Tag>Tag</Tag>),
+    },
+    {
+      label: 'Small',
+      background: 'surface',
+      Example: () => source(<Tag size="small">Tag</Tag>),
+    },
+    {
+      label: 'With an icon',
+      background: 'surface',
+      Example: () => source(<Tag icon={<IconTag />}>Tag</Tag>),
+    },
+    {
+      label: 'Clearable',
+      background: 'surface',
+      Example: ({ getState, setState }) =>
+        source(
+          <Inline space="small" alignY="center">
+            <Tag>One</Tag>
+            {!getState('clearTwo') ? (
+              <Tag
+                onClear={() => setState('clearTwo', true)}
+                clearLabel={'Clear "Two"'}
+              >
+                Two
+              </Tag>
+            ) : null}
+            {!getState('clearThree') ? (
+              <Tag
+                onClear={() => setState('clearThree', true)}
+                clearLabel={'Clear "Three"'}
+              >
+                Three
+              </Tag>
+            ) : null}
+            <Text tone="secondary">
+              <TextLinkButton
+                weight="weak"
+                hitArea="large"
+                onClick={() => {
+                  setState('clearTwo', false);
+                  setState('clearThree', false);
+                }}
+              >
+                Reset
+              </TextLinkButton>
+            </Text>
+          </Inline>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Text/Text.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Text/Text.gallery.tsx
@@ -1,88 +1,90 @@
 import React from 'react';
 import { Box, Text, Stack, IconImage } from '../';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Sizes',
-    Example: () =>
-      source(
-        <Stack space="large">
-          <Text size="large">Large</Text>
-          <Text size="standard">Standard (default)</Text>
-          <Text size="small">Small</Text>
-          <Text size="xsmall">Xsmall</Text>
-        </Stack>,
-      ),
-  },
-  {
-    label: 'Weights',
-    Example: () =>
-      source(
-        <Stack space="large">
-          <Text weight="regular">Regular (default)</Text>
-          <Text weight="medium">Medium</Text>
-          <Text weight="strong">Strong</Text>
-        </Stack>,
-      ),
-  },
-  {
-    label: 'Alignment',
-    Example: () =>
-      source(
-        <Stack space="large" dividers>
-          <Text align="left">Left (default)</Text>
-          <Text align="center">Center</Text>
-          <Text align="right">Right</Text>
-          <Text align={{ mobile: 'center', tablet: 'left' }}>
-            Center on mobile
-          </Text>
-        </Stack>,
-      ),
-  },
-  {
-    label: 'Truncation',
-    Example: () =>
-      source(
-        <Box style={{ width: 90 }}>
-          <Text maxLines={1}>Long piece of text</Text>
-        </Box>,
-      ),
-  },
-  {
-    label: 'Tones',
-    background: 'surface',
-    Example: () =>
-      source(
-        <Stack space="large">
-          <Text tone="neutral">neutral (default)</Text>
-          <Text tone="secondary">secondary</Text>
-          <Text tone="promote">promote</Text>
-          <Text tone="info">info</Text>
-          <Text tone="positive">positive</Text>
-          <Text tone="critical">critical</Text>
-        </Stack>,
-      ),
-  },
-  {
-    label: 'With an icon',
-    Example: () =>
-      source(
-        <Stack space="large">
-          <Text size="large" icon={<IconImage />}>
-            Large with icon
-          </Text>
-          <Text size="standard" icon={<IconImage />}>
-            Standard with icon
-          </Text>
-          <Text size="small" icon={<IconImage />}>
-            Small with icon
-          </Text>
-          <Text size="xsmall" icon={<IconImage />}>
-            Xsmall with icon
-          </Text>
-        </Stack>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Sizes',
+      Example: () =>
+        source(
+          <Stack space="large">
+            <Text size="large">Large</Text>
+            <Text size="standard">Standard (default)</Text>
+            <Text size="small">Small</Text>
+            <Text size="xsmall">Xsmall</Text>
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Weights',
+      Example: () =>
+        source(
+          <Stack space="large">
+            <Text weight="regular">Regular (default)</Text>
+            <Text weight="medium">Medium</Text>
+            <Text weight="strong">Strong</Text>
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Alignment',
+      Example: () =>
+        source(
+          <Stack space="large" dividers>
+            <Text align="left">Left (default)</Text>
+            <Text align="center">Center</Text>
+            <Text align="right">Right</Text>
+            <Text align={{ mobile: 'center', tablet: 'left' }}>
+              Center on mobile
+            </Text>
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Truncation',
+      Example: () =>
+        source(
+          <Box style={{ width: 90 }}>
+            <Text maxLines={1}>Long piece of text</Text>
+          </Box>,
+        ),
+    },
+    {
+      label: 'Tones',
+      background: 'surface',
+      Example: () =>
+        source(
+          <Stack space="large">
+            <Text tone="neutral">neutral (default)</Text>
+            <Text tone="secondary">secondary</Text>
+            <Text tone="promote">promote</Text>
+            <Text tone="info">info</Text>
+            <Text tone="positive">positive</Text>
+            <Text tone="critical">critical</Text>
+          </Stack>,
+        ),
+    },
+    {
+      label: 'With an icon',
+      Example: () =>
+        source(
+          <Stack space="large">
+            <Text size="large" icon={<IconImage />}>
+              Large with icon
+            </Text>
+            <Text size="standard" icon={<IconImage />}>
+              Standard with icon
+            </Text>
+            <Text size="small" icon={<IconImage />}>
+              Small with icon
+            </Text>
+            <Text size="xsmall" icon={<IconImage />}>
+              Xsmall with icon
+            </Text>
+          </Stack>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.gallery.tsx
@@ -1,68 +1,70 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Heading, Strong, Text, TextDropdown } from '..';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Standard',
-    Example: ({ id, setState, getState, setDefaultState }) =>
-      source(
-        <>
-          {setDefaultState('textdropdown', 'Option 1')}
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Standard',
+      Example: ({ id, setState, getState, setDefaultState }) =>
+        source(
+          <>
+            {setDefaultState('textdropdown', 'Option 1')}
 
-          <Text>
-            <TextDropdown
-              label="Options"
-              id={id}
-              value={getState('textdropdown')}
-              onChange={setState('textdropdown')}
-              options={['Option 1', 'Option 2', 'Option 3']}
-            />
-          </Text>
-        </>,
-      ),
-  },
-  {
-    label: 'Emphasised within a sentence',
-    Example: ({ id, setState, getState, setDefaultState }) =>
-      source(
-        <>
-          {setDefaultState('sortby', 'Relevance')}
-
-          <Text>
-            Sort by{' '}
-            <Strong>
+            <Text>
               <TextDropdown
-                label="Sort by"
+                label="Options"
                 id={id}
-                value={getState('sortby')}
-                onChange={setState('sortby')}
-                options={['Relevance', 'Date', 'Keyword']}
+                value={getState('textdropdown')}
+                onChange={setState('textdropdown')}
+                options={['Option 1', 'Option 2', 'Option 3']}
               />
-            </Strong>
-          </Text>
-        </>,
-      ),
-  },
-  {
-    label: 'Within a heading',
-    Example: ({ id, setState, getState, setDefaultState }) =>
-      source(
-        <>
-          {setDefaultState('textdropdown', 'Option 1')}
+            </Text>
+          </>,
+        ),
+    },
+    {
+      label: 'Emphasised within a sentence',
+      Example: ({ id, setState, getState, setDefaultState }) =>
+        source(
+          <>
+            {setDefaultState('sortby', 'Relevance')}
 
-          <Heading level="2">
-            Heading with{' '}
-            <TextDropdown
-              label="Options"
-              id={id}
-              value={getState('textdropdown')}
-              onChange={setState('textdropdown')}
-              options={['Option 1', 'Option 2', 'Option 3']}
-            />
-          </Heading>
-        </>,
-      ),
-  },
-];
+            <Text>
+              Sort by{' '}
+              <Strong>
+                <TextDropdown
+                  label="Sort by"
+                  id={id}
+                  value={getState('sortby')}
+                  onChange={setState('sortby')}
+                  options={['Relevance', 'Date', 'Keyword']}
+                />
+              </Strong>
+            </Text>
+          </>,
+        ),
+    },
+    {
+      label: 'Within a heading',
+      Example: ({ id, setState, getState, setDefaultState }) =>
+        source(
+          <>
+            {setDefaultState('textdropdown', 'Option 1')}
+
+            <Heading level="2">
+              Heading with{' '}
+              <TextDropdown
+                label="Options"
+                id={id}
+                value={getState('textdropdown')}
+                onChange={setState('textdropdown')}
+                options={['Option 1', 'Option 2', 'Option 3']}
+              />
+            </Heading>
+          </>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/TextField/TextField.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/TextField/TextField.gallery.tsx
@@ -1,149 +1,151 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { IconSearch, IconHelp, TextField, TextLink } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Standard',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <TextField
-          label="Label"
-          id={id}
-          onChange={setState('textfield')}
-          value={getState('textfield')}
-          onClear={() => setState('textfield', '')}
-        />,
-      ),
-  },
-  {
-    label: 'With additional labels',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <TextField
-          label="Label"
-          id={id}
-          onChange={setState('textfield')}
-          value={getState('textfield')}
-          secondaryLabel="optional"
-          tertiaryLabel={
-            <TextLink href="#" icon={<IconHelp />}>
-              Help
-            </TextLink>
-          }
-        />,
-      ),
-  },
-  {
-    label: 'With a description',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <TextField
-          label="Label"
-          id={id}
-          onChange={setState('textfield')}
-          value={getState('textfield')}
-          onClear={() => setState('textfield', '')}
-          description="Longer description of this field"
-        />,
-      ),
-  },
-  {
-    label: 'With a critical message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <TextField
-          label="Label"
-          id={id}
-          onChange={setState('textfield')}
-          value={getState('textfield')}
-          tone="critical"
-          message="Critical message"
-        />,
-      ),
-  },
-  {
-    label: 'With a positive message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <TextField
-          label="Label"
-          id={id}
-          onChange={setState('textfield')}
-          value={getState('textfield')}
-          tone="positive"
-          message="Positive message"
-        />,
-      ),
-  },
-  {
-    label: 'With a caution message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <TextField
-          label="Label"
-          id={id}
-          onChange={setState('textfield')}
-          value={getState('textfield')}
-          tone="caution"
-          message="Caution message"
-        />,
-      ),
-  },
-  {
-    label: 'With a neutral message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <TextField
-          label="Label"
-          id={id}
-          onChange={setState('textfield')}
-          value={getState('textfield')}
-          tone="neutral"
-          message="Neutral message"
-        />,
-      ),
-  },
-  {
-    label: 'With an icon',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <TextField
-          label="Job Title"
-          id={id}
-          onChange={setState('textfield')}
-          value={getState('textfield')}
-          icon={<IconSearch />}
-          placeholder="Enter a job title"
-        />,
-      ),
-  },
-  {
-    label: 'With a prefix',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <TextField
-          label="Phone number"
-          id={id}
-          onChange={setState('textfield')}
-          value={getState('textfield')}
-          prefix="+61"
-        />,
-      ),
-  },
-  {
-    label: 'Disabled field',
-    background: 'surface',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <TextField
-          label="Label"
-          id={id}
-          onChange={setState('textfield')}
-          value={getState('textfield')}
-          disabled={true}
-        />,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Standard',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <TextField
+            label="Label"
+            id={id}
+            onChange={setState('textfield')}
+            value={getState('textfield')}
+            onClear={() => setState('textfield', '')}
+          />,
+        ),
+    },
+    {
+      label: 'With additional labels',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <TextField
+            label="Label"
+            id={id}
+            onChange={setState('textfield')}
+            value={getState('textfield')}
+            secondaryLabel="optional"
+            tertiaryLabel={
+              <TextLink href="#" icon={<IconHelp />}>
+                Help
+              </TextLink>
+            }
+          />,
+        ),
+    },
+    {
+      label: 'With a description',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <TextField
+            label="Label"
+            id={id}
+            onChange={setState('textfield')}
+            value={getState('textfield')}
+            onClear={() => setState('textfield', '')}
+            description="Longer description of this field"
+          />,
+        ),
+    },
+    {
+      label: 'With a critical message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <TextField
+            label="Label"
+            id={id}
+            onChange={setState('textfield')}
+            value={getState('textfield')}
+            tone="critical"
+            message="Critical message"
+          />,
+        ),
+    },
+    {
+      label: 'With a positive message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <TextField
+            label="Label"
+            id={id}
+            onChange={setState('textfield')}
+            value={getState('textfield')}
+            tone="positive"
+            message="Positive message"
+          />,
+        ),
+    },
+    {
+      label: 'With a caution message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <TextField
+            label="Label"
+            id={id}
+            onChange={setState('textfield')}
+            value={getState('textfield')}
+            tone="caution"
+            message="Caution message"
+          />,
+        ),
+    },
+    {
+      label: 'With a neutral message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <TextField
+            label="Label"
+            id={id}
+            onChange={setState('textfield')}
+            value={getState('textfield')}
+            tone="neutral"
+            message="Neutral message"
+          />,
+        ),
+    },
+    {
+      label: 'With an icon',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <TextField
+            label="Job Title"
+            id={id}
+            onChange={setState('textfield')}
+            value={getState('textfield')}
+            icon={<IconSearch />}
+            placeholder="Enter a job title"
+          />,
+        ),
+    },
+    {
+      label: 'With a prefix',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <TextField
+            label="Phone number"
+            id={id}
+            onChange={setState('textfield')}
+            value={getState('textfield')}
+            prefix="+61"
+          />,
+        ),
+    },
+    {
+      label: 'Disabled field',
+      background: 'surface',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <TextField
+            label="Label"
+            id={id}
+            onChange={setState('textfield')}
+            value={getState('textfield')}
+            disabled={true}
+          />,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/TextLink/TextLink.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/TextLink/TextLink.gallery.tsx
@@ -1,43 +1,45 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Text, TextLink } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Standard',
-    Example: () =>
-      source(
-        <Text>
-          <TextLink href="#" hitArea="large">
-            TextLink
-          </TextLink>
-        </Text>,
-      ),
-  },
-  {
-    label: 'Weak weight',
-    Example: () =>
-      source(
-        <Text>
-          This sentence contains a{' '}
-          <TextLink href="#" weight="weak">
-            weak TextLink
-          </TextLink>
-          .
-        </Text>,
-      ),
-  },
-  {
-    label: 'Visited links',
-    Example: () =>
-      source(
-        <Text>
-          This sentence contains a{' '}
-          <TextLink href="" showVisited>
-            visited TextLink.
-          </TextLink>
-        </Text>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Standard',
+      Example: () =>
+        source(
+          <Text>
+            <TextLink href="#" hitArea="large">
+              TextLink
+            </TextLink>
+          </Text>,
+        ),
+    },
+    {
+      label: 'Weak weight',
+      Example: () =>
+        source(
+          <Text>
+            This sentence contains a{' '}
+            <TextLink href="#" weight="weak">
+              weak TextLink
+            </TextLink>
+            .
+          </Text>,
+        ),
+    },
+    {
+      label: 'Visited links',
+      Example: () =>
+        source(
+          <Text>
+            This sentence contains a{' '}
+            <TextLink href="" showVisited>
+              visited TextLink.
+            </TextLink>
+          </Text>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.gallery.tsx
@@ -1,164 +1,166 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Textarea, TextLink, IconHelp } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Standard',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <Textarea
-          id={id}
-          label="Label"
-          value={getState('textarea')}
-          onChange={setState('textarea')}
-        />,
-      ),
-  },
-  {
-    label: 'With additional labels',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <Textarea
-          id={id}
-          label="Label"
-          onChange={setState('textarea')}
-          value={getState('textarea')}
-          secondaryLabel="optional"
-          tertiaryLabel={
-            <TextLink href="#" icon={<IconHelp />}>
-              Help
-            </TextLink>
-          }
-        />,
-      ),
-  },
-  {
-    label: 'With a description',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <Textarea
-          id={id}
-          label="Label"
-          onChange={setState('textarea')}
-          value={getState('textarea')}
-          description="Longer description of this field"
-        />,
-      ),
-  },
-  {
-    label: 'With a critical message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <Textarea
-          id={id}
-          label="Label"
-          onChange={setState('textarea')}
-          value={getState('textarea')}
-          tone="critical"
-          message="Critical message"
-        />,
-      ),
-  },
-  {
-    label: 'With a positive message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <Textarea
-          id={id}
-          label="Label"
-          onChange={setState('textarea')}
-          value={getState('textarea')}
-          tone="positive"
-          message="Positive message"
-        />,
-      ),
-  },
-  {
-    label: 'With a caution message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <Textarea
-          id={id}
-          label="Label"
-          onChange={setState('textarea')}
-          value={getState('textarea')}
-          tone="caution"
-          message="Caution message"
-        />,
-      ),
-  },
-  {
-    label: 'With a neutral message',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <Textarea
-          id={id}
-          label="Label"
-          onChange={setState('textarea')}
-          value={getState('textarea')}
-          tone="neutral"
-          message="Neutral message"
-        />,
-      ),
-  },
-  {
-    label: 'Disabled field',
-    background: 'surface',
-    Example: ({ id, getState, setState }) =>
-      source(
-        <Textarea
-          id={id}
-          label="Label"
-          onChange={setState('textarea')}
-          value={getState('textarea')}
-          disabled={true}
-        />,
-      ),
-  },
-  {
-    label: 'Limiting the number of characters',
-    Example: ({ id, getState, setState, setDefaultState }) =>
-      source(
-        <>
-          {setDefaultState(
-            'textarea',
-            'A long piece of text exceeding the specified character limit of 50',
-          )}
-
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Standard',
+      Example: ({ id, getState, setState }) =>
+        source(
           <Textarea
-            label="Label"
             id={id}
+            label="Label"
+            value={getState('textarea')}
+            onChange={setState('textarea')}
+          />,
+        ),
+    },
+    {
+      label: 'With additional labels',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <Textarea
+            id={id}
+            label="Label"
             onChange={setState('textarea')}
             value={getState('textarea')}
-            description="Character limit of 50"
-            characterLimit={50}
-          />
-        </>,
-      ),
-  },
-  {
-    label: 'Highlighting ranges',
-    Example: ({ id, getState, setState, setDefaultState }) =>
-      source(
-        <>
-          {setDefaultState(
-            'textarea',
-            'A long piece of text with a highlighted range',
-          )}
-
+            secondaryLabel="optional"
+            tertiaryLabel={
+              <TextLink href="#" icon={<IconHelp />}>
+                Help
+              </TextLink>
+            }
+          />,
+        ),
+    },
+    {
+      label: 'With a description',
+      Example: ({ id, getState, setState }) =>
+        source(
           <Textarea
-            label="Label"
             id={id}
+            label="Label"
+            onChange={setState('textarea')}
+            value={getState('textarea')}
+            description="Longer description of this field"
+          />,
+        ),
+    },
+    {
+      label: 'With a critical message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <Textarea
+            id={id}
+            label="Label"
             onChange={setState('textarea')}
             value={getState('textarea')}
             tone="critical"
             message="Critical message"
-            description="Characters 7-20 are highlighted"
-            highlightRanges={[{ start: 7, end: 20 }]}
-          />
-        </>,
-      ),
-  },
-];
+          />,
+        ),
+    },
+    {
+      label: 'With a positive message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <Textarea
+            id={id}
+            label="Label"
+            onChange={setState('textarea')}
+            value={getState('textarea')}
+            tone="positive"
+            message="Positive message"
+          />,
+        ),
+    },
+    {
+      label: 'With a caution message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <Textarea
+            id={id}
+            label="Label"
+            onChange={setState('textarea')}
+            value={getState('textarea')}
+            tone="caution"
+            message="Caution message"
+          />,
+        ),
+    },
+    {
+      label: 'With a neutral message',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <Textarea
+            id={id}
+            label="Label"
+            onChange={setState('textarea')}
+            value={getState('textarea')}
+            tone="neutral"
+            message="Neutral message"
+          />,
+        ),
+    },
+    {
+      label: 'Disabled field',
+      background: 'surface',
+      Example: ({ id, getState, setState }) =>
+        source(
+          <Textarea
+            id={id}
+            label="Label"
+            onChange={setState('textarea')}
+            value={getState('textarea')}
+            disabled={true}
+          />,
+        ),
+    },
+    {
+      label: 'Limiting the number of characters',
+      Example: ({ id, getState, setState, setDefaultState }) =>
+        source(
+          <>
+            {setDefaultState(
+              'textarea',
+              'A long piece of text exceeding the specified character limit of 50',
+            )}
+
+            <Textarea
+              label="Label"
+              id={id}
+              onChange={setState('textarea')}
+              value={getState('textarea')}
+              description="Character limit of 50"
+              characterLimit={50}
+            />
+          </>,
+        ),
+    },
+    {
+      label: 'Highlighting ranges',
+      Example: ({ id, getState, setState, setDefaultState }) =>
+        source(
+          <>
+            {setDefaultState(
+              'textarea',
+              'A long piece of text with a highlighted range',
+            )}
+
+            <Textarea
+              label="Label"
+              id={id}
+              onChange={setState('textarea')}
+              value={getState('textarea')}
+              tone="critical"
+              message="Critical message"
+              description="Characters 7-20 are highlighted"
+              highlightRanges={[{ start: 7, end: 20 }]}
+            />
+          </>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Tiles/Tiles.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Tiles/Tiles.gallery.tsx
@@ -1,71 +1,73 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Tiles } from '../';
 import { Placeholder } from '../private/Placeholder/Placeholder';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: '3 columns',
-    Example: () =>
-      source(
-        <Tiles columns={3} space="small">
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-        </Tiles>,
-      ),
-  },
-  {
-    label: 'Responsive columns (e.g. 2 on mobile, 4 from tablet upwards)',
-    Example: () =>
-      source(
-        <Tiles space="small" columns={{ mobile: 2, tablet: 4 }}>
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-        </Tiles>,
-      ),
-  },
-  {
-    label: 'Space between tiles',
-    Example: () =>
-      source(
-        <Tiles space="large" columns={3}>
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-          <Placeholder height={40} />
-        </Tiles>,
-      ),
-  },
-  {
-    label: 'Dividers (when in single column)',
-    Example: () =>
-      source(
-        <Tiles space="medium" columns={1} dividers>
-          <Placeholder height={80} />
-          <Placeholder height={80} />
-          <Placeholder height={80} />
-        </Tiles>,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: '3 columns',
+      Example: () =>
+        source(
+          <Tiles columns={3} space="small">
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+          </Tiles>,
+        ),
+    },
+    {
+      label: 'Responsive columns (e.g. 2 on mobile, 4 from tablet upwards)',
+      Example: () =>
+        source(
+          <Tiles space="small" columns={{ mobile: 2, tablet: 4 }}>
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+          </Tiles>,
+        ),
+    },
+    {
+      label: 'Space between tiles',
+      Example: () =>
+        source(
+          <Tiles space="large" columns={3}>
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+            <Placeholder height={40} />
+          </Tiles>,
+        ),
+    },
+    {
+      label: 'Dividers (when in single column)',
+      Example: () =>
+        source(
+          <Tiles space="medium" columns={1} dividers>
+            <Placeholder height={80} />
+            <Placeholder height={80} />
+            <Placeholder height={80} />
+          </Tiles>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.gallery.tsx
@@ -1,45 +1,47 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { Toggle } from '../';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Standard',
-    Example: ({ id, getState, toggleState }) =>
-      source(
-        <Toggle
-          label="Label"
-          id={id}
-          on={getState('toggle')}
-          onChange={() => toggleState('toggle')}
-        />,
-      ),
-  },
-  {
-    label: 'Small',
-    Example: ({ id, getState, toggleState }) =>
-      source(
-        <Toggle
-          label="Label"
-          id={id}
-          on={getState('toggle')}
-          onChange={() => toggleState('toggle')}
-          size="small"
-        />,
-      ),
-  },
-  {
-    label: 'Toggle Alignment: "left" | "justify" | "right"',
-    Example: ({ id, getState, toggleState }) =>
-      source(
-        <Toggle
-          align="right"
-          label="Right aligned"
-          id={id}
-          on={getState('toggle')}
-          onChange={() => toggleState('toggle')}
-        />,
-      ),
-  },
-];
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Standard',
+      Example: ({ id, getState, toggleState }) =>
+        source(
+          <Toggle
+            label="Label"
+            id={id}
+            on={getState('toggle')}
+            onChange={() => toggleState('toggle')}
+          />,
+        ),
+    },
+    {
+      label: 'Small',
+      Example: ({ id, getState, toggleState }) =>
+        source(
+          <Toggle
+            label="Label"
+            id={id}
+            on={getState('toggle')}
+            onChange={() => toggleState('toggle')}
+            size="small"
+          />,
+        ),
+    },
+    {
+      label: 'Toggle Alignment: "left" | "justify" | "right"',
+      Example: ({ id, getState, toggleState }) =>
+        source(
+          <Toggle
+            align="right"
+            label="Right aligned"
+            id={id}
+            on={getState('toggle')}
+            onChange={() => toggleState('toggle')}
+          />,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.gallery.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import source from '@braid-design-system/source.macro';
 import { TooltipRenderer, Inline, Stack, Text, IconHelp, Box } from '../';
 import { type TooltipRendererProps, TooltipContent } from './TooltipRenderer';
@@ -33,66 +33,68 @@ const MockTooltipContent = ({
   </Box>
 );
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'Single line of text',
-    Example: () =>
-      source(
-        <MockTooltipContent placement="top">
-          <Text>Tooltip</Text>
-        </MockTooltipContent>,
-      ),
-  },
-  {
-    label: 'Multiple lines of text',
-    Example: () =>
-      source(
-        <MockTooltipContent placement="top">
-          <Text>
-            The quick brown fox jumps over the lazy dog. The quick brown fox
-            jumps over the lazy dog. The quick brown fox jumps over the lazy
-            dog.
-          </Text>
-        </MockTooltipContent>,
-      ),
-  },
-  {
-    label: 'Custom formatting',
-    Example: () =>
-      source(
-        <MockTooltipContent placement="top">
-          <Stack space="medium">
-            <Text weight="strong">Strong text</Text>
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Single line of text',
+      Example: () =>
+        source(
+          <MockTooltipContent placement="top">
+            <Text>Tooltip</Text>
+          </MockTooltipContent>,
+        ),
+    },
+    {
+      label: 'Multiple lines of text',
+      Example: () =>
+        source(
+          <MockTooltipContent placement="top">
             <Text>
               The quick brown fox jumps over the lazy dog. The quick brown fox
               jumps over the lazy dog. The quick brown fox jumps over the lazy
               dog.
             </Text>
-          </Stack>
-        </MockTooltipContent>,
-      ),
-  },
-  {
-    label: 'Preview animation',
-    Example: ({ id }) =>
-      source(
-        <Inline space="small">
-          <TooltipRenderer
-            id={id}
-            tooltip={
+          </MockTooltipContent>,
+        ),
+    },
+    {
+      label: 'Custom formatting',
+      Example: () =>
+        source(
+          <MockTooltipContent placement="top">
+            <Stack space="medium">
+              <Text weight="strong">Strong text</Text>
               <Text>
-                This is a tooltip! If you provide enough content, the text will
-                wrap onto multiple lines.
+                The quick brown fox jumps over the lazy dog. The quick brown fox
+                jumps over the lazy dog. The quick brown fox jumps over the lazy
+                dog.
               </Text>
-            }
-          >
-            {({ triggerProps }) => (
-              <Box aria-label="Help" {...triggerProps}>
-                <IconHelp />
-              </Box>
-            )}
-          </TooltipRenderer>
-        </Inline>,
-      ),
-  },
-];
+            </Stack>
+          </MockTooltipContent>,
+        ),
+    },
+    {
+      label: 'Preview animation',
+      Example: ({ id }) =>
+        source(
+          <Inline space="small">
+            <TooltipRenderer
+              id={id}
+              tooltip={
+                <Text>
+                  This is a tooltip! If you provide enough content, the text
+                  will wrap onto multiple lines.
+                </Text>
+              }
+            >
+              {({ triggerProps }) => (
+                <Box aria-label="Help" {...triggerProps}>
+                  <IconHelp />
+                </Box>
+              )}
+            </TooltipRenderer>
+          </Inline>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/useToast/useToast.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/useToast/useToast.gallery.tsx
@@ -1,302 +1,304 @@
 import React from 'react';
-import type { ComponentExample } from 'site/types';
+import type { GalleryComponent } from 'site/types';
 import { useBraidTheme } from '../BraidProvider/BraidThemeContext';
 import { Button, IconBookmark, Inline } from '..';
 import Toast from './Toast';
 import source from '@braid-design-system/source.macro';
 
-export const galleryItems: ComponentExample[] = [
-  {
-    label: 'With a positive message',
-    Example: ({ id, handler, showToast }) => {
-      const { vanillaTheme } = useBraidTheme();
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'With a positive message',
+      Example: ({ id, handler, showToast }) => {
+        const { vanillaTheme } = useBraidTheme();
 
-      const { code } = source(
-        <Inline space="small">
-          <Button
-            onClick={() =>
-              showToast({
-                message: 'Positive message',
-                tone: 'positive',
-              })
-            }
-          >
-            Show Toast
-          </Button>
-        </Inline>,
-      );
+        const { code } = source(
+          <Inline space="small">
+            <Button
+              onClick={() =>
+                showToast({
+                  message: 'Positive message',
+                  tone: 'positive',
+                })
+              }
+            >
+              Show Toast
+            </Button>
+          </Inline>,
+        );
 
-      return {
-        code,
-        value: (
-          <Inline space="gutter" align="center">
+        return {
+          code,
+          value: (
+            <Inline space="gutter" align="center">
+              <Toast
+                id={id}
+                dedupeKey={id}
+                shouldRemove={false}
+                vanillaTheme={vanillaTheme}
+                onClose={handler}
+                message="Positive message"
+                tone="positive"
+              />
+            </Inline>
+          ),
+        };
+      },
+    },
+    {
+      label: 'With a critical message',
+      Example: ({ id, handler, showToast }) => {
+        const { vanillaTheme } = useBraidTheme();
+
+        const { code } = source(
+          <Inline space="small">
+            <Button
+              onClick={() =>
+                showToast({
+                  message: 'Critical message',
+                  tone: 'critical',
+                })
+              }
+            >
+              Show Toast
+            </Button>
+          </Inline>,
+        );
+
+        return {
+          code,
+          value: (
+            <Inline space="gutter" align="center">
+              <Toast
+                id={id}
+                dedupeKey={id}
+                shouldRemove={false}
+                vanillaTheme={vanillaTheme}
+                onClose={handler}
+                message="Critical message"
+                tone="critical"
+              />
+            </Inline>
+          ),
+        };
+      },
+    },
+    {
+      label: 'With a neutral message',
+      Example: ({ id, handler, showToast }) => {
+        const { vanillaTheme } = useBraidTheme();
+
+        const { code } = source(
+          <Inline space="small">
+            <Button
+              onClick={() =>
+                showToast({
+                  message: 'Neutral message',
+                  tone: 'neutral',
+                })
+              }
+            >
+              Show Toast
+            </Button>
+          </Inline>,
+        );
+
+        return {
+          code,
+          value: (
+            <Inline space="gutter" align="center">
+              <Toast
+                id={id}
+                dedupeKey={id}
+                shouldRemove={false}
+                vanillaTheme={vanillaTheme}
+                onClose={handler}
+                message="Neutral message"
+                tone="neutral"
+              />
+            </Inline>
+          ),
+        };
+      },
+    },
+    {
+      label: 'With a custom icon (neutral tone only)',
+      Example: ({ id, handler, showToast }) => {
+        const { vanillaTheme } = useBraidTheme();
+
+        const { code } = source(
+          <Inline space="small">
+            <Button
+              onClick={() =>
+                showToast({
+                  message: 'Neutral message with icon',
+                  tone: 'neutral',
+                  icon: <IconBookmark />,
+                })
+              }
+            >
+              Show Toast
+            </Button>
+          </Inline>,
+        );
+
+        return {
+          code,
+          value: (
+            <Inline space="gutter" align="center">
+              <Toast
+                id={id}
+                dedupeKey={id}
+                shouldRemove={false}
+                vanillaTheme={vanillaTheme}
+                onClose={handler}
+                message="Neutral message with icon"
+                tone="neutral"
+                icon={<IconBookmark />}
+              />
+            </Inline>
+          ),
+        };
+      },
+    },
+    {
+      label: 'With a description',
+      Example: ({ id, handler, showToast }) => {
+        const { vanillaTheme } = useBraidTheme();
+
+        const { code } = source(
+          <Inline space="small">
+            <Button
+              onClick={() =>
+                showToast({
+                  message: 'Toast message',
+                  tone: 'positive',
+                  description:
+                    'With a longer piece of text describing what has occured.',
+                })
+              }
+            >
+              Show Toast
+            </Button>
+          </Inline>,
+        );
+
+        return {
+          code,
+          value: (
             <Toast
               id={id}
               dedupeKey={id}
               shouldRemove={false}
               vanillaTheme={vanillaTheme}
               onClose={handler}
-              message="Positive message"
+              message="Toast message"
               tone="positive"
+              description="With a longer piece of text describing what has occured."
             />
-          </Inline>
-        ),
-      };
+          ),
+        };
+      },
     },
-  },
-  {
-    label: 'With a critical message',
-    Example: ({ id, handler, showToast }) => {
-      const { vanillaTheme } = useBraidTheme();
+    {
+      label: 'With an action',
+      Example: ({ id, handler, showToast }) => {
+        const { vanillaTheme } = useBraidTheme();
 
-      const { code } = source(
-        <Inline space="small">
-          <Button
-            onClick={() =>
-              showToast({
-                message: 'Critical message',
-                tone: 'critical',
-              })
-            }
-          >
-            Show Toast
-          </Button>
-        </Inline>,
-      );
+        const { code } = source(
+          <Inline space="small">
+            <Button
+              onClick={() =>
+                showToast({
+                  message: 'Toast message',
+                  tone: 'critical',
+                  action: { label: 'Action', onClick: () => {} },
+                })
+              }
+            >
+              Show Toast
+            </Button>
+          </Inline>,
+        );
 
-      return {
-        code,
-        value: (
-          <Inline space="gutter" align="center">
+        return {
+          code,
+          value: (
             <Toast
               id={id}
               dedupeKey={id}
               shouldRemove={false}
               vanillaTheme={vanillaTheme}
               onClose={handler}
-              message="Critical message"
+              message="Toast message"
               tone="critical"
+              action={{ label: 'Action', onClick: handler }}
             />
-          </Inline>
-        ),
-      };
+          ),
+        };
+      },
     },
-  },
-  {
-    label: 'With a neutral message',
-    Example: ({ id, handler, showToast }) => {
-      const { vanillaTheme } = useBraidTheme();
+    {
+      label: 'With an action and description',
+      Example: ({ id, handler, showToast }) => {
+        const { vanillaTheme } = useBraidTheme();
 
-      const { code } = source(
-        <Inline space="small">
-          <Button
-            onClick={() =>
-              showToast({
-                message: 'Neutral message',
-                tone: 'neutral',
-              })
-            }
-          >
-            Show Toast
-          </Button>
-        </Inline>,
-      );
+        const { code } = source(
+          <Inline space="small">
+            <Button
+              onClick={() =>
+                showToast({
+                  message: 'Toast message',
+                  tone: 'positive',
+                  description:
+                    'With a longer piece of text describing what has occured.',
+                  action: { label: 'Action', onClick: () => {} },
+                })
+              }
+            >
+              Show Toast
+            </Button>
+          </Inline>,
+        );
 
-      return {
-        code,
-        value: (
-          <Inline space="gutter" align="center">
+        return {
+          code,
+          value: (
             <Toast
               id={id}
               dedupeKey={id}
               shouldRemove={false}
               vanillaTheme={vanillaTheme}
               onClose={handler}
-              message="Neutral message"
-              tone="neutral"
+              message="Toast message"
+              tone="positive"
+              description="With a longer piece of text describing what has occured."
+              action={{ label: 'Action', onClick: handler }}
             />
-          </Inline>
-        ),
-      };
+          ),
+        };
+      },
     },
-  },
-  {
-    label: 'With a custom icon (neutral tone only)',
-    Example: ({ id, handler, showToast }) => {
-      const { vanillaTheme } = useBraidTheme();
-
-      const { code } = source(
-        <Inline space="small">
-          <Button
-            onClick={() =>
-              showToast({
-                message: 'Neutral message with icon',
-                tone: 'neutral',
-                icon: <IconBookmark />,
-              })
-            }
-          >
-            Show Toast
-          </Button>
-        </Inline>,
-      );
-
-      return {
-        code,
-        value: (
-          <Inline space="gutter" align="center">
-            <Toast
-              id={id}
-              dedupeKey={id}
-              shouldRemove={false}
-              vanillaTheme={vanillaTheme}
-              onClose={handler}
-              message="Neutral message with icon"
-              tone="neutral"
-              icon={<IconBookmark />}
-            />
-          </Inline>
+    {
+      label: 'Preview animation',
+      Example: ({ showToast }) =>
+        source(
+          <Inline space="small" align="center">
+            <Button
+              onClick={() =>
+                showToast({
+                  message: 'Toast message',
+                  tone: 'critical',
+                  description:
+                    'With a longer piece of text describing what has occured.',
+                  action: { label: 'Action', onClick: () => {} },
+                })
+              }
+            >
+              Show animation
+            </Button>
+          </Inline>,
         ),
-      };
     },
-  },
-  {
-    label: 'With a description',
-    Example: ({ id, handler, showToast }) => {
-      const { vanillaTheme } = useBraidTheme();
-
-      const { code } = source(
-        <Inline space="small">
-          <Button
-            onClick={() =>
-              showToast({
-                message: 'Toast message',
-                tone: 'positive',
-                description:
-                  'With a longer piece of text describing what has occured.',
-              })
-            }
-          >
-            Show Toast
-          </Button>
-        </Inline>,
-      );
-
-      return {
-        code,
-        value: (
-          <Toast
-            id={id}
-            dedupeKey={id}
-            shouldRemove={false}
-            vanillaTheme={vanillaTheme}
-            onClose={handler}
-            message="Toast message"
-            tone="positive"
-            description="With a longer piece of text describing what has occured."
-          />
-        ),
-      };
-    },
-  },
-  {
-    label: 'With an action',
-    Example: ({ id, handler, showToast }) => {
-      const { vanillaTheme } = useBraidTheme();
-
-      const { code } = source(
-        <Inline space="small">
-          <Button
-            onClick={() =>
-              showToast({
-                message: 'Toast message',
-                tone: 'critical',
-                action: { label: 'Action', onClick: () => {} },
-              })
-            }
-          >
-            Show Toast
-          </Button>
-        </Inline>,
-      );
-
-      return {
-        code,
-        value: (
-          <Toast
-            id={id}
-            dedupeKey={id}
-            shouldRemove={false}
-            vanillaTheme={vanillaTheme}
-            onClose={handler}
-            message="Toast message"
-            tone="critical"
-            action={{ label: 'Action', onClick: handler }}
-          />
-        ),
-      };
-    },
-  },
-  {
-    label: 'With an action and description',
-    Example: ({ id, handler, showToast }) => {
-      const { vanillaTheme } = useBraidTheme();
-
-      const { code } = source(
-        <Inline space="small">
-          <Button
-            onClick={() =>
-              showToast({
-                message: 'Toast message',
-                tone: 'positive',
-                description:
-                  'With a longer piece of text describing what has occured.',
-                action: { label: 'Action', onClick: () => {} },
-              })
-            }
-          >
-            Show Toast
-          </Button>
-        </Inline>,
-      );
-
-      return {
-        code,
-        value: (
-          <Toast
-            id={id}
-            dedupeKey={id}
-            shouldRemove={false}
-            vanillaTheme={vanillaTheme}
-            onClose={handler}
-            message="Toast message"
-            tone="positive"
-            description="With a longer piece of text describing what has occured."
-            action={{ label: 'Action', onClick: handler }}
-          />
-        ),
-      };
-    },
-  },
-  {
-    label: 'Preview animation',
-    Example: ({ showToast }) =>
-      source(
-        <Inline space="small" align="center">
-          <Button
-            onClick={() =>
-              showToast({
-                message: 'Toast message',
-                tone: 'critical',
-                description:
-                  'With a longer piece of text describing what has occured.',
-                action: { label: 'Action', onClick: () => {} },
-              })
-            }
-          >
-            Show animation
-          </Button>
-        </Inline>,
-      ),
-  },
-];
+  ],
+};

--- a/site/src/App/navigationHelpers.ts
+++ b/site/src/App/navigationHelpers.ts
@@ -3,7 +3,12 @@ import * as components from 'braid-src/lib/components';
 import * as testComponents from 'braid-src/entries/test';
 import * as css from 'braid-src/entries/css';
 import type { Snippets } from 'braid-src/lib/components/private/Snippets';
-import type { ComponentDocs, ComponentExample, CssDoc } from '../types';
+import type {
+  ComponentDocs,
+  ComponentExample,
+  CssDoc,
+  GalleryComponent,
+} from '../types';
 import undocumentedExports from '../undocumentedExports.json';
 
 const componentDocsContext = require.context(
@@ -106,5 +111,9 @@ const getComponentNameFromFilename = (filename: string) => {
 
 export const galleryComponents = galleryContext.keys().map((filename) => ({
   name: getComponentNameFromFilename(filename),
-  examples: galleryContext(filename).galleryItems as ComponentExample[],
+  itemWidth:
+    (galleryContext(filename).galleryItems
+      .itemWidth as GalleryComponent['itemWidth']) || 'standard',
+  examples: galleryContext(filename).galleryItems
+    .examples as ComponentExample[],
 }));

--- a/site/src/App/routes/gallery/Gallery.tsx
+++ b/site/src/App/routes/gallery/Gallery.tsx
@@ -80,13 +80,10 @@ const DefaultContainer = ({ children }: { children: ReactNode }) => (
 
 const COLUMN_SIZE = 4;
 
-const galleryComponents = allGalleryComponents.map(
-  ({ itemWidth, examples, ...rest }) => ({
-    ...rest,
-    itemWidth,
-    examples: chunk(examples, COLUMN_SIZE),
-  }),
-);
+const galleryComponents = allGalleryComponents.map(({ examples, ...rest }) => ({
+  ...rest,
+  examples: chunk(examples, COLUMN_SIZE),
+}));
 
 const galleryComponentNames = allGalleryComponents.map(({ name }) => name);
 

--- a/site/src/App/routes/gallery/Gallery.tsx
+++ b/site/src/App/routes/gallery/Gallery.tsx
@@ -80,41 +80,47 @@ const DefaultContainer = ({ children }: { children: ReactNode }) => (
 
 const COLUMN_SIZE = 4;
 
-const galleryComponents = allGalleryComponents.map(({ examples, ...rest }) => ({
-  ...rest,
-  examples: chunk(examples, COLUMN_SIZE),
-}));
+const galleryComponents = allGalleryComponents.map(
+  ({ itemWidth, examples, ...rest }) => ({
+    ...rest,
+    itemWidth,
+    examples: chunk(examples, COLUMN_SIZE),
+  }),
+);
 
 const galleryComponentNames = allGalleryComponents.map(({ name }) => name);
 
-export const galleryIcons = Object.keys(icons).map((iconName) => {
-  const IconComponent = icons[iconName as keyof typeof icons];
+export const galleryIcons: typeof galleryComponents = Object.keys(icons).map(
+  (iconName) => {
+    const IconComponent = icons[iconName as keyof typeof icons];
 
-  return {
-    name: iconName,
-    examples: [
-      [
-        {
-          Container: ({ children }: { children: ReactNode }) => (
-            <Box
-              display="flex"
-              alignItems="center"
-              justifyContent="center"
-              paddingY="medium"
-              paddingX="xxlarge"
-            >
-              <Box flexShrink={0} style={{ height: 60, width: 60 }}>
-                {children}
+    return {
+      name: iconName,
+      itemWidth: 'icon',
+      examples: [
+        [
+          {
+            Container: ({ children }: { children: ReactNode }) => (
+              <Box
+                display="flex"
+                alignItems="center"
+                justifyContent="center"
+                paddingY="medium"
+                paddingX="xxlarge"
+              >
+                <Box flexShrink={0} style={{ height: 60, width: 60 }}>
+                  {children}
+                </Box>
               </Box>
-            </Box>
-          ),
-          Example: () => source(<IconComponent size="fill" />),
-          code: `<${iconName} />`,
-        },
+            ),
+            Example: () => source(<IconComponent size="fill" />),
+            code: `<${iconName} />`,
+          },
+        ],
       ],
-    ],
-  };
-});
+    };
+  },
+);
 
 type SetName = 'components' | 'icons';
 const getRowsFor = memoize((type: SetName) => {
@@ -198,6 +204,12 @@ const GalleryItem = ({
   ).length;
   const updateCount = markAsNew ? actualUpdateCount - 1 : actualUpdateCount;
 
+  const widthMap = {
+    icon: undefined,
+    standard: '700px',
+    wide: '1500px',
+  };
+
   const isAnIcon = componentDocs.category === 'Icon';
 
   return (
@@ -265,7 +277,7 @@ const GalleryItem = ({
                   <Box
                     component={isAnIcon ? undefined : 'section'}
                     style={{
-                      width: isAnIcon ? undefined : '700px',
+                      width: widthMap[item.itemWidth],
                     }}
                     key={`${example.label}_${index}`}
                     className={styles.animationsOnlyOnHover}

--- a/site/src/types.d.ts
+++ b/site/src/types.d.ts
@@ -66,6 +66,11 @@ interface ExampleProps {
 }
 interface PlayroomExampleProps extends ReturnType<typeof useScope> {}
 
+export interface GalleryComponent {
+  itemWidth?: 'icon' | 'standard' | 'wide';
+  examples: ComponentExample[];
+}
+
 export interface ComponentExample {
   label?: string;
   description?: ReactNodeNoStrings;


### PR DESCRIPTION
This change makes it easier to visually compare the layout options of wider components in Gallery on the docs site

* Add an optional `itemWidth` prop for galleryComponents, with a `wide` option (`1500px`). This width is configured in the `.gallery.tsx` file for each component, similar to `screenshotWidths` in `screenshots.tsx` files
* Update all `gallery.tsx` files to conform to the new `GalleryComponent` type. The diffs are pretty unhelpful for these, but they are all essentially a 4 line change
* Use `wide` option for `PageBlock` and `ContentBlock` components

Currently, only `PageBlock` and `ContentBlock` really benefit from a wide view, so it makes more sense to have this configurable per component, rather than applying `wide` to all Layout components

Want to keep these components in Gallery to help with discoverability. It's nice to have visual comparison for the different widths that you can't see on the standard docs page

Should explore separating all Layout components into their own Gallery section as a seperate piece of work 