### PR TITLE
site: Update example bgs from checkers to dots

### DIFF
--- a/site/src/App/ThemeSetting/ThemedExample.css.ts
+++ b/site/src/App/ThemeSetting/ThemedExample.css.ts
@@ -1,3 +1,4 @@
+import { palette } from 'braid-src/lib/color/palette';
 import { colorModeStyle } from 'braid-src/entries/css';
 import { createVar, style } from '@vanilla-extract/css';
 import tokens from 'braid-src/lib/themes/docs/tokens';
@@ -6,13 +7,12 @@ export const unthemedBorderRadius = style({
   borderRadius: tokens.border.radius.large,
 });
 
-const bgColor = createVar();
 const dotColor = createVar();
 const dotSize = createVar();
 export const canvas = style([
   {
     vars: {
-      [dotSize]: '12px',
+      [dotSize]: '8px',
     },
     backgroundImage: `radial-gradient(${dotColor} 1px, transparent 0)`,
     backgroundSize: `${dotSize} ${dotSize}`,
@@ -20,8 +20,7 @@ export const canvas = style([
 ]);
 
 const darkVars = {
-  [dotColor]: 'rgba(255,255,255, .1)',
-  [bgColor]: tokens.color.background.bodyDark,
+  [dotColor]: palette.grey[800],
 };
 export const explicitDark = style({
   vars: darkVars,
@@ -31,8 +30,7 @@ export const adaptiveCanvas = style(
   colorModeStyle({
     lightMode: {
       vars: {
-        [dotColor]: 'rgba(0,0,0, .1)',
-        [bgColor]: tokens.color.background.body,
+        [dotColor]: palette.grey[100],
       },
     },
     darkMode: {

--- a/site/src/App/ThemeSetting/ThemedExample.css.ts
+++ b/site/src/App/ThemeSetting/ThemedExample.css.ts
@@ -7,25 +7,20 @@ export const unthemedBorderRadius = style({
 });
 
 const bgColor = createVar();
-const cubeColor = createVar();
-const cubeSize = createVar();
+const dotColor = createVar();
+const dotSize = createVar();
 export const canvas = style([
   {
     vars: {
-      [cubeSize]: '12px',
+      [dotSize]: '12px',
     },
-    backgroundColor: bgColor,
-    backgroundImage: [
-      `linear-gradient(45deg, ${cubeColor} 25%, transparent 25%, transparent 75%, ${cubeColor} 75%, ${cubeColor})`,
-      `linear-gradient(45deg, ${cubeColor} 25%, transparent 25%, transparent 75%, ${cubeColor} 75%, ${cubeColor})`,
-    ].join(', '),
-    backgroundSize: `calc(${cubeSize} * 2) calc(${cubeSize} * 2)`,
-    backgroundPosition: `0 0, ${cubeSize} ${cubeSize}`,
+    backgroundImage: `radial-gradient(${dotColor} 1px, transparent 0)`,
+    backgroundSize: `${dotSize} ${dotSize}`,
   },
 ]);
 
 const darkVars = {
-  [cubeColor]: 'rgba(255,255,255, .08)',
+  [dotColor]: 'rgba(255,255,255, .1)',
   [bgColor]: tokens.color.background.bodyDark,
 };
 export const explicitDark = style({
@@ -36,7 +31,7 @@ export const adaptiveCanvas = style(
   colorModeStyle({
     lightMode: {
       vars: {
-        [cubeColor]: 'rgba(0,0,0, .04)',
+        [dotColor]: 'rgba(0,0,0, .1)',
         [bgColor]: tokens.color.background.body,
       },
     },

--- a/site/src/App/ThemeSetting/ThemedExample.css.ts
+++ b/site/src/App/ThemeSetting/ThemedExample.css.ts
@@ -9,13 +9,16 @@ export const unthemedBorderRadius = style({
 
 const dotColor = createVar();
 const dotSize = createVar();
+const dotOffset = createVar();
 export const canvas = style([
   {
     vars: {
-      [dotSize]: '8px',
+      [dotSize]: `${tokens.grid * 2}px`,
+      [dotOffset]: `calc((${dotSize} / 2) * -1)`,
     },
     backgroundImage: `radial-gradient(${dotColor} 1px, transparent 0)`,
     backgroundSize: `${dotSize} ${dotSize}`,
+    backgroundPosition: `${dotOffset} ${dotOffset}`,
   },
 ]);
 


### PR DESCRIPTION
Lighten the visual treatment of the transparent background pattern for the examples on the docs site

### Preview

<img src="https://github.com/seek-oss/braid-design-system/assets/912060/812d97a9-9bb7-4ea4-a605-83bc53768df3" width="45%" align="left" alt="Checkers example background" />

<img src="https://github.com/seek-oss/braid-design-system/assets/912060/d3004907-efb8-4b8d-9c8c-8b34e9a2fc93" width="45%" alt="Dots example background" />
