### PR TITLE
site: Fix dark canvas for token examples

### DIFF
--- a/site/src/App/ThemeSetting/ThemedExample.css.ts
+++ b/site/src/App/ThemeSetting/ThemedExample.css.ts
@@ -7,6 +7,7 @@ export const unthemedBorderRadius = style({
   borderRadius: tokens.border.radius.large,
 });
 
+const bgColor = createVar();
 const dotColor = createVar();
 const dotSize = createVar();
 const dotOffset = createVar();
@@ -16,6 +17,7 @@ export const canvas = style([
       [dotSize]: `${tokens.grid * 2}px`,
       [dotOffset]: `calc((${dotSize} / 2) * -1)`,
     },
+    backgroundColor: bgColor,
     backgroundImage: `radial-gradient(${dotColor} 1px, transparent 0)`,
     backgroundSize: `${dotSize} ${dotSize}`,
     backgroundPosition: `${dotOffset} ${dotOffset}`,
@@ -23,7 +25,8 @@ export const canvas = style([
 ]);
 
 const darkVars = {
-  [dotColor]: palette.grey[800],
+  [dotColor]: palette.grey[700],
+  [bgColor]: palette.grey[800],
 };
 export const explicitDark = style({
   vars: darkVars,
@@ -34,6 +37,7 @@ export const adaptiveCanvas = style(
     lightMode: {
       vars: {
         [dotColor]: palette.grey[100],
+        [bgColor]: 'white',
       },
     },
     darkMode: {

--- a/site/src/App/ThemeSetting/ThemedExample.tsx
+++ b/site/src/App/ThemeSetting/ThemedExample.tsx
@@ -23,8 +23,7 @@ export function ThemedExample({
     <Box opacity={!ready ? 0 : undefined} transition="fast">
       <BraidProvider styleBody={false} theme={theme}>
         <Box
-          background={darkCanvas ? 'bodyDark' : 'body'}
-          style={{ backgroundColor: 'transparent' }}
+          background={darkCanvas ? 'customDark' : undefined}
           borderRadius="large"
         >
           <Box


### PR DESCRIPTION
The forced dark canvas on the token examples on site got broken in some of its late refactoring, so this fixes them up.

<img src="https://github.com/user-attachments/assets/94bd8f21-f09a-4404-86cc-b21704e88092" width="45%" align="left" />
<img src="https://github.com/user-attachments/assets/883a0675-f181-4efc-851b-31efa5a4eeb9 " width="45%" />
