### PR TITLE
Toggle: fix label text vertical centering for small size

### DIFF
--- a/.changeset/brave-walls-ring.md
+++ b/.changeset/brave-walls-ring.md
@@ -1,0 +1,10 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Toggle
+---
+
+**Toggle**: Fix label text vertical centering

--- a/.changeset/sixty-knives-worry.md
+++ b/.changeset/sixty-knives-worry.md
@@ -7,4 +7,4 @@ updated:
   - Toggle
 ---
 
-**Toggle**: Fix label text vertical centering
+**Toggle:** Improve label text vertical alignment at `small` size

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.screenshots.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { Toggle, Box, Tiles, Inline } from '../';
+import { Toggle, Box, Tiles, Inline, Text } from '../';
 import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 import { debugTouchableAttrForDataProp } from '../private/touchable/debugTouchable';
 
@@ -188,7 +188,36 @@ export const screenshots: ComponentScreenshot = {
         />
       ),
     },
-
+    {
+      label: 'With Inline text (standard size)',
+      Container: ({ children }) => (
+        <div style={{ maxWidth: '300px' }}>{children}</div>
+      ),
+      Example: ({ id, handler }) => (
+        <Inline space="xsmall" alignY="center">
+          <Toggle on={true} label="Toggle" id={id} onChange={handler} />
+          <Text>Inline text</Text>
+        </Inline>
+      ),
+    },
+    {
+      label: 'With Inline text (small size)',
+      Container: ({ children }) => (
+        <div style={{ maxWidth: '300px' }}>{children}</div>
+      ),
+      Example: ({ id, handler }) => (
+        <Inline space="xsmall" alignY="center">
+          <Toggle
+            on={true}
+            label="Toggle"
+            id={id}
+            onChange={handler}
+            size="small"
+          />
+          <Text size="small">Inline text</Text>
+        </Inline>
+      ),
+    },
     {
       label: 'Virtual touch target',
       Example: ({ id, handler }) => (

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -170,6 +170,9 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
           paddingRight={
             appliedTogglePosition === 'leading' ? undefined : 'xsmall'
           }
+          display="flex"
+          flexDirection="column"
+          justifyContent="center"
           flexGrow={align === 'justify' ? 1 : undefined}
           userSelect="none"
           cursor="pointer"


### PR DESCRIPTION
Label text can be vertically misaligned in some scenarios - [Playroom](https://seek-oss.github.io/braid-design-system/playroom/#?code=N4Igxg9gJgpiBcIA8AhCAPABAIwIZgGsBzAJwgFcA7KAXgB1wSBLAFybFwBsAZJogCxYMAfHUqZMSAJKVOTSjExc%2BlAJr1wMSixgkGmAM4AHfDA3p0BgLZdOIsRIlIAKhCJFOizrmwxOG7h8-fQMmAC8zBmtbfQB6UXFHFxh0FkNwyJBozjsQYWzOTB1UpFjnFJYEp1iZOQUE0rR0BJAAGhAWfhgrGAMEAG0QXBMwNqyYGAIAKQhsPoBddoB3JihOvvh%2BgGYAJgAGeYBfIA)
With a small size `Toggle`, the text sits slightly too high

This change resolves these issues