### PR TITLE
Toggle: add `bleedY` prop

### DIFF
--- a/.changeset/purple-clocks-impress.md
+++ b/.changeset/purple-clocks-impress.md
@@ -13,5 +13,5 @@ Introduces the `bleedY` prop, allowing you to remove excess vertical space creat
 
 **EXAMPLE USAGE:**
 ```jsx
-<Toggle label="Label" bleedY/>
+<Toggle label="Label" bleedY />
 ```

--- a/.changeset/purple-clocks-impress.md
+++ b/.changeset/purple-clocks-impress.md
@@ -1,0 +1,17 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Toggle
+---
+
+**Toggle:** Add `bleedY` prop
+
+Introduces the `bleedY` prop, allowing you to remove excess vertical space created by the toggle handle.
+
+**EXAMPLE USAGE:**
+```jsx
+<Toggle label="Label" bleedY/>
+```

--- a/.changeset/purple-clocks-impress.md
+++ b/.changeset/purple-clocks-impress.md
@@ -9,9 +9,13 @@ updated:
 
 **Toggle:** Add `bleedY` prop
 
-Introduces the `bleedY` prop, allowing you to remove excess vertical space created by the toggle input.
+Introduces the `bleedY` prop, enabling vertical bleed for the `Toggle` component. This removes excess vertical space created by the `Toggle` input.
 
 **EXAMPLE USAGE:**
 ```jsx
 <Toggle label="Label" bleedY />
 ```
+
+**MIGRATION GUIDE:**
+
+Vertical bleed will become standard for the `Toggle` component in a future version. Please use the `bleedY` prop with a value of `true` and update your layout accordingly.

--- a/.changeset/purple-clocks-impress.md
+++ b/.changeset/purple-clocks-impress.md
@@ -9,7 +9,7 @@ updated:
 
 **Toggle:** Add `bleedY` prop
 
-Introduces the `bleedY` prop, allowing you to remove excess vertical space created by the toggle handle.
+Introduces the `bleedY` prop, allowing you to remove excess vertical space created by the toggle input.
 
 **EXAMPLE USAGE:**
 ```jsx

--- a/packages/braid-design-system/src/lib/components/Button/Button.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.docs.tsx
@@ -567,6 +567,7 @@ const docs: ComponentDocs = {
                   label="Bleed"
                   align="right"
                   onChange={() => toggleState('bleed')}
+                  bleedY={false}
                 />
                 <Text tone="secondary" weight="strong">
                   Standard size alignment

--- a/packages/braid-design-system/src/lib/components/Button/Button.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.docs.tsx
@@ -567,7 +567,7 @@ const docs: ComponentDocs = {
                   label="Bleed"
                   align="right"
                   onChange={() => toggleState('bleed')}
-                  bleedY={false}
+                  bleedY
                 />
                 <Text tone="secondary" weight="strong">
                   Standard size alignment

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.css.ts
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.css.ts
@@ -5,11 +5,19 @@ import { hitArea } from '../private/touchable/hitArea';
 import { debugTouchable } from '../private/touchable/debugTouchable';
 import { rgba } from 'polished';
 import { colorModeStyle } from '../../css/colorModeStyle';
+import { responsiveStyle } from '../../css/responsiveStyle';
 
 const sizes = {
   standard: 'standard',
   small: 'small',
 } as const;
+
+export const bleedToCapHeight = styleVariants(sizes, (size) =>
+  responsiveStyle({
+    mobile: { height: vars.textSize[size].mobile.capHeight },
+    tablet: { height: vars.textSize[size].tablet.capHeight },
+  }),
+);
 
 export type Size = keyof typeof sizes;
 
@@ -37,18 +45,6 @@ export const realFieldPosition = styleVariants(sizes, (size) => ({
     .negate()
     .toString(),
 }));
-
-export const label = styleVariants(sizes, (size) => {
-  const padding = calc(vars.inlineFieldSize[size])
-    .subtract(vars.textSize.standard.mobile.lineHeight)
-    .divide(2)
-    .toString();
-
-  return {
-    paddingTop: padding,
-    paddingBottom: padding,
-  };
-});
 
 export const fieldSize = styleVariants(sizes, (size) => ({
   width: calc.multiply(vars.inlineFieldSize[size], toggleWidthRatio),

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
@@ -15,6 +15,7 @@ const docs: ComponentDocs = {
         id={id}
         on={getState('toggle')}
         onChange={() => toggleState('toggle')}
+        bleedY={false}
       />,
     ),
   alternatives: [
@@ -40,6 +41,7 @@ const docs: ComponentDocs = {
               on={getState('toggle1')}
               onChange={() => toggleState('toggle1')}
               align="left"
+              bleedY={false}
             />
             <Toggle
               label="Justify"
@@ -47,6 +49,7 @@ const docs: ComponentDocs = {
               on={getState('toggle2')}
               onChange={() => toggleState('toggle2')}
               align="justify"
+              bleedY={false}
             />
             <Toggle
               label="Right"
@@ -54,6 +57,7 @@ const docs: ComponentDocs = {
               on={getState('toggle3')}
               onChange={() => toggleState('toggle3')}
               align="right"
+              bleedY={false}
             />
           </Stack>,
         ),
@@ -76,6 +80,7 @@ const docs: ComponentDocs = {
               on={getState('two')}
               onChange={() => toggleState('two')}
               size="standard"
+              bleedY={false}
             />
             <Toggle
               id={`${id}_small`}
@@ -83,6 +88,7 @@ const docs: ComponentDocs = {
               on={getState('one')}
               onChange={() => toggleState('one')}
               size="small"
+              bleedY={false}
             />
           </Stack>,
         ),

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
@@ -134,29 +134,36 @@ const docs: ComponentDocs = {
         <Fragment>
           <Text>
             With the <Strong>bleedY</Strong> prop, you can remove excess
-            vertical space created by the toggle handle.
+            vertical space created by the toggle input.
           </Text>
           <Text>
             For example, you can include a toggle in a{' '}
             <TextLink href="/components/Stack">Stack</TextLink> with all text
-            evenly spaced.
+            evenly spaced. If you disable the vertical bleed in this example,
+            the toggle input will introduce unwanted space before and after the
+            toggle label.
           </Text>
         </Fragment>
       ),
-      Example: ({ id, getState, toggleState }) =>
+      Example: ({ id, setDefaultState, getState, toggleState }) =>
         source(
-          <Stack space="medium">
-            <Text>Text</Text>
-            <Text>Text</Text>
-            <Toggle
-              label="Vertical bleed"
-              id={`${id}_toggle_bleed`}
-              on={!getState('disableVerticalBleed')}
-              onChange={() => toggleState('disableVerticalBleed')}
-              align="justify"
-              bleedY={!getState('disableVerticalBleed')}
-            />
-          </Stack>,
+          <>
+            {setDefaultState('verticalBleed', true)}
+            <Stack space="medium">
+              <Text>Text</Text>
+              <Text>Text</Text>
+              <Toggle
+                label="Vertical bleed"
+                id={`${id}_toggle_bleed`}
+                on={getState('verticalBleed')}
+                onChange={() => toggleState('verticalBleed')}
+                align="left"
+                togglePosition="trailing"
+                bleedY={getState('verticalBleed')}
+              />
+              <Text>Text</Text>
+            </Stack>
+          </>,
         ),
     },
     {

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import type { ComponentDocs } from 'site/types';
-import { TextLink, Toggle } from '../';
+import { Box, TextLink, Toggle } from '../';
 import { Text } from '../Text/Text';
 import { Strong } from '../Strong/Strong';
 import source from '@braid-design-system/source.macro';
@@ -15,6 +15,7 @@ const docs: ComponentDocs = {
         id={id}
         on={getState('toggle')}
         onChange={() => toggleState('toggle')}
+        bleedY
       />,
     ),
   alternatives: [
@@ -40,6 +41,7 @@ const docs: ComponentDocs = {
               on={getState('toggle1')}
               onChange={() => toggleState('toggle1')}
               align="left"
+              bleedY
             />
             <Toggle
               label="Justify"
@@ -47,6 +49,7 @@ const docs: ComponentDocs = {
               on={getState('toggle2')}
               onChange={() => toggleState('toggle2')}
               align="justify"
+              bleedY
             />
             <Toggle
               label="Right"
@@ -54,6 +57,7 @@ const docs: ComponentDocs = {
               on={getState('toggle3')}
               onChange={() => toggleState('toggle3')}
               align="right"
+              bleedY
             />
           </Stack>,
         ),
@@ -82,6 +86,7 @@ const docs: ComponentDocs = {
               on={getState('toggleLeading')}
               onChange={() => toggleState('toggleLeading')}
               togglePosition="leading"
+              bleedY
             />
             <Toggle
               label="Trailing"
@@ -89,6 +94,7 @@ const docs: ComponentDocs = {
               on={getState('toggleTrailing')}
               onChange={() => toggleState('toggleTrailing')}
               togglePosition="trailing"
+              bleedY
             />
           </Stack>,
         ),
@@ -117,6 +123,7 @@ const docs: ComponentDocs = {
               on={getState('toggleLeading')}
               onChange={() => toggleState('toggleLeading')}
               togglePosition="leading"
+              bleedY
             />
             <Toggle
               label="Trailing"
@@ -124,6 +131,7 @@ const docs: ComponentDocs = {
               on={getState('toggleTrailing')}
               onChange={() => toggleState('toggleTrailing')}
               togglePosition="trailing"
+              bleedY
             />
           </Stack>,
         ),
@@ -138,10 +146,10 @@ const docs: ComponentDocs = {
           </Text>
           <Text>
             For example, you can include a toggle in a{' '}
-            <TextLink href="/components/Stack">Stack</TextLink> with all text
-            evenly spaced. If you disable the vertical bleed in this example,
-            the toggle input will introduce unwanted space before and after the
-            toggle label.
+            <TextLink href="/components/Stack">Stack</TextLink> with even
+            vertical spacing. If you disable the <Strong>bleedY</Strong> prop
+            below, the toggle input will introduce unwanted space before and
+            after the toggle label.
           </Text>
         </Fragment>
       ),
@@ -152,15 +160,18 @@ const docs: ComponentDocs = {
             <Stack space="medium">
               <Text>Text</Text>
               <Text>Text</Text>
-              <Toggle
-                label="Vertical bleed"
-                id={`${id}_toggle_bleed`}
-                on={getState('verticalBleed')}
-                onChange={() => toggleState('verticalBleed')}
-                align="left"
-                togglePosition="trailing"
-                bleedY={getState('verticalBleed')}
-              />
+              <Box background="surface" boxShadow="borderCriticalLight">
+                <Toggle
+                  label="BleedY"
+                  id={`${id}_toggle_bleed`}
+                  on={getState('verticalBleed')}
+                  onChange={() => toggleState('verticalBleed')}
+                  align="left"
+                  togglePosition="trailing"
+                  bleedY={getState('verticalBleed')}
+                />
+              </Box>
+
               <Text>Text</Text>
             </Stack>
           </>,
@@ -177,13 +188,14 @@ const docs: ComponentDocs = {
       ),
       Example: ({ id, getState, toggleState }) =>
         source(
-          <Stack space="medium">
+          <Stack space="large">
             <Toggle
               id={`${id}_standard`}
               label="Standard"
               on={getState('two')}
               onChange={() => toggleState('two')}
               size="standard"
+              bleedY
             />
             <Toggle
               id={`${id}_small`}
@@ -191,6 +203,7 @@ const docs: ComponentDocs = {
               on={getState('one')}
               onChange={() => toggleState('one')}
               size="small"
+              bleedY
             />
           </Stack>,
         ),

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
@@ -111,8 +111,8 @@ const docs: ComponentDocs = {
             For example, you can include a toggle in a{' '}
             <TextLink href="/components/Stack">Stack</TextLink> with even
             vertical spacing. If you disable the <Strong>bleedY</Strong> prop
-            below, the toggle input will introduce unwanted space before and
-            after the toggle label.
+            below, the toggle input will introduce unwanted space above and
+            below the toggle label.
           </Text>
         </Fragment>
       ),

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
@@ -1,6 +1,6 @@
-import React from 'react';
+import React, { Fragment } from 'react';
 import type { ComponentDocs } from 'site/types';
-import { Toggle } from '../';
+import { TextLink, Toggle } from '../';
 import { Text } from '../Text/Text';
 import { Strong } from '../Strong/Strong';
 import source from '@braid-design-system/source.macro';
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
         id={id}
         on={getState('toggle')}
         onChange={() => toggleState('toggle')}
-        bleedY={false}
+        bleedY
       />,
     ),
   alternatives: [
@@ -41,7 +41,7 @@ const docs: ComponentDocs = {
               on={getState('toggle1')}
               onChange={() => toggleState('toggle1')}
               align="left"
-              bleedY={false}
+              bleedY
             />
             <Toggle
               label="Justify"
@@ -49,7 +49,7 @@ const docs: ComponentDocs = {
               on={getState('toggle2')}
               onChange={() => toggleState('toggle2')}
               align="justify"
-              bleedY={false}
+              bleedY
             />
             <Toggle
               label="Right"
@@ -57,7 +57,38 @@ const docs: ComponentDocs = {
               on={getState('toggle3')}
               onChange={() => toggleState('toggle3')}
               align="right"
-              bleedY={false}
+              bleedY
+            />
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Vertical bleed',
+      description: (
+        <Fragment>
+          <Text>
+            With the <Strong>bleedY</Strong> prop, you can remove excess
+            vertical space created by the toggle handle.
+          </Text>
+          <Text>
+            For example, you can include a toggle in a{' '}
+            <TextLink href="/components/Stack">Stack</TextLink> with all text
+            evenly spaced.
+          </Text>
+        </Fragment>
+      ),
+      Example: ({ id, getState, toggleState }) =>
+        source(
+          <Stack space="medium">
+            <Text>Text</Text>
+            <Text>Text</Text>
+            <Toggle
+              label="Vertical bleed"
+              id={`${id}_toggle_bleed`}
+              on={!getState('disableVerticalBleed')}
+              onChange={() => toggleState('disableVerticalBleed')}
+              align="justify"
+              bleedY={!getState('disableVerticalBleed')}
             />
           </Stack>,
         ),

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
@@ -1,6 +1,6 @@
 import React, { Fragment } from 'react';
 import type { ComponentDocs } from 'site/types';
-import { Box, TextLink, Toggle } from '../';
+import { Alert, Box, TextLink, Toggle } from '../';
 import { Text } from '../Text/Text';
 import { Strong } from '../Strong/Strong';
 import source from '@braid-design-system/source.macro';
@@ -104,15 +104,28 @@ const docs: ComponentDocs = {
       description: (
         <Fragment>
           <Text>
-            With the <Strong>bleedY</Strong> prop, you can remove excess
-            vertical space created by the toggle input.
+            The <Strong>bleedY</Strong> prop removes the excess vertical space
+            created by the toggle input — ensuring it’s only as tall as the{' '}
+            provided label text.
           </Text>
           <Text>
-            For example, you can include a toggle in a{' '}
-            <TextLink href="/components/Stack">Stack</TextLink> with even
-            vertical spacing. If you disable the <Strong>bleedY</Strong> prop
-            below, the toggle input will introduce unwanted space above and
-            below the toggle label.
+            This better aligns with the{' '}
+            <TextLink href="/foundations/layout">layout principles</TextLink> of
+            the system, enabling the surrounding white space to be controlled by
+            the parent layout component, e.g.{' '}
+            <TextLink href="/components/Stack">Stack</TextLink>.
+          </Text>
+          <Alert tone="caution">
+            <Text>
+              In the future this will become the standard behaviour. Migrating
+              layouts to work with this option now is recommended.
+            </Text>
+          </Alert>
+          <Text>
+            In the following example, a{' '}
+            <TextLink href="/components/Stack">Stack</TextLink> controls the
+            space between child elements. Switching the toggle off introduces
+            unwanted space above and below the label.
           </Text>
         </Fragment>
       ),

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.gallery.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { GalleryComponent } from 'site/types';
-import { Text, Toggle, Stack } from '../';
+import { Toggle } from '../';
 import source from '@braid-design-system/source.macro';
 
 export const galleryItems: GalleryComponent = {
@@ -14,6 +14,7 @@ export const galleryItems: GalleryComponent = {
             id={id}
             on={getState('toggle')}
             onChange={() => toggleState('toggle')}
+            bleedY
           />,
         ),
     },
@@ -27,6 +28,7 @@ export const galleryItems: GalleryComponent = {
             on={getState('toggle')}
             onChange={() => toggleState('toggle')}
             size="small"
+            bleedY
           />,
         ),
     },
@@ -40,6 +42,7 @@ export const galleryItems: GalleryComponent = {
             id={id}
             on={getState('toggle')}
             onChange={() => toggleState('toggle')}
+            bleedY
           />,
         ),
     },
@@ -53,25 +56,8 @@ export const galleryItems: GalleryComponent = {
             id={id}
             on={getState('toggle')}
             onChange={() => toggleState('toggle')}
+            bleedY
           />,
-        ),
-    },
-    {
-      label: 'Vertical bleed',
-      Example: ({ id, getState, toggleState }) =>
-        source(
-          <Stack space="medium">
-            <Text>Text</Text>
-            <Text>Text</Text>
-            <Toggle
-              label="Vertical bleed"
-              id={id}
-              on={getState('toggle')}
-              onChange={() => toggleState('toggle')}
-              togglePosition="trailing"
-              bleedY
-            />
-          </Stack>,
         ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.gallery.tsx
@@ -42,4 +42,17 @@ export const galleryItems: ComponentExample[] = [
         />,
       ),
   },
+  {
+    label: 'Vertical bleed',
+    Example: ({ id, getState, toggleState }) =>
+      source(
+        <Toggle
+          label="Vertical bleed"
+          id={id}
+          on={getState('toggle')}
+          onChange={() => toggleState('toggle')}
+          bleedY
+        />,
+      ),
+  },
 ];

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.screenshots.tsx
@@ -92,6 +92,21 @@ export const screenshots: ComponentScreenshot = {
         />
       ),
     },
+    {
+      label: 'With bleedY',
+      Container: ({ children }) => (
+        <div style={{ maxWidth: '300px' }}>{children}</div>
+      ),
+      Example: ({ id, handler }) => (
+        <Toggle
+          on={true}
+          label="Vertical bleed"
+          id={id}
+          onChange={handler}
+          bleedY
+        />
+      ),
+    },
 
     {
       label: 'Virtual touch target',

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.screenshots.tsx
@@ -245,21 +245,6 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Without bleedY',
-      Container: ({ children }) => (
-        <div style={{ maxWidth: '300px' }}>{children}</div>
-      ),
-      Example: ({ id, handler }) => (
-        <Toggle
-          on={true}
-          label="Without vertical bleed"
-          id={id}
-          onChange={handler}
-          bleedY={false}
-        />
-      ),
-    },
-    {
       label: 'Virtual touch target',
       Example: ({ id, handler }) => (
         <Inline space="large" data={{ [debugTouchableAttrForDataProp]: '' }}>

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.screenshots.tsx
@@ -10,13 +10,25 @@ export const screenshots: ComponentScreenshot = {
     {
       label: 'Toggle off',
       Example: ({ id, handler }) => (
-        <Toggle on={false} label="Toggled off" id={id} onChange={handler} />
+        <Toggle
+          on={false}
+          label="Toggled off"
+          id={id}
+          onChange={handler}
+          bleedY
+        />
       ),
     },
     {
       label: 'Toggle on',
       Example: ({ id, handler }) => (
-        <Toggle on={true} label="Toggled on" id={id} onChange={handler} />
+        <Toggle
+          on={true}
+          label="Toggled on"
+          id={id}
+          onChange={handler}
+          bleedY
+        />
       ),
     },
     {
@@ -28,11 +40,13 @@ export const screenshots: ComponentScreenshot = {
           label="Small"
           id={id}
           onChange={handler}
+          bleedY
         />
       ),
     },
     {
-      label: 'Right aligned with default toggle position with default toggle position',
+      label:
+        'Right aligned with default toggle position with default toggle position',
       Container: ({ children }) => (
         <div style={{ maxWidth: '300px' }}>{children}</div>
       ),
@@ -43,11 +57,13 @@ export const screenshots: ComponentScreenshot = {
           label="Aligned right"
           id={id}
           onChange={handler}
+          bleedY
         />
       ),
     },
     {
-      label: 'Justified with default toggle position with default toggle position',
+      label:
+        'Justified with default toggle position with default toggle position',
       Container: ({ children }) => (
         <div style={{ maxWidth: '300px' }}>{children}</div>
       ),
@@ -58,6 +74,7 @@ export const screenshots: ComponentScreenshot = {
           label="Justified"
           id={id}
           onChange={handler}
+          bleedY
         />
       ),
     },
@@ -74,6 +91,7 @@ export const screenshots: ComponentScreenshot = {
             label="Justified"
             id={id}
             onChange={handler}
+            bleedY
           />
         </Box>
       ),
@@ -91,6 +109,7 @@ export const screenshots: ComponentScreenshot = {
           label="Aligned left, leading toggle"
           id={id}
           onChange={handler}
+          bleedY
         />
       ),
     },
@@ -107,6 +126,7 @@ export const screenshots: ComponentScreenshot = {
           label="Aligned left, trailing toggle"
           id={id}
           onChange={handler}
+          bleedY
         />
       ),
     },
@@ -123,6 +143,7 @@ export const screenshots: ComponentScreenshot = {
           label="Justified, leading toggle"
           id={id}
           onChange={handler}
+          bleedY
         />
       ),
     },
@@ -139,6 +160,7 @@ export const screenshots: ComponentScreenshot = {
           label="Justified, trailing toggle"
           id={id}
           onChange={handler}
+          bleedY
         />
       ),
     },
@@ -155,6 +177,7 @@ export const screenshots: ComponentScreenshot = {
           label="Right aligned, leading toggle"
           id={id}
           onChange={handler}
+          bleedY
         />
       ),
     },
@@ -171,6 +194,7 @@ export const screenshots: ComponentScreenshot = {
           label="Right aligned, trailing toggle"
           id={id}
           onChange={handler}
+          bleedY
         />
       ),
     },
@@ -187,6 +211,7 @@ export const screenshots: ComponentScreenshot = {
           label="Aligned left, leading toggle"
           id={id}
           onChange={handler}
+          bleedY
         />
       ),
     },
@@ -203,6 +228,7 @@ export const screenshots: ComponentScreenshot = {
           label="Aligned left, trailing toggle"
           id={id}
           onChange={handler}
+          bleedY
         />
       ),
     },
@@ -219,6 +245,7 @@ export const screenshots: ComponentScreenshot = {
           label="Justified, leading toggle"
           id={id}
           onChange={handler}
+          bleedY
         />
       ),
     },
@@ -235,6 +262,7 @@ export const screenshots: ComponentScreenshot = {
           label="Justified, trailing toggle"
           id={id}
           onChange={handler}
+          bleedY
         />
       ),
     },
@@ -251,6 +279,7 @@ export const screenshots: ComponentScreenshot = {
           label="Right aligned, leading toggle"
           id={id}
           onChange={handler}
+          bleedY
         />
       ),
     },
@@ -267,6 +296,7 @@ export const screenshots: ComponentScreenshot = {
           label="Right aligned, trailing toggle"
           id={id}
           onChange={handler}
+          bleedY
         />
       ),
     },
@@ -281,6 +311,7 @@ export const screenshots: ComponentScreenshot = {
           label="The quick brown fox jumps over the lazy dog. The quick brown fox jumps over the lazy dog."
           id={id}
           onChange={handler}
+          bleedY
         />
       ),
     },
@@ -291,7 +322,7 @@ export const screenshots: ComponentScreenshot = {
       ),
       Example: ({ id, handler }) => (
         <Inline space="xsmall" alignY="center">
-          <Toggle on={true} label="Toggle" id={id} onChange={handler} />
+          <Toggle on={true} label="Toggle" id={id} onChange={handler} bleedY />
           <Text>Inline text</Text>
         </Inline>
       ),
@@ -309,12 +340,14 @@ export const screenshots: ComponentScreenshot = {
             id={id}
             onChange={handler}
             size="small"
+            bleedY
           />
           <Text size="small">Inline text</Text>
         </Inline>
       ),
-    },    {
-      label: 'With bleedY',
+    },
+    {
+      label: 'Without bleedY',
       Container: ({ children }) => (
         <div style={{ maxWidth: '300px' }}>{children}</div>
       ),
@@ -324,7 +357,7 @@ export const screenshots: ComponentScreenshot = {
           label="Vertical bleed"
           id={id}
           onChange={handler}
-          bleedY
+          bleedY={false}
         />
       ),
     },
@@ -338,6 +371,7 @@ export const screenshots: ComponentScreenshot = {
             label="Small"
             id={`${id}-1`}
             onChange={handler}
+            bleedY
           />
           <Toggle
             on={true}
@@ -345,6 +379,7 @@ export const screenshots: ComponentScreenshot = {
             label="Standard"
             id={`${id}-2`}
             onChange={handler}
+            bleedY
           />
         </Inline>
       ),
@@ -355,8 +390,20 @@ export const screenshots: ComponentScreenshot = {
         <Box maxWidth="xsmall">
           <BackgroundContrastTest>
             <Tiles space="small" columns={2}>
-              <Toggle on={true} label="Label" id={id} onChange={handler} />
-              <Toggle on={false} label="Label" id={id} onChange={handler} />
+              <Toggle
+                on={true}
+                label="Label"
+                id={id}
+                onChange={handler}
+                bleedY
+              />
+              <Toggle
+                on={false}
+                label="Label"
+                id={id}
+                onChange={handler}
+                bleedY
+              />
             </Tiles>
           </BackgroundContrastTest>
         </Box>

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.screenshots.tsx
@@ -45,8 +45,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label:
-        'Right aligned with default toggle position with default toggle position',
+      label: 'Right aligned with default toggle position',
       Container: ({ children }) => (
         <div style={{ maxWidth: '300px' }}>{children}</div>
       ),
@@ -62,8 +61,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label:
-        'Justified with default toggle position with default toggle position',
+      label: 'Justified with default toggle position',
       Container: ({ children }) => (
         <div style={{ maxWidth: '300px' }}>{children}</div>
       ),
@@ -219,7 +217,7 @@ export const screenshots: ComponentScreenshot = {
         <div style={{ maxWidth: '300px' }}>{children}</div>
       ),
       Example: ({ id, handler }) => (
-        <Inline space="xsmall" alignY="center">
+        <Inline space="xsmall">
           <Toggle on={true} label="Toggle" id={id} onChange={handler} bleedY />
           <Text>Inline text</Text>
         </Inline>
@@ -231,7 +229,7 @@ export const screenshots: ComponentScreenshot = {
         <div style={{ maxWidth: '300px' }}>{children}</div>
       ),
       Example: ({ id, handler }) => (
-        <Inline space="xsmall" alignY="center">
+        <Inline space="xsmall">
           <Toggle
             on={true}
             label="Toggle"

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.snippets.tsx
@@ -6,22 +6,22 @@ import source from '@braid-design-system/source.macro';
 export const snippets: Snippets = [
   {
     name: 'Standard',
-    code: source(<Toggle label="Label" />),
+    code: source(<Toggle label="Label" bleedY />),
   },
   {
     name: 'Small',
-    code: source(<Toggle label="Label" size="small" />),
+    code: source(<Toggle label="Label" size="small" bleedY />),
   },
   {
     name: 'Right aligned',
-    code: source(<Toggle label="Label" align="right" />),
+    code: source(<Toggle label="Label" align="right" bleedY />),
   },
   {
     name: 'Justified',
-    code: source(<Toggle label="Label" align="justify" />),
+    code: source(<Toggle label="Label" align="justify" bleedY />),
   },
   {
     name: 'Trailing toggle position',
-    code: source(<Toggle label="Label" togglePosition="trailing" />),
+    code: source(<Toggle label="Label" togglePosition="trailing" bleedY />),
   },
 ];

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.test.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.test.tsx
@@ -9,7 +9,13 @@ describe('Toggle', () => {
   it('associates toggle with label correctly', () => {
     const { getByLabelText } = render(
       <BraidTestProvider>
-        <Toggle id="field" label="My toggle" onChange={() => {}} on={false} />
+        <Toggle
+          id="field"
+          label="My toggle"
+          onChange={() => {}}
+          on={false}
+          bleedY
+        />
       </BraidTestProvider>,
     );
 
@@ -29,6 +35,7 @@ describe('Toggle', () => {
             on={false}
             onChange={() => {}}
             ref={ref}
+            bleedY
           />
         </BraidTestProvider>
       );

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -7,7 +7,6 @@ import React, {
 import { Box } from '../Box/Box';
 import { FieldOverlay } from '../private/FieldOverlay/FieldOverlay';
 import { Text } from '../Text/Text';
-import { Bleed } from '../Bleed/Bleed';
 import { IconTick } from '../icons';
 import { useBackgroundLightness } from '../Box/BackgroundContext';
 import buildDataAttributes, {
@@ -38,8 +37,6 @@ const handleChange =
       onChange(event.target.checked);
     }
   };
-
-const verticalPadding = 'xxsmall';
 
 export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
   (
@@ -87,7 +84,12 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
       (align !== 'left' && appliedTogglePosition === 'leading');
 
     const ToggleInput = () => (
-      <Box position="relative">
+      <Box
+        position="relative"
+        className={bleedY && styles.bleedToCapHeight[size]}
+        display={bleedY ? 'flex' : undefined}
+        alignItems={bleedY ? 'center' : undefined}
+      >
         <Box
           component="input"
           type="checkbox"
@@ -195,10 +197,10 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
         flexGrow={align === 'justify' ? 1 : undefined}
         userSelect="none"
         cursor="pointer"
-        className={[styles.label[size], virtualTouchable]}
+        className={virtualTouchable}
       >
         <Text
-          baseline={false}
+          baseline={bleedY}
           weight={on ? 'strong' : undefined}
           size={size}
           align={
@@ -212,7 +214,7 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
       </Box>
     );
 
-    const content = (
+    return (
       <Box
         position="relative"
         zIndex={0}
@@ -221,18 +223,12 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
           appliedTogglePosition === 'trailing' ? 'rowReverse' : 'row'
         }
         justifyContent={alignToEnd ? 'flexEnd' : undefined}
-        className={styles.root}
+        className={[styles.root]}
         {...buildDataAttributes({ data, validateRestProps: restProps })}
       >
         <ToggleInput />
         <ToggleLabel />
       </Box>
-    );
-
-    return bleedY ? (
-      <Bleed vertical={verticalPadding}>{content}</Bleed>
-    ) : (
-      content
     );
   },
 );

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -102,8 +102,8 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
           opacity={0}
           className={[
             styles.realField,
-            styles.realFieldPosition[size],
             styles.fieldSize[size],
+            !bleedY && styles.realFieldPosition[size],
           ]}
           ref={forwardedRef}
         />

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -77,6 +77,132 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
       (align === 'left' && appliedTogglePosition === 'trailing') ||
       (align !== 'left' && appliedTogglePosition === 'leading');
 
+    const ToggleInput = () => (
+      <Box position="relative">
+        <Box
+          component="input"
+          type="checkbox"
+          id={id}
+          checked={on}
+          onChange={handleChange(onChange)}
+          position="absolute"
+          zIndex={1}
+          cursor="pointer"
+          opacity={0}
+          className={[
+            styles.realField,
+            styles.realFieldPosition[size],
+            styles.fieldSize[size],
+          ]}
+          ref={forwardedRef}
+        />
+        <Box
+          position="relative"
+          display="flex"
+          alignItems="center"
+          flexShrink={0}
+          className={[
+            styles.slideContainer,
+            styles.slideContainerSize[size],
+            styles.fieldSize[size],
+          ]}
+        >
+          <Box
+            position="absolute"
+            width="full"
+            overflow="hidden"
+            borderRadius="full"
+            className={[
+              styles.slideTrack[size],
+              styles.slideTrackMask,
+              styles.slideTrackBgLightMode[lightness.lightMode],
+              styles.slideTrackBgDarkMode[lightness.darkMode],
+            ]}
+          >
+            <Box
+              position="absolute"
+              width="full"
+              height="full"
+              background="formAccent"
+              transition="fast"
+              className={styles.slideTrackSelected}
+            />
+          </Box>
+          <Box
+            position="absolute"
+            background="surface"
+            transition="fast"
+            display="flex"
+            alignItems="center"
+            justifyContent="center"
+            borderRadius="full"
+            className={styles.slider[size]}
+          >
+            <FieldOverlay
+              variant={on ? 'formAccent' : 'default'}
+              borderRadius="full"
+              visible
+              className={{
+                [styles.hideBorderOnDarkBackgroundInLightMode]:
+                  lightness.lightMode === 'dark',
+              }}
+            />
+            <FieldOverlay className={styles.icon}>
+              <IconTick tone="formAccent" size="fill" />
+            </FieldOverlay>
+            <FieldOverlay
+              variant="focus"
+              borderRadius="full"
+              className={styles.focusOverlay}
+            />
+            <FieldOverlay
+              variant="formAccent"
+              borderRadius="full"
+              className={!on ? styles.hoverOverlay : undefined}
+            />
+          </Box>
+        </Box>
+      </Box>
+    );
+
+    const ToggleLabel = () => (
+      <Box
+        component="label"
+        htmlFor={id}
+        // Todo - Replace paddings with flex-gap after browser policy change
+        /*
+      Apply padding by default to prevent padding disappearing
+      during partial completion of togglePosition and align props in Playroom
+      */
+        paddingLeft={
+          appliedTogglePosition === 'trailing' ? undefined : 'xsmall'
+        }
+        paddingRight={
+          appliedTogglePosition === 'leading' ? undefined : 'xsmall'
+        }
+        display="flex"
+        flexDirection="column"
+        justifyContent="center"
+        flexGrow={align === 'justify' ? 1 : undefined}
+        userSelect="none"
+        cursor="pointer"
+        className={[styles.label[size], virtualTouchable]}
+      >
+        <Text
+          baseline={false}
+          weight={on ? 'strong' : undefined}
+          size={size}
+          align={
+            align === 'justify' && appliedTogglePosition === 'leading'
+              ? 'right'
+              : undefined
+          }
+        >
+          {label}
+        </Text>
+      </Box>
+    );
+
     const content = (
       <Box
         position="relative"
@@ -89,126 +215,8 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
         className={styles.root}
         {...buildDataAttributes({ data, validateRestProps: restProps })}
       >
-        <Box position="relative">
-          <Box
-            component="input"
-            type="checkbox"
-            id={id}
-            checked={on}
-            onChange={handleChange(onChange)}
-            position="absolute"
-            zIndex={1}
-            cursor="pointer"
-            opacity={0}
-            className={[
-              styles.realField,
-              styles.realFieldPosition[size],
-              styles.fieldSize[size],
-            ]}
-            ref={forwardedRef}
-          />
-          <Box
-            position="relative"
-            display="flex"
-            alignItems="center"
-            flexShrink={0}
-            className={[
-              styles.slideContainer,
-              styles.slideContainerSize[size],
-              styles.fieldSize[size],
-            ]}
-          >
-            <Box
-              position="absolute"
-              width="full"
-              overflow="hidden"
-              borderRadius="full"
-              className={[
-                styles.slideTrack[size],
-                styles.slideTrackMask,
-                styles.slideTrackBgLightMode[lightness.lightMode],
-                styles.slideTrackBgDarkMode[lightness.darkMode],
-              ]}
-            >
-              <Box
-                position="absolute"
-                width="full"
-                height="full"
-                background="formAccent"
-                transition="fast"
-                className={styles.slideTrackSelected}
-              />
-            </Box>
-            <Box
-              position="absolute"
-              background="surface"
-              transition="fast"
-              display="flex"
-              alignItems="center"
-              justifyContent="center"
-              borderRadius="full"
-              className={styles.slider[size]}
-            >
-              <FieldOverlay
-                variant={on ? 'formAccent' : 'default'}
-                borderRadius="full"
-                visible
-                className={{
-                  [styles.hideBorderOnDarkBackgroundInLightMode]:
-                    lightness.lightMode === 'dark',
-                }}
-              />
-              <FieldOverlay className={styles.icon}>
-                <IconTick tone="formAccent" size="fill" />
-              </FieldOverlay>
-              <FieldOverlay
-                variant="focus"
-                borderRadius="full"
-                className={styles.focusOverlay}
-              />
-              <FieldOverlay
-                variant="formAccent"
-                borderRadius="full"
-                className={!on ? styles.hoverOverlay : undefined}
-              />
-            </Box>
-          </Box>
-        </Box>
-        <Box
-          component="label"
-          htmlFor={id}
-          // Todo - Replace paddings with flex-gap after browser policy change
-          /*
-          Apply padding by default to prevent padding disappearing
-          during partial completion of togglePosition and align props in Playroom
-          */
-          paddingLeft={
-            appliedTogglePosition === 'trailing' ? undefined : 'xsmall'
-          }
-          paddingRight={
-            appliedTogglePosition === 'leading' ? undefined : 'xsmall'
-          }
-          display="flex"
-          flexDirection="column"
-          justifyContent="center"
-          flexGrow={align === 'justify' ? 1 : undefined}
-          userSelect="none"
-          cursor="pointer"
-          className={[styles.label[size], virtualTouchable]}
-        >
-          <Text
-            baseline={false}
-            weight={on ? 'strong' : undefined}
-            size={size}
-            align={
-              align === 'justify' && appliedTogglePosition === 'leading'
-                ? 'right'
-                : undefined
-            }
-          >
-            {label}
-          </Text>
-        </Box>
+        <ToggleInput />
+        <ToggleLabel />
       </Box>
     );
 

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -16,6 +16,7 @@ import buildDataAttributes, {
 import { virtualTouchable } from '../private/touchable/virtualTouchable.css';
 import * as styles from './Toggle.css';
 import type { Size } from './Toggle.css';
+import dedent from 'dedent';
 
 type HTMLInputProps = AllHTMLAttributes<HTMLInputElement>;
 type ChangeHandler = (value: boolean) => void;
@@ -54,6 +55,18 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
     },
     forwardedRef,
   ) => {
+    if (process.env.NODE_ENV !== 'production') {
+      if (bleedY === undefined) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          dedent`
+          Please specify bleed with the "bleedY" prop.
+          Bleed will be the default in a future version.
+          To maintain the current appearance, set "bleedY" to "false"`,
+        );
+      }
+    }
+
     const lightness = useBackgroundLightness();
 
     const content = (

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -223,7 +223,7 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
           appliedTogglePosition === 'trailing' ? 'rowReverse' : 'row'
         }
         justifyContent={alignToEnd ? 'flexEnd' : undefined}
-        className={[styles.root]}
+        className={styles.root}
         {...buildDataAttributes({ data, validateRestProps: restProps })}
       >
         <ToggleInput />

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -61,9 +61,9 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
         // eslint-disable-next-line no-console
         console.warn(
           dedent`
-          Please specify bleed with the "bleedY" prop.
-          Bleed will be the default in a future version.
-          To maintain the current appearance, set "bleedY" to "false"`,
+          Please specify an explicit value for the "bleedY" prop.
+          The default value of "bleedY" will change to "true" in a future version.
+          To maintain the current appearance, set "bleedY" to "false".`,
         );
       }
     }

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -40,6 +40,7 @@ const handleChange =
   };
 
 const verticalPadding = 'xxsmall';
+
 export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
   (
     {
@@ -61,9 +62,17 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
         // eslint-disable-next-line no-console
         console.warn(
           dedent`
-          Please specify an explicit value for the "bleedY" prop.
-          The default value of "bleedY" will change to "true" in a future version.
-          To maintain the current appearance, set "bleedY" to "false".`,
+          Vertical bleed will become standard in a future version, which will affect your layout.
+          Please add the "bleedY" prop with a value of "true" and optimise your layout.
+          `,
+        );
+      }
+      if (bleedY === false) {
+        // eslint-disable-next-line no-console
+        console.warn(
+          dedent`
+          Using "bleedY" set to "false" will be deprecated in a future version.
+          Please set the "bleedY" prop to "true" and optimise your layout.`,
         );
       }
     }
@@ -171,9 +180,9 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
         htmlFor={id}
         // Todo - Replace paddings with flex-gap after browser policy change
         /*
-      Apply padding by default to prevent padding disappearing
-      during partial completion of togglePosition and align props in Playroom
-      */
+        Apply padding by default to prevent padding disappearing
+        during partial completion of togglePosition and align props in Playroom
+        */
         paddingLeft={
           appliedTogglePosition === 'trailing' ? undefined : 'xsmall'
         }

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -7,6 +7,7 @@ import React, {
 import { Box } from '../Box/Box';
 import { FieldOverlay } from '../private/FieldOverlay/FieldOverlay';
 import { Text } from '../Text/Text';
+import { Bleed } from '../Bleed/Bleed';
 import { IconTick } from '../icons';
 import { useBackgroundLightness } from '../Box/BackgroundContext';
 import buildDataAttributes, {
@@ -25,6 +26,7 @@ export interface ToggleProps {
   onChange: ChangeHandler;
   align?: 'left' | 'right' | 'justify';
   size?: Size;
+  bleedY?: boolean;
   data?: DataAttributeMap;
 }
 
@@ -35,6 +37,8 @@ const handleChange =
     }
   };
 
+const verticalPadding = 'xxsmall';
+
 export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
   (
     {
@@ -44,6 +48,7 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
       label,
       align = 'left',
       size = 'standard',
+      bleedY = false,
       data,
       ...restProps
     },
@@ -51,7 +56,7 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
   ) => {
     const lightness = useBackgroundLightness();
 
-    return (
+    const content = (
       <Box
         position="relative"
         zIndex={0}
@@ -160,6 +165,12 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
           </Text>
         </Box>
       </Box>
+    );
+
+    return bleedY ? (
+      <Bleed vertical={verticalPadding}>{content}</Bleed>
+    ) : (
+      content
     );
   },
 );

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -8542,6 +8542,7 @@ exports[`Toggle 1`] = `
         | "justify"
         | "left"
         | "right"
+    bleedY?: boolean
     data?: DataAttributeMap
     id: string
     label: ReactNode


### PR DESCRIPTION
This change:

* Adds `bleedY` prop
* Separates Toggle component JSX into sub sections, as the component is getting a bit lengthy
* Adds dev warning if `Toggle` is used without specifying `bleedY`
* Adds `bleedY` set to `true` in all `Toggle` uses across the repo