### PR TITLE
Spread: Add new layout component

### DIFF
--- a/.changeset/proud-moles-exist.md
+++ b/.changeset/proud-moles-exist.md
@@ -1,0 +1,42 @@
+---
+'braid-design-system': minor
+---
+
+---
+new:
+  - Spread
+---
+
+**Spread:** Add new layout component
+
+Introduce a new layout component, `Spread`, used to justify content with both an equally distribute and a specify the minimum amount of space in between each child.
+
+**EXAMPLE USAGE:**
+
+The `Spread` component will work horizontally by default:
+
+```jsx
+<Spread space="small" alignY="center">
+  <Heading level="4">Heading</Heading>
+
+  <OverflowMenu label="Options">
+    <MenuItem>First</MenuItem>
+    <MenuItem>Second</MenuItem>
+  </OverflowMenu>
+</Spread>
+```
+
+But can be switched to `vertical` via the `direction` prop:
+
+```jsx
+<Spread space="large" direction="vertical">
+  <Stack space="small">
+    <Heading level="4">Heading</Heading>
+    <Text>Text</Text>
+  </Stack>
+
+  <Text size="small" tone="secondary">
+    Date
+  </Text>
+</Spread>
+```

--- a/.changeset/proud-moles-exist.md
+++ b/.changeset/proud-moles-exist.md
@@ -9,11 +9,11 @@ new:
 
 **Spread:** Add new layout component
 
-Introduce a new layout component, `Spread`, used to justify content with both an equally distribute and a specify the minimum amount of space in between each child.
+Introduce a new layout component, `Spread`, used to justify content with both an equally distributed and a specified minimum amount of space in between each child.
 
 **EXAMPLE USAGE:**
 
-The `Spread` component will work horizontally by default:
+The `Spread` component works horizontally by default:
 
 ```jsx
 <Spread space="small" alignY="center">

--- a/packages/braid-design-system/src/lib/components/Card/Card.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/Card/Card.snippets.tsx
@@ -5,8 +5,7 @@ import {
   Stack,
   Heading,
   Text,
-  Columns,
-  Column,
+  Spread,
   OverflowMenu,
   MenuItem,
   Placeholder,
@@ -18,8 +17,8 @@ export const snippets: Snippets = [
     name: 'With Heading',
     code: source(
       <Card>
-        <Stack space="gutter">
-          <Heading level="3">Heading</Heading>
+        <Stack space="large">
+          <Heading level="4">Heading</Heading>
           <Text>Text</Text>
         </Stack>
       </Card>,
@@ -29,7 +28,7 @@ export const snippets: Snippets = [
     name: 'With promote tone',
     code: source(
       <Card tone="promote">
-        <Stack space="gutter">
+        <Stack space="large">
           <Placeholder height={200} />
         </Stack>
       </Card>,
@@ -39,7 +38,7 @@ export const snippets: Snippets = [
     name: 'With formAccent tone',
     code: source(
       <Card tone="formAccent">
-        <Stack space="gutter">
+        <Stack space="large">
           <Placeholder height={200} />
         </Stack>
       </Card>,
@@ -49,7 +48,7 @@ export const snippets: Snippets = [
     name: 'With rounded corners',
     code: source(
       <Card rounded>
-        <Stack space="gutter">
+        <Stack space="large">
           <Placeholder height={200} />
         </Stack>
       </Card>,
@@ -59,17 +58,13 @@ export const snippets: Snippets = [
     name: 'With Overflow Menu',
     code: source(
       <Card>
-        <Stack space="gutter">
-          <Columns space="gutter">
-            <Column>
-              <Heading level="3">Heading</Heading>
-            </Column>
-            <Column width="content">
-              <OverflowMenu label="Options">
-                <MenuItem>Menu Item</MenuItem>
-              </OverflowMenu>
-            </Column>
-          </Columns>
+        <Stack space="large">
+          <Spread space="small" alignY="center">
+            <Heading level="4">Heading</Heading>
+            <OverflowMenu label="Options">
+              <MenuItem>Menu Item</MenuItem>
+            </OverflowMenu>
+          </Spread>
           <Text>Text</Text>
         </Stack>
       </Card>,

--- a/packages/braid-design-system/src/lib/components/Columns/Columns.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Columns/Columns.docs.tsx
@@ -34,6 +34,11 @@ const docs: ComponentDocs = {
       description: 'For laying out flowing content that is allowed to wrap.',
     },
     {
+      name: 'Spread',
+      description:
+        'For justifying content with equally distributed space in between.',
+    },
+    {
       name: 'Tiles',
       description: 'For laying out content over many columns and rows.',
     },

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.docs.tsx
@@ -19,8 +19,7 @@ import {
   IconBookmark,
   IconProfile,
   MenuItemDivider,
-  Column,
-  Columns,
+  Spread,
   Badge,
   List,
 } from '..';
@@ -379,71 +378,65 @@ const docs: ComponentDocs = {
             {setDefaultState('closeReason', {})}
             {setDefaultState('action', '')}
 
-            <Columns space="large">
-              <Column>
-                <Inline space="none">
-                  <MenuRenderer
-                    offsetSpace="small"
-                    width="small"
-                    onOpen={() => {
-                      setState('action', 'open');
-                      setState('closeReason', {});
-                    }}
-                    onClose={(closeReason) => {
-                      setState('action', 'close');
-                      setState('closeReason', closeReason);
-                    }}
-                    trigger={(triggerProps, { open }) => (
-                      <Box userSelect="none" cursor="pointer" {...triggerProps}>
-                        <Text>
-                          Menu{' '}
-                          <IconChevron
-                            direction={open ? 'up' : 'down'}
-                            alignY="lowercase"
-                          />
-                        </Text>
-                      </Box>
-                    )}
-                  >
-                    <MenuItem id="menuItem1" onClick={() => {}}>
-                      Item 1
-                    </MenuItem>
-                    <MenuItem id="menuItem2" onClick={() => {}}>
-                      Item 2
-                    </MenuItem>
-                    <MenuItem id="menuItem3" onClick={() => {}}>
-                      Item 3
-                    </MenuItem>
-                  </MenuRenderer>
-                </Inline>
-              </Column>
-              <Column width="content">
-                <Inline space="small" collapseBelow="tablet">
-                  {getState('action') ? (
-                    <Badge
-                      tone="info"
-                      weight="strong"
-                      bleedY
-                    >{`Action: ${getState('action')}`}</Badge>
-                  ) : null}
-                  {getState('closeReason').reason ? (
-                    <Badge tone="info" bleedY>
-                      {`Reason: ${getState('closeReason').reason}`}
-                    </Badge>
-                  ) : null}
-                  {typeof getState('closeReason').index !== 'undefined' ? (
-                    <Badge tone="info" bleedY>
-                      {`Selected index: ${getState('closeReason').index}`}
-                    </Badge>
-                  ) : null}
-                  {getState('closeReason').id ? (
-                    <Badge tone="info" bleedY>
-                      {`Selected ID: ${getState('closeReason').id}`}
-                    </Badge>
-                  ) : null}
-                </Inline>
-              </Column>
-            </Columns>
+            <Spread space="large">
+              <MenuRenderer
+                offsetSpace="small"
+                width="small"
+                onOpen={() => {
+                  setState('action', 'open');
+                  setState('closeReason', {});
+                }}
+                onClose={(closeReason) => {
+                  setState('action', 'close');
+                  setState('closeReason', closeReason);
+                }}
+                trigger={(triggerProps, { open }) => (
+                  <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                    <Text>
+                      Menu{' '}
+                      <IconChevron
+                        direction={open ? 'up' : 'down'}
+                        alignY="lowercase"
+                      />
+                    </Text>
+                  </Box>
+                )}
+              >
+                <MenuItem id="menuItem1" onClick={() => {}}>
+                  Item 1
+                </MenuItem>
+                <MenuItem id="menuItem2" onClick={() => {}}>
+                  Item 2
+                </MenuItem>
+                <MenuItem id="menuItem3" onClick={() => {}}>
+                  Item 3
+                </MenuItem>
+              </MenuRenderer>
+              <Inline space="small" collapseBelow="tablet">
+                {getState('action') ? (
+                  <Badge
+                    tone="info"
+                    weight="strong"
+                    bleedY
+                  >{`Action: ${getState('action')}`}</Badge>
+                ) : null}
+                {getState('closeReason').reason ? (
+                  <Badge tone="info" bleedY>
+                    {`Reason: ${getState('closeReason').reason}`}
+                  </Badge>
+                ) : null}
+                {typeof getState('closeReason').index !== 'undefined' ? (
+                  <Badge tone="info" bleedY>
+                    {`Selected index: ${getState('closeReason').index}`}
+                  </Badge>
+                ) : null}
+                {getState('closeReason').id ? (
+                  <Badge tone="info" bleedY>
+                    {`Selected ID: ${getState('closeReason').id}`}
+                  </Badge>
+                ) : null}
+              </Inline>
+            </Spread>
           </>,
         ),
     },

--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.docs.tsx
@@ -15,8 +15,7 @@ import {
   Button,
   IconDelete,
   Badge,
-  Column,
-  Columns,
+  Spread,
   Inline,
   List,
 } from '../';
@@ -138,60 +137,56 @@ const docs: ComponentDocs = {
             {setDefaultState('closeReason', {})}
             {setDefaultState('action', '')}
 
-            <Columns space="large">
-              <Column>
-                <Box style={{ maxWidth: '100px' }}>
-                  <OverflowMenu
-                    label="Options"
-                    id="example"
-                    onOpen={() => {
-                      setState('action', 'open');
-                      setState('closeReason', {});
-                    }}
-                    onClose={(closeReason) => {
-                      setState('action', 'close');
-                      setState('closeReason', closeReason);
-                    }}
-                  >
-                    <MenuItem id="menuItem1" onClick={() => {}}>
-                      Item 1
-                    </MenuItem>
-                    <MenuItem id="menuItem2" onClick={() => {}}>
-                      Item 2
-                    </MenuItem>
-                    <MenuItem id="menuItem3" onClick={() => {}}>
-                      Item 3
-                    </MenuItem>
-                  </OverflowMenu>
-                </Box>
-              </Column>
-              <Column width="content">
-                <Inline space="small" collapseBelow="tablet">
-                  {getState('action') ? (
-                    <Badge
-                      tone="info"
-                      weight="strong"
-                      bleedY
-                    >{`Action: ${getState('action')}`}</Badge>
-                  ) : null}
-                  {getState('closeReason').reason ? (
-                    <Badge tone="info" bleedY>
-                      {`Reason: ${getState('closeReason').reason}`}
-                    </Badge>
-                  ) : null}
-                  {typeof getState('closeReason').index !== 'undefined' ? (
-                    <Badge tone="info" bleedY>
-                      {`Selected index: ${getState('closeReason').index}`}
-                    </Badge>
-                  ) : null}
-                  {getState('closeReason').id ? (
-                    <Badge tone="info" bleedY>
-                      {`Selected ID: ${getState('closeReason').id}`}
-                    </Badge>
-                  ) : null}
-                </Inline>
-              </Column>
-            </Columns>
+            <Spread space="large">
+              <Box width="full" style={{ maxWidth: '100px' }}>
+                <OverflowMenu
+                  label="Options"
+                  id="example"
+                  onOpen={() => {
+                    setState('action', 'open');
+                    setState('closeReason', {});
+                  }}
+                  onClose={(closeReason) => {
+                    setState('action', 'close');
+                    setState('closeReason', closeReason);
+                  }}
+                >
+                  <MenuItem id="menuItem1" onClick={() => {}}>
+                    Item 1
+                  </MenuItem>
+                  <MenuItem id="menuItem2" onClick={() => {}}>
+                    Item 2
+                  </MenuItem>
+                  <MenuItem id="menuItem3" onClick={() => {}}>
+                    Item 3
+                  </MenuItem>
+                </OverflowMenu>
+              </Box>
+              <Inline space="small" collapseBelow="tablet">
+                {getState('action') ? (
+                  <Badge
+                    tone="info"
+                    weight="strong"
+                    bleedY
+                  >{`Action: ${getState('action')}`}</Badge>
+                ) : null}
+                {getState('closeReason').reason ? (
+                  <Badge tone="info" bleedY>
+                    {`Reason: ${getState('closeReason').reason}`}
+                  </Badge>
+                ) : null}
+                {typeof getState('closeReason').index !== 'undefined' ? (
+                  <Badge tone="info" bleedY>
+                    {`Selected index: ${getState('closeReason').index}`}
+                  </Badge>
+                ) : null}
+                {getState('closeReason').id ? (
+                  <Badge tone="info" bleedY>
+                    {`Selected ID: ${getState('closeReason').id}`}
+                  </Badge>
+                ) : null}
+              </Inline>
+            </Spread>
           </>,
         ),
     },

--- a/packages/braid-design-system/src/lib/components/Spread/Spread.css.ts
+++ b/packages/braid-design-system/src/lib/components/Spread/Spread.css.ts
@@ -1,0 +1,31 @@
+import {
+  defineProperties,
+  createSprinkles,
+  type RequiredConditionalValue,
+} from '@vanilla-extract/sprinkles';
+import { breakpoints } from '../../css/breakpoints';
+import { space } from '../../css/atoms/atomicProperties';
+
+const responsiveGapProperties = defineProperties({
+  defaultCondition: 'mobile',
+  conditions: {
+    mobile: {},
+    tablet: {
+      '@media': `screen and (min-width: ${breakpoints.tablet}px)`,
+    },
+    desktop: {
+      '@media': `screen and (min-width: ${breakpoints.desktop}px)`,
+    },
+    wide: {
+      '@media': `screen and (min-width: ${breakpoints.wide}px)`,
+    },
+  },
+  properties: {
+    gap: space,
+  },
+});
+
+export const responsiveGap = createSprinkles(responsiveGapProperties);
+
+export type RequiredResponsiveValue<Value extends string | number> =
+  RequiredConditionalValue<typeof responsiveGapProperties, Value>;

--- a/packages/braid-design-system/src/lib/components/Spread/Spread.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Spread/Spread.docs.tsx
@@ -1,0 +1,129 @@
+import React from 'react';
+import type { ComponentDocs } from 'site/types';
+import { Spread, Stack, Strong, Text, Tiles } from '../';
+import { Placeholder } from '../private/Placeholder/Placeholder';
+import source from '@braid-design-system/source.macro';
+
+const docs: ComponentDocs = {
+  category: 'Layout',
+  Example: () =>
+    source(
+      <Spread space="large">
+        <Placeholder height={60} width={50} />
+        <Placeholder height={60} width={80} />
+      </Spread>,
+    ),
+  description: (
+    <Text>
+      <Strong>Spread</Strong> is a layout component used to justify content with
+      both an equally distributed and a specified minimum amount of space in
+      between each child.
+    </Text>
+  ),
+  alternatives: [
+    {
+      name: 'Columns',
+      description: 'For fine-grained control of widths, spacing and alignment.',
+    },
+    {
+      name: 'Inline',
+      description: 'For laying out flowing content that is allowed to wrap.',
+    },
+  ],
+  additional: [
+    {
+      label: 'Direction',
+      description: (
+        <Text>
+          By default, children are spread horizontally. Setting the{' '}
+          <Strong>direction</Strong> prop to <Strong>vertical</Strong> will
+          spread children vertically, consuming the full height of its
+          container.
+        </Text>
+      ),
+      Example: () =>
+        source(
+          <Tiles space="large" columns={3}>
+            <Spread space="small" direction="vertical">
+              <Placeholder height={60} />
+              <Placeholder height={30} />
+            </Spread>
+            <Spread space="small" direction="vertical" alignY="center">
+              <Placeholder height={30} />
+              <Placeholder height={30} />
+            </Spread>
+            <Spread space="small" direction="vertical">
+              <Placeholder height={90} />
+              <Placeholder height={30} />
+            </Spread>
+          </Tiles>,
+        ),
+    },
+    {
+      label: 'Vertical alignment',
+      description: (
+        <>
+          <Text>
+            When spreading content of varying height, vertical alignment can be
+            controlled using the <Strong>alignY</Strong> prop. Responsive values
+            are supported.
+          </Text>
+          <Text tone="secondary" size="small">
+            Note: Only applies when spreading horizontally.
+          </Text>
+        </>
+      ),
+      Example: () =>
+        source(
+          <Stack space="large" dividers>
+            <Spread space="small" alignY="top">
+              <Placeholder height={30} width={80} label="top" />
+              <Placeholder height={100} width={50} />
+            </Spread>
+            <Spread space="small" alignY="center">
+              <Placeholder height={30} width={80} label="center" />
+              <Placeholder height={100} width={50} />
+            </Spread>
+            <Spread space="small" alignY="bottom">
+              <Placeholder height={30} width={80} label="bottom" />
+              <Placeholder height={100} width={50} />
+            </Spread>
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Horizontal alignment',
+      description: (
+        <>
+          <Text>
+            When spreading content of varying widths, horizontal alignment can
+            be controlled using the <Strong>align</Strong> prop. Responsive
+            values are supported.
+          </Text>
+          <Text tone="secondary" size="small">
+            Note: Only applies when spreading vertically.
+          </Text>
+        </>
+      ),
+      Example: () =>
+        source(
+          <Tiles space="large" columns={3}>
+            <Spread space="small" direction="vertical" align="left">
+              <Placeholder height={60} width={80} label="left" />
+              <Placeholder height={30} width={50} />
+            </Spread>
+            <Spread space="small" direction="vertical" align="center">
+              <Placeholder height={30} width={80} label="center" />
+              <Placeholder height={30} width={100} />
+            </Spread>
+            <Spread space="small" direction="vertical" align="right">
+              <Placeholder height={90} width={80} label="right" />
+              <Placeholder height={30} width={50} />
+            </Spread>
+          </Tiles>,
+        ),
+    },
+  ],
+};
+
+export default docs;

--- a/packages/braid-design-system/src/lib/components/Spread/Spread.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Spread/Spread.gallery.tsx
@@ -1,0 +1,80 @@
+import React from 'react';
+import type { GalleryComponent } from 'site/types';
+import { Spread, Stack, Tiles } from '../';
+import source from '@braid-design-system/source.macro';
+import { Placeholder } from '../private/Placeholder/Placeholder';
+
+export const galleryItems: GalleryComponent = {
+  examples: [
+    {
+      label: 'Horizontal direction',
+      Example: () =>
+        source(
+          <Spread space="large">
+            <Placeholder height={60} width={50} />
+            <Placeholder height={60} width={80} />
+          </Spread>,
+        ),
+    },
+    {
+      label: 'Vertical direction',
+      Example: () =>
+        source(
+          <Tiles space="large" columns={3}>
+            <Spread space="small" direction="vertical">
+              <Placeholder height={60} />
+              <Placeholder height={30} />
+            </Spread>
+            <Spread space="small" direction="vertical">
+              <Placeholder height={30} />
+              <Placeholder height={30} />
+            </Spread>
+            <Spread space="small" direction="vertical">
+              <Placeholder height={90} />
+              <Placeholder height={30} />
+            </Spread>
+          </Tiles>,
+        ),
+    },
+    {
+      label: 'Vertical alignment',
+      Example: () =>
+        source(
+          <Stack space="large" dividers>
+            <Spread space="small" alignY="top">
+              <Placeholder height={30} width={80} label="top" />
+              <Placeholder height={100} width={50} />
+            </Spread>
+            <Spread space="small" alignY="center">
+              <Placeholder height={30} width={80} label="center" />
+              <Placeholder height={100} width={50} />
+            </Spread>
+            <Spread space="small" alignY="bottom">
+              <Placeholder height={30} width={80} label="bottom" />
+              <Placeholder height={100} width={50} />
+            </Spread>
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Horizontal alignment',
+      Example: () =>
+        source(
+          <Stack space="large" dividers>
+            <Spread space="small" direction="vertical" align="left">
+              <Placeholder height={60} width={80} label="left" />
+              <Placeholder height={30} width={50} />
+            </Spread>
+            <Spread space="small" direction="vertical" align="center">
+              <Placeholder height={30} width={80} label="center" />
+              <Placeholder height={30} width={100} />
+            </Spread>
+            <Spread space="small" direction="vertical" align="right">
+              <Placeholder height={90} width={80} label="right" />
+              <Placeholder height={30} width={50} />
+            </Spread>
+          </Stack>,
+        ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Spread/Spread.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/Spread/Spread.playroom.tsx
@@ -1,0 +1,11 @@
+import React from 'react';
+import { type SpreadProps, Spread as BraidSpread } from './Spread';
+import { cleanSpaceValue } from '../../playroom/cleanSpaceValue';
+import type { RequiredResponsiveValue } from './Spread.css';
+import type { Space } from '../../css/atoms/atoms';
+
+export const Spread = ({ space, ...restProps }: SpreadProps) => {
+  /* Temporary cast to satisfy `cleanSpaceValue`. Wont be required when `gap` moves to core atoms */
+  const cleanSpace = cleanSpaceValue(space) as RequiredResponsiveValue<Space>;
+  return <BraidSpread space={cleanSpace || 'none'} {...restProps} />;
+};

--- a/packages/braid-design-system/src/lib/components/Spread/Spread.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Spread/Spread.screenshots.tsx
@@ -5,6 +5,7 @@ import { Placeholder } from '../private/Placeholder/Placeholder';
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320, 768, 992, 1200],
+  screenshotOnlyInWireframe: true,
   examples: [
     {
       label: 'Horizontal',
@@ -29,6 +30,14 @@ export const screenshots: ComponentScreenshot = {
       Example: () => (
         <Spread space="large">
           <Placeholder height={60} width="100%" />
+          <Placeholder height={60} width="100%" />
+        </Spread>
+      ),
+    },
+    {
+      label: 'Horizontal single child full width',
+      Example: () => (
+        <Spread space="large">
           <Placeholder height={60} width="100%" />
         </Spread>
       ),

--- a/packages/braid-design-system/src/lib/components/Spread/Spread.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Spread/Spread.screenshots.tsx
@@ -1,0 +1,170 @@
+import React from 'react';
+import type { ComponentScreenshot } from 'site/types';
+import { Spread, Tiles } from '../';
+import { Placeholder } from '../private/Placeholder/Placeholder';
+
+export const screenshots: ComponentScreenshot = {
+  screenshotWidths: [320, 768, 992, 1200],
+  examples: [
+    {
+      label: 'Horizontal',
+      Example: () => (
+        <Spread space="large">
+          <Placeholder height={60} width={50} />
+          <Placeholder height={60} width={80} />
+        </Spread>
+      ),
+    },
+    {
+      label: 'Horizontal single full width',
+      Example: () => (
+        <Spread space="large">
+          <Placeholder height={60} width="100%" />
+          <Placeholder height={60} width={80} />
+        </Spread>
+      ),
+    },
+    {
+      label: 'Horizontal both full width',
+      Example: () => (
+        <Spread space="large">
+          <Placeholder height={60} width="100%" />
+          <Placeholder height={60} width="100%" />
+        </Spread>
+      ),
+    },
+    {
+      label: 'Horizontal responsive space',
+      Example: () => (
+        <Spread
+          space={{
+            mobile: 'small',
+            tablet: 'large',
+            desktop: 'xlarge',
+            wide: 'xxlarge',
+          }}
+        >
+          <Placeholder height={60} width="100%" />
+          <Placeholder height={60} width={80} />
+        </Spread>
+      ),
+    },
+    {
+      label: 'Horizontal alignY top',
+      Example: () => (
+        <Spread space="large" alignY="top">
+          <Placeholder height={20} width={80} label="top" />
+          <Placeholder height={60} width="100%" />
+        </Spread>
+      ),
+    },
+    {
+      label: 'Horizontal alignY center',
+      Example: () => (
+        <Spread space="large" alignY="center">
+          <Placeholder height={20} width={80} label="center" />
+          <Placeholder height={60} width="100%" />
+        </Spread>
+      ),
+    },
+    {
+      label: 'Horizontal alignY bottom',
+      Example: () => (
+        <Spread space="large" alignY="bottom">
+          <Placeholder height={20} width={80} label="bottom" />
+          <Placeholder height={60} width="100%" />
+        </Spread>
+      ),
+    },
+    {
+      label: 'Horizontal align center (no impact)',
+      Example: () => (
+        <Spread space="large" align="center">
+          <Placeholder height={60} width="100%" />
+          <Placeholder height={60} width={80} />
+        </Spread>
+      ),
+    },
+    {
+      label: 'Vertical',
+      Example: () => (
+        <Tiles space="large" columns={3}>
+          <Spread direction="vertical" space="large">
+            <Placeholder height={60} width={50} />
+            <Placeholder height={20} width={80} />
+          </Spread>
+          <Spread direction="vertical" space="large">
+            <Placeholder height={20} width={50} />
+            <Placeholder height={20} width={80} />
+          </Spread>
+          <Spread direction="vertical" space="large">
+            <Placeholder height={100} width={50} />
+            <Placeholder height={20} width={80} />
+          </Spread>
+        </Tiles>
+      ),
+    },
+    {
+      label: 'Vertical single full width',
+      Example: () => (
+        <Spread direction="vertical" space="large">
+          <Placeholder height={60} width="100%" />
+          <Placeholder height={20} width={80} />
+        </Spread>
+      ),
+    },
+    {
+      label: 'Vertical responsive space',
+      Example: () => (
+        <Spread
+          direction="vertical"
+          space={{
+            mobile: 'small',
+            tablet: 'large',
+            desktop: 'xlarge',
+            wide: 'xxlarge',
+          }}
+        >
+          <Placeholder height={60} width="100%" />
+          <Placeholder height={60} width={80} />
+        </Spread>
+      ),
+    },
+    {
+      label: 'Vertical align left',
+      Example: () => (
+        <Spread direction="vertical" space="large" align="left">
+          <Placeholder height={20} width={80} label="left" />
+          <Placeholder height={60} width={100} />
+        </Spread>
+      ),
+    },
+    {
+      label: 'Vertical align center',
+      Example: () => (
+        <Spread direction="vertical" space="large" align="center">
+          <Placeholder height={20} width={80} label="center" />
+          <Placeholder height={60} width={100} />
+        </Spread>
+      ),
+    },
+    {
+      label: 'Vertical align right',
+      Example: () => (
+        <Spread direction="vertical" space="large" align="right">
+          <Placeholder height={20} width={80} label="right" />
+          <Placeholder height={60} width={100} />
+        </Spread>
+      ),
+    },
+    {
+      label: 'Vertical alignY center (no impact)',
+      Example: () => (
+        <Spread direction="vertical" space="large" alignY="center">
+          <Placeholder height={60} width="100%" />
+          <Placeholder height={60} width={80} />
+        </Spread>
+      ),
+    },
+  ],
+};

--- a/packages/braid-design-system/src/lib/components/Spread/Spread.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/Spread/Spread.snippets.tsx
@@ -1,0 +1,59 @@
+import React from 'react';
+import type { Snippets } from '../private/Snippets';
+import {
+  Heading,
+  MenuItem,
+  OverflowMenu,
+  Placeholder,
+  Spread,
+  Stack,
+  Text,
+} from '../../playroom/components';
+import source from '@braid-design-system/source.macro';
+
+export const snippets: Snippets = [
+  {
+    name: 'Horizontal direction',
+    code: source(
+      <Spread space="small" alignY="center">
+        <Placeholder height={60} width={50} />
+        <Placeholder height={60} width={80} />
+      </Spread>,
+    ),
+  },
+  {
+    name: 'Vertical direction',
+    code: source(
+      <Spread space="small" direction="vertical">
+        <Placeholder height={60} />
+        <Placeholder height={30} />
+      </Spread>,
+    ),
+  },
+  {
+    name: 'Heading and action',
+    code: source(
+      <Spread space="small" alignY="center">
+        <Heading level="4">Heading</Heading>
+        <OverflowMenu label="Options">
+          <MenuItem>First</MenuItem>
+          <MenuItem>Second</MenuItem>
+        </OverflowMenu>
+      </Spread>,
+    ),
+  },
+  {
+    name: 'Content stack and date stamp',
+    code: source(
+      <Spread space="large" direction="vertical">
+        <Stack space="small">
+          <Heading level="4">Heading</Heading>
+          <Text>Text</Text>
+        </Stack>
+        <Text size="small" tone="secondary">
+          Date
+        </Text>
+      </Spread>,
+    ),
+  },
+];

--- a/packages/braid-design-system/src/lib/components/Spread/Spread.tsx
+++ b/packages/braid-design-system/src/lib/components/Spread/Spread.tsx
@@ -1,0 +1,51 @@
+import type { Space } from '../../css/atoms/atoms';
+import { Box, type BoxProps } from '../Box/Box';
+import type { ReactNodeNoStrings } from '../private/ReactNodeNoStrings';
+import type { OptionalResponsiveValue } from '../../css/atoms/sprinkles.css';
+import {
+  alignYToFlexAlign,
+  type AlignY,
+  type Align,
+  alignToFlexAlign,
+} from '../../utils/align';
+import { type RequiredResponsiveValue, responsiveGap } from './Spread.css';
+
+interface SpreadProps {
+  children: ReactNodeNoStrings;
+  space: RequiredResponsiveValue<Space>;
+  direction?: 'horizontal' | 'vertical';
+  align?: OptionalResponsiveValue<Align>;
+  alignY?: OptionalResponsiveValue<AlignY>;
+}
+
+export const Spread = ({
+  children,
+  space,
+  direction = 'horizontal',
+  align,
+  alignY,
+}: SpreadProps) => {
+  const isVertical = direction === 'vertical';
+  const isHorizontal = !isVertical;
+  let alignItems: BoxProps['alignItems'];
+
+  if (align && isVertical) {
+    alignItems = alignToFlexAlign(align);
+  } else if (alignY && isHorizontal) {
+    alignItems = alignYToFlexAlign(alignY);
+  }
+
+  return (
+    <Box
+      display="flex"
+      flexDirection={isVertical ? 'column' : 'row'}
+      width="full"
+      height={isVertical ? 'full' : undefined}
+      justifyContent="spaceBetween"
+      alignItems={alignItems}
+      className={responsiveGap({ gap: space })}
+    >
+      {children}
+    </Box>
+  );
+};

--- a/packages/braid-design-system/src/lib/components/Spread/Spread.tsx
+++ b/packages/braid-design-system/src/lib/components/Spread/Spread.tsx
@@ -10,7 +10,7 @@ import {
 } from '../../utils/align';
 import { type RequiredResponsiveValue, responsiveGap } from './Spread.css';
 
-interface SpreadProps {
+export interface SpreadProps {
   children: ReactNodeNoStrings;
   space: RequiredResponsiveValue<Space>;
   direction?: 'horizontal' | 'vertical';

--- a/packages/braid-design-system/src/lib/components/index.ts
+++ b/packages/braid-design-system/src/lib/components/index.ts
@@ -65,6 +65,7 @@ export { RadioGroup } from './RadioGroup/RadioGroup';
 export { RadioItem } from './RadioGroup/RadioItem';
 export { Rating } from './Rating/Rating';
 export { Secondary } from './Secondary/Secondary';
+export { Spread } from './Spread/Spread';
 export { Stack } from './Stack/Stack';
 export { Step } from './Stepper/Step';
 export { Stepper } from './Stepper/Stepper';

--- a/packages/braid-design-system/src/lib/playroom/components.ts
+++ b/packages/braid-design-system/src/lib/playroom/components.ts
@@ -35,6 +35,7 @@ export { PasswordField } from '../components/PasswordField/PasswordField.playroo
 export { Radio } from '../components/Radio/Radio.playroom';
 export { RadioGroup } from '../components/RadioGroup/RadioGroup.playroom';
 export { Rating } from '../components/Rating/Rating.playroom';
+export { Spread } from '../components/Spread/Spread.playroom';
 export { Stack } from '../components/Stack/Stack.playroom';
 export { TabsProvider, Tabs, Tab } from '../components/Tabs/Tabs.playroom';
 export { Tag } from '../components/Tag/Tag.playroom';

--- a/packages/braid-design-system/src/lib/playroom/snippets.ts
+++ b/packages/braid-design-system/src/lib/playroom/snippets.ts
@@ -31,6 +31,7 @@ import { snippets as PasswordField } from './snippets/PasswordField';
 import { snippets as RadioGroup } from './snippets/RadioGroup';
 import { snippets as Rating } from './snippets/Rating';
 import { snippets as Secondary } from './snippets/Secondary';
+import { snippets as Spread } from './snippets/Spread';
 import { snippets as Stack } from './snippets/Stack';
 import { snippets as Stepper } from './snippets/Stepper';
 import { snippets as Strong } from './snippets/Strong';
@@ -79,6 +80,7 @@ export default Object.entries({
   RadioGroup,
   Rating,
   Secondary,
+  Spread,
   Stack,
   Stepper,
   Strong,

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -7485,6 +7485,42 @@ exports[`Secondary 1`] = `
 }
 `;
 
+exports[`Spread 1`] = `
+{
+  exportType: component,
+  props: {
+    align?: 
+        | "center"
+        | "left"
+        | "right"
+        | Partial<Record<"mobile" | "tablet" | "desktop" | "wide", Align>>
+        | ResponsiveArray<1 | 2 | 3 | 4, Align | null>
+    alignY?: 
+        | "bottom"
+        | "center"
+        | "top"
+        | Partial<Record<"mobile" | "tablet" | "desktop" | "wide", AlignY>>
+        | ResponsiveArray<1 | 2 | 3 | 4, AlignY | null>
+    children: ReactNodeNoStrings
+    direction?: 
+        | "horizontal"
+        | "vertical"
+    space: 
+        | "gutter"
+        | "large"
+        | "medium"
+        | "none"
+        | "small"
+        | "xlarge"
+        | "xsmall"
+        | "xxlarge"
+        | "xxsmall"
+        | "xxxlarge"
+        | RequiredConditionalObject<"mobile", "tablet" | "desktop" | "wide", Space>
+},
+}
+`;
+
 exports[`Stack 1`] = `
 {
   exportType: component,

--- a/site/src/App/DocNavigation/DocReleases.tsx
+++ b/site/src/App/DocNavigation/DocReleases.tsx
@@ -6,8 +6,7 @@ import {
   Badge,
   TextLink,
   Text,
-  Column,
-  Columns,
+  Spread,
   List,
 } from 'braid-src/lib/components';
 import { LinkableHeading } from '@braid-design-system/docs-ui';
@@ -59,21 +58,17 @@ export const DocReleases = () => {
                 paddingTop={index > 0 ? 'medium' : undefined}
               >
                 <Stack space="large">
-                  <Columns space="small" alignY="center">
-                    <Column>
-                      <LinkableHeading level="3">{`v${version}`}</LinkableHeading>
-                    </Column>
+                  <Spread space="small" alignY="center">
+                    <LinkableHeading level="3">{`v${version}`}</LinkableHeading>
                     {historyItem.time ? (
-                      <Column width="content">
-                        <Badge
-                          bleedY
-                          tone={historyItem.isRecent ? 'promote' : 'neutral'}
-                        >
-                          {historyItem.time}
-                        </Badge>
-                      </Column>
+                      <Badge
+                        bleedY
+                        tone={historyItem.isRecent ? 'promote' : 'neutral'}
+                      >
+                        {historyItem.time}
+                      </Badge>
                     ) : null}
-                  </Columns>
+                  </Spread>
                   <List space="xlarge">
                     {historyItem.changesets.map((change, changeIndex) => (
                       <Markdown key={`${version}_${index}_${changeIndex}`}>

--- a/site/src/App/routes/examples/job-summary/job-summary.tsx
+++ b/site/src/App/routes/examples/job-summary/job-summary.tsx
@@ -6,8 +6,6 @@ import {
   Divider,
   Card,
   Stack,
-  Columns,
-  Column,
   Badge,
   IconTag,
   Rating,
@@ -18,6 +16,7 @@ import {
   TextLink,
   List,
   ButtonIcon,
+  Spread,
 } from 'braid-src/lib/components';
 import { TextStack } from '../../../TextStack/TextStack';
 import { Placeholder } from 'braid-src/lib/playroom/components';
@@ -55,51 +54,47 @@ const page: Page = {
 
       <Code collapsedByDefault>
         <Card>
-          <Stack space="gutter">
-            <Columns space="gutter">
-              <Column>
-                <Stack space="small">
-                  <Badge tone="positive">New</Badge>
-                  <Heading level="3">Product Designer</Heading>
-                  <Inline space="small">
-                    <Text tone="secondary">Braid Design Pty Ltd</Text>
-                    <Rating rating={4.5} />
-                  </Inline>
-                </Stack>
-              </Column>
-              <Column width="content">
-                <ButtonIcon
-                  variant="transparent"
-                  size="large"
-                  icon={<IconBookmark />}
-                  label="Save job"
-                  id="save-preview"
-                />
-              </Column>
-            </Columns>
+          <Stack space="large">
+            <Spread space="small">
+              <Stack space="small">
+                <Badge tone="positive">New</Badge>
+                <Heading level="4">Product Designer</Heading>
+                <Inline space="small" alignY="center">
+                  <Text>Braid Design Pty Ltd</Text>
+                  <Rating rating={4.5} />
+                </Inline>
+              </Stack>
+              <ButtonIcon
+                variant="transparent"
+                size="large"
+                icon={<IconBookmark />}
+                label="Save job"
+                id="save-preview"
+              />
+            </Spread>
 
             <Stack space="small">
-              <Text size="small" tone="secondary" icon={<IconLocation />}>
+              <Text tone="secondary" icon={<IconLocation />}>
                 Melbourne
               </Text>
-              <Text size="small" tone="secondary" icon={<IconTag />}>
+              <Text tone="secondary" icon={<IconTag />}>
                 Information Technology
               </Text>
-              <Text size="small" tone="secondary" icon={<IconMoney />}>
+              <Text tone="secondary" icon={<IconMoney />}>
                 150k+
               </Text>
             </Stack>
             <Text>
               Long description of card details providing more information.
             </Text>
-            <Text tone="secondary" size="xsmall">
+            <Text tone="secondary" size="small">
               2d ago
             </Text>
           </Stack>
         </Card>
       </Code>
 
-      <Heading level="3">How do I build this example for myself?</Heading>
+      <Heading level="4">How do I build this example for myself?</Heading>
 
       <Text>
         Designs like this are rarely built top-to-bottom in a single pass.
@@ -135,7 +130,7 @@ const page: Page = {
           }
         >
           <Card>
-            <Heading level="3">Product Designer</Heading>
+            <Heading level="4">Product Designer</Heading>
             <Text>Braid Design Pty Ltd</Text>
             <Text>Melbourne</Text>
             <Text>Information Technology</Text>
@@ -161,8 +156,8 @@ const page: Page = {
           }
         >
           <Card>
-            <Stack space="gutter">
-              <Heading level="3">Product Designer</Heading>
+            <Stack space="large">
+              <Heading level="4">Product Designer</Heading>
               <Text>Braid Design Pty Ltd</Text>
               <Text>Melbourne</Text>
               <Text>Information Technology</Text>
@@ -190,9 +185,9 @@ const page: Page = {
           }
         >
           <Card>
-            <Stack space="gutter">
+            <Stack space="large">
               <Stack space="small">
-                <Heading level="3">Product Designer</Heading>
+                <Heading level="4">Product Designer</Heading>
                 <Text>Braid Design Pty Ltd</Text>
               </Stack>
 
@@ -225,29 +220,23 @@ const page: Page = {
           }
         >
           <Card>
-            <Stack space="gutter">
+            <Stack space="large">
               <Stack space="small">
-                <Heading level="3">Product Designer</Heading>
-                <Text tone="secondary">Braid Design Pty Ltd</Text>
+                <Heading level="4">Product Designer</Heading>
+                <Text>Braid Design Pty Ltd</Text>
               </Stack>
 
               <Stack space="small">
-                <Text tone="secondary" size="small">
-                  Melbourne
-                </Text>
-                <Text tone="secondary" size="small">
-                  Information Technology
-                </Text>
-                <Text tone="secondary" size="small">
-                  150k+
-                </Text>
+                <Text tone="secondary">Melbourne</Text>
+                <Text tone="secondary">Information Technology</Text>
+                <Text tone="secondary">150k+</Text>
               </Stack>
 
               <Text>
                 Long description of card details providing more information.
               </Text>
 
-              <Text tone="secondary" size="xsmall">
+              <Text tone="secondary" size="small">
                 2d ago
               </Text>
             </Stack>
@@ -266,20 +255,20 @@ const page: Page = {
           }
         >
           <Card>
-            <Stack space="gutter">
+            <Stack space="large">
               <Stack space="small">
-                <Heading level="3">Product Designer</Heading>
-                <Text tone="secondary">Braid Design Pty Ltd</Text>
+                <Heading level="4">Product Designer</Heading>
+                <Text>Braid Design Pty Ltd</Text>
               </Stack>
 
-              <Stack space="xsmall">
-                <Text tone="secondary" size="small" icon={<IconLocation />}>
+              <Stack space="small">
+                <Text tone="secondary" icon={<IconLocation />}>
                   Melbourne
                 </Text>
-                <Text tone="secondary" size="small" icon={<IconTag />}>
+                <Text tone="secondary" icon={<IconTag />}>
                   Information Technology
                 </Text>
-                <Text tone="secondary" size="small" icon={<IconMoney />}>
+                <Text tone="secondary" icon={<IconMoney />}>
                   150k+
                 </Text>
               </Stack>
@@ -288,7 +277,7 @@ const page: Page = {
                 Long description of card details providing more information.
               </Text>
 
-              <Text tone="secondary" size="xsmall">
+              <Text tone="secondary" size="small">
                 2d ago
               </Text>
             </Stack>
@@ -307,21 +296,21 @@ const page: Page = {
           }
         >
           <Card>
-            <Stack space="gutter">
+            <Stack space="large">
               <Stack space="small">
                 <Badge tone="positive">New</Badge>
-                <Heading level="3">Product Designer</Heading>
-                <Text tone="secondary">Braid Design Pty Ltd</Text>
+                <Heading level="4">Product Designer</Heading>
+                <Text>Braid Design Pty Ltd</Text>
               </Stack>
 
-              <Stack space="xsmall">
-                <Text tone="secondary" size="small" icon={<IconLocation />}>
+              <Stack space="small">
+                <Text tone="secondary" icon={<IconLocation />}>
                   Melbourne
                 </Text>
-                <Text tone="secondary" size="small" icon={<IconTag />}>
+                <Text tone="secondary" icon={<IconTag />}>
                   Information Technology
                 </Text>
-                <Text tone="secondary" size="small" icon={<IconMoney />}>
+                <Text tone="secondary" icon={<IconMoney />}>
                   150k+
                 </Text>
               </Stack>
@@ -330,7 +319,7 @@ const page: Page = {
                 Long description of card details providing more information.
               </Text>
 
-              <Text tone="secondary" size="xsmall">
+              <Text tone="secondary" size="small">
                 2d ago
               </Text>
             </Stack>
@@ -356,24 +345,24 @@ const page: Page = {
           }
         >
           <Card>
-            <Stack space="gutter">
+            <Stack space="large">
               <Stack space="small">
                 <Badge tone="positive">New</Badge>
-                <Heading level="3">Product Designer</Heading>
-                <Inline space="small">
-                  <Text tone="secondary">Braid Design Pty Ltd</Text>
+                <Heading level="4">Product Designer</Heading>
+                <Inline space="small" alignY="center">
+                  <Text>Braid Design Pty Ltd</Text>
                   <Rating rating={4.5} />
                 </Inline>
               </Stack>
 
-              <Stack space="xsmall">
-                <Text tone="secondary" size="small" icon={<IconLocation />}>
+              <Stack space="small">
+                <Text tone="secondary" icon={<IconLocation />}>
                   Melbourne
                 </Text>
-                <Text tone="secondary" size="small" icon={<IconTag />}>
+                <Text tone="secondary" icon={<IconTag />}>
                   Information Technology
                 </Text>
-                <Text tone="secondary" size="small" icon={<IconMoney />}>
+                <Text tone="secondary" icon={<IconMoney />}>
                   150k+
                 </Text>
               </Stack>
@@ -382,7 +371,7 @@ const page: Page = {
                 Long description of card details providing more information.
               </Text>
 
-              <Text tone="secondary" size="xsmall">
+              <Text tone="secondary" size="small">
                 2d ago
               </Text>
             </Stack>
@@ -396,8 +385,8 @@ const page: Page = {
               <Text>
                 Sometimes adding new features can necessitate changing the
                 layout. First, we&rsquo;ll use a{' '}
-                <TextLink href="/components/columns">Columns</TextLink>{' '}
-                component to break up our card into two columns.
+                <TextLink href="/components/spread">Spread</TextLink> component
+                to separate our content and action.
               </Text>
               <Text tone="secondary">
                 NOTE: To make this easier to follow, we&rsquo;ve replaced the
@@ -407,170 +396,101 @@ const page: Page = {
           }
         >
           <Card>
-            <Columns space="gutter">
-              <Column>
-                <Placeholder label="Job content" height={80} />
-              </Column>
-              <Column>
-                <Placeholder label="Save action" height={80} />
-              </Column>
-            </Columns>
+            <Spread space="small">
+              <Placeholder label="Job content" height={80} />
+              <Placeholder label="Save action" height={80} />
+            </Spread>
           </Card>
         </Step>
 
         <Step
           detail={
             <Text>
-              In the second column we&rsquo;ll use a{' '}
+              For the save action we&rsquo;ll use a{' '}
               <TextLink href="/components/ButtonIcon">ButtonIcon</TextLink> with
               an{' '}
-              <TextLink href="/components/IconBookmark">IconBookmark</TextLink>{' '}
-              as the save action. By default, `Columns` are of equal width. In
-              this design however, the second column should only be as wide as
-              the save action itself. This can be controlled by setting the
-              `Column` to have a &ldquo;width&rdquo; of &ldquo;content&rdquo;.
+              <TextLink href="/components/IconBookmark">IconBookmark</TextLink>.
+              We can now replace our &ldquo;Save action&rdquo; Placeholder with
+              the ButtonIcon.
             </Text>
           }
         >
           <Card>
-            <Columns space="gutter">
-              <Column>
-                <Placeholder label="Job content" height={80} />
-              </Column>
-              <Column width="content">
-                <ButtonIcon
-                  variant="transparent"
-                  size="large"
-                  icon={<IconBookmark />}
-                  label="Save job"
-                  id="save-7a"
-                />
-              </Column>
-            </Columns>
+            <Spread space="small">
+              <Placeholder label="Job content" height={80} />
+              <ButtonIcon
+                variant="transparent"
+                size="large"
+                icon={<IconBookmark />}
+                label="Save job"
+                id="save-7a"
+              />
+            </Spread>
           </Card>
         </Step>
 
         <Step
           detail={
             <Text>
-              Now that we&rsquo;ve adjusted the layout, let&rsquo;s reinstate
-              our job content in the main column.
+              Now that we&rsquo;ve added the action, let&rsquo;s reinstate our
+              content by replacing the &ldquo;Job content&rdquo; Placeholder.
             </Text>
           }
         >
           <Card>
-            <Columns space="gutter">
-              <Column>
-                <Stack space="gutter">
-                  <Stack space="small">
-                    <Badge tone="positive">New</Badge>
-                    <Heading level="3">Product Designer</Heading>
-                    <Inline space="small">
-                      <Text tone="secondary">Braid Design Pty Ltd</Text>
-                      <Rating rating={4.5} />
-                    </Inline>
-                  </Stack>
+            <Spread space="small">
+              <Stack space="large">
+                <Stack space="small">
+                  <Badge tone="positive">New</Badge>
+                  <Heading level="4">Product Designer</Heading>
+                  <Inline space="small" alignY="center">
+                    <Text>Braid Design Pty Ltd</Text>
+                    <Rating rating={4.5} />
+                  </Inline>
+                </Stack>
 
-                  <Stack space="xsmall">
-                    <Text tone="secondary" size="small" icon={<IconLocation />}>
-                      Melbourne
-                    </Text>
-                    <Text tone="secondary" size="small" icon={<IconTag />}>
-                      Information Technology
-                    </Text>
-                    <Text tone="secondary" size="small" icon={<IconMoney />}>
-                      150k+
-                    </Text>
-                  </Stack>
-
-                  <Text>
-                    Long description of card details providing more information.
+                <Stack space="small">
+                  <Text tone="secondary" icon={<IconLocation />}>
+                    Melbourne
                   </Text>
-
-                  <Text tone="secondary" size="xsmall">
-                    2d ago
+                  <Text tone="secondary" icon={<IconTag />}>
+                    Information Technology
+                  </Text>
+                  <Text tone="secondary" icon={<IconMoney />}>
+                    150k+
                   </Text>
                 </Stack>
-              </Column>
-              <Column width="content">
-                <ButtonIcon
-                  variant="transparent"
-                  size="large"
-                  icon={<IconBookmark />}
-                  label="Save job"
-                  id="save-7b"
-                />
-              </Column>
-            </Columns>
-          </Card>
-        </Step>
 
-        <Step
-          heading="8. Polish!"
-          detail={
-            <Stack space="xlarge">
-              <Text>
-                Now that we have all our elements in place we can polish until
-                we are happy. Adjusting white space between elements, or even
-                responsively, to achieve the desired goal.
-              </Text>
-              <Text>
-                In this case, we might loosen up the metadata section by
-                increasing the space to &ldquo;small&rdquo;.
-              </Text>
-            </Stack>
-          }
-        >
-          <Card>
-            <Stack space="gutter">
-              <Columns space="gutter">
-                <Column>
-                  <Stack space="small">
-                    <Badge tone="positive">New</Badge>
-                    <Heading level="3">Product Designer</Heading>
-                    <Inline space="small">
-                      <Text tone="secondary">Braid Design Pty Ltd</Text>
-                      <Rating rating={4.5} />
-                    </Inline>
-                  </Stack>
-                </Column>
-                <Column width="content">
-                  <ButtonIcon
-                    variant="transparent"
-                    size="large"
-                    icon={<IconBookmark />}
-                    label="Save job"
-                    id="save-8"
-                  />
-                </Column>
-              </Columns>
+                <Text>
+                  Long description of card details providing more information.
+                </Text>
 
-              <Stack space="small">
-                <Text size="small" tone="secondary" icon={<IconLocation />}>
-                  Melbourne
-                </Text>
-                <Text size="small" tone="secondary" icon={<IconTag />}>
-                  Information Technology
-                </Text>
-                <Text size="small" tone="secondary" icon={<IconMoney />}>
-                  150k+
+                <Text tone="secondary" size="small">
+                  2d ago
                 </Text>
               </Stack>
-              <Text>
-                Long description of card details providing more information.
-              </Text>
-              <Text tone="secondary" size="xsmall">
-                2d ago
-              </Text>
-            </Stack>
+              <ButtonIcon
+                variant="transparent"
+                size="large"
+                icon={<IconBookmark />}
+                label="Save job"
+                id="save-7b"
+              />
+            </Spread>
           </Card>
         </Step>
+
+        <Text>
+          Now that we have all our elements in place we can polish until we are
+          happy. Adjusting white space between elements, or even responsively,
+          to achieve the desired goal.
+        </Text>
       </Stack>
 
       <Divider />
 
       <TextStack>
-        <LinkableHeading level="3">Next steps</LinkableHeading>
+        <LinkableHeading level="4">Next steps</LinkableHeading>
 
         <Stack space="xlarge">
           <Text>

--- a/site/src/App/routes/foundations/layout/layout.tsx
+++ b/site/src/App/routes/foundations/layout/layout.tsx
@@ -641,10 +641,9 @@ const page: DocsPage = {
 
       <LinkableHeading>Spread</LinkableHeading>
       <Text>
-        If you’d like to spread components to opposite ends of a container
-        while maintaining a minimum amount of space in between them, Braid
-        provides the <TextLink href="/components/Spread">Spread</TextLink>{' '}
-        component.
+        If you’d like to spread components to opposite ends of a container while
+        maintaining a minimum amount of space in between them, Braid provides
+        the <TextLink href="/components/Spread">Spread</TextLink> component.
       </Text>
 
       <Text>

--- a/site/src/App/routes/foundations/layout/layout.tsx
+++ b/site/src/App/routes/foundations/layout/layout.tsx
@@ -23,6 +23,7 @@ import {
   Bleed,
   PageBlock,
   Page,
+  Spread,
 } from 'braid-src/lib/components';
 import { TextStack } from '../../../TextStack/TextStack';
 import Code from '../../../Code/Code';
@@ -115,6 +116,9 @@ const page: DocsPage = {
         </Text>
         <Text>
           <TextLink href="#columns">Columns</TextLink>
+        </Text>
+        <Text>
+          <TextLink href="#spread">Spread</TextLink>
         </Text>
         <Text>
           <TextLink href="#tiles">Tiles</TextLink>
@@ -540,40 +544,30 @@ const page: DocsPage = {
         as the content within it.
       </Text>
       <Text>
-        For example, if you wanted a card with a left-aligned{' '}
-        <TextLink href="/components/Heading">Heading</TextLink> and a
-        right-aligned{' '}
-        <TextLink href="/components/OverflowMenu">OverflowMenu</TextLink>:
+        For example, if you wanted a column to be as large as its illustration
+        followed by a second column that filled the space:
       </Text>
       <Code>
         {source(
           <Card>
-            <Stack space="medium">
-              <Columns space="small">
-                <Column>
-                  <Heading level="3">Card heading</Heading>
-                </Column>
-                <Column width="content">
-                  <OverflowMenu label="Options">
-                    <MenuItem
-                      onClick={() => {
-                        /* */
-                      }}
-                    >
-                      First
-                    </MenuItem>
-                    <MenuItem
-                      onClick={() => {
-                        /* */
-                      }}
-                    >
-                      Second
-                    </MenuItem>
-                  </OverflowMenu>
-                </Column>
-              </Columns>
-              <Text>Card content</Text>
-            </Stack>
+            <Columns space="medium" alignY="center">
+              <Column width="content">
+                <Placeholder
+                  shape="round"
+                  height={128}
+                  width={128}
+                  label="Illustration"
+                />
+              </Column>
+              <Column>
+                <Text>
+                  Lorem ipsum dolor sit amet, consectetur adipiscing elit.
+                  Suspendisse dignissim dapibus elit, vel egestas felis pharetra
+                  non. Cras malesuada, massa nec ultricies efficitur, lectus
+                  ante consequat magna, a porttitor massa ex ut quam.
+                </Text>
+              </Column>
+            </Columns>
           </Card>,
         )}
       </Code>
@@ -640,6 +634,76 @@ const page: DocsPage = {
               </Card>
             </Column>
           </Columns>,
+        )}
+      </Code>
+
+      <Divider />
+
+      <LinkableHeading>Spread</LinkableHeading>
+      <Text>
+        If you’d like to spread components to opposite ends of its container
+        while maintaining a minimum amount of space in between them, Braid
+        provides the <TextLink href="/components/Spread">Spread</TextLink>{' '}
+        component.
+      </Text>
+
+      <Text>
+        An example might be a card with a left-aligned{' '}
+        <TextLink href="/components/Heading">Heading</TextLink> and a
+        right-aligned{' '}
+        <TextLink href="/components/OverflowMenu">OverflowMenu</TextLink>:
+      </Text>
+
+      <Code>
+        {source(
+          <Card>
+            <Spread space="small">
+              <Heading level="4">Heading</Heading>
+              <OverflowMenu label="Options">
+                <MenuItem>First</MenuItem>
+                <MenuItem>Second</MenuItem>
+              </OverflowMenu>
+            </Spread>
+          </Card>,
+        )}
+      </Code>
+
+      <Text>
+        By default, components will be spread horizontally but you can change
+        the direction to vertical by providing the{' '}
+        <TextLink href="/components/Spread#direction">direction</TextLink> prop.
+      </Text>
+
+      <Text>
+        This is useful when aligning content vertically across containers while
+        maintaining predicatable spacing — particularly when wrapping text comes
+        into play.
+      </Text>
+
+      <Code collapsedByDefault>
+        {source(
+          <Tiles space="small" columns={3}>
+            <Card height="full">
+              <Spread space="medium" direction="vertical">
+                <Text>
+                  Minim aliqua nulla id excepteur labore amet do dolore.
+                </Text>
+                <Text tone="secondary">Duis</Text>
+              </Spread>
+            </Card>
+            <Card height="full">
+              <Spread space="medium" direction="vertical">
+                <Text>Minim aliqua nulla id.</Text>
+                <Text tone="secondary">Duis</Text>
+              </Spread>
+            </Card>
+            <Card height="full">
+              <Spread space="medium" direction="vertical">
+                <Text>Minim aliqua nulla id excepteur labore.</Text>
+                <Text tone="secondary">Duis</Text>
+              </Spread>
+            </Card>
+          </Tiles>,
         )}
       </Code>
 

--- a/site/src/App/routes/foundations/layout/layout.tsx
+++ b/site/src/App/routes/foundations/layout/layout.tsx
@@ -641,7 +641,7 @@ const page: DocsPage = {
 
       <LinkableHeading>Spread</LinkableHeading>
       <Text>
-        If you’d like to spread components to opposite ends of its container
+        If you’d like to spread components to opposite ends of a container
         while maintaining a minimum amount of space in between them, Braid
         provides the <TextLink href="/components/Spread">Spread</TextLink>{' '}
         component.

--- a/site/src/App/routes/gallery/Gallery.tsx
+++ b/site/src/App/routes/gallery/Gallery.tsx
@@ -40,6 +40,7 @@ import {
   Secondary,
   IconCopy,
   ButtonIcon,
+  Spread,
 } from 'braid-src/lib/components';
 // TODO: COLORMODE RELEASE
 // Use public import
@@ -158,26 +159,22 @@ const RenderExample = ({ id, example, isIcon }: RenderExampleProps) => {
   const { code, value } = useSourceFromExample(id, example);
 
   const CopyCodeButton = () => (
-    <Columns space="medium" alignY="center">
-      <Column>
-        {label ? (
-          <Text component="h5" tone="secondary">
-            {label}
-          </Text>
-        ) : null}
-      </Column>
-      {code ? (
-        <Column width="content">
-          <CodeButton
-            title="Copy code to clipboard"
-            onClick={() => copy(formatSnippet(code))}
-            successLabel="Copied!"
-          >
-            <IconCopy /> Copy code
-          </CodeButton>
-        </Column>
+    <Spread space="medium" alignY="center">
+      {label ? (
+        <Text component="h5" tone="secondary">
+          {label}
+        </Text>
       ) : null}
-    </Columns>
+      {code ? (
+        <CodeButton
+          title="Copy code to clipboard"
+          onClick={() => copy(formatSnippet(code))}
+          successLabel="Copied!"
+        >
+          <IconCopy /> Copy code
+        </CodeButton>
+      ) : null}
+    </Spread>
   );
 
   const children = [


### PR DESCRIPTION
Introduce a new layout component, `Spread`, used to justify content with both an equally distribute and a specify the minimum amount of space in between each child.

**EXAMPLE USAGE:**

The `Spread` component will work horizontally by default:

```jsx
<Spread space="small" alignY="center">
  <Heading level="4">Heading</Heading>

  <OverflowMenu label="Options">
    <MenuItem>First</MenuItem>
    <MenuItem>Second</MenuItem>
  </OverflowMenu>
</Spread>
```

But can be switched to `vertical` via the `direction` prop:

```jsx
<Spread space="large" direction="vertical">
  <Stack space="small">
    <Heading level="4">Heading</Heading>
    <Text>Text</Text>
  </Stack>

  <Text size="small" tone="secondary">
    Date
  </Text>
</Spread>
```

### Previews

#### `direction="horizontal"`

![Horizontal demo](https://github.com/user-attachments/assets/2c379778-4272-4074-89cc-29adab641b88)

#### `direction="vertical"`
![Vertical demo](https://github.com/user-attachments/assets/5a66e045-15c8-421f-b7a2-5d47ce0b50f6)

### Review notes

Includes updated snippets and examples to use latest spacing and layout guidance, e.g. `Job Summary` example, and `Card` snippets.
