### PR TITLE
site: Apply transparent backgrounds to documentation examples

### DIFF
--- a/packages/braid-design-system/src/entries/css/atoms.docs.tsx
+++ b/packages/braid-design-system/src/entries/css/atoms.docs.tsx
@@ -371,102 +371,93 @@ const docs: CssDoc = {
               ways when upgrading Braid.
             </Text>
           </Alert>
-          <ThemedExample>
-            <Tiles space="large" columns={{ mobile: 1, desktop: 2 }}>
-              {Object.entries(
-                validateBoxShadows({
-                  small: 'Used for small shadows.',
-                  medium: 'Used for medium shadows.',
-                  large: 'Used for large shadows.',
-                  borderNeutral: 'Used for neutral element borders.',
-                  borderNeutralLarge: 'Used for large neutral element borders.',
-                  borderNeutralInverted:
-                    'Used for neutral borders on dark backgrounds.',
-                  borderNeutralInvertedLarge:
-                    'Used for large neutral borders on dark backgrounds.',
-                  borderNeutralLight: 'Used for light neutral element borders.',
-                  borderField: 'Used for borders around form fields.',
-                  outlineFocus:
-                    'Used for focus states of interactive elements.',
-                  borderFormAccent:
-                    'Used for borders around prominent interactive elements.',
-                  borderFormAccentLarge:
-                    'Used for large borders around prominent interactive elements.',
-                  borderFormAccentLight:
-                    'Used for borders around prominent interactive elements in a dark context.',
-                  borderFormAccentLightLarge:
-                    'Used for large borders around prominent interactive elements in a dark context.',
-                  borderBrandAccent:
-                    'Used for borders around branded elements.',
-                  borderBrandAccentLarge:
-                    'Used for large borders around branded elements.',
-                  borderBrandAccentLight:
-                    'Used for borders around branded elements in a dark context.',
-                  borderBrandAccentLightLarge:
-                    'Used for large borders around branded elements in a dark context.',
-                  borderPositive:
-                    'Used for borders around “positive” elements.',
-                  borderPositiveLight:
-                    'Used for borders around “positiveLight” elements.',
-                  borderCritical:
-                    'Used for borders around “critical” elements.',
-                  borderCriticalLarge:
-                    'Used for large borders around “critical” elements.',
-                  borderCriticalLight:
-                    'Used for borders around “criticalLight” elements.',
-                  borderCriticalLightLarge:
-                    'Used for large borders around “criticalLight” elements.',
-                  borderCaution: 'Used for borders around “caution” elements.',
-                  borderCautionLight:
-                    'Used for borders around “cautionLight” elements.',
-                  borderInfo: 'Used for borders around “info” elements.',
-                  borderInfoLight:
-                    'Used for borders around “infoLight” elements.',
-                  borderPromote: 'Used for borders around “promote” elements.',
-                  borderPromoteLight:
-                    'Used for borders around “promoteLight” elements.',
-                }),
-              ).map(([boxShadow, description]) => (
-                <Columns key={boxShadow} space="medium" alignY="center">
-                  <Column width="content">
+          <Tiles space="large" columns={{ mobile: 1, desktop: 2 }}>
+            {Object.entries(
+              validateBoxShadows({
+                small: 'Used for small shadows.',
+                medium: 'Used for medium shadows.',
+                large: 'Used for large shadows.',
+                borderNeutral: 'Used for neutral element borders.',
+                borderNeutralLarge: 'Used for large neutral element borders.',
+                borderNeutralInverted:
+                  'Used for neutral borders on dark backgrounds.',
+                borderNeutralInvertedLarge:
+                  'Used for large neutral borders on dark backgrounds.',
+                borderNeutralLight: 'Used for light neutral element borders.',
+                borderField: 'Used for borders around form fields.',
+                outlineFocus: 'Used for focus states of interactive elements.',
+                borderFormAccent:
+                  'Used for borders around prominent interactive elements.',
+                borderFormAccentLarge:
+                  'Used for large borders around prominent interactive elements.',
+                borderFormAccentLight:
+                  'Used for borders around prominent interactive elements in a dark context.',
+                borderFormAccentLightLarge:
+                  'Used for large borders around prominent interactive elements in a dark context.',
+                borderBrandAccent: 'Used for borders around branded elements.',
+                borderBrandAccentLarge:
+                  'Used for large borders around branded elements.',
+                borderBrandAccentLight:
+                  'Used for borders around branded elements in a dark context.',
+                borderBrandAccentLightLarge:
+                  'Used for large borders around branded elements in a dark context.',
+                borderPositive: 'Used for borders around “positive” elements.',
+                borderPositiveLight:
+                  'Used for borders around “positiveLight” elements.',
+                borderCritical: 'Used for borders around “critical” elements.',
+                borderCriticalLarge:
+                  'Used for large borders around “critical” elements.',
+                borderCriticalLight:
+                  'Used for borders around “criticalLight” elements.',
+                borderCriticalLightLarge:
+                  'Used for large borders around “criticalLight” elements.',
+                borderCaution: 'Used for borders around “caution” elements.',
+                borderCautionLight:
+                  'Used for borders around “cautionLight” elements.',
+                borderInfo: 'Used for borders around “info” elements.',
+                borderInfoLight:
+                  'Used for borders around “infoLight” elements.',
+                borderPromote: 'Used for borders around “promote” elements.',
+                borderPromoteLight:
+                  'Used for borders around “promoteLight” elements.',
+              }),
+            ).map(([boxShadow, description]) => (
+              <Columns key={boxShadow} space="medium" alignY="center">
+                <Column width="content">
+                  <ThemedExample
+                    darkCanvas={
+                      boxShadow.includes('Light') ||
+                      boxShadow.includes('Inverted')
+                    }
+                  >
                     <Box
-                      background={{
-                        lightMode: boxShadow.includes('Inverted')
-                          ? 'neutral'
-                          : 'surface',
-                        darkMode: /^border|outline/.test(boxShadow)
-                          ? 'surfaceDark'
-                          : 'surface',
+                      background={
+                        ['small', 'medium', 'large'].includes(boxShadow)
+                          ? 'surface'
+                          : undefined
+                      }
+                      boxShadow={{
+                        lightMode: boxShadow as keyof BoxShadowDocs,
+                        darkMode: boxShadow as keyof BoxShadowDocs,
                       }}
                       borderRadius="standard"
-                      padding="gutter"
-                    >
-                      <Box
-                        boxShadow={{
-                          lightMode: boxShadow as keyof BoxShadowDocs,
-                          darkMode: boxShadow as keyof BoxShadowDocs,
-                        }}
-                        borderRadius="standard"
-                        padding="gutter"
-                      />
-                    </Box>
-                  </Column>
-                  <Column>
-                    <Box paddingRight="medium">
-                      <Stack space="small">
-                        <Text weight="medium">
-                          <Box style={{ wordBreak: 'break-all' }}>
-                            {boxShadow}
-                          </Box>
-                        </Text>
-                        <Text tone="secondary">{description}</Text>
-                      </Stack>
-                    </Box>
-                  </Column>
-                </Columns>
-              ))}
-            </Tiles>
-          </ThemedExample>
+                      padding="medium"
+                    />
+                  </ThemedExample>
+                </Column>
+                <Column>
+                  <Stack space="medium">
+                    <Text weight="strong">
+                      <Box component="span" style={{ wordBreak: 'break-all' }}>
+                        {boxShadow}
+                      </Box>
+                    </Text>
+                    <Text tone="secondary">{description}</Text>
+                  </Stack>
+                </Column>
+              </Columns>
+            ))}
+          </Tiles>
         </>
       ),
     },

--- a/packages/braid-design-system/src/entries/css/vars.docs.tsx
+++ b/packages/braid-design-system/src/entries/css/vars.docs.tsx
@@ -11,7 +11,7 @@ import {
   Alert,
   List,
 } from 'braid-src/lib/components';
-import { type BoxProps, Box } from 'braid-src/lib/components/Box/Box';
+import { Box } from 'braid-src/lib/components/Box/Box';
 import type { ReactNodeNoStrings } from 'braid-src/lib/components/private/ReactNodeNoStrings';
 import Code from 'site/App/Code/Code';
 import { ThemedExample, useThemeSettings } from 'site/App/ThemeSetting';
@@ -21,12 +21,14 @@ const Row = ({
   group,
   name,
   children,
-  background,
+  hideCanvas = false,
+  darkCanvas = false,
 }: {
   group?: string;
   name: string;
   children: ReactNode;
-  background?: BoxProps['background'];
+  hideCanvas?: boolean;
+  darkCanvas?: boolean;
 }) => (
   <Columns space="large" alignY="center">
     <Column>
@@ -37,7 +39,7 @@ const Row = ({
     </Column>
     <Column width="content">
       <Box style={{ color: vars.foregroundColor.neutral as any }}>
-        <ThemedExample background={background}>
+        <ThemedExample transparent={hideCanvas} darkCanvas={darkCanvas}>
           <Box display="flex">{children}</Box>
         </ThemedExample>
       </Box>
@@ -73,7 +75,7 @@ const ContentWidthValue = ({ var: varName }: { var: string }) => {
 
 const varDocs: Record<keyof typeof vars, ReactNodeNoStrings> = {
   grid: (
-    <Row name="grid">
+    <Row name="grid" hideCanvas>
       <Box
         style={{
           background: 'currentColor',
@@ -84,7 +86,7 @@ const varDocs: Record<keyof typeof vars, ReactNodeNoStrings> = {
     </Row>
   ),
   touchableSize: (
-    <Row name="touchableSize">
+    <Row name="touchableSize" hideCanvas>
       <Box
         style={{
           background: 'currentColor',
@@ -96,9 +98,9 @@ const varDocs: Record<keyof typeof vars, ReactNodeNoStrings> = {
     </Row>
   ),
   contentWidth: (
-    <Stack space="medium" dividers>
+    <Stack space="large" dividers>
       {Object.entries(vars.contentWidth).map(([widthName, widthVar]) => (
-        <Row key={widthName} group="contentWidth" name={widthName}>
+        <Row key={widthName} group="contentWidth" name={widthName} hideCanvas>
           <Text>
             <ContentWidthValue var={widthVar} />
           </Text>
@@ -107,9 +109,9 @@ const varDocs: Record<keyof typeof vars, ReactNodeNoStrings> = {
     </Stack>
   ),
   space: (
-    <Stack space="medium" dividers>
+    <Stack space="large" dividers>
       {Object.entries(vars.space).map(([spaceName, spaceVar]) => (
-        <Row key={spaceName} group="space" name={spaceName}>
+        <Row key={spaceName} group="space" name={spaceName} hideCanvas>
           <Box
             style={{
               background: 'currentColor',
@@ -125,22 +127,24 @@ const varDocs: Record<keyof typeof vars, ReactNodeNoStrings> = {
   foregroundColor: (
     <Stack space="small" dividers>
       {Object.entries(vars.foregroundColor).map(([colorName, colorVar]) => (
-        <Row key={colorName} group="foregroundColor" name={colorName}>
-          <Box
-            background="body"
-            display="inlineBlock"
-            padding="xsmall"
-            borderRadius="standard"
-          >
+        <Row
+          key={colorName}
+          group="foregroundColor"
+          name={colorName}
+          darkCanvas={
+            colorVar.includes('Light') || colorVar.includes('Inverted')
+          }
+        >
+          <Text size="large">
             <Box
-              borderRadius="standard"
+              component="span"
               style={{
-                background: colorVar,
-                width: '32px',
-                height: '32px',
+                color: colorVar,
               }}
-            />
-          </Box>
+            >
+              Aa
+            </Box>
+          </Text>
         </Row>
       ))}
     </Stack>
@@ -150,20 +154,13 @@ const varDocs: Record<keyof typeof vars, ReactNodeNoStrings> = {
       {Object.entries(vars.backgroundColor).map(([colorName, colorVar]) => (
         <Row key={colorName} group="backgroundColor" name={colorName}>
           <Box
-            background="body"
-            display="inlineBlock"
-            padding="xsmall"
             borderRadius="standard"
-          >
-            <Box
-              borderRadius="standard"
-              style={{
-                background: colorVar,
-                width: '32px',
-                height: '32px',
-              }}
-            />
-          </Box>
+            style={{
+              background: colorVar,
+              width: '32px',
+              height: '32px',
+            }}
+          />
         </Row>
       ))}
     </Stack>
@@ -182,22 +179,22 @@ const varDocs: Record<keyof typeof vars, ReactNodeNoStrings> = {
   borderColor: (
     <Stack space="small" dividers>
       {Object.entries(vars.borderColor).map(([colorName, colorVar]) => (
-        <Row key={colorName} group="borderColor" name={colorName}>
+        <Row
+          key={colorName}
+          group="borderColor"
+          name={colorName}
+          darkCanvas={
+            colorVar.includes('Light') || colorVar.includes('Inverted')
+          }
+        >
           <Box
-            background="body"
-            display="inlineBlock"
-            padding="xsmall"
             borderRadius="standard"
-          >
-            <Box
-              borderRadius="standard"
-              style={{
-                border: `2px solid ${colorVar}`,
-                width: '32px',
-                height: '32px',
-              }}
-            />
-          </Box>
+            style={{
+              border: `2px solid ${colorVar}`,
+              width: '32px',
+              height: '32px',
+            }}
+          />
         </Row>
       ))}
     </Stack>
@@ -207,20 +204,13 @@ const varDocs: Record<keyof typeof vars, ReactNodeNoStrings> = {
       {Object.entries(vars.borderWidth).map(([widthName, widthVar]) => (
         <Row key={widthName} group="borderWidth" name={widthName}>
           <Box
-            background="body"
-            display="inlineBlock"
-            padding="xsmall"
             borderRadius="standard"
-          >
-            <Box
-              borderRadius="standard"
-              style={{
-                border: `${widthVar} solid currentColor`,
-                width: '32px',
-                height: '32px',
-              }}
-            />
-          </Box>
+            style={{
+              border: `${widthVar} solid currentColor`,
+              width: '32px',
+              height: '32px',
+            }}
+          />
         </Row>
       ))}
     </Stack>
@@ -230,20 +220,14 @@ const varDocs: Record<keyof typeof vars, ReactNodeNoStrings> = {
       {Object.entries(vars.borderRadius).map(([radiusName, radiusVar]) => (
         <Row key={radiusName} group="borderRadius" name={radiusName}>
           <Box
-            background="body"
-            display="inlineBlock"
-            padding="xsmall"
-            borderRadius="standard"
-          >
-            <Box
-              style={{
-                border: `2px solid currentColor`,
-                borderRadius: radiusVar,
-                width: '32px',
-                height: '32px',
-              }}
-            />
-          </Box>
+            style={{
+              borderTop: `${vars.borderWidth.large} solid ${vars.borderColor.brandAccent}`,
+              borderLeft: `${vars.borderWidth.large} solid ${vars.borderColor.brandAccent}`,
+              borderTopLeftRadius: radiusVar,
+              width: '48px',
+              height: '48px',
+            }}
+          />
         </Row>
       ))}
     </Stack>
@@ -251,22 +235,15 @@ const varDocs: Record<keyof typeof vars, ReactNodeNoStrings> = {
   shadow: (
     <Stack space="small" dividers>
       {Object.entries(vars.shadow).map(([shadowName, shadowVar]) => (
-        <Row
-          key={shadowName}
-          group="shadow"
-          name={shadowName}
-          background={{ lightMode: 'body', darkMode: 'body' }}
-        >
-          <Box display="inlineBlock" padding="xsmall" borderRadius="standard">
-            <Box
-              background={{ lightMode: 'surface', darkMode: 'surface' }}
-              style={{
-                boxShadow: shadowVar,
-                width: '32px',
-                height: '32px',
-              }}
-            />
-          </Box>
+        <Row key={shadowName} group="shadow" name={shadowName}>
+          <Box
+            background="surface"
+            style={{
+              boxShadow: shadowVar,
+              width: '48px',
+              height: '48px',
+            }}
+          />
         </Row>
       ))}
     </Stack>

--- a/packages/braid-design-system/src/lib/components/Accordion/Accordion.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Accordion/Accordion.docs.tsx
@@ -5,7 +5,6 @@ import {
   Accordion,
   AccordionItem,
   Badge,
-  Card,
   Text,
   TextLink,
   Strong,
@@ -85,34 +84,23 @@ const docs: ComponentDocs = {
       ),
       Example: () =>
         source(
-          <Card>
-            <Accordion
-              size="standard"
-              tone="secondary"
-              space="xlarge"
-              weight="regular"
-              dividers={false}
-            >
-              <AccordionItem
-                label="Accordion item 1"
-                id="accordion_appearance_1"
-              >
-                <Placeholder height={80} />
-              </AccordionItem>
-              <AccordionItem
-                label="Accordion item 2"
-                id="accordion_appearance_2"
-              >
-                <Placeholder height={80} />
-              </AccordionItem>
-              <AccordionItem
-                label="Accordion item 3"
-                id="accordion_appearance_3"
-              >
-                <Placeholder height={80} />
-              </AccordionItem>
-            </Accordion>
-          </Card>,
+          <Accordion
+            size="standard"
+            tone="secondary"
+            space="xlarge"
+            weight="regular"
+            dividers={false}
+          >
+            <AccordionItem label="Accordion item 1" id="accordion_appearance_1">
+              <Placeholder height={80} />
+            </AccordionItem>
+            <AccordionItem label="Accordion item 2" id="accordion_appearance_2">
+              <Placeholder height={80} />
+            </AccordionItem>
+            <AccordionItem label="Accordion item 3" id="accordion_appearance_3">
+              <Placeholder height={80} />
+            </AccordionItem>
+          </Accordion>,
         ),
     },
     {

--- a/packages/braid-design-system/src/lib/components/Actions/Actions.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Actions/Actions.docs.tsx
@@ -1,19 +1,17 @@
 import React from 'react';
 import type { ComponentDocs } from 'site/types';
 import source from '@braid-design-system/source.macro';
-import { Actions, Button, TextLink, Text, Strong, Card, Stack } from '../';
+import { Actions, Button, TextLink, Text, Strong, Stack } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
   Example: () =>
     source(
-      <Card rounded>
-        <Actions>
-          <Button>Button 1</Button>
-          <Button>Button 2</Button>
-          <Button variant="transparent">Button 3</Button>
-        </Actions>
-      </Card>,
+      <Actions>
+        <Button>Button 1</Button>
+        <Button>Button 2</Button>
+        <Button variant="transparent">Button 3</Button>
+      </Actions>,
     ),
   alternatives: [
     {

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.docs.tsx
@@ -7,7 +7,6 @@ import {
   TextLink,
   Text,
   Strong,
-  Box,
   Alert,
   List,
   Stack,
@@ -558,52 +557,48 @@ const docs: ComponentDocs = {
       description: (
         <>
           <Text>
-            You can optionally display an overlay behind the field on mobile
-            using the <Strong>showMobileBackdrop</Strong> prop. Note that, for
-            this visual style to work, the field needs to be on a dark
-            background.
+            An overlay can optionally be displayed behind the field on mobile
+            using the <Strong>showMobileBackdrop</Strong> prop.
           </Text>
           <Text>
-            You can also scroll the field to the top of the viewport on focus
-            using the <Strong>scrollToTopOnMobile</Strong> prop.
+            Additionally, you can also scroll the field to the top of the
+            viewport on focus using the <Strong>scrollToTopOnMobile</Strong>{' '}
+            prop.
           </Text>
         </>
       ),
-      background: 'brand',
       Example: ({ id, setDefaultState, getState, setState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: '' })}
 
-            <Box height="full" background="brand">
-              <Autosuggest
-                showMobileBackdrop
-                scrollToTopOnMobile
-                label="Label"
-                id={id}
-                value={getState('value')}
-                onChange={setState('value')}
-                onClear={() => resetState('value')}
-                suggestions={filterSuggestions([
-                  {
-                    text: 'Apples',
-                    value: 1,
-                  },
-                  {
-                    text: 'Bananas',
-                    value: 2,
-                  },
-                  {
-                    text: 'Broccoli',
-                    value: 3,
-                  },
-                  {
-                    text: 'Carrots',
-                    value: 4,
-                  },
-                ])}
-              />
-            </Box>
+            <Autosuggest
+              showMobileBackdrop
+              scrollToTopOnMobile
+              label="Label"
+              id={id}
+              value={getState('value')}
+              onChange={setState('value')}
+              onClear={() => resetState('value')}
+              suggestions={filterSuggestions([
+                {
+                  text: 'Apples',
+                  value: 1,
+                },
+                {
+                  text: 'Bananas',
+                  value: 2,
+                },
+                {
+                  text: 'Broccoli',
+                  value: 3,
+                },
+                {
+                  text: 'Carrots',
+                  value: 4,
+                },
+              ])}
+            />
           </>,
         ),
     },

--- a/packages/braid-design-system/src/lib/components/Badge/Badge.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Badge/Badge.docs.tsx
@@ -1,44 +1,42 @@
 import React, { Fragment } from 'react';
 import type { ComponentDocs } from 'site/types';
 import source from '@braid-design-system/source.macro';
-import { Badge, Card, Inline, Heading, Text, TextLink, Strong } from '../';
+import { Badge, Box, Inline, Heading, Text, TextLink, Strong } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
   Example: () =>
     source(
-      <Card rounded>
-        <Inline space="medium" align="center">
-          <Inline space="medium" collapseBelow="desktop" align="center">
-            <Badge tone="positive">Positive</Badge>
-            <Badge tone="promote">Promote</Badge>
-            <Badge tone="info">Info</Badge>
-            <Badge tone="neutral">Neutral</Badge>
-            <Badge tone="caution">Caution</Badge>
-            <Badge tone="critical">Critical</Badge>
-          </Inline>
-          <Inline space="medium" collapseBelow="desktop" align="center">
-            <Badge weight="strong" tone="positive">
-              Positive
-            </Badge>
-            <Badge weight="strong" tone="promote">
-              Promote
-            </Badge>
-            <Badge weight="strong" tone="info">
-              Info
-            </Badge>
-            <Badge weight="strong" tone="neutral">
-              Neutral
-            </Badge>
-            <Badge weight="strong" tone="caution">
-              Caution
-            </Badge>
-            <Badge weight="strong" tone="critical">
-              Critical
-            </Badge>
-          </Inline>
+      <Inline space="medium" align="center">
+        <Inline space="medium" collapseBelow="desktop" align="center">
+          <Badge tone="positive">Positive</Badge>
+          <Badge tone="promote">Promote</Badge>
+          <Badge tone="info">Info</Badge>
+          <Badge tone="neutral">Neutral</Badge>
+          <Badge tone="caution">Caution</Badge>
+          <Badge tone="critical">Critical</Badge>
         </Inline>
-      </Card>,
+        <Inline space="medium" collapseBelow="desktop" align="center">
+          <Badge weight="strong" tone="positive">
+            Positive
+          </Badge>
+          <Badge weight="strong" tone="promote">
+            Promote
+          </Badge>
+          <Badge weight="strong" tone="info">
+            Info
+          </Badge>
+          <Badge weight="strong" tone="neutral">
+            Neutral
+          </Badge>
+          <Badge weight="strong" tone="caution">
+            Caution
+          </Badge>
+          <Badge weight="strong" tone="critical">
+            Critical
+          </Badge>
+        </Inline>
+      </Inline>,
     ),
   alternatives: [
     {
@@ -55,7 +53,6 @@ const docs: ComponentDocs = {
           <Strong>strong</Strong>.
         </Text>
       ),
-      background: 'surface',
       Example: () =>
         source(
           <Inline space="medium" align="center">
@@ -98,15 +95,16 @@ const docs: ComponentDocs = {
           </Text>
         </Fragment>
       ),
-      background: 'surface',
       Example: () =>
         source(
-          <Inline space="xsmall" alignY="center">
-            <Heading level="4">Heading</Heading>
-            <Badge tone="positive" bleedY>
-              New
-            </Badge>
-          </Inline>,
+          <Box boxShadow="borderCriticalLight">
+            <Inline space="xsmall" alignY="center">
+              <Heading level="4">Heading</Heading>
+              <Badge tone="positive" bleedY>
+                New
+              </Badge>
+            </Inline>
+          </Box>,
         ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/Badge/Badge.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Badge/Badge.gallery.tsx
@@ -7,7 +7,6 @@ export const galleryItems: GalleryComponent = {
   examples: [
     {
       label: 'Positive',
-      background: 'surface',
       Example: () => source(<Badge tone="positive">Positive</Badge>),
     },
     {
@@ -21,7 +20,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Critical',
-      background: 'surface',
       Example: () => source(<Badge tone="critical">Critical</Badge>),
     },
     {
@@ -35,7 +33,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Caution',
-      background: 'surface',
       Example: () => source(<Badge tone="caution">Caution</Badge>),
     },
     {
@@ -49,7 +46,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Info',
-      background: 'surface',
       Example: () => source(<Badge tone="info">Info</Badge>),
     },
     {
@@ -63,7 +59,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Promote',
-      background: 'surface',
       Example: () => source(<Badge tone="promote">Promote</Badge>),
     },
     {
@@ -77,7 +72,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Neutral',
-      background: 'surface',
       Example: () => source(<Badge tone="neutral">Neutral</Badge>),
     },
     {

--- a/packages/braid-design-system/src/lib/components/Box/Box.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Box/Box.docs.tsx
@@ -10,7 +10,9 @@ import {
   Column,
   Strong,
   Alert,
+  BraidProvider,
 } from '../';
+import docsTheme from 'braid-design-system/themes/docs';
 // TODO: COLORMODE RELEASE
 // Use public import
 import { type SimpleBackground, Box } from './Box';
@@ -434,7 +436,7 @@ const docs: ComponentDocs = {
             <Strong>customLight</Strong> or <Strong>customDark</Strong>.
           </Text>
           <Stack space="xxsmall">
-            <ThemedExample background="body">
+            <ThemedExample>
               <Stack space="large">
                 <Box
                   padding="medium"
@@ -495,6 +497,8 @@ const docs: ComponentDocs = {
           </Alert>
         </>
       ),
+      code: false,
+      background: false,
       Example: () => {
         const { code, value } = source(
           <Tiles space="large" columns={{ mobile: 1, desktop: 2 }}>
@@ -553,40 +557,26 @@ const docs: ComponentDocs = {
             ).map(([background, description]) => (
               <Columns key={background} space="medium" alignY="center">
                 <Column width="content">
-                  <Box
-                    background="surface"
-                    borderRadius="large"
-                    padding="gutter"
-                  >
+                  <ThemedExample>
                     <Box
                       background={{
                         lightMode: background as keyof BackgroundDocs,
                         darkMode: background as keyof BackgroundDocs,
                       }}
-                      boxShadow={
-                        (
-                          {
-                            surface: { lightMode: 'borderNeutralLight' },
-                            surfaceDark: { darkMode: 'borderNeutral' },
-                          } as const
-                        )[background]
-                      }
-                      borderRadius="large"
-                      padding="gutter"
+                      borderRadius="standard"
+                      padding="medium"
                     />
-                  </Box>
+                  </ThemedExample>
                 </Column>
                 <Column>
-                  <Box paddingRight="medium">
-                    <Stack space="small">
-                      <Text weight="medium">
-                        <Box style={{ wordBreak: 'break-all' }}>
-                          {background}
-                        </Box>
-                      </Text>
-                      <Text tone="secondary">{description}</Text>
-                    </Stack>
-                  </Box>
+                  <Stack space="medium">
+                    <Text weight="strong">
+                      <Box component="span" style={{ wordBreak: 'break-all' }}>
+                        {background}
+                      </Box>
+                    </Text>
+                    <Text tone="secondary">{description}</Text>
+                  </Stack>
                 </Column>
               </Columns>
             ))}
@@ -597,7 +587,11 @@ const docs: ComponentDocs = {
           code: code
             .replace('validateBackgrounds', '')
             .replace(' as keyof BackgroundDocs', ''),
-          value,
+          value: (
+            <BraidProvider styleBody={false} theme={docsTheme}>
+              {value}
+            </BraidProvider>
+          ),
         };
       },
     },
@@ -626,6 +620,8 @@ const docs: ComponentDocs = {
           </Alert>
         </>
       ),
+      code: false,
+      background: false,
       Example: () => {
         const { code, value } = source(
           <Tiles space="large" columns={{ mobile: 1, desktop: 2 }}>
@@ -681,39 +677,36 @@ const docs: ComponentDocs = {
             ).map(([boxShadow, description]) => (
               <Columns key={boxShadow} space="medium" alignY="center">
                 <Column width="content">
-                  <Box
-                    background={{
-                      lightMode: boxShadow.includes('Inverted')
-                        ? 'neutral'
-                        : 'surface',
-                      darkMode: /^border|outline/.test(boxShadow)
-                        ? 'surfaceDark'
-                        : 'surface',
-                    }}
-                    borderRadius="large"
-                    padding="gutter"
+                  <ThemedExample
+                    darkCanvas={
+                      boxShadow.includes('Light') ||
+                      boxShadow.includes('Inverted')
+                    }
                   >
                     <Box
+                      background={
+                        ['small', 'medium', 'large'].includes(boxShadow)
+                          ? 'surface'
+                          : undefined
+                      }
                       boxShadow={{
                         lightMode: boxShadow as keyof BoxShadowDocs,
                         darkMode: boxShadow as keyof BoxShadowDocs,
                       }}
-                      borderRadius="large"
-                      padding="gutter"
+                      borderRadius="standard"
+                      padding="medium"
                     />
-                  </Box>
+                  </ThemedExample>
                 </Column>
                 <Column>
-                  <Box paddingRight="medium">
-                    <Stack space="small">
-                      <Text weight="medium">
-                        <Box style={{ wordBreak: 'break-all' }}>
-                          {boxShadow}
-                        </Box>
-                      </Text>
-                      <Text tone="secondary">{description}</Text>
-                    </Stack>
-                  </Box>
+                  <Stack space="medium">
+                    <Text weight="strong">
+                      <Box component="span" style={{ wordBreak: 'break-all' }}>
+                        {boxShadow}
+                      </Box>
+                    </Text>
+                    <Text tone="secondary">{description}</Text>
+                  </Stack>
                 </Column>
               </Columns>
             ))}
@@ -724,7 +717,11 @@ const docs: ComponentDocs = {
           code: code
             .replace('validateBoxShadows', '')
             .replace(' as keyof BoxShadowDocs', ''),
-          value,
+          value: (
+            <BraidProvider styleBody={false} theme={docsTheme}>
+              {value}
+            </BraidProvider>
+          ),
         };
       },
     },

--- a/packages/braid-design-system/src/lib/components/Box/Box.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Box/Box.docs.tsx
@@ -12,7 +12,7 @@ import {
   Alert,
   BraidProvider,
 } from '../';
-import docsTheme from 'braid-design-system/themes/docs';
+import docsTheme from 'braid-src/lib/themes/docs';
 // TODO: COLORMODE RELEASE
 // Use public import
 import { type SimpleBackground, Box } from './Box';

--- a/packages/braid-design-system/src/lib/components/Button/Button.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.docs.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import type { ComponentDocs } from 'site/types';
 import {
   Button,
-  Card,
   Stack,
   Box,
   Heading,
@@ -36,7 +35,6 @@ const choosingRightButtonDoc = [
         </Text>
       </>
     ),
-    background: 'surface',
     playroom: false,
     code: false,
     Example: () =>
@@ -65,7 +63,6 @@ const choosingRightButtonDoc = [
         </Text>
       </>
     ),
-    background: 'surface',
     playroom: false,
     code: false,
     Example: () =>
@@ -93,7 +90,6 @@ const choosingRightButtonDoc = [
         </Text>
       </>
     ),
-    background: 'surface',
     playroom: false,
     code: false,
     Example: () =>
@@ -117,14 +113,12 @@ const docs: ComponentDocs = {
   category: 'Content',
   Example: () =>
     source(
-      <Card rounded>
-        <Inline space="small" collapseBelow="desktop">
-          <Button variant="solid">Solid</Button>
-          <Button variant="ghost">Ghost</Button>
-          <Button variant="soft">Soft</Button>
-          <Button variant="transparent">Transparent</Button>
-        </Inline>
-      </Card>,
+      <Inline space="small" collapseBelow="desktop">
+        <Button variant="solid">Solid</Button>
+        <Button variant="ghost">Ghost</Button>
+        <Button variant="soft">Soft</Button>
+        <Button variant="transparent">Transparent</Button>
+      </Inline>,
     ),
   alternatives: [
     {
@@ -143,7 +137,6 @@ const docs: ComponentDocs = {
   additional: [
     {
       label: 'Variants',
-      background: 'surface',
       description: (
         <>
           <Text>
@@ -173,7 +166,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Branding',
-      background: 'surface',
       description: (
         <Text>
           For hero actions that want to leverage the brand colour, you can set
@@ -200,7 +192,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Destructive actions',
-      background: 'surface',
       description: (
         <Text>
           For destructive actions like “Delete” you can set the button’s{' '}
@@ -227,7 +218,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Emphasizing actions',
-      background: 'surface',
       description: (
         <>
           <Text>
@@ -262,7 +252,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'De-emphasized actions',
-      background: 'surface',
       description: (
         <>
           <Text>
@@ -322,7 +311,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Sizes',
-      background: 'surface',
       description: (
         <Text>
           You can customise the size of the button via the <Strong>size</Strong>{' '}
@@ -369,7 +357,6 @@ const docs: ComponentDocs = {
     ...choosingRightButtonDoc,
     {
       label: 'Icons',
-      background: 'surface',
       description: (
         <Text>
           For decoration or help distinguishing between buttons, an{' '}
@@ -379,13 +366,13 @@ const docs: ComponentDocs = {
       Example: () =>
         source(
           <Inline space="gutter" alignY="center">
-            <Stack space="small" align="center">
+            <Stack space="small">
               <Text tone="secondary" weight="strong">
                 Standard size
               </Text>
               <Button icon={<IconSend />}>Send</Button>
             </Stack>
-            <Stack space="small" align="center">
+            <Stack space="small">
               <Text tone="secondary" weight="strong">
                 Small size
               </Text>
@@ -397,7 +384,6 @@ const docs: ComponentDocs = {
         ),
     },
     {
-      background: 'surface',
       description: (
         <Text>
           By default, an icon will be <Strong>leading</Strong> the label,
@@ -419,7 +405,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Loading Button',
-      background: 'surface',
       description: (
         <>
           <Text>
@@ -553,14 +538,13 @@ const docs: ComponentDocs = {
           </Text>
         </>
       ),
-      background: 'surface',
       Example: ({ setDefaultState, toggleState, getState }) =>
         source(
           <>
             {setDefaultState('bleed', true)}
 
-            <Stack space="large">
-              <Stack space="small">
+            <Stack space="xlarge">
+              <Stack space="large">
                 <Toggle
                   id="bleed"
                   on={getState('bleed')}
@@ -571,75 +555,54 @@ const docs: ComponentDocs = {
                 <Text tone="secondary" weight="strong">
                   Standard size alignment
                 </Text>
-                <Box
-                  background="body"
-                  borderRadius="large"
-                  boxShadow="borderNeutralLight"
-                  padding="gutter"
-                >
-                  <Box background="surface" boxShadow="borderCriticalLight">
-                    <Inline space="xsmall" alignY="center">
-                      <Heading level="2">Heading</Heading>
-                      <Button
-                        bleed={getState('bleed')}
-                        tone="formAccent"
-                        variant="solid"
-                      >
-                        Button
-                      </Button>
-                    </Inline>
-                  </Box>
+                <Box boxShadow="borderCriticalLight">
+                  <Inline space="xsmall" alignY="center">
+                    <Heading level="2">Heading</Heading>
+                    <Button
+                      bleed={getState('bleed')}
+                      tone="formAccent"
+                      variant="solid"
+                    >
+                      Button
+                    </Button>
+                  </Inline>
                 </Box>
               </Stack>
-              <Stack space="small">
+              <Stack space="medium">
                 <Text tone="secondary" weight="strong">
                   Small size alignment
                 </Text>
-                <Box
-                  background="body"
-                  borderRadius="large"
-                  boxShadow="borderNeutralLight"
-                  padding="gutter"
-                >
-                  <Box background="surface" boxShadow="borderCriticalLight">
-                    <Inline space="xsmall" alignY="center">
-                      <Heading level="2">Heading</Heading>
+                <Box boxShadow="borderCriticalLight">
+                  <Inline space="xsmall" alignY="center">
+                    <Heading level="2">Heading</Heading>
+                    <Button
+                      bleed={getState('bleed')}
+                      size="small"
+                      tone="formAccent"
+                      variant="solid"
+                    >
+                      Button
+                    </Button>
+                  </Inline>
+                </Box>
+              </Stack>
+              <Stack space="medium">
+                <Text tone="secondary" weight="strong">
+                  Transparent variant alignment
+                </Text>
+                <Box boxShadow="borderCriticalLight">
+                  <Stack space="gutter">
+                    <Heading level="2">Heading</Heading>
+                    <Inline space="none">
                       <Button
                         bleed={getState('bleed')}
-                        size="small"
+                        variant="transparent"
                         tone="formAccent"
-                        variant="solid"
                       >
                         Button
                       </Button>
                     </Inline>
-                  </Box>
-                </Box>
-              </Stack>
-              <Stack space="small">
-                <Text tone="secondary" weight="strong">
-                  Transparent variant alignment
-                </Text>
-                <Box
-                  background="body"
-                  borderRadius="large"
-                  boxShadow="borderNeutralLight"
-                  padding="gutter"
-                >
-                  <Box background="surface" boxShadow="borderCriticalLight">
-                    <Stack space="gutter">
-                      <Heading level="2">Heading</Heading>
-                      <Inline space="none">
-                        <Button
-                          bleed={getState('bleed')}
-                          variant="transparent"
-                          tone="formAccent"
-                        >
-                          Button
-                        </Button>
-                      </Inline>
-                    </Stack>
-                  </Box>
+                  </Stack>
                 </Box>
               </Stack>
             </Stack>

--- a/packages/braid-design-system/src/lib/components/Button/Button.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.gallery.tsx
@@ -7,7 +7,6 @@ export const galleryItems: GalleryComponent = {
   examples: [
     {
       label: 'Critical',
-      background: 'surface',
       Example: () =>
         source(
           <Inline space="small">
@@ -28,7 +27,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'BrandAccent',
-      background: 'surface',
       Example: () =>
         source(
           <Inline space="small">
@@ -49,7 +47,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'FormAccent',
-      background: 'surface',
       Example: () =>
         source(
           <Inline space="small">
@@ -70,7 +67,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Neutral',
-      background: 'surface',
       Example: () =>
         source(
           <Inline space="small">

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.docs.tsx
@@ -19,7 +19,6 @@ import {
   Notice,
   IconOverflow,
   IconAdd,
-  Card,
   IconArrow,
 } from '..';
 
@@ -27,14 +26,12 @@ const docs: ComponentDocs = {
   category: 'Content',
   Example: () =>
     source(
-      <Card rounded>
-        <Inline space="small">
-          <ButtonIcon icon={<IconBookmark />} label="Bookmark" id="example-1" />
-          <ButtonIcon icon={<IconAdd />} label="Add" id="example-2" />
-          <ButtonIcon icon={<IconShare />} label="Share" id="example-3" />
-          <ButtonIcon icon={<IconOverflow />} label="More" id="example-4" />
-        </Inline>
-      </Card>,
+      <Inline space="small">
+        <ButtonIcon icon={<IconBookmark />} label="Bookmark" id="example-1" />
+        <ButtonIcon icon={<IconAdd />} label="Add" id="example-2" />
+        <ButtonIcon icon={<IconShare />} label="Share" id="example-3" />
+        <ButtonIcon icon={<IconOverflow />} label="More" id="example-4" />
+      </Inline>,
     ),
   accessibility: (
     <>
@@ -66,7 +63,6 @@ const docs: ComponentDocs = {
   additional: [
     {
       label: 'Variants',
-      background: 'surface',
       description: (
         <Text>
           The button appearance can be customised via the{' '}
@@ -105,7 +101,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Sizes',
-      background: 'surface',
       description: (
         <>
           <Text>
@@ -164,7 +159,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Tone',
-      background: 'surface',
       description: (
         <Text>
           By default, the button adopts the <Strong>neutral</Strong> tone,
@@ -204,7 +198,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Tooltip Placement',
-      background: 'surface',
       description: (
         <>
           <Text>
@@ -251,7 +244,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Bleed',
-      background: 'surface',
       description: (
         <>
           <Text>
@@ -277,46 +269,34 @@ const docs: ComponentDocs = {
               <Text tone="secondary" size="xsmall">
                 BLEED
               </Text>
-              <Box
-                background="neutralLight"
-                borderRadius="standard"
-                padding="gutter"
-              >
-                <Box background="surface">
-                  <Inline space="small" alignY="center">
-                    <Heading level="2">Heading</Heading>
-                    <ButtonIcon
-                      bleed={true}
-                      size="large"
-                      icon={<IconHelp />}
-                      label="Bleed"
-                      id="bleed-1"
-                    />
-                  </Inline>
-                </Box>
+              <Box boxShadow="borderCriticalLight">
+                <Inline space="small" alignY="center">
+                  <Heading level="2">Heading</Heading>
+                  <ButtonIcon
+                    bleed={true}
+                    size="large"
+                    icon={<IconHelp />}
+                    label="Bleed"
+                    id="bleed-1"
+                  />
+                </Inline>
               </Box>
             </Stack>
             <Stack space="small">
               <Text tone="secondary" size="xsmall">
                 NO BLEED
               </Text>
-              <Box
-                background="neutralLight"
-                borderRadius="standard"
-                padding="gutter"
-              >
-                <Box background="surface">
-                  <Inline space="small" alignY="center">
-                    <Heading level="2">Heading</Heading>
-                    <ButtonIcon
-                      bleed={false}
-                      size="large"
-                      icon={<IconHelp />}
-                      label="No Bleed"
-                      id="bleed-2"
-                    />
-                  </Inline>
-                </Box>
+              <Box boxShadow="borderCriticalLight">
+                <Inline space="small" alignY="center">
+                  <Heading level="2">Heading</Heading>
+                  <ButtonIcon
+                    bleed={false}
+                    size="large"
+                    icon={<IconHelp />}
+                    label="No Bleed"
+                    id="bleed-2"
+                  />
+                </Inline>
               </Box>
             </Stack>
           </Stack>,

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.gallery.tsx
@@ -19,7 +19,6 @@ export const galleryItems: GalleryComponent = {
   examples: [
     {
       label: 'Soft',
-      background: 'surface',
       Example: () =>
         source(
           <Inline space="small">
@@ -48,7 +47,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Transparent',
-      background: 'surface',
       Example: () =>
         source(
           <Inline space="medium">
@@ -81,7 +79,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Sizes',
-      background: 'surface',
       Example: () =>
         source(
           <Stack space="medium">
@@ -123,7 +120,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Tone',
-      background: 'surface',
       Example: () =>
         source(
           <Stack space="medium">
@@ -172,7 +168,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'With bleed',
-      background: 'surface',
       Example: () =>
         source(
           <Inline space="small" alignY="center">

--- a/packages/braid-design-system/src/lib/components/ButtonLink/ButtonLink.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonLink/ButtonLink.docs.tsx
@@ -1,29 +1,27 @@
 import React from 'react';
 import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
-import { ButtonLink, Strong, Text, Card, Inline } from '../';
+import { ButtonLink, Strong, Text, Inline } from '../';
 import { TextLink } from '../TextLink/TextLink';
 
 const docs: ComponentDocs = {
   category: 'Content',
   Example: () =>
     source(
-      <Card rounded>
-        <Inline space="small" collapseBelow="desktop">
-          <ButtonLink href="#" variant="solid">
-            Solid
-          </ButtonLink>
-          <ButtonLink href="#" variant="ghost">
-            Ghost
-          </ButtonLink>
-          <ButtonLink href="#" variant="soft">
-            Soft
-          </ButtonLink>
-          <ButtonLink href="#" variant="transparent">
-            Transparent
-          </ButtonLink>
-        </Inline>
-      </Card>,
+      <Inline space="small" collapseBelow="desktop">
+        <ButtonLink href="#" variant="solid">
+          Solid
+        </ButtonLink>
+        <ButtonLink href="#" variant="ghost">
+          Ghost
+        </ButtonLink>
+        <ButtonLink href="#" variant="soft">
+          Soft
+        </ButtonLink>
+        <ButtonLink href="#" variant="transparent">
+          Transparent
+        </ButtonLink>
+      </Inline>,
     ),
   accessibility: (
     <Text>

--- a/packages/braid-design-system/src/lib/components/Checkbox/Checkbox.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Checkbox/Checkbox.gallery.tsx
@@ -67,7 +67,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'States',
-      background: 'surface',
       Example: ({ id, handler }) =>
         source(
           <Stack space="medium">

--- a/packages/braid-design-system/src/lib/components/Divider/Divider.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Divider/Divider.docs.tsx
@@ -1,24 +1,22 @@
 import React from 'react';
 import type { ComponentDocs } from 'site/types';
-import { Divider, Card, Stack, Text, Strong } from '../';
+import { Divider, Stack, Text, Strong } from '../';
 import source from '@braid-design-system/source.macro';
 
 const docs: ComponentDocs = {
   category: 'Layout',
   Example: () =>
     source(
-      <Card rounded>
-        <Stack space="xlarge">
-          <Stack space="medium">
-            <Text tone="secondary">Regular weight</Text>
-            <Divider />
-          </Stack>
-          <Stack space="medium">
-            <Text tone="secondary">Strong weight</Text>
-            <Divider weight="strong" />
-          </Stack>
+      <Stack space="xlarge">
+        <Stack space="medium">
+          <Text tone="secondary">Regular weight</Text>
+          <Divider />
         </Stack>
-      </Card>,
+        <Stack space="medium">
+          <Text tone="secondary">Strong weight</Text>
+          <Divider weight="strong" />
+        </Stack>
+      </Stack>,
     ),
   accessibility: (
     <Text>

--- a/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.gallery.tsx
@@ -157,7 +157,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Disabled field',
-      background: 'surface',
       Example: ({ id, getState, setState }) =>
         source(
           <Dropdown

--- a/packages/braid-design-system/src/lib/components/MenuItem/MenuItem.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItem/MenuItem.gallery.tsx
@@ -19,7 +19,6 @@ export const galleryItems: GalleryComponent = {
   examples: [
     {
       label: 'Default',
-      background: 'surface',
       Example: () =>
         source(
           <Inline space="none">
@@ -45,7 +44,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'With an icon',
-      background: 'surface',
       Example: () =>
         source(
           <Inline space="none">
@@ -77,7 +75,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'With a Badge',
-      background: 'surface',
       Example: () =>
         source(
           <Inline space="none">
@@ -113,7 +110,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'With a critical tone',
-      background: 'surface',
       Example: () =>
         source(
           <Inline space="none">

--- a/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.gallery.tsx
@@ -15,7 +15,6 @@ export const galleryItems: GalleryComponent = {
   examples: [
     {
       label: 'Default',
-      background: 'surface',
       Example: ({ setDefaultState, getState, toggleState }) =>
         source(
           <>
@@ -62,7 +61,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'With a Badge',
-      background: 'surface',
       Example: ({ setDefaultState, getState, toggleState }) =>
         source(
           <>

--- a/packages/braid-design-system/src/lib/components/MenuItemDivider/MenuItemDivider.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItemDivider/MenuItemDivider.gallery.tsx
@@ -16,7 +16,6 @@ import source from '@braid-design-system/source.macro';
 export const galleryItems: GalleryComponent = {
   examples: [
     {
-      background: 'surface',
       Example: ({ setDefaultState, getState, toggleState }) =>
         source(
           <>

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.docs.tsx
@@ -349,7 +349,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Menu interactions',
-      background: 'surface',
       description: (
         <>
           <Text>

--- a/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.gallery.tsx
@@ -106,7 +106,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Disabled field',
-      background: 'surface',
       Example: ({ id, getState, setState }) =>
         source(
           <MonthPicker

--- a/packages/braid-design-system/src/lib/components/Notice/Notice.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Notice/Notice.docs.tsx
@@ -1,28 +1,26 @@
 import React from 'react';
 import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
-import { Notice, Card, Text, Strong, Stack, TextLink, List } from '../';
+import { Notice, Text, Strong, Stack, TextLink, List } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
   Example: () =>
     source(
-      <Card rounded>
-        <Stack space="medium">
-          <Notice tone="promote">
-            <Text>This is a promoted message.</Text>
-          </Notice>
-          <Notice tone="info">
-            <Text>This is an informative message.</Text>
-          </Notice>
-          <Notice tone="positive">
-            <Text>This is a positive message.</Text>
-          </Notice>
-          <Notice tone="critical">
-            <Text>This is a critical message.</Text>
-          </Notice>
-        </Stack>
-      </Card>,
+      <Stack space="medium">
+        <Notice tone="promote">
+          <Text>This is a promoted message.</Text>
+        </Notice>
+        <Notice tone="info">
+          <Text>This is an informative message.</Text>
+        </Notice>
+        <Notice tone="positive">
+          <Text>This is a positive message.</Text>
+        </Notice>
+        <Notice tone="critical">
+          <Text>This is a critical message.</Text>
+        </Notice>
+      </Stack>,
     ),
   accessibility: (
     <>
@@ -80,21 +78,19 @@ const docs: ComponentDocs = {
       ),
       Example: () =>
         source(
-          <Card>
-            <Notice tone="info">
-              <Stack space="large">
-                <Text>
-                  This is an important piece of information with a{' '}
-                  <TextLink href="#">TextLink.</TextLink>
-                </Text>
-                <List space="medium">
-                  <Text>Bullet 1</Text>
-                  <Text>Bullet 2</Text>
-                  <Text>Bullet 3</Text>
-                </List>
-              </Stack>
-            </Notice>
-          </Card>,
+          <Notice tone="info">
+            <Stack space="large">
+              <Text>
+                This is an important piece of information with a{' '}
+                <TextLink href="#">TextLink.</TextLink>
+              </Text>
+              <List space="medium">
+                <Text>Bullet 1</Text>
+                <Text>Bullet 2</Text>
+                <Text>Bullet 3</Text>
+              </List>
+            </Stack>
+          </Notice>,
         ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.docs.tsx
@@ -108,7 +108,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Menu interactions',
-      background: 'surface',
       description: (
         <>
           <Text>

--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.gallery.tsx
@@ -6,7 +6,6 @@ import source from '@braid-design-system/source.macro';
 export const galleryItems: GalleryComponent = {
   examples: [
     {
-      background: 'surface',
       Example: ({ handler }) =>
         source(
           <Box style={{ maxWidth: '100px' }}>

--- a/packages/braid-design-system/src/lib/components/Pagination/Pagination.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Pagination/Pagination.gallery.tsx
@@ -7,7 +7,6 @@ export const galleryItems: GalleryComponent = {
   examples: [
     {
       label: 'Standard',
-      background: 'surface',
       Example: () => source(<Pagination />),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.gallery.tsx
@@ -102,7 +102,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Disabled field',
-      background: 'surface',
       Example: ({ id, getState, setState }) =>
         source(
           <PasswordField

--- a/packages/braid-design-system/src/lib/components/Tabs/Tabs.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Tabs/Tabs.docs.tsx
@@ -13,7 +13,7 @@ import {
   Badge,
   Strong,
   List,
-  Card,
+  Box,
   IconCompany,
   IconHome,
   IconProfile,
@@ -26,34 +26,30 @@ const docs: ComponentDocs = {
   subComponents: ['TabsProvider', 'Tab', 'TabPanels', 'TabPanel'],
   Example: ({ id }) =>
     source(
-      <Card rounded>
-        <TabsProvider id={id}>
-          <Stack space="medium">
-            <Tabs label="Test tabs">
-              <Tab>The first tab</Tab>
-              <Tab>The second tab</Tab>
-              <Tab>The third tab</Tab>
-              <Tab badge={<Badge tone="positive">New</Badge>}>
-                The fourth tab
-              </Tab>
-            </Tabs>
-            <TabPanels>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 1" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 2" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 3" />
-              </TabPanel>
-              <TabPanel>
-                <Placeholder height={200} label="Panel 4" />
-              </TabPanel>
-            </TabPanels>
-          </Stack>
-        </TabsProvider>
-      </Card>,
+      <TabsProvider id={id}>
+        <Stack space="medium">
+          <Tabs label="Test tabs">
+            <Tab>The first tab</Tab>
+            <Tab>The second tab</Tab>
+            <Tab>The third tab</Tab>
+            <Tab badge={<Badge tone="positive">New</Badge>}>The fourth tab</Tab>
+          </Tabs>
+          <TabPanels>
+            <TabPanel>
+              <Placeholder height={200} label="Panel 1" />
+            </TabPanel>
+            <TabPanel>
+              <Placeholder height={200} label="Panel 2" />
+            </TabPanel>
+            <TabPanel>
+              <Placeholder height={200} label="Panel 3" />
+            </TabPanel>
+            <TabPanel>
+              <Placeholder height={200} label="Panel 4" />
+            </TabPanel>
+          </TabPanels>
+        </Stack>
+      </TabsProvider>,
     ),
   accessibility: (
     <Text>
@@ -115,24 +111,22 @@ const docs: ComponentDocs = {
       ),
       Example: ({ id }) =>
         source(
-          <Card>
-            <TabsProvider id={id}>
-              <Stack space="medium">
-                <Tabs label="Test tabs" align="center">
-                  <Tab>The first tab</Tab>
-                  <Tab>The second tab</Tab>
-                </Tabs>
-                <TabPanels>
-                  <TabPanel>
-                    <Placeholder height={200} label="Panel 1" />
-                  </TabPanel>
-                  <TabPanel>
-                    <Placeholder height={200} label="Panel 2" />
-                  </TabPanel>
-                </TabPanels>
-              </Stack>
-            </TabsProvider>
-          </Card>,
+          <TabsProvider id={id}>
+            <Stack space="medium">
+              <Tabs label="Test tabs" align="center">
+                <Tab>The first tab</Tab>
+                <Tab>The second tab</Tab>
+              </Tabs>
+              <TabPanels>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 1" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 2" />
+                </TabPanel>
+              </TabPanels>
+            </Stack>
+          </TabsProvider>,
         ),
     },
     {
@@ -147,24 +141,22 @@ const docs: ComponentDocs = {
       ),
       Example: ({ id }) =>
         source(
-          <Card>
-            <TabsProvider id={`${id}_1`}>
-              <Stack space="medium">
-                <Tabs label="Test tabs" divider="full">
-                  <Tab>The first tab</Tab>
-                  <Tab>The second tab</Tab>
-                </Tabs>
-                <TabPanels>
-                  <TabPanel>
-                    <Placeholder height={200} label="Panel 1" />
-                  </TabPanel>
-                  <TabPanel>
-                    <Placeholder height={200} label="Panel 2" />
-                  </TabPanel>
-                </TabPanels>
-              </Stack>
-            </TabsProvider>
-          </Card>,
+          <TabsProvider id={`${id}_1`}>
+            <Stack space="medium">
+              <Tabs label="Test tabs" divider="full">
+                <Tab>The first tab</Tab>
+                <Tab>The second tab</Tab>
+              </Tabs>
+              <TabPanels>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 1" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 2" />
+                </TabPanel>
+              </TabPanels>
+            </Stack>
+          </TabsProvider>,
         ),
     },
     {
@@ -186,7 +178,11 @@ const docs: ComponentDocs = {
               <Tab>The third tab</Tab>
               <Tab>The fourth tab</Tab>
             </Tabs>
-            <Card>
+            <Box
+              background="surface"
+              boxShadow="borderNeutralLight"
+              padding="gutter"
+            >
               <TabPanels>
                 <TabPanel>
                   <Placeholder height={200} label="Panel 1" />
@@ -201,7 +197,7 @@ const docs: ComponentDocs = {
                   <Placeholder height={200} label="Panel 4" />
                 </TabPanel>
               </TabPanels>
-            </Card>
+            </Box>
           </TabsProvider>,
         ),
     },
@@ -228,7 +224,11 @@ const docs: ComponentDocs = {
               <Tab>The third tab</Tab>
               <Tab>The fourth tab</Tab>
             </Tabs>
-            <Card>
+            <Box
+              background="surface"
+              boxShadow="borderNeutralLight"
+              padding="gutter"
+            >
               <TabPanels>
                 <TabPanel>
                   <Placeholder height={200} label="Panel 1" />
@@ -243,7 +243,7 @@ const docs: ComponentDocs = {
                   <Placeholder height={200} label="Panel 4" />
                 </TabPanel>
               </TabPanels>
-            </Card>
+            </Box>
           </TabsProvider>,
         ),
     },
@@ -257,34 +257,32 @@ const docs: ComponentDocs = {
       ),
       Example: ({ id }) =>
         source(
-          <Card>
-            <TabsProvider id={id}>
-              <Stack space="medium">
-                <Tabs label="Test tabs">
-                  <Tab>The first tab</Tab>
-                  <Tab badge={<Badge tone="positive">New</Badge>}>
-                    The second tab
-                  </Tab>
-                  <Tab>The third tab</Tab>
-                  <Tab>The fourth tab</Tab>
-                </Tabs>
-                <TabPanels>
-                  <TabPanel>
-                    <Placeholder height={200} label="Panel 1" />
-                  </TabPanel>
-                  <TabPanel>
-                    <Placeholder height={200} label="Panel 2" />
-                  </TabPanel>
-                  <TabPanel>
-                    <Placeholder height={200} label="Panel 3" />
-                  </TabPanel>
-                  <TabPanel>
-                    <Placeholder height={200} label="Panel 4" />
-                  </TabPanel>
-                </TabPanels>
-              </Stack>
-            </TabsProvider>
-          </Card>,
+          <TabsProvider id={id}>
+            <Stack space="medium">
+              <Tabs label="Test tabs">
+                <Tab>The first tab</Tab>
+                <Tab badge={<Badge tone="positive">New</Badge>}>
+                  The second tab
+                </Tab>
+                <Tab>The third tab</Tab>
+                <Tab>The fourth tab</Tab>
+              </Tabs>
+              <TabPanels>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 1" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 2" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 3" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 4" />
+                </TabPanel>
+              </TabPanels>
+            </Stack>
+          </TabsProvider>,
         ),
     },
     {
@@ -300,32 +298,30 @@ const docs: ComponentDocs = {
       ),
       Example: ({ id }) =>
         source(
-          <Card>
-            <TabsProvider id={id}>
-              <Stack space="medium">
-                <Tabs label="Test tabs">
-                  <Tab icon={<IconHome />}>The first tab</Tab>
-                  <Tab icon={<IconRecommended />}>The second tab</Tab>
-                  <Tab icon={<IconCompany />}>The third tab</Tab>
-                  <Tab icon={<IconProfile />}>The fourth tab</Tab>
-                </Tabs>
-                <TabPanels>
-                  <TabPanel>
-                    <Placeholder height={200} label="Panel 1" />
-                  </TabPanel>
-                  <TabPanel>
-                    <Placeholder height={200} label="Panel 2" />
-                  </TabPanel>
-                  <TabPanel>
-                    <Placeholder height={200} label="Panel 3" />
-                  </TabPanel>
-                  <TabPanel>
-                    <Placeholder height={200} label="Panel 4" />
-                  </TabPanel>
-                </TabPanels>
-              </Stack>
-            </TabsProvider>
-          </Card>,
+          <TabsProvider id={id}>
+            <Stack space="medium">
+              <Tabs label="Test tabs">
+                <Tab icon={<IconHome />}>The first tab</Tab>
+                <Tab icon={<IconRecommended />}>The second tab</Tab>
+                <Tab icon={<IconCompany />}>The third tab</Tab>
+                <Tab icon={<IconProfile />}>The fourth tab</Tab>
+              </Tabs>
+              <TabPanels>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 1" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 2" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 3" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={200} label="Panel 4" />
+                </TabPanel>
+              </TabPanels>
+            </Stack>
+          </TabsProvider>,
         ),
     },
     {
@@ -349,18 +345,13 @@ const docs: ComponentDocs = {
               selectedItem={getState('tab')}
               onChange={(index, item) => setState('tab', item)}
             >
-              <Tabs
-                label="Test tabs"
-                gutter="gutter"
-                divider="none"
-                reserveHitArea
-              >
-                <Tab item="first">The first tab</Tab>
-                <Tab item="second">The second tab</Tab>
-                <Tab item="third">The third tab</Tab>
-                <Tab item="fourth">The fourth tab</Tab>
-              </Tabs>
-              <Card>
+              <Stack space="medium">
+                <Tabs label="Test tabs" divider="none" reserveHitArea>
+                  <Tab item="first">The first tab</Tab>
+                  <Tab item="second">The second tab</Tab>
+                  <Tab item="third">The third tab</Tab>
+                  <Tab item="fourth">The fourth tab</Tab>
+                </Tabs>
                 <TabPanels>
                   <TabPanel item="first">
                     <Placeholder height={200} label="Panel 1" />
@@ -375,7 +366,7 @@ const docs: ComponentDocs = {
                     <Placeholder height={200} label="Panel 4" />
                   </TabPanel>
                 </TabPanels>
-              </Card>
+              </Stack>
             </TabsProvider>
           </>,
         ),

--- a/packages/braid-design-system/src/lib/components/Tabs/Tabs.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Tabs/Tabs.gallery.tsx
@@ -8,7 +8,6 @@ import {
   TabPanels,
   TabsProvider,
   Badge,
-  Card,
   IconCompany,
   IconHome,
   IconRecommended,
@@ -22,52 +21,48 @@ export const galleryItems: GalleryComponent = {
       label: 'Left aligned',
       Example: ({ id }) =>
         source(
-          <Card>
-            <TabsProvider id={id}>
-              <Stack space="medium">
-                <Tabs label="Test tabs">
-                  <Tab>The first tab</Tab>
-                  <Tab>The second tab</Tab>
-                  <Tab>The third tab</Tab>
-                </Tabs>
-                <TabPanels>
-                  <TabPanel>
-                    <Placeholder height={100} label="Panel 1" />
-                  </TabPanel>
-                  <TabPanel>
-                    <Placeholder height={100} label="Panel 2" />
-                  </TabPanel>
-                  <TabPanel>
-                    <Placeholder height={100} label="Panel 3" />
-                  </TabPanel>
-                </TabPanels>
-              </Stack>
-            </TabsProvider>
-          </Card>,
+          <TabsProvider id={id}>
+            <Stack space="medium">
+              <Tabs label="Test tabs">
+                <Tab>The first tab</Tab>
+                <Tab>The second tab</Tab>
+                <Tab>The third tab</Tab>
+              </Tabs>
+              <TabPanels>
+                <TabPanel>
+                  <Placeholder height={100} label="Panel 1" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={100} label="Panel 2" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={100} label="Panel 3" />
+                </TabPanel>
+              </TabPanels>
+            </Stack>
+          </TabsProvider>,
         ),
     },
     {
       label: 'Center aligned',
       Example: ({ id }) =>
         source(
-          <Card>
-            <TabsProvider id={id}>
-              <Stack space="medium">
-                <Tabs label="Test tabs" align="center">
-                  <Tab>The first tab</Tab>
-                  <Tab>The second tab</Tab>
-                </Tabs>
-                <TabPanels>
-                  <TabPanel>
-                    <Placeholder height={100} label="Panel 1" />
-                  </TabPanel>
-                  <TabPanel>
-                    <Placeholder height={100} label="Panel 2" />
-                  </TabPanel>
-                </TabPanels>
-              </Stack>
-            </TabsProvider>
-          </Card>,
+          <TabsProvider id={id}>
+            <Stack space="medium">
+              <Tabs label="Test tabs" align="center">
+                <Tab>The first tab</Tab>
+                <Tab>The second tab</Tab>
+              </Tabs>
+              <TabPanels>
+                <TabPanel>
+                  <Placeholder height={100} label="Panel 1" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={100} label="Panel 2" />
+                </TabPanel>
+              </TabPanels>
+            </Stack>
+          </TabsProvider>,
         ),
     },
     {
@@ -80,19 +75,17 @@ export const galleryItems: GalleryComponent = {
               <Tab>The second tab</Tab>
               <Tab>The third tab</Tab>
             </Tabs>
-            <Card>
-              <TabPanels>
-                <TabPanel>
-                  <Placeholder height={100} label="Panel 1" />
-                </TabPanel>
-                <TabPanel>
-                  <Placeholder height={100} label="Panel 2" />
-                </TabPanel>
-                <TabPanel>
-                  <Placeholder height={100} label="Panel 3" />
-                </TabPanel>
-              </TabPanels>
-            </Card>
+            <TabPanels>
+              <TabPanel>
+                <Placeholder height={100} label="Panel 1" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={100} label="Panel 2" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={100} label="Panel 3" />
+              </TabPanel>
+            </TabPanels>
           </TabsProvider>,
         ),
     },
@@ -100,24 +93,22 @@ export const galleryItems: GalleryComponent = {
       label: 'Full width divider',
       Example: ({ id }) =>
         source(
-          <Card>
-            <TabsProvider id={id}>
-              <Stack space="medium">
-                <Tabs label="Test tabs" divider="full">
-                  <Tab>The first tab</Tab>
-                  <Tab>The second tab</Tab>
-                </Tabs>
-                <TabPanels>
-                  <TabPanel>
-                    <Placeholder height={100} label="Panel 1" />
-                  </TabPanel>
-                  <TabPanel>
-                    <Placeholder height={100} label="Panel 2" />
-                  </TabPanel>
-                </TabPanels>
-              </Stack>
-            </TabsProvider>
-          </Card>,
+          <TabsProvider id={id}>
+            <Stack space="medium">
+              <Tabs label="Test tabs" divider="full">
+                <Tab>The first tab</Tab>
+                <Tab>The second tab</Tab>
+              </Tabs>
+              <TabPanels>
+                <TabPanel>
+                  <Placeholder height={100} label="Panel 1" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={100} label="Panel 2" />
+                </TabPanel>
+              </TabPanels>
+            </Stack>
+          </TabsProvider>,
         ),
     },
     {
@@ -130,7 +121,33 @@ export const galleryItems: GalleryComponent = {
               <Tab>The second tab</Tab>
               <Tab>The third tab</Tab>
             </Tabs>
-            <Card>
+            <TabPanels>
+              <TabPanel>
+                <Placeholder height={100} label="Panel 1" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={100} label="Panel 2" />
+              </TabPanel>
+              <TabPanel>
+                <Placeholder height={100} label="Panel 3" />
+              </TabPanel>
+            </TabPanels>
+          </TabsProvider>,
+        ),
+    },
+    {
+      label: 'With a badge',
+      Example: ({ id }) =>
+        source(
+          <TabsProvider id={id}>
+            <Stack space="medium">
+              <Tabs label="Test tabs">
+                <Tab>The first tab</Tab>
+                <Tab>The second tab</Tab>
+                <Tab badge={<Badge tone="positive">New</Badge>}>
+                  The third tab
+                </Tab>
+              </Tabs>
               <TabPanels>
                 <TabPanel>
                   <Placeholder height={100} label="Panel 1" />
@@ -142,66 +159,34 @@ export const galleryItems: GalleryComponent = {
                   <Placeholder height={100} label="Panel 3" />
                 </TabPanel>
               </TabPanels>
-            </Card>
+            </Stack>
           </TabsProvider>,
-        ),
-    },
-    {
-      label: 'With a badge',
-      Example: ({ id }) =>
-        source(
-          <Card>
-            <TabsProvider id={id}>
-              <Stack space="medium">
-                <Tabs label="Test tabs">
-                  <Tab>The first tab</Tab>
-                  <Tab>The second tab</Tab>
-                  <Tab badge={<Badge tone="positive">New</Badge>}>
-                    The third tab
-                  </Tab>
-                </Tabs>
-                <TabPanels>
-                  <TabPanel>
-                    <Placeholder height={100} label="Panel 1" />
-                  </TabPanel>
-                  <TabPanel>
-                    <Placeholder height={100} label="Panel 2" />
-                  </TabPanel>
-                  <TabPanel>
-                    <Placeholder height={100} label="Panel 3" />
-                  </TabPanel>
-                </TabPanels>
-              </Stack>
-            </TabsProvider>
-          </Card>,
         ),
     },
     {
       label: 'With an icon',
       Example: ({ id }) =>
         source(
-          <Card>
-            <TabsProvider id={id}>
-              <Stack space="medium">
-                <Tabs label="Test tabs">
-                  <Tab icon={<IconHome />}>The first tab</Tab>
-                  <Tab icon={<IconRecommended />}>The second tab</Tab>
-                  <Tab icon={<IconCompany />}>The third tab</Tab>
-                </Tabs>
-                <TabPanels>
-                  <TabPanel>
-                    <Placeholder height={100} label="Panel 1" />
-                  </TabPanel>
-                  <TabPanel>
-                    <Placeholder height={100} label="Panel 2" />
-                  </TabPanel>
-                  <TabPanel>
-                    <Placeholder height={100} label="Panel 3" />
-                  </TabPanel>
-                </TabPanels>
-              </Stack>
-            </TabsProvider>
-          </Card>,
+          <TabsProvider id={id}>
+            <Stack space="medium">
+              <Tabs label="Test tabs">
+                <Tab icon={<IconHome />}>The first tab</Tab>
+                <Tab icon={<IconRecommended />}>The second tab</Tab>
+                <Tab icon={<IconCompany />}>The third tab</Tab>
+              </Tabs>
+              <TabPanels>
+                <TabPanel>
+                  <Placeholder height={100} label="Panel 1" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={100} label="Panel 2" />
+                </TabPanel>
+                <TabPanel>
+                  <Placeholder height={100} label="Panel 3" />
+                </TabPanel>
+              </TabPanels>
+            </Stack>
+          </TabsProvider>,
         ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/Tag/Tag.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Tag/Tag.docs.tsx
@@ -1,7 +1,6 @@
 import React from 'react';
 import type { ComponentDocs } from 'site/types';
 import {
-  Card,
   Inline,
   Tag,
   Strong,
@@ -17,19 +16,16 @@ const docs: ComponentDocs = {
   category: 'Content',
   Example: () =>
     source(
-      <Card rounded>
-        <Inline space="small">
-          <Tag>One</Tag>
-          <Tag>Two</Tag>
-          <Tag>Three</Tag>
-        </Inline>
-      </Card>,
+      <Inline space="small">
+        <Tag>One</Tag>
+        <Tag>Two</Tag>
+        <Tag>Three</Tag>
+      </Inline>,
     ),
   alternatives: [{ name: 'Badge', description: 'For static labels.' }],
   additional: [
     {
       label: 'Sizes',
-      background: 'surface',
       description: (
         <>
           <Text>
@@ -82,7 +78,6 @@ const docs: ComponentDocs = {
           </Text>
         </>
       ),
-      background: 'surface',
       Example: ({ getState, setState, toggleState }) =>
         source(
           <Inline space="small" alignY="center">
@@ -131,7 +126,6 @@ const docs: ComponentDocs = {
     },
     {
       label: 'Inserting an icon',
-      background: 'surface',
       description: (
         <>
           <Text>

--- a/packages/braid-design-system/src/lib/components/Tag/Tag.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Tag/Tag.gallery.tsx
@@ -7,22 +7,18 @@ export const galleryItems: GalleryComponent = {
   examples: [
     {
       label: 'Standard',
-      background: 'surface',
       Example: () => source(<Tag>Tag</Tag>),
     },
     {
       label: 'Small',
-      background: 'surface',
       Example: () => source(<Tag size="small">Tag</Tag>),
     },
     {
       label: 'With an icon',
-      background: 'surface',
       Example: () => source(<Tag icon={<IconTag />}>Tag</Tag>),
     },
     {
       label: 'Clearable',
-      background: 'surface',
       Example: ({ getState, setState }) =>
         source(
           <Inline space="small" alignY="center">

--- a/packages/braid-design-system/src/lib/components/Text/Text.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Text/Text.docs.tsx
@@ -151,7 +151,6 @@ const docs: ComponentDocs = {
           </Text>
         </>
       ),
-      background: 'surface',
       Example: () =>
         source(
           <Inline space="gutter">
@@ -180,7 +179,6 @@ const docs: ComponentDocs = {
           </List>
         </>
       ),
-      background: 'surface',
       Example: () =>
         source(
           <Inline space="gutter">
@@ -197,7 +195,6 @@ const docs: ComponentDocs = {
           text tone will be matched by default.
         </Text>
       ),
-      background: 'surface',
       Example: () =>
         source(
           <Inline space="gutter">

--- a/packages/braid-design-system/src/lib/components/Text/Text.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Text/Text.gallery.tsx
@@ -53,7 +53,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Tones',
-      background: 'surface',
       Example: () =>
         source(
           <Stack space="large">

--- a/packages/braid-design-system/src/lib/components/TextField/TextField.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/TextField/TextField.gallery.tsx
@@ -135,7 +135,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Disabled field',
-      background: 'surface',
       Example: ({ id, getState, setState }) =>
         source(
           <TextField

--- a/packages/braid-design-system/src/lib/components/TextLink/TextLink.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/TextLink/TextLink.docs.tsx
@@ -157,7 +157,7 @@ const docs: ComponentDocs = {
           </Text>
         </>
       ),
-      background: { lightMode: 'surface', darkMode: 'bodyDark' },
+      background: 'surface',
       Example: () =>
         source(
           <Stack space="large">

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.gallery.tsx
@@ -106,7 +106,6 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Disabled field',
-      background: 'surface',
       Example: ({ id, getState, setState }) =>
         source(
           <Textarea

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
@@ -136,7 +136,7 @@ const docs: ComponentDocs = {
             <Stack space="medium">
               <Text>Text</Text>
               <Text>Text</Text>
-              <Box background="surface" boxShadow="borderCriticalLight">
+              <Box boxShadow="borderCriticalLight">
                 <Toggle
                   label="BleedY"
                   id={`${id}_toggle_bleed`}

--- a/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.docs.tsx
@@ -125,7 +125,6 @@ const docs: ComponentDocs = {
           </Text>
         </>
       ),
-      background: 'surface',
       Example: ({ id }) =>
         source(
           <Inline space="small">

--- a/packages/braid-design-system/src/lib/components/icons/IconBookmark/IconBookmark.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconBookmark/IconBookmark.docs.tsx
@@ -39,7 +39,6 @@ const docs: ComponentDocs = {
   additional: [
     {
       label: 'Toggling active state',
-      background: 'surface',
       description: (
         <Text>
           The bookmark can be marked as active using the <Strong>active</Strong>{' '}

--- a/packages/braid-design-system/src/lib/components/icons/IconCareer/IconCareer.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCareer/IconCareer.docs.tsx
@@ -39,7 +39,6 @@ const docs: ComponentDocs = {
   additional: [
     {
       label: 'Toggling active state',
-      background: 'surface',
       description: (
         <Text>
           Can be marked as active using the <Strong>active</Strong> prop.

--- a/packages/braid-design-system/src/lib/components/icons/IconEnlarge/IconEnlarge.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconEnlarge/IconEnlarge.docs.tsx
@@ -39,7 +39,6 @@ const docs: ComponentDocs = {
   additional: [
     {
       label: 'Toggling active state',
-      background: 'surface',
       description: (
         <Text>
           Often used to toggle between englarged and reduced states, setting the{' '}

--- a/packages/braid-design-system/src/lib/components/icons/IconHeart/IconHeart.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconHeart/IconHeart.docs.tsx
@@ -39,7 +39,6 @@ const docs: ComponentDocs = {
   additional: [
     {
       label: 'Toggling active state',
-      background: 'surface',
       description: (
         <Text>
           The star can be marked as active using the <Strong>active</Strong>{' '}

--- a/packages/braid-design-system/src/lib/components/icons/IconSentiment/IconSentiment.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSentiment/IconSentiment.docs.tsx
@@ -39,7 +39,6 @@ const docs: ComponentDocs = {
   additional: [
     {
       label: 'Changing the feeling',
-      background: 'surface',
       description: (
         <Text>
           The sentiment of the icon can be changed using the{' '}

--- a/site/src/App/Code/Code.tsx
+++ b/site/src/App/Code/Code.tsx
@@ -181,18 +181,16 @@ export const CodeBlock = ({
   return (
     <Box
       position="relative"
-      padding="xxsmall"
-      borderRadius="large"
+      padding="gutter"
+      borderRadius="xlarge"
       background="surfaceDark"
       className={styles.code}
     >
-      <Box padding={['medium', 'medium', 'large']}>
-        <Text size="small" component="pre" baseline={false}>
-          <SyntaxHighlighter language={resolvedLanguage} style={editorTheme}>
-            {children}
-          </SyntaxHighlighter>
-        </Text>
-      </Box>
+      <Text size="small" component="pre" baseline={false}>
+        <SyntaxHighlighter language={resolvedLanguage} style={editorTheme}>
+          {children}
+        </SyntaxHighlighter>
+      </Text>
     </Box>
   );
 };

--- a/site/src/App/ThemeSetting/ThemedExample.css.ts
+++ b/site/src/App/ThemeSetting/ThemedExample.css.ts
@@ -1,6 +1,47 @@
-import { style } from '@vanilla-extract/css';
+import { colorModeStyle } from 'braid-src/entries/css';
+import { createVar, style } from '@vanilla-extract/css';
 import tokens from 'braid-src/lib/themes/docs/tokens';
 
 export const unthemedBorderRadius = style({
   borderRadius: tokens.border.radius.large,
 });
+
+const bgColor = createVar();
+const cubeColor = createVar();
+const cubeSize = createVar();
+export const canvas = style([
+  {
+    vars: {
+      [cubeSize]: '12px',
+    },
+    backgroundColor: bgColor,
+    backgroundImage: [
+      `linear-gradient(45deg, ${cubeColor} 25%, transparent 25%, transparent 75%, ${cubeColor} 75%, ${cubeColor})`,
+      `linear-gradient(45deg, ${cubeColor} 25%, transparent 25%, transparent 75%, ${cubeColor} 75%, ${cubeColor})`,
+    ].join(', '),
+    backgroundSize: `calc(${cubeSize} * 2) calc(${cubeSize} * 2)`,
+    backgroundPosition: `0 0, ${cubeSize} ${cubeSize}`,
+  },
+]);
+
+const darkVars = {
+  [cubeColor]: 'rgba(255,255,255, .08)',
+  [bgColor]: tokens.color.background.bodyDark,
+};
+export const explicitDark = style({
+  vars: darkVars,
+});
+
+export const adaptiveCanvas = style(
+  colorModeStyle({
+    lightMode: {
+      vars: {
+        [cubeColor]: 'rgba(0,0,0, .04)',
+        [bgColor]: tokens.color.background.body,
+      },
+    },
+    darkMode: {
+      vars: darkVars,
+    },
+  }),
+);

--- a/site/src/App/ThemeSetting/ThemedExample.tsx
+++ b/site/src/App/ThemeSetting/ThemedExample.tsx
@@ -7,12 +7,14 @@ import * as styles from './ThemedExample.css';
 interface ThemedExampleProps {
   background?: BoxProps['background'];
   transparent?: boolean;
+  darkCanvas?: boolean;
   children: ReactNode;
 }
 
 export function ThemedExample({
   background,
   transparent = false,
+  darkCanvas = false,
   children,
 }: ThemedExampleProps) {
   const { theme, ready } = useThemeSettings();
@@ -21,19 +23,30 @@ export function ThemedExample({
     <Box opacity={!ready ? 0 : undefined} transition="fast">
       <BraidProvider styleBody={false} theme={theme}>
         <Box
-          boxShadow={
-            transparent
-              ? undefined
-              : {
-                  lightMode: background ? 'borderNeutralLight' : undefined,
-                  darkMode: 'borderNeutralLarge',
-                }
-          }
-          background={transparent ? undefined : background || 'body'}
-          padding={transparent ? undefined : ['small', 'medium', 'large']}
-          className={styles.unthemedBorderRadius}
+          background={darkCanvas ? 'bodyDark' : 'body'}
+          style={{ backgroundColor: 'transparent' }}
+          borderRadius="large"
         >
-          {children}
+          <Box
+            boxShadow={
+              transparent || (background && background !== 'surface')
+                ? undefined
+                : 'borderNeutralLight'
+            }
+            background={!darkCanvas ? background : undefined}
+            borderRadius="large"
+            padding={transparent ? undefined : 'gutter'}
+            className={
+              transparent
+                ? undefined
+                : [
+                    styles.canvas,
+                    darkCanvas ? styles.explicitDark : styles.adaptiveCanvas,
+                  ]
+            }
+          >
+            {children}
+          </Box>
         </Box>
       </BraidProvider>
     </Box>

--- a/site/src/App/routes/foundations/tones/tones.tsx
+++ b/site/src/App/routes/foundations/tones/tones.tsx
@@ -145,7 +145,7 @@ const ToneDefinition = ({ tone }: { tone: Tone }) => {
     <Stack space="small">
       <Columns space="medium" alignY="center">
         <Column width="content">
-          <ThemedExample>
+          <ThemedExample transparent>
             <Box background={swatch} className={styles.square} />
           </ThemedExample>
         </Column>
@@ -214,7 +214,7 @@ function TonePage() {
         {tones.map((tone) => (
           <Column key={tone}>
             <Stack space={['none', 'xsmall']}>
-              <ThemedExample>
+              <ThemedExample transparent>
                 <Box
                   background={toneDocs[tone].swatch}
                   width="full"

--- a/site/src/App/routes/gallery/Gallery.tsx
+++ b/site/src/App/routes/gallery/Gallery.tsx
@@ -112,7 +112,6 @@ export const galleryIcons: typeof galleryComponents = Object.keys(icons).map(
             ),
             Example: () => source(<IconComponent size="fill" />),
             code: `<${iconName} />`,
-            background: 'surface',
           },
         ],
       ],
@@ -140,7 +139,7 @@ interface RenderExampleProps {
   isIcon: boolean;
 }
 const RenderExample = ({ id, example, isIcon }: RenderExampleProps) => {
-  const { label, Container = DefaultContainer, background } = example;
+  const { label, Container = DefaultContainer } = example;
   const { code, value } = useSourceFromExample(id, example);
 
   const CopyCodeButton = () => (
@@ -169,7 +168,7 @@ const RenderExample = ({ id, example, isIcon }: RenderExampleProps) => {
   const children = [
     <CopyCodeButton key="copyCode" />,
     value ? (
-      <ThemedExample background={background || undefined} key="themedExample">
+      <ThemedExample key="themedExample">
         <Container>
           <Box height="full" width="full" style={{ cursor: 'auto' }}>
             {value}

--- a/site/src/types.d.ts
+++ b/site/src/types.d.ts
@@ -40,7 +40,7 @@ export interface ComponentDocs {
   banner?: ReactNodeNoStrings;
   description?: ReactNodeNoStrings;
   subComponents?: string[];
-  examplebackground?: NonNullable<BoxProps['background']> | false;
+  examplebackground?: false;
   Example?: (
     props: ExampleProps & PlayroomExampleProps,
   ) => Source<ReactElement>;


### PR DESCRIPTION
Moving component examples on the site to use a consistent transparent (checkered) background, this helps delineate the site from the themed examples, as well as protects against different body and surface backgrounds across themes.

Note, as a further clean up I have removed extraneous `Card` wrappers from examples allowing them to focus on the component being demo'd.

### Preview

#### Before
![Before](https://github.com/seek-oss/braid-design-system/assets/912060/c5531b9b-1bc1-452e-896b-4b6a180045d6)

#### After
![After](https://github.com/seek-oss/braid-design-system/assets/912060/964b5457-b35c-4d2f-82e2-05faccc40f6a)
