### PR TITLE
MenuRenderer, OverflowMenu: Limit the menu height

### DIFF
--- a/.changeset/bright-nails-cry.md
+++ b/.changeset/bright-nails-cry.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - MenuRenderer
+  - OverflowMenu
+---
+
+**MenuRenderer, OverflowMenu:** Limit the menu height
+
+Limit the menu to show a maximum of around 10 items before scrolling (a little less so its evident there is more to scroll to).

--- a/.changeset/bright-nails-cry.md
+++ b/.changeset/bright-nails-cry.md
@@ -10,4 +10,4 @@ updated:
 
 **MenuRenderer, OverflowMenu:** Limit the menu height
 
-Limit the menu to show a maximum of around 10 items before scrolling (a little less so its evident there is more to scroll to).
+Limit the menu to show a maximum of around 10 items before scrolling (a little less so it's evident there is more to scroll to).

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.css.ts
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.css.ts
@@ -26,3 +26,8 @@ export const width = styleVariants({ small, medium, large }, (w) => [
 export const placementBottom = style({
   bottom: '100%',
 });
+
+export const menuHeightLimit = style({
+  maxHeight: calc(vars.touchableSize).multiply(9.5).toString(),
+  overflowY: 'auto',
+});

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.css.ts
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.css.ts
@@ -27,7 +27,12 @@ export const placementBottom = style({
   bottom: '100%',
 });
 
+export const menuYPadding = 'xxsmall';
+
 export const menuHeightLimit = style({
-  maxHeight: calc(vars.touchableSize).multiply(9.5).toString(),
+  maxHeight: calc(vars.touchableSize)
+    .multiply(9.5)
+    .add(vars.space[menuYPadding])
+    .toString(),
   overflowY: 'auto',
 });

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
@@ -380,7 +380,7 @@ export function Menu({
           placement === 'top' && styles.placementBottom,
         ]}
       >
-        <Box paddingY="xxsmall">
+        <Box paddingY="xxsmall" className={styles.menuHeightLimit}>
           {Children.map(children, (item, i) => {
             if (isDivider(item)) {
               dividerCount++;

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
@@ -380,7 +380,7 @@ export function Menu({
           placement === 'top' && styles.placementBottom,
         ]}
       >
-        <Box paddingY="xxsmall" className={styles.menuHeightLimit}>
+        <Box paddingY={styles.menuYPadding} className={styles.menuHeightLimit}>
           {Children.map(children, (item, i) => {
             if (isDivider(item)) {
               dividerCount++;


### PR DESCRIPTION
Limit the menu to show a maximum of around 10 items before scrolling (a little less so its evident there is more to scroll to).