### PR TITLE
Badge: Ensure label follows correct tone

### DIFF
--- a/.changeset/perfect-rockets-tan.md
+++ b/.changeset/perfect-rockets-tan.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Badge
+---
+
+**Badge:** Ensure label follows correct tone
+
+Ensure that the foreground text of a `Badge` always follows the correct tone for the background colour.
+Fixes a bug where using a `Badge` in a `List` that overrides the default tone would result in the `Badge` text following the `List` tone instead of the `Badge` tone.

--- a/packages/braid-design-system/src/lib/components/Badge/Badge.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Badge/Badge.screenshots.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { Badge, Inline, Heading } from '../';
+import { Badge, Inline, Heading, List } from '../';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],
@@ -106,6 +106,17 @@ export const screenshots: ComponentScreenshot = {
         <Badge tone="neutral" weight="strong">
           Neutral
         </Badge>
+      ),
+    },
+    {
+      label: 'Test: Badge text should follow tone not default set by `List`',
+      Example: () => (
+        <List tone="secondary">
+          <Badge tone="critical">Critical</Badge>
+          <Badge tone="critical" weight="strong">
+            Critical
+          </Badge>
+        </List>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/Badge/Badge.tsx
+++ b/packages/braid-design-system/src/lib/components/Badge/Badge.tsx
@@ -6,6 +6,7 @@ import buildDataAttributes, {
   type DataAttributeMap,
 } from '../private/buildDataAttributes';
 import { Bleed } from '../Bleed/Bleed';
+import { DefaultTextPropsProvider } from '../private/defaultTextProps';
 
 type ValueOrArray<T> = T | T[];
 
@@ -83,35 +84,39 @@ export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
     );
 
     const content = (
-      <Box
-        component="span"
-        display="flex"
-        cursor="default"
-        {...buildDataAttributes({ data, validateRestProps: restProps })}
-      >
+      // Ensures the foreground text tone follows the default
+      // for the selected background colour
+      <DefaultTextPropsProvider tone="neutral">
         <Box
           component="span"
-          id={id}
-          ref={ref}
-          tabIndex={tabIndex}
-          aria-describedby={ariaDescribedBy}
-          title={
-            title ??
-            (!ariaDescribedBy ? stringifyChildren(children) : undefined)
-          }
-          background={
-            weight === 'strong' ? tone : lightModeBackgroundForTone[tone]
-          }
-          paddingY={verticalPadding}
-          paddingX="xsmall"
-          borderRadius="standard"
-          overflow="hidden"
+          display="flex"
+          cursor="default"
+          {...buildDataAttributes({ data, validateRestProps: restProps })}
         >
-          <Text size="xsmall" weight="medium" maxLines={1}>
-            {children}
-          </Text>
+          <Box
+            component="span"
+            id={id}
+            ref={ref}
+            tabIndex={tabIndex}
+            aria-describedby={ariaDescribedBy}
+            title={
+              title ??
+              (!ariaDescribedBy ? stringifyChildren(children) : undefined)
+            }
+            background={
+              weight === 'strong' ? tone : lightModeBackgroundForTone[tone]
+            }
+            paddingY={verticalPadding}
+            paddingX="xsmall"
+            borderRadius="standard"
+            overflow="hidden"
+          >
+            <Text size="xsmall" weight="medium" maxLines={1}>
+              {children}
+            </Text>
+          </Box>
         </Box>
-      </Box>
+      </DefaultTextPropsProvider>
     );
 
     return bleedY ? (


### PR DESCRIPTION
Ensure that the foreground text of a `Badge` always follows the correct tone for the background colour.
Fixes a bug where using a `Badge` in a `List` that overrides the default tone would result in the `Badge` text following the `List` tone instead of the `Badge` tone.