### PR TITLE
Implement `babel-loader` cache on CI

### DIFF
--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -27,6 +27,14 @@ jobs:
       - name: Install Dependencies
         run: pnpm i
 
+      - name: Cache babel-loader
+        id: babel-loader-cache
+        uses: actions/cache@v4
+        with:
+          path: 'site/node_modules/.cache/babel-loader'
+          key: babel-loader-${{ runner.os }}-${{ hashFiles('./pnpm-lock.yaml') }}
+          restore-keys: babel-loader-${{ runner.os }}-
+
       - name: Build
         run: pnpm build:site
 


### PR DESCRIPTION
Sku 12.7.0 cut down the docs site build time from about [~2m 15s](https://github.com/seek-oss/braid-design-system/actions/runs/9592121467/job/26450122500#step:6:271) to [nearly 2m flat](https://github.com/seek-oss/braid-design-system/actions/runs/9677868465/job/26700433147#step:6:271) thanks to SWC minification.

With a warm `babel-loader` cache (it will be warm almost all the time), that drops down to about [1m 30s](https://github.com/seek-oss/braid-design-system/actions/runs/9688590668/job/26735665716#step:7:271).