### PR TITLE
Autosuggest group headings

### DIFF
--- a/.changeset/good-hats-remember.md
+++ b/.changeset/good-hats-remember.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Autosuggest
+---
+
+**Autosuggest:** Update suggestion group heading design
+
+Updating the design of the suggestion group headings, moving from `formAccent` to `secondary` tone, from all caps to provided casing, and from `xsmall` to `small` size.

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.css.ts
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.css.ts
@@ -30,7 +30,3 @@ export const menu = style(
     },
   }),
 );
-
-export const groupHeading = style({
-  textTransform: 'uppercase',
-});

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.tsx
@@ -207,13 +207,12 @@ function GroupHeading({ children }: GroupHeadingProps) {
     <Box
       paddingX="small"
       className={[
-        styles.groupHeading,
         touchableText.xsmall,
         textStyles({
-          size: 'xsmall',
-          baseline: false,
+          size: 'small',
+          baseline: true,
           weight: 'strong',
-          tone: 'formAccent',
+          tone: 'secondary',
         }),
       ]}
       data-testid={


### PR DESCRIPTION
Updating the design of the suggestion group headings, moving from `formAccent` to `secondary` tone, from all caps to provided casing, and from `xsmall` to `small` size.

### Preview
(Left: before, right: after)

<img src="https://github.com/user-attachments/assets/d5c2a683-fed6-4d3f-bf80-cf40f2a44cf3" width="45%"  alt="Before" />
<img src="https://github.com/user-attachments/assets/4fedbbc2-9dff-4fcd-84a6-90e66c980f51"  width="45%" align="left" alt="After" />

