### PR TITLE
Tag: Introduce “addable” support

### DIFF
--- a/.changeset/sharp-bears-remember.md
+++ b/.changeset/sharp-bears-remember.md
@@ -1,0 +1,18 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Tag
+---
+
+**Tag:** Introduce "addable" support
+
+Tag actions have been extended to now support being “added”.
+A `Tag` will include a small add icon button when both an `onAdd` handler and `addLabel` prop are provided.
+
+**EXAMPLE USAGE:**
+```jsx
+<Tag onAdd={() => {...}} addLabel="Add Tag" />
+```

--- a/packages/braid-design-system/src/lib/components/Tag/Tag.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Tag/Tag.docs.tsx
@@ -80,8 +80,8 @@ const docs: ComponentDocs = {
           </Text>
 
           <Text>
-            Alternatively, providing an <Strong>onAdd</Strong> handler and a{' '}
-            <Strong>addLabel</Strong>, will insert a{' '}
+            Alternatively, providing an <Strong>onAdd</Strong> handler and an{' '}
+            <Strong>addLabel</Strong> will insert a{' '}
             <TextLink href="/components/ButtonIcon">ButtonIcon</TextLink>{' '}
             component with an add icon to the right of the tag label.
           </Text>

--- a/packages/braid-design-system/src/lib/components/Tag/Tag.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Tag/Tag.docs.tsx
@@ -1,12 +1,11 @@
 import React from 'react';
 import type { ComponentDocs } from 'site/types';
 import {
-  Card,
   Inline,
   Tag,
   Strong,
   Text,
-  TextLinkButton,
+  TextLink,
   Stack,
   IconLanguage,
   IconTag,
@@ -17,13 +16,11 @@ const docs: ComponentDocs = {
   category: 'Content',
   Example: () =>
     source(
-      <Card rounded>
-        <Inline space="small">
-          <Tag>One</Tag>
-          <Tag>Two</Tag>
-          <Tag>Three</Tag>
-        </Inline>
-      </Card>,
+      <Inline space="small">
+        <Tag>One</Tag>
+        <Tag>Two</Tag>
+        <Tag>Three</Tag>
+      </Inline>,
     ),
   alternatives: [{ name: 'Badge', description: 'For static labels.' }],
   additional: [
@@ -66,68 +63,98 @@ const docs: ComponentDocs = {
         ),
     },
     {
-      label: 'Clearable',
+      label: 'Actionable tags',
       description: (
         <>
           <Text>
-            Tags can be made clearable, by providing an <Strong>onClear</Strong>{' '}
-            handler and a <Strong>clearLabel</Strong> to describe what clicking
-            it will do.
+            Tags can be made actionable to support either being “cleared” or
+            “added”.
+          </Text>
+
+          <Text>
+            By providing an <Strong>onClear</Strong> handler and a{' '}
+            <Strong>clearLabel</Strong>, a{' '}
+            <TextLink href="/components/ButtonIcon">ButtonIcon</TextLink>{' '}
+            component with a clear icon will be added to the right of the tag
+            label.
+          </Text>
+
+          <Text>
+            Alternatively, providing an <Strong>onAdd</Strong> handler and a{' '}
+            <Strong>addLabel</Strong>, will insert a{' '}
+            <TextLink href="/components/ButtonIcon">ButtonIcon</TextLink>{' '}
+            component with an add icon to the right of the tag label.
           </Text>
 
           <Text tone="promote" id="translations">
             <IconLanguage title="Translation hint" titleId="translations" /> The{' '}
-            <Strong>aria-label</Strong> for the clear button can be customised
-            by providing the <Strong>clearLabel</Strong> prop.
+            <Strong>aria-label</Strong> for the button can be customised by
+            providing the relevant <Strong>clearLabel</Strong> or{' '}
+            <Strong>addLabel</Strong> prop.
           </Text>
         </>
       ),
       background: 'surface',
-      Example: ({ getState, setState, toggleState }) =>
-        source(
-          <Inline space="small" alignY="center">
-            {!getState('clearOne') ? (
-              <Tag
-                onClear={() => toggleState('clearOne')}
-                clearLabel={'Clear "One"'}
-                id="clear-1"
-              >
-                One
-              </Tag>
-            ) : null}
-            {!getState('clearTwo') ? (
-              <Tag
-                onClear={() => toggleState('clearTwo')}
-                clearLabel={'Clear "Two"'}
-                id="clear-2"
-              >
-                Two
-              </Tag>
-            ) : null}
-            {!getState('clearThree') ? (
-              <Tag
-                onClear={() => toggleState('clearThree')}
-                clearLabel={'Clear "Three"'}
-                id="clear-3"
-              >
-                Three
-              </Tag>
-            ) : null}
-            <Text tone="secondary">
-              <TextLinkButton
-                weight="weak"
-                hitArea="large"
-                onClick={() => {
-                  setState('clearOne', false);
-                  setState('clearTwo', false);
-                  setState('clearThree', false);
-                }}
-              >
-                Reset
-              </TextLinkButton>
-            </Text>
-          </Inline>,
-        ),
+      Example: ({ setDefaultState, getState, setState }) => {
+        const { code, value } = source(
+          <>
+            {setDefaultState('selected', ['One', 'Two', 'Three'])}
+
+            <Stack space="large">
+              <Stack space="small">
+                <Text size="xsmall" tone="secondary">
+                  ADDABLE
+                </Text>
+                <Inline space="small" alignY="center">
+                  {['One', 'Two', 'Three', 'Four', 'Five']
+                    .filter((tag) => !getState('selected').includes(tag))
+                    .map((tag) => (
+                      <Tag
+                        key={tag}
+                        onAdd={() =>
+                          setState('selected', [...getState('selected'), tag])
+                        }
+                        addLabel={`Add "${tag}"`}
+                        id={`add-${tag}`}
+                      >
+                        {tag}
+                      </Tag>
+                    ))}
+                </Inline>
+              </Stack>
+              <Stack space="small">
+                <Text size="xsmall" tone="secondary">
+                  CLEARABLE
+                </Text>
+                <Inline space="small" alignY="center">
+                  {getState('selected').map((selectedTag: string) => (
+                    <Tag
+                      key={selectedTag}
+                      onClear={() => {
+                        setState(
+                          'selected',
+                          getState('selected').filter(
+                            (tag: string) => tag !== selectedTag,
+                          ),
+                        );
+                      }}
+                      clearLabel={`Clear "${selectedTag}"`}
+                      id={`clear-${selectedTag}`}
+                    >
+                      {selectedTag}
+                    </Tag>
+                  ))}
+                </Inline>
+              </Stack>
+            </Stack>
+          </>,
+        );
+
+        return {
+          code: code.replaceAll(': string', ''),
+          value,
+        };
+      },
     },
     {
       label: 'Inserting an icon',

--- a/packages/braid-design-system/src/lib/components/Tag/Tag.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Tag/Tag.gallery.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { GalleryComponent } from 'site/types';
-import { Tag, Inline, Text, TextLinkButton, IconTag } from '../';
+import { Tag, Inline, IconTag } from '../';
 import source from '@braid-design-system/source.macro';
 
 export const galleryItems: GalleryComponent = {
@@ -21,40 +21,17 @@ export const galleryItems: GalleryComponent = {
       Example: () => source(<Tag icon={<IconTag />}>Tag</Tag>),
     },
     {
-      label: 'Clearable',
+      label: 'Actionable',
       background: 'surface',
-      Example: ({ getState, setState }) =>
+      Example: () =>
         source(
           <Inline space="small" alignY="center">
-            <Tag>One</Tag>
-            {!getState('clearTwo') ? (
-              <Tag
-                onClear={() => setState('clearTwo', true)}
-                clearLabel={'Clear "Two"'}
-              >
-                Two
-              </Tag>
-            ) : null}
-            {!getState('clearThree') ? (
-              <Tag
-                onClear={() => setState('clearThree', true)}
-                clearLabel={'Clear "Three"'}
-              >
-                Three
-              </Tag>
-            ) : null}
-            <Text tone="secondary">
-              <TextLinkButton
-                weight="weak"
-                hitArea="large"
-                onClick={() => {
-                  setState('clearTwo', false);
-                  setState('clearThree', false);
-                }}
-              >
-                Reset
-              </TextLinkButton>
-            </Text>
+            <Tag addLabel="Add" onAdd={() => {}}>
+              Addable
+            </Tag>
+            <Tag clearLabel="Clear" onClear={() => {}}>
+              Clearable
+            </Tag>
           </Inline>,
         ),
     },

--- a/packages/braid-design-system/src/lib/components/Tag/Tag.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Tag/Tag.screenshots.tsx
@@ -4,7 +4,7 @@ import { Tag, Inline, IconTag, Stack } from '../';
 import { debugTouchableAttrForDataProp } from '../private/touchable/debugTouchable';
 
 export const screenshots: ComponentScreenshot = {
-  screenshotWidths: [320],
+  screenshotWidths: [768],
   examples: [
     {
       label: 'Standard Tag',
@@ -14,6 +14,9 @@ export const screenshots: ComponentScreenshot = {
           <Tag>Tag</Tag>
           <Tag icon={<IconTag />}>Tag</Tag>
           <Tag icon={<IconTag />} onClear={handler} clearLabel="Clear">
+            Tag
+          </Tag>
+          <Tag icon={<IconTag />} onAdd={handler} addLabel="Add">
             Tag
           </Tag>
         </Inline>
@@ -36,6 +39,9 @@ export const screenshots: ComponentScreenshot = {
           >
             Tag
           </Tag>
+          <Tag size="small" icon={<IconTag />} onAdd={handler} addLabel="Add">
+            Tag
+          </Tag>
         </Inline>
       ),
     },
@@ -43,13 +49,36 @@ export const screenshots: ComponentScreenshot = {
       label: 'Truncated Tag',
       background: 'surface',
       Example: ({ handler }) => (
-        <Tag onClear={handler} clearLabel="Clear tag">
-          The quick brown fox jumps over the lazy dog. The quick brown fox jumps
-          over the lazy dog. The quick brown fox jumps over the lazy dog. The
-          quick brown fox jumps over the lazy dog. The quick brown fox jumps
-          over the lazy dog. The quick brown fox jumps over the lazy dog. The
-          quick brown fox jumps over the lazy dog.
-        </Tag>
+        <Stack space="small">
+          <Tag>
+            The quick brown fox jumps over the lazy dog. The quick brown fox
+            jumps over the lazy dog. The quick brown fox jumps over the lazy
+            dog. The quick brown fox jumps over the lazy dog. The quick brown
+            fox jumps over the lazy dog. The quick brown fox jumps over the lazy
+            dog. The quick brown fox jumps over the lazy dog.
+          </Tag>
+          <Tag icon={<IconTag />}>
+            The quick brown fox jumps over the lazy dog. The quick brown fox
+            jumps over the lazy dog. The quick brown fox jumps over the lazy
+            dog. The quick brown fox jumps over the lazy dog. The quick brown
+            fox jumps over the lazy dog. The quick brown fox jumps over the lazy
+            dog. The quick brown fox jumps over the lazy dog.
+          </Tag>
+          <Tag onClear={handler} clearLabel="Clear tag">
+            The quick brown fox jumps over the lazy dog. The quick brown fox
+            jumps over the lazy dog. The quick brown fox jumps over the lazy
+            dog. The quick brown fox jumps over the lazy dog. The quick brown
+            fox jumps over the lazy dog. The quick brown fox jumps over the lazy
+            dog. The quick brown fox jumps over the lazy dog.
+          </Tag>
+          <Tag icon={<IconTag />} onClear={handler} clearLabel="Clear tag">
+            The quick brown fox jumps over the lazy dog. The quick brown fox
+            jumps over the lazy dog. The quick brown fox jumps over the lazy
+            dog. The quick brown fox jumps over the lazy dog. The quick brown
+            fox jumps over the lazy dog. The quick brown fox jumps over the lazy
+            dog. The quick brown fox jumps over the lazy dog.
+          </Tag>
+        </Stack>
       ),
     },
     {
@@ -58,26 +87,19 @@ export const screenshots: ComponentScreenshot = {
       Example: ({ handler }) => (
         <Stack space="large">
           <Inline space="xsmall" data={{ [debugTouchableAttrForDataProp]: '' }}>
-            <Tag size="small">Tag</Tag>
             <Tag size="small" onClear={handler} clearLabel="Clear">
               Tag
             </Tag>
-            <Tag
-              size="small"
-              icon={<IconTag />}
-              onClear={handler}
-              clearLabel="Clear"
-            >
+            <Tag size="small" onAdd={handler} addLabel="Add">
               Tag
             </Tag>
           </Inline>
 
           <Inline space="small" data={{ [debugTouchableAttrForDataProp]: '' }}>
-            <Tag>Tag</Tag>
             <Tag onClear={handler} clearLabel="Clear">
               Tag
             </Tag>
-            <Tag icon={<IconTag />} onClear={handler} clearLabel="Clear">
+            <Tag onAdd={handler} addLabel="Add">
               Tag
             </Tag>
           </Inline>

--- a/packages/braid-design-system/src/lib/components/Tag/Tag.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/Tag/Tag.snippets.tsx
@@ -41,6 +41,22 @@ export const snippets: Snippets = [
     ),
   },
   {
+    name: 'Addable',
+    code: source(
+      <Inline space="small">
+        <Tag onAdd={() => {}} addLabel="Add">
+          Tag
+        </Tag>
+        <Tag onAdd={() => {}} addLabel="Add">
+          Tag
+        </Tag>
+        <Tag onAdd={() => {}} addLabel="Add">
+          Tag
+        </Tag>
+      </Inline>,
+    ),
+  },
+  {
     name: 'With icon',
     code: source(
       <Inline space="small">

--- a/packages/braid-design-system/src/lib/components/Tag/Tag.tsx
+++ b/packages/braid-design-system/src/lib/components/Tag/Tag.tsx
@@ -1,26 +1,41 @@
-import React, { type AllHTMLAttributes } from 'react';
+import React from 'react';
 import assert from 'assert';
 import { Box } from '../Box/Box';
 import { type TextProps, Text } from '../Text/Text';
-import { ButtonIcon } from '../ButtonIcon/ButtonIcon';
-import { IconClear } from '../icons';
+import { ButtonIcon, type ButtonIconProps } from '../ButtonIcon/ButtonIcon';
+import { IconAdd, IconClear } from '../icons';
 import buildDataAttributes, {
   type DataAttributeMap,
 } from '../private/buildDataAttributes';
-import type { AllOrNone } from '../private/AllOrNone';
 import type { Space } from '../../css/atoms/atoms';
 import * as styles from './Tag.css';
 
 export const tagSizes = ['small', 'standard'] as const;
-type NativeButtonProps = AllHTMLAttributes<HTMLButtonElement>;
 
-export type TagProps = {
+type CommonProps = {
   children: string;
   size?: (typeof tagSizes)[number];
   data?: DataAttributeMap;
   id?: string;
   icon?: TextProps['icon'];
-} & AllOrNone<{ onClear: NativeButtonProps['onClick']; clearLabel: string }>;
+};
+
+interface AddableTag extends CommonProps {
+  onAdd: ButtonIconProps['onClick'];
+  addLabel: string;
+}
+interface ClearableTag extends CommonProps {
+  onClear: ButtonIconProps['onClick'];
+  clearLabel: string;
+}
+interface BaseTag extends CommonProps {
+  onClear?: never;
+  clearLabel?: never;
+  onAdd?: never;
+  addLabel?: never;
+}
+
+export type TagProps = ClearableTag | AddableTag | BaseTag;
 
 const paddingXForSize: Record<NonNullable<TagProps['size']>, Space> = {
   small: 'xsmall',
@@ -28,8 +43,6 @@ const paddingXForSize: Record<NonNullable<TagProps['size']>, Space> = {
 };
 
 export const Tag = ({
-  onClear,
-  clearLabel = 'Clear',
   size = 'standard',
   data,
   id,
@@ -47,6 +60,24 @@ export const Tag = ({
     "Icons cannot set the 'size' or 'tone' prop when passed to a Tag component",
   );
 
+  let label = 'Clear';
+  let buttonType = 'clear';
+  let handler;
+
+  const clearable = 'onClear' in restProps && restProps.onClear;
+  const addable = 'onAdd' in restProps && restProps.onAdd;
+
+  if (clearable) {
+    label = restProps.clearLabel;
+    handler = restProps.onClear;
+    buttonType = 'clear';
+  } else if (addable) {
+    label = restProps.addLabel;
+    handler = restProps.onAdd;
+    buttonType = 'add';
+  }
+  const hasButton = clearable || addable;
+
   return (
     <Box
       id={id}
@@ -57,18 +88,23 @@ export const Tag = ({
         display="flex"
         minWidth={0}
         alignItems="center"
-        background="neutralLight"
+        background={addable ? 'formAccentSoft' : 'neutralLight'}
         paddingY="xxsmall"
         paddingX={paddingXForSize[size]}
-        paddingRight={onClear ? 'xsmall' : paddingXForSize[size]}
+        paddingRight={hasButton ? 'xsmall' : paddingXForSize[size]}
         borderRadius="full"
       >
         <Box minWidth={0} title={children}>
-          <Text size={size} baseline={false} maxLines={1}>
+          <Text
+            size={size}
+            baseline={false}
+            maxLines={1}
+            tone={addable ? 'formAccent' : undefined}
+          >
             {icon} {children}
           </Text>
         </Box>
-        {onClear ? (
+        {hasButton ? (
           <Box
             flexShrink={0}
             marginLeft="xxsmall"
@@ -77,12 +113,13 @@ export const Tag = ({
             <ButtonIcon
               // @ts-expect-error With no id, ButtonIcon will fallback from Tooltip to title internally.
               // ID will no longer be required when React 18 has sufficient adoption and we can safely `useId()`
-              id={id ? `${id}-clear` : undefined}
-              icon={<IconClear tone="secondary" />}
-              label={clearLabel}
+              id={id ? `${id}-${buttonType}` : undefined}
+              icon={addable ? <IconAdd /> : <IconClear tone="secondary" />}
+              label={label}
               size="small"
+              tone={addable ? 'formAccent' : 'neutral'}
               variant="transparent"
-              onClick={onClear}
+              onClick={handler}
             />
           </Box>
         ) : null}

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -7574,11 +7574,13 @@ exports[`Tag 1`] = `
 {
   exportType: component,
   props: {
+    addLabel?: string
     children: string
     clearLabel?: string
     data?: DataAttributeMap
     icon?: ReactElement<UseIconProps, string | JSXElementConstructor<any>>
     id?: string
+    onAdd?: MouseEventHandler<HTMLButtonElement>
     onClear?: MouseEventHandler<HTMLButtonElement>
     size?: 
         | "small"


### PR DESCRIPTION
Tag actions have been extended to now support being “added”.
A `Tag` will include a small add icon button when both an `onAdd` handler and `addLabel` prop are provided.

**EXAMPLE USAGE:**
```jsx
<Tag onAdd={() => {...}} addLabel="Add Tag" />
```

### Preview

<img width="340" alt="Preview of Addable Tag" src="https://github.com/seek-oss/braid-design-system/assets/912060/a7f1dd43-0717-4614-8cf5-2f53e647612f">
