### PR TITLE
Toggle: Remove tick and fix antialias haze

### DIFF
--- a/.changeset/strong-eggs-relax.md
+++ b/.changeset/strong-eggs-relax.md
@@ -1,0 +1,14 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Toggle
+---
+
+**Toggle:** Remove tick icon & fix antialias haze when selected
+
+Simplying the selected state design by removing the tick icon from the toggle thumb.
+
+Also fixes the antialias haze that appears around the thumb when selected.

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.css.ts
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.css.ts
@@ -128,19 +128,10 @@ export const slider = styleVariants(sizes, (size) => {
   };
 });
 
-export const icon = style({
-  transform: 'scale(.75)',
-  selectors: {
-    [`${realField}:active + ${slideContainer} &`]: {
-      transform: 'scale(.75) rotate(-25deg)',
-    },
-    [`${realField}:checked + ${slideContainer} &`]: {
-      opacity: 1,
-    },
-    [`${realField}:active:checked + ${slideContainer} &`]: {
-      transform: 'scale(.75) rotate(6deg)',
-    },
-  },
+// Subtly scale the outline overlay to prevent thumb background
+// antialiasing bleeding outside outline.
+export const sliderThumbOutlineFix = style({
+  transform: 'scale(1.04)',
 });
 
 export const hideBorderOnDarkBackgroundInLightMode = style(

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.tsx
@@ -7,7 +7,6 @@ import React, {
 import { Box } from '../Box/Box';
 import { FieldOverlay } from '../private/FieldOverlay/FieldOverlay';
 import { Text } from '../Text/Text';
-import { IconTick } from '../icons';
 import { useBackgroundLightness } from '../Box/BackgroundContext';
 import buildDataAttributes, {
   type DataAttributeMap,
@@ -54,6 +53,8 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
     },
     forwardedRef,
   ) => {
+    const lightness = useBackgroundLightness();
+
     if (process.env.NODE_ENV !== 'production') {
       if (bleedY === undefined) {
         // eslint-disable-next-line no-console
@@ -74,145 +75,12 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
       }
     }
 
-    const lightness = useBackgroundLightness();
-
     const defaultTogglePosition = align === 'left' ? 'leading' : 'trailing';
     const appliedTogglePosition = togglePosition || defaultTogglePosition;
 
     const alignToEnd =
       (align === 'left' && appliedTogglePosition === 'trailing') ||
       (align !== 'left' && appliedTogglePosition === 'leading');
-
-    const ToggleInput = () => (
-      <Box
-        position="relative"
-        className={bleedY && styles.bleedToCapHeight[size]}
-        display={bleedY ? 'flex' : undefined}
-        alignItems={bleedY ? 'center' : undefined}
-      >
-        <Box
-          component="input"
-          type="checkbox"
-          id={id}
-          checked={on}
-          onChange={handleChange(onChange)}
-          position="absolute"
-          zIndex={1}
-          cursor="pointer"
-          opacity={0}
-          className={[
-            styles.realField,
-            styles.fieldSize[size],
-            !bleedY && styles.realFieldPosition[size],
-          ]}
-          ref={forwardedRef}
-        />
-        <Box
-          position="relative"
-          display="flex"
-          alignItems="center"
-          flexShrink={0}
-          className={[
-            styles.slideContainer,
-            styles.slideContainerSize[size],
-            styles.fieldSize[size],
-          ]}
-        >
-          <Box
-            position="absolute"
-            width="full"
-            overflow="hidden"
-            borderRadius="full"
-            className={[
-              styles.slideTrack[size],
-              styles.slideTrackMask,
-              styles.slideTrackBgLightMode[lightness.lightMode],
-              styles.slideTrackBgDarkMode[lightness.darkMode],
-            ]}
-          >
-            <Box
-              position="absolute"
-              width="full"
-              height="full"
-              background="formAccent"
-              transition="fast"
-              className={styles.slideTrackSelected}
-            />
-          </Box>
-          <Box
-            position="absolute"
-            background="surface"
-            transition="fast"
-            display="flex"
-            alignItems="center"
-            justifyContent="center"
-            borderRadius="full"
-            className={styles.slider[size]}
-          >
-            <FieldOverlay
-              variant={on ? 'formAccent' : 'default'}
-              borderRadius="full"
-              visible
-              className={{
-                [styles.hideBorderOnDarkBackgroundInLightMode]:
-                  lightness.lightMode === 'dark',
-              }}
-            />
-            <FieldOverlay className={styles.icon}>
-              <IconTick tone="formAccent" size="fill" />
-            </FieldOverlay>
-            <FieldOverlay
-              variant="focus"
-              borderRadius="full"
-              className={styles.focusOverlay}
-            />
-            <FieldOverlay
-              variant="formAccent"
-              borderRadius="full"
-              className={!on ? styles.hoverOverlay : undefined}
-            />
-          </Box>
-        </Box>
-      </Box>
-    );
-
-    const ToggleLabel = () => (
-      <Box
-        component="label"
-        htmlFor={id}
-        // Todo - Replace paddings with flex-gap after browser policy change
-        /*
-        Apply padding by default to prevent padding disappearing
-        during partial completion of togglePosition and align props in Playroom
-        */
-        paddingLeft={
-          appliedTogglePosition === 'trailing' ? undefined : 'xsmall'
-        }
-        paddingRight={
-          appliedTogglePosition === 'leading' ? undefined : 'xsmall'
-        }
-        display="flex"
-        flexDirection="column"
-        justifyContent="center"
-        flexGrow={align === 'justify' ? 1 : undefined}
-        userSelect="none"
-        cursor="pointer"
-        className={virtualTouchable}
-      >
-        <Text
-          baseline={bleedY}
-          weight={on ? 'strong' : undefined}
-          size={size}
-          align={
-            align === 'justify' && appliedTogglePosition === 'leading'
-              ? 'right'
-              : undefined
-          }
-        >
-          {label}
-        </Text>
-      </Box>
-    );
 
     return (
       <Box
@@ -226,8 +94,129 @@ export const Toggle = forwardRef<HTMLInputElement, ToggleProps>(
         className={styles.root}
         {...buildDataAttributes({ data, validateRestProps: restProps })}
       >
-        <ToggleInput />
-        <ToggleLabel />
+        <Box
+          position="relative"
+          className={bleedY && styles.bleedToCapHeight[size]}
+          display={bleedY ? 'flex' : undefined}
+          alignItems={bleedY ? 'center' : undefined}
+        >
+          <Box
+            component="input"
+            type="checkbox"
+            id={id}
+            checked={on}
+            onChange={handleChange(onChange)}
+            position="absolute"
+            zIndex={1}
+            cursor="pointer"
+            opacity={0}
+            className={[
+              styles.realField,
+              !bleedY && styles.realFieldPosition[size],
+              styles.fieldSize[size],
+            ]}
+            ref={forwardedRef}
+          />
+          <Box
+            position="relative"
+            display="flex"
+            alignItems="center"
+            flexShrink={0}
+            className={[
+              styles.slideContainer,
+              styles.slideContainerSize[size],
+              styles.fieldSize[size],
+            ]}
+          >
+            <Box
+              position="absolute"
+              width="full"
+              overflow="hidden"
+              borderRadius="full"
+              className={[
+                styles.slideTrack[size],
+                styles.slideTrackMask,
+                styles.slideTrackBgLightMode[lightness.lightMode],
+                styles.slideTrackBgDarkMode[lightness.darkMode],
+              ]}
+            >
+              <Box
+                position="absolute"
+                width="full"
+                height="full"
+                background="formAccent"
+                transition="fast"
+                className={styles.slideTrackSelected}
+              />
+            </Box>
+            <Box
+              position="absolute"
+              background="surface"
+              transition="fast"
+              display="flex"
+              alignItems="center"
+              justifyContent="center"
+              borderRadius="full"
+              className={styles.slider[size]}
+            >
+              <FieldOverlay
+                variant={on ? 'formAccent' : 'default'}
+                borderRadius="full"
+                visible
+                className={{
+                  [styles.sliderThumbOutlineFix]: true,
+                  [styles.hideBorderOnDarkBackgroundInLightMode]:
+                    lightness.lightMode === 'dark',
+                }}
+              />
+              <FieldOverlay
+                variant="focus"
+                borderRadius="full"
+                className={styles.focusOverlay}
+              />
+              <FieldOverlay
+                variant="formAccent"
+                borderRadius="full"
+                className={!on ? styles.hoverOverlay : undefined}
+              />
+            </Box>
+          </Box>
+        </Box>
+        <Box
+          component="label"
+          htmlFor={id}
+          // Todo - Replace paddings with flex-gap after browser policy change
+          /*
+          Apply padding by default to prevent padding disappearing
+          during partial completion of togglePosition and align props in Playroom
+          */
+          paddingLeft={
+            appliedTogglePosition === 'trailing' ? undefined : 'xsmall'
+          }
+          paddingRight={
+            appliedTogglePosition === 'leading' ? undefined : 'xsmall'
+          }
+          display="flex"
+          flexDirection="column"
+          justifyContent="center"
+          flexGrow={align === 'justify' ? 1 : undefined}
+          userSelect="none"
+          cursor="pointer"
+          className={virtualTouchable}
+        >
+          <Text
+            baseline={bleedY}
+            weight={on ? 'strong' : undefined}
+            size={size}
+            align={
+              align === 'justify' && appliedTogglePosition === 'leading'
+                ? 'right'
+                : undefined
+            }
+          >
+            {label}
+          </Text>
+        </Box>
       </Box>
     );
   },


### PR DESCRIPTION
**Toggle:** Remove tick icon & fix antialias haze when selected

Simplying the selected state design by removing the tick icon from the toggle thumb.

Also fixes the antialias haze that appears around the thumb when selected.

#### Review Notes

Also reverts internal refactor to use separate components due to re-rendering preventing the animation. Best reviewed by turning off white space highlighting.