### PR TITLE
Tag: Pass click event object to `onClear` handler

### DIFF
--- a/.changeset/popular-mails-hunt.md
+++ b/.changeset/popular-mails-hunt.md
@@ -1,0 +1,22 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Tag
+---
+
+The `onClear` handler now accepts a click event object as an argument.
+
+**EXAMPLE USAGE:**
+```jsx
+<Tag
+  onClear={(event: React.MouseEvent<HTMLButtonElement>) => {
+    event.stopPropagation();
+    toggleTag();
+  }}
+>
+  Tag
+</Tag>
+```

--- a/packages/braid-design-system/src/lib/components/Tag/Tag.tsx
+++ b/packages/braid-design-system/src/lib/components/Tag/Tag.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { type AllHTMLAttributes } from 'react';
 import assert from 'assert';
 import { Box } from '../Box/Box';
 import { type TextProps, Text } from '../Text/Text';
@@ -12,6 +12,7 @@ import type { Space } from '../../css/atoms/atoms';
 import * as styles from './Tag.css';
 
 export const tagSizes = ['small', 'standard'] as const;
+type NativeButtonProps = AllHTMLAttributes<HTMLButtonElement>;
 
 export type TagProps = {
   children: string;
@@ -19,7 +20,7 @@ export type TagProps = {
   data?: DataAttributeMap;
   id?: string;
   icon?: TextProps['icon'];
-} & AllOrNone<{ onClear: () => void; clearLabel: string }>;
+} & AllOrNone<{ onClear: NativeButtonProps['onClick']; clearLabel: string }>;
 
 const paddingXForSize: Record<NonNullable<TagProps['size']>, Space> = {
   small: 'xsmall',

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -7579,7 +7579,7 @@ exports[`Tag 1`] = `
     data?: DataAttributeMap
     icon?: ReactElement<UseIconProps, string | JSXElementConstructor<any>>
     id?: string
-    onClear?: () => void
+    onClear?: MouseEventHandler<HTMLButtonElement>
     size?: 
         | "small"
         | "standard"


### PR DESCRIPTION
Allow optionally providing an click event to `Tag` `onClear` handler. This is useful to stopPropagation if the tag is within a clickable element.

See changeset for details