### PR TITLE
site: Fix Box & atoms unresponsive prop values

### DIFF
--- a/packages/braid-design-system/src/entries/css/atoms.docs.tsx
+++ b/packages/braid-design-system/src/entries/css/atoms.docs.tsx
@@ -136,7 +136,11 @@ const docs: CssDoc = {
                 <AtomicProperty
                   key={prop}
                   name={prop}
-                  values={Object.keys(unresponsiveProperties[prop])}
+                  values={
+                    Array.isArray(unresponsiveProperties[prop])
+                      ? Object.values(unresponsiveProperties[prop])
+                      : Object.keys(unresponsiveProperties[prop])
+                  }
                 />
               ))}
             </Tiles>

--- a/packages/braid-design-system/src/lib/components/Box/Box.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Box/Box.docs.tsx
@@ -227,7 +227,11 @@ const docs: ComponentDocs = {
                 <AtomicProperty
                   key={prop}
                   name={prop}
-                  values={Object.keys(unresponsiveProperties[prop])}
+                  values={
+                    Array.isArray(unresponsiveProperties[prop])
+                      ? Object.values(unresponsiveProperties[prop])
+                      : Object.keys(unresponsiveProperties[prop])
+                  }
                 />
               ))}
             </Tiles>


### PR DESCRIPTION
Fix an issue where the docs site was rendering array indexes instead of the correct values for unresponsive prop values.

Need to handle both the possible array and object data structures.

Before:
![Before](https://github.com/user-attachments/assets/5cb446f3-13d7-4f16-bf04-4d74360c8613)

After:
![After](https://github.com/user-attachments/assets/82468082-24ef-45a0-9097-2e1ede8c3c35)
