### PR TITLE
Text, Heading: Ensure `maxLines` truncates correctly in flex container

### DIFF
--- a/.changeset/hungry-ads-cheer.md
+++ b/.changeset/hungry-ads-cheer.md
@@ -8,6 +8,4 @@ updated:
   - Heading
 ---
 
-**Text, Heading:** Ensure `maxLines` truncates correctly in flex container
-
-Provide `min-width` to `Text` and `Heading` components to ensure `maxLines` truncates as expected when typography components are used as a direct child of a flex container.
+**Text, Heading:** Ensure `maxLines` truncates correctly when used as the direct child of a flex container.

--- a/.changeset/hungry-ads-cheer.md
+++ b/.changeset/hungry-ads-cheer.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Text
+  - Heading
+---
+
+**Text, Heading:** Ensure `maxLines` truncates correctly in flex container
+
+Provide `min-width` to `Text` and `Heading` components to ensure `maxLines` truncates as expected when typography components are used as a direct child of a flex container.

--- a/packages/braid-design-system/src/lib/components/Heading/Heading.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Heading/Heading.screenshots.tsx
@@ -111,6 +111,18 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
+      label: 'Max lines = 1 (in flex container, should be same as truncation)',
+      Example: () => (
+        <Box display="flex" flexDirection="column" style={{ width: 220 }}>
+          <Box style={{ border: '1px solid red' }} />
+          <Heading level="2" maxLines={1}>
+            Limiting to 1 line that won’t fit in the layout
+          </Heading>
+          <Box style={{ border: '1px solid red' }} />
+        </Box>
+      ),
+    },
+    {
       label: 'Max lines = 3',
       Example: () => (
         <Box style={{ width: 220 }}>

--- a/packages/braid-design-system/src/lib/components/Text/Text.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Text/Text.screenshots.tsx
@@ -140,6 +140,16 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
+      label: 'Max lines = 1 (in flex container, should be same as truncation)',
+      Example: () => (
+        <Box display="flex" style={{ width: 215 }}>
+          <Text maxLines={1}>
+            Text limited to 1 line that won’t fit in the layout
+          </Text>
+        </Box>
+      ),
+    },
+    {
       label: 'Max lines = 3',
       Example: () => (
         <Box style={{ width: 215 }}>

--- a/packages/braid-design-system/src/lib/components/private/Typography/Typography.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Typography/Typography.tsx
@@ -70,6 +70,7 @@ export const Typography = ({
         className,
         isTruncated ? descenderCropFixForWebkitBox : undefined,
       ]}
+      minWidth={isTruncated ? 0 : undefined}
       {...buildDataAttributes({ data, validateRestProps: restProps })}
     >
       {icon ? (


### PR DESCRIPTION
Provide `min-width` to `Text` and `Heading` components to ensure `maxLines` truncates as expected when typography components are used as a direct child of a flex container.