### PR TITLE
site: Switch default theme from 'apac' to 'seekJobs'

### DIFF
--- a/site/src/App/ThemeSetting/ThemeSettingContext.tsx
+++ b/site/src/App/ThemeSetting/ThemeSettingContext.tsx
@@ -11,7 +11,7 @@ import * as themes from 'braid-src/lib/themes';
 import type { BraidTheme } from 'braid-src/lib/themes/makeBraidTheme';
 type ThemeKey = keyof typeof themes;
 
-const defaultTheme = 'apac' as const;
+const defaultTheme = 'seekJobs' as const;
 
 interface ThemeSettingsContext {
   ready: boolean;


### PR DESCRIPTION
Switching the default docs theme to 'seekJobs', as it is now the standard flagship theme