### PR TITLE
icons: Support rendering inline as child of a flex container

### DIFF
--- a/.changeset/spicy-olives-travel.md
+++ b/.changeset/spicy-olives-travel.md
@@ -1,0 +1,105 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - IconAI
+  - IconAdd
+  - IconArrow
+  - IconBookmark
+  - IconCareer
+  - IconCategory
+  - IconCaution
+  - IconChevron
+  - IconClear
+  - IconCompany
+  - IconCompose
+  - IconCopy
+  - IconCreditCard
+  - IconCritical
+  - IconDate
+  - IconDelete
+  - IconDesktop
+  - IconDocument
+  - IconDocumentBroken
+  - IconDownload
+  - IconEdit
+  - IconEducation
+  - IconEnlarge
+  - IconExperience
+  - IconFilter
+  - IconFlag
+  - IconGift
+  - IconGlobe
+  - IconGrid
+  - IconHash
+  - IconHeart
+  - IconHelp
+  - IconHistory
+  - IconHome
+  - IconImage
+  - IconInfo
+  - IconInvoice
+  - IconLanguage
+  - IconLink
+  - IconLinkBroken
+  - IconList
+  - IconLocation
+  - IconMail
+  - IconMessage
+  - IconMinus
+  - IconMobile
+  - IconMoney
+  - IconNewWindow
+  - IconNote
+  - IconNotification
+  - IconOverflow
+  - IconPeople
+  - IconPersonAdd
+  - IconPersonVerified
+  - IconPhone
+  - IconPlatformAndroid
+  - IconPlatformApple
+  - IconPositive
+  - IconPrint
+  - IconProfile
+  - IconPromote
+  - IconRecommended
+  - IconRefresh
+  - IconResume
+  - IconRocket
+  - IconSearch
+  - IconSecurity
+  - IconSend
+  - IconSent
+  - IconSentiment
+  - IconSettings
+  - IconShare
+  - IconSkills
+  - IconSocialFacebook
+  - IconSocialGitHub
+  - IconSocialInstagram
+  - IconSocialLinkedIn
+  - IconSocialMedium
+  - IconSocialTwitter
+  - IconSocialX
+  - IconSocialYouTube
+  - IconSort
+  - IconStar
+  - IconStatistics
+  - IconSubCategory
+  - IconTag
+  - IconThumb
+  - IconTick
+  - IconTime
+  - IconTip
+  - IconUpload
+  - IconVideo
+  - IconVisibility
+  - IconWorkExperience
+  - IconZoomIn
+  - IconZoomOut
+---
+
+**Icons:** Support rendering inline as child of a flex container

--- a/packages/braid-design-system/scripts/generateIcons.cts
+++ b/packages/braid-design-system/scripts/generateIcons.cts
@@ -152,16 +152,18 @@ const svgrConfig = {
       dedent/* ts */ `
         import React from 'react';
         import { Box } from '${relative(`${baseDir}/src/lib/components/Box/Box`)}';
-        import useIcon, { type UseIconProps } from '${relative(`${baseDir}/src/lib/hooks/useIcon`)}';
+        import { IconContainer, type IconContainerProps } from '${relative(
+          `${baseDir}/src/lib/components/icons/IconContainer`,
+        )}';
         import { ${svgComponentName} } from '${relative(`${iconDir}/${svgComponentName}`)}';
 
-        export type ${iconName}Props = UseIconProps;
+        export type ${iconName}Props = IconContainerProps;
 
-        export const ${iconName} = (props: ${iconName}Props) => {
-          const iconProps = useIcon(props);
-
-          return <Box component={${svgComponentName}} {...iconProps} />;
-        };
+        export const ${iconName} = (props: ${iconName}Props) => (
+          <IconContainer {...props}>
+            {(boxProps) => <Box component={${svgComponentName}} {...boxProps} />}
+          </IconContainer>
+        );
       `,
     );
 

--- a/packages/braid-design-system/scripts/generateIcons.cts
+++ b/packages/braid-design-system/scripts/generateIcons.cts
@@ -161,7 +161,7 @@ const svgrConfig = {
 
         export const ${iconName} = (props: ${iconName}Props) => (
           <IconContainer {...props}>
-            {(boxProps) => <Box component={${svgComponentName}} {...boxProps} />}
+            {(svgProps) => <Box component={${svgComponentName}} {...svgProps} />}
           </IconContainer>
         );
       `,

--- a/packages/braid-design-system/src/lib/components/Rating/Rating.tsx
+++ b/packages/braid-design-system/src/lib/components/Rating/Rating.tsx
@@ -19,7 +19,7 @@ type RatingStar = {
 const RatingStar = ({ percent, ...restProps }: RatingStar) => {
   const currentBg = useBackground();
   const {
-    boxProps: { className, ...iconProps },
+    svgProps: { className, ...svgProps },
   } = useIcon(restProps);
 
   let component = IconStarEmptySvg;
@@ -35,7 +35,7 @@ const RatingStar = ({ percent, ...restProps }: RatingStar) => {
   return (
     <Box
       component={component}
-      {...iconProps}
+      {...svgProps}
       className={[
         className,
         {

--- a/packages/braid-design-system/src/lib/components/Rating/Rating.tsx
+++ b/packages/braid-design-system/src/lib/components/Rating/Rating.tsx
@@ -18,7 +18,9 @@ type RatingStar = {
 } & UseIconProps;
 const RatingStar = ({ percent, ...restProps }: RatingStar) => {
   const currentBg = useBackground();
-  const { className, ...iconProps } = useIcon(restProps);
+  const {
+    boxProps: { className, ...iconProps },
+  } = useIcon(restProps);
 
   let component = IconStarEmptySvg;
 

--- a/packages/braid-design-system/src/lib/components/icons/IconAI/IconAI.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconAI/IconAI.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconAISvg } from './IconAISvg';
 
-export type IconAiProps = UseIconProps;
+export type IconAiProps = IconContainerProps;
 
-export const IconAI = (props: IconAiProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconAISvg} {...iconProps} />;
-};
+export const IconAI = (props: IconAiProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconAISvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconAI/IconAI.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconAI/IconAI.tsx
@@ -7,6 +7,6 @@ export type IconAiProps = IconContainerProps;
 
 export const IconAI = (props: IconAiProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconAISvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconAISvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconAdd/IconAdd.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconAdd/IconAdd.tsx
@@ -7,6 +7,6 @@ export type IconAddProps = IconContainerProps;
 
 export const IconAdd = (props: IconAddProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconAddSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconAddSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconAdd/IconAdd.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconAdd/IconAdd.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconAddSvg } from './IconAddSvg';
 
-export type IconAddProps = UseIconProps;
+export type IconAddProps = IconContainerProps;
 
-export const IconAdd = (props: IconAddProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconAddSvg} {...iconProps} />;
-};
+export const IconAdd = (props: IconAddProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconAddSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconArrow/IconArrow.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconArrow/IconArrow.tsx
@@ -1,29 +1,29 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconArrowSvg } from './IconArrowSvg';
 import * as styles from './IconArrow.css';
 
-export type IconArrowProps = UseIconProps & {
+export type IconArrowProps = IconContainerProps & {
   direction?: 'up' | 'down' | 'left' | 'right';
 };
 
-export const IconArrow = ({ direction = 'up', ...props }: IconArrowProps) => {
-  const { className, ...iconProps } = useIcon(props);
-
-  return (
-    <Box
-      component={IconArrowSvg}
-      className={[
-        styles.root,
-        className,
-        {
-          [styles.rotate]: direction === 'right' || direction === 'left',
-          [styles.flip]: direction === 'down',
-          [styles.mirror]: direction === 'left',
-        },
-      ]}
-      {...iconProps}
-    />
-  );
-};
+export const IconArrow = ({ direction = 'up', ...props }: IconArrowProps) => (
+  <IconContainer {...props}>
+    {({ className, ...iconProps }) => (
+      <Box
+        component={IconArrowSvg}
+        className={[
+          styles.root,
+          className,
+          {
+            [styles.rotate]: direction === 'right' || direction === 'left',
+            [styles.flip]: direction === 'down',
+            [styles.mirror]: direction === 'left',
+          },
+        ]}
+        {...iconProps}
+      />
+    )}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconArrow/IconArrow.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconArrow/IconArrow.tsx
@@ -10,7 +10,7 @@ export type IconArrowProps = IconContainerProps & {
 
 export const IconArrow = ({ direction = 'up', ...props }: IconArrowProps) => (
   <IconContainer {...props}>
-    {({ className, ...iconProps }) => (
+    {({ className, ...svgProps }) => (
       <Box
         component={IconArrowSvg}
         className={[
@@ -22,7 +22,7 @@ export const IconArrow = ({ direction = 'up', ...props }: IconArrowProps) => (
             [styles.mirror]: direction === 'left',
           },
         ]}
-        {...iconProps}
+        {...svgProps}
       />
     )}
   </IconContainer>

--- a/packages/braid-design-system/src/lib/components/icons/IconBookmark/IconBookmark.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconBookmark/IconBookmark.tsx
@@ -13,10 +13,10 @@ export const IconBookmark = ({
   ...props
 }: IconBookmarkProps) => (
   <IconContainer {...props}>
-    {(boxProps) => (
+    {(svgProps) => (
       <Box
         component={active ? IconBookmarkActiveSvg : IconBookmarkSvg}
-        {...boxProps}
+        {...svgProps}
       />
     )}
   </IconContainer>

--- a/packages/braid-design-system/src/lib/components/icons/IconBookmark/IconBookmark.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconBookmark/IconBookmark.tsx
@@ -1,23 +1,23 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconBookmarkSvg } from './IconBookmarkSvg';
 import { IconBookmarkActiveSvg } from './IconBookmarkActiveSvg';
 
-export type IconBookmarkProps = UseIconProps & {
+export type IconBookmarkProps = IconContainerProps & {
   active?: boolean;
 };
 
 export const IconBookmark = ({
   active = false,
   ...props
-}: IconBookmarkProps) => {
-  const iconProps = useIcon(props);
-
-  return (
-    <Box
-      component={active ? IconBookmarkActiveSvg : IconBookmarkSvg}
-      {...iconProps}
-    />
-  );
-};
+}: IconBookmarkProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => (
+      <Box
+        component={active ? IconBookmarkActiveSvg : IconBookmarkSvg}
+        {...boxProps}
+      />
+    )}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconCareer/IconCareer.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCareer/IconCareer.tsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconCareerSvg } from './IconCareerSvg';
 import { IconCareerActiveSvg } from './IconCareerActiveSvg';
 
-export type IconCareerProps = UseIconProps & {
+export type IconCareerProps = IconContainerProps & {
   active?: boolean;
 };
 
-export const IconCareer = ({ active = false, ...props }: IconCareerProps) => {
-  const iconProps = useIcon(props);
-
-  return (
-    <Box
-      component={active ? IconCareerActiveSvg : IconCareerSvg}
-      {...iconProps}
-    />
-  );
-};
+export const IconCareer = ({ active = false, ...props }: IconCareerProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => (
+      <Box
+        component={active ? IconCareerActiveSvg : IconCareerSvg}
+        {...boxProps}
+      />
+    )}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconCareer/IconCareer.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCareer/IconCareer.tsx
@@ -10,10 +10,10 @@ export type IconCareerProps = IconContainerProps & {
 
 export const IconCareer = ({ active = false, ...props }: IconCareerProps) => (
   <IconContainer {...props}>
-    {(boxProps) => (
+    {(svgProps) => (
       <Box
         component={active ? IconCareerActiveSvg : IconCareerSvg}
-        {...boxProps}
+        {...svgProps}
       />
     )}
   </IconContainer>

--- a/packages/braid-design-system/src/lib/components/icons/IconCategory/IconCategory.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCategory/IconCategory.tsx
@@ -7,6 +7,6 @@ export type IconCategoryProps = IconContainerProps;
 
 export const IconCategory = (props: IconCategoryProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconCategorySvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconCategorySvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconCategory/IconCategory.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCategory/IconCategory.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconCategorySvg } from './IconCategorySvg';
 
-export type IconCategoryProps = UseIconProps;
+export type IconCategoryProps = IconContainerProps;
 
-export const IconCategory = (props: IconCategoryProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconCategorySvg} {...iconProps} />;
-};
+export const IconCategory = (props: IconCategoryProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconCategorySvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconCaution/IconCaution.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCaution/IconCaution.tsx
@@ -7,6 +7,6 @@ export type IconCautionProps = IconContainerProps;
 
 export const IconCaution = (props: IconCautionProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconCautionSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconCautionSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconCaution/IconCaution.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCaution/IconCaution.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconCautionSvg } from './IconCautionSvg';
 
-export type IconCautionProps = UseIconProps;
+export type IconCautionProps = IconContainerProps;
 
-export const IconCaution = (props: IconCautionProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconCautionSvg} {...iconProps} />;
-};
+export const IconCaution = (props: IconCautionProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconCautionSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconChevron/IconChevron.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconChevron/IconChevron.tsx
@@ -1,32 +1,32 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconChevronSvg } from './IconChevronSvg';
 import * as styles from './IconChevron.css';
 
-export type IconChevronProps = UseIconProps & {
+export type IconChevronProps = IconContainerProps & {
   direction?: 'up' | 'down' | 'left' | 'right';
 };
 
 export const IconChevron = ({
   direction = 'down',
   ...props
-}: IconChevronProps) => {
-  const { className, ...iconProps } = useIcon(props);
-
-  return (
-    <Box
-      component={IconChevronSvg}
-      className={[
-        styles.root,
-        className,
-        {
-          [styles.up]: direction === 'up',
-          [styles.left]: direction === 'left',
-          [styles.right]: direction === 'right',
-        },
-      ]}
-      {...iconProps}
-    />
-  );
-};
+}: IconChevronProps) => (
+  <IconContainer {...props}>
+    {({ className, ...iconProps }) => (
+      <Box
+        component={IconChevronSvg}
+        className={[
+          styles.root,
+          className,
+          {
+            [styles.up]: direction === 'up',
+            [styles.left]: direction === 'left',
+            [styles.right]: direction === 'right',
+          },
+        ]}
+        {...iconProps}
+      />
+    )}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconChevron/IconChevron.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconChevron/IconChevron.tsx
@@ -13,7 +13,7 @@ export const IconChevron = ({
   ...props
 }: IconChevronProps) => (
   <IconContainer {...props}>
-    {({ className, ...iconProps }) => (
+    {({ className, ...svgProps }) => (
       <Box
         component={IconChevronSvg}
         className={[
@@ -25,7 +25,7 @@ export const IconChevron = ({
             [styles.right]: direction === 'right',
           },
         ]}
-        {...iconProps}
+        {...svgProps}
       />
     )}
   </IconContainer>

--- a/packages/braid-design-system/src/lib/components/icons/IconClear/IconClear.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconClear/IconClear.tsx
@@ -7,6 +7,6 @@ export type IconClearProps = IconContainerProps;
 
 export const IconClear = (props: IconClearProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconClearSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconClearSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconClear/IconClear.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconClear/IconClear.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconClearSvg } from './IconClearSvg';
 
-export type IconClearProps = UseIconProps;
+export type IconClearProps = IconContainerProps;
 
-export const IconClear = (props: IconClearProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconClearSvg} {...iconProps} />;
-};
+export const IconClear = (props: IconClearProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconClearSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconCompany/IconCompany.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCompany/IconCompany.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconCompanySvg } from './IconCompanySvg';
 
-export type IconCompanyProps = UseIconProps;
+export type IconCompanyProps = IconContainerProps;
 
-export const IconCompany = (props: IconCompanyProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconCompanySvg} {...iconProps} />;
-};
+export const IconCompany = (props: IconCompanyProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconCompanySvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconCompany/IconCompany.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCompany/IconCompany.tsx
@@ -7,6 +7,6 @@ export type IconCompanyProps = IconContainerProps;
 
 export const IconCompany = (props: IconCompanyProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconCompanySvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconCompanySvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconCompose/IconCompose.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCompose/IconCompose.tsx
@@ -7,6 +7,6 @@ export type IconComposeProps = IconContainerProps;
 
 export const IconCompose = (props: IconComposeProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconComposeSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconComposeSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconCompose/IconCompose.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCompose/IconCompose.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconComposeSvg } from './IconComposeSvg';
 
-export type IconComposeProps = UseIconProps;
+export type IconComposeProps = IconContainerProps;
 
-export const IconCompose = (props: IconComposeProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconComposeSvg} {...iconProps} />;
-};
+export const IconCompose = (props: IconComposeProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconComposeSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconContainer.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconContainer.tsx
@@ -1,0 +1,26 @@
+import type { ReactElement } from 'react';
+import useIcon, { type UseIconProps } from '../../hooks/useIcon';
+import { Box, type PublicBoxProps } from '../Box/Box';
+
+export type IconContainerProps = UseIconProps;
+
+type IconRenderProp = {
+  children: (boxProps: PublicBoxProps) => ReactElement | null;
+};
+type VerticalCorrection = Parameters<typeof useIcon>[1];
+
+export const IconContainer = ({
+  children,
+  verticalCorrection,
+  ...props
+}: IconContainerProps & IconRenderProp & VerticalCorrection) => {
+  const { isInline, boxProps } = useIcon(props, { verticalCorrection });
+
+  return isInline ? (
+    <Box component="span" display="inlineBlock">
+      {children(boxProps)}
+    </Box>
+  ) : (
+    children(boxProps)
+  );
+};

--- a/packages/braid-design-system/src/lib/components/icons/IconContainer.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconContainer.tsx
@@ -5,7 +5,7 @@ import { Box, type PublicBoxProps } from '../Box/Box';
 export type IconContainerProps = UseIconProps;
 
 type IconRenderProp = {
-  children: (boxProps: PublicBoxProps) => ReactElement | null;
+  children: (svgProps: PublicBoxProps) => ReactElement | null;
 };
 type VerticalCorrection = Parameters<typeof useIcon>[1];
 
@@ -14,13 +14,15 @@ export const IconContainer = ({
   verticalCorrection,
   ...props
 }: IconContainerProps & IconRenderProp & VerticalCorrection) => {
-  const { isInline, boxProps } = useIcon(props, { verticalCorrection });
+  const { isInline, svgProps: svgProps } = useIcon(props, {
+    verticalCorrection,
+  });
 
   return isInline ? (
     <Box component="span" display="inlineBlock">
-      {children(boxProps)}
+      {children(svgProps)}
     </Box>
   ) : (
-    children(boxProps)
+    children(svgProps)
   );
 };

--- a/packages/braid-design-system/src/lib/components/icons/IconCopy/IconCopy.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCopy/IconCopy.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconCopySvg } from './IconCopySvg';
 
-export type IconCopyProps = UseIconProps;
+export type IconCopyProps = IconContainerProps;
 
-export const IconCopy = (props: IconCopyProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconCopySvg} {...iconProps} />;
-};
+export const IconCopy = (props: IconCopyProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconCopySvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconCopy/IconCopy.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCopy/IconCopy.tsx
@@ -7,6 +7,6 @@ export type IconCopyProps = IconContainerProps;
 
 export const IconCopy = (props: IconCopyProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconCopySvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconCopySvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconCreditCard/IconCreditCard.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCreditCard/IconCreditCard.tsx
@@ -7,6 +7,6 @@ export type IconCreditCardProps = IconContainerProps;
 
 export const IconCreditCard = (props: IconCreditCardProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconCreditCardSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconCreditCardSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconCreditCard/IconCreditCard.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCreditCard/IconCreditCard.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconCreditCardSvg } from './IconCreditCardSvg';
 
-export type IconCreditCardProps = UseIconProps;
+export type IconCreditCardProps = IconContainerProps;
 
-export const IconCreditCard = (props: IconCreditCardProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconCreditCardSvg} {...iconProps} />;
-};
+export const IconCreditCard = (props: IconCreditCardProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconCreditCardSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconCritical/IconCritical.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCritical/IconCritical.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconCriticalSvg } from './IconCriticalSvg';
 
-export type IconCriticalProps = UseIconProps;
+export type IconCriticalProps = IconContainerProps;
 
-export const IconCritical = (props: IconCriticalProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconCriticalSvg} {...iconProps} />;
-};
+export const IconCritical = (props: IconCriticalProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconCriticalSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconCritical/IconCritical.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCritical/IconCritical.tsx
@@ -7,6 +7,6 @@ export type IconCriticalProps = IconContainerProps;
 
 export const IconCritical = (props: IconCriticalProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconCriticalSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconCriticalSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconDate/IconDate.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDate/IconDate.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconDateSvg } from './IconDateSvg';
 
-export type IconDateProps = UseIconProps;
+export type IconDateProps = IconContainerProps;
 
-export const IconDate = (props: IconDateProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconDateSvg} {...iconProps} />;
-};
+export const IconDate = (props: IconDateProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconDateSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconDate/IconDate.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDate/IconDate.tsx
@@ -7,6 +7,6 @@ export type IconDateProps = IconContainerProps;
 
 export const IconDate = (props: IconDateProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconDateSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconDateSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconDelete/IconDelete.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDelete/IconDelete.tsx
@@ -7,6 +7,6 @@ export type IconDeleteProps = IconContainerProps;
 
 export const IconDelete = (props: IconDeleteProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconDeleteSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconDeleteSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconDelete/IconDelete.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDelete/IconDelete.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconDeleteSvg } from './IconDeleteSvg';
 
-export type IconDeleteProps = UseIconProps;
+export type IconDeleteProps = IconContainerProps;
 
-export const IconDelete = (props: IconDeleteProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconDeleteSvg} {...iconProps} />;
-};
+export const IconDelete = (props: IconDeleteProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconDeleteSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconDesktop/IconDesktop.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDesktop/IconDesktop.tsx
@@ -7,6 +7,6 @@ export type IconDesktopProps = IconContainerProps;
 
 export const IconDesktop = (props: IconDesktopProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconDesktopSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconDesktopSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconDesktop/IconDesktop.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDesktop/IconDesktop.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconDesktopSvg } from './IconDesktopSvg';
 
-export type IconDesktopProps = UseIconProps;
+export type IconDesktopProps = IconContainerProps;
 
-export const IconDesktop = (props: IconDesktopProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconDesktopSvg} {...iconProps} />;
-};
+export const IconDesktop = (props: IconDesktopProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconDesktopSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconDocument/IconDocument.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDocument/IconDocument.tsx
@@ -7,6 +7,6 @@ export type IconDocumentProps = IconContainerProps;
 
 export const IconDocument = (props: IconDocumentProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconDocumentSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconDocumentSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconDocument/IconDocument.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDocument/IconDocument.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconDocumentSvg } from './IconDocumentSvg';
 
-export type IconDocumentProps = UseIconProps;
+export type IconDocumentProps = IconContainerProps;
 
-export const IconDocument = (props: IconDocumentProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconDocumentSvg} {...iconProps} />;
-};
+export const IconDocument = (props: IconDocumentProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconDocumentSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconDocumentBroken/IconDocumentBroken.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDocumentBroken/IconDocumentBroken.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconDocumentBrokenSvg } from './IconDocumentBrokenSvg';
 
-export type IconDocumentBrokenProps = UseIconProps;
+export type IconDocumentBrokenProps = IconContainerProps;
 
-export const IconDocumentBroken = (props: IconDocumentBrokenProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconDocumentBrokenSvg} {...iconProps} />;
-};
+export const IconDocumentBroken = (props: IconDocumentBrokenProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconDocumentBrokenSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconDocumentBroken/IconDocumentBroken.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDocumentBroken/IconDocumentBroken.tsx
@@ -7,6 +7,6 @@ export type IconDocumentBrokenProps = IconContainerProps;
 
 export const IconDocumentBroken = (props: IconDocumentBrokenProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconDocumentBrokenSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconDocumentBrokenSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconDownload/IconDownload.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDownload/IconDownload.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconDownloadSvg } from './IconDownloadSvg';
 
-export type IconDownloadProps = UseIconProps;
+export type IconDownloadProps = IconContainerProps;
 
-export const IconDownload = (props: IconDownloadProps) => {
-  const iconProps = useIcon(props, {
-    verticalCorrection: {
+export const IconDownload = (props: IconDownloadProps) => (
+  <IconContainer
+    {...props}
+    verticalCorrection={{
       uppercase: 'none',
       lowercase: 'up',
-    },
-  });
-
-  return <Box component={IconDownloadSvg} {...iconProps} />;
-};
+    }}
+  >
+    {(boxProps) => <Box component={IconDownloadSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconDownload/IconDownload.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDownload/IconDownload.tsx
@@ -13,6 +13,6 @@ export const IconDownload = (props: IconDownloadProps) => (
       lowercase: 'up',
     }}
   >
-    {(boxProps) => <Box component={IconDownloadSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconDownloadSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconEdit/IconEdit.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconEdit/IconEdit.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconEditSvg } from './IconEditSvg';
 
-export type IconEditProps = UseIconProps;
+export type IconEditProps = IconContainerProps;
 
-export const IconEdit = (props: IconEditProps) => {
-  const iconProps = useIcon(props, {
-    verticalCorrection: {
+export const IconEdit = (props: IconEditProps) => (
+  <IconContainer
+    {...props}
+    verticalCorrection={{
       uppercase: 'none',
       lowercase: 'up',
-    },
-  });
-
-  return <Box component={IconEditSvg} {...iconProps} />;
-};
+    }}
+  >
+    {(boxProps) => <Box component={IconEditSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconEdit/IconEdit.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconEdit/IconEdit.tsx
@@ -13,6 +13,6 @@ export const IconEdit = (props: IconEditProps) => (
       lowercase: 'up',
     }}
   >
-    {(boxProps) => <Box component={IconEditSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconEditSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconEducation/IconEducation.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconEducation/IconEducation.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconEducationSvg } from './IconEducationSvg';
 
-export type IconEducationProps = UseIconProps;
+export type IconEducationProps = IconContainerProps;
 
-export const IconEducation = (props: IconEducationProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconEducationSvg} {...iconProps} />;
-};
+export const IconEducation = (props: IconEducationProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconEducationSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconEducation/IconEducation.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconEducation/IconEducation.tsx
@@ -7,6 +7,6 @@ export type IconEducationProps = IconContainerProps;
 
 export const IconEducation = (props: IconEducationProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconEducationSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconEducationSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconEnlarge/IconEnlarge.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconEnlarge/IconEnlarge.tsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconEnlargeSvg } from './IconEnlargeSvg';
 import { IconEnlargeActiveSvg } from './IconEnlargeActiveSvg';
 
-export type IconEnlargeProps = UseIconProps & {
+export type IconEnlargeProps = IconContainerProps & {
   active?: boolean;
 };
 
-export const IconEnlarge = ({ active = false, ...props }: IconEnlargeProps) => {
-  const iconProps = useIcon(props);
-
-  return (
-    <Box
-      component={active ? IconEnlargeActiveSvg : IconEnlargeSvg}
-      {...iconProps}
-    />
-  );
-};
+export const IconEnlarge = ({ active = false, ...props }: IconEnlargeProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => (
+      <Box
+        component={active ? IconEnlargeActiveSvg : IconEnlargeSvg}
+        {...boxProps}
+      />
+    )}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconEnlarge/IconEnlarge.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconEnlarge/IconEnlarge.tsx
@@ -10,10 +10,10 @@ export type IconEnlargeProps = IconContainerProps & {
 
 export const IconEnlarge = ({ active = false, ...props }: IconEnlargeProps) => (
   <IconContainer {...props}>
-    {(boxProps) => (
+    {(svgProps) => (
       <Box
         component={active ? IconEnlargeActiveSvg : IconEnlargeSvg}
-        {...boxProps}
+        {...svgProps}
       />
     )}
   </IconContainer>

--- a/packages/braid-design-system/src/lib/components/icons/IconExperience/IconExperience.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconExperience/IconExperience.tsx
@@ -7,6 +7,6 @@ export type IconExperienceProps = IconContainerProps;
 
 export const IconExperience = (props: IconExperienceProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconExperienceSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconExperienceSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconExperience/IconExperience.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconExperience/IconExperience.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconExperienceSvg } from './IconExperienceSvg';
 
-export type IconExperienceProps = UseIconProps;
+export type IconExperienceProps = IconContainerProps;
 
-export const IconExperience = (props: IconExperienceProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconExperienceSvg} {...iconProps} />;
-};
+export const IconExperience = (props: IconExperienceProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconExperienceSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconFilter/IconFilter.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconFilter/IconFilter.tsx
@@ -7,6 +7,6 @@ export type IconFilterProps = IconContainerProps;
 
 export const IconFilter = (props: IconFilterProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconFilterSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconFilterSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconFilter/IconFilter.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconFilter/IconFilter.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconFilterSvg } from './IconFilterSvg';
 
-export type IconFilterProps = UseIconProps;
+export type IconFilterProps = IconContainerProps;
 
-export const IconFilter = (props: IconFilterProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconFilterSvg} {...iconProps} />;
-};
+export const IconFilter = (props: IconFilterProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconFilterSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconFlag/IconFlag.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconFlag/IconFlag.tsx
@@ -7,6 +7,6 @@ export type IconFlagProps = IconContainerProps;
 
 export const IconFlag = (props: IconFlagProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconFlagSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconFlagSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconFlag/IconFlag.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconFlag/IconFlag.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconFlagSvg } from './IconFlagSvg';
 
-export type IconFlagProps = UseIconProps;
+export type IconFlagProps = IconContainerProps;
 
-export const IconFlag = (props: IconFlagProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconFlagSvg} {...iconProps} />;
-};
+export const IconFlag = (props: IconFlagProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconFlagSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconGift/IconGift.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconGift/IconGift.tsx
@@ -7,6 +7,6 @@ export type IconGiftProps = IconContainerProps;
 
 export const IconGift = (props: IconGiftProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconGiftSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconGiftSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconGift/IconGift.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconGift/IconGift.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconGiftSvg } from './IconGiftSvg';
 
-export type IconGiftProps = UseIconProps;
+export type IconGiftProps = IconContainerProps;
 
-export const IconGift = (props: IconGiftProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconGiftSvg} {...iconProps} />;
-};
+export const IconGift = (props: IconGiftProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconGiftSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconGlobe/IconGlobe.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconGlobe/IconGlobe.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconGlobeSvg } from './IconGlobeSvg';
 
-export type IconGlobeProps = UseIconProps;
+export type IconGlobeProps = IconContainerProps;
 
-export const IconGlobe = (props: IconGlobeProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconGlobeSvg} {...iconProps} />;
-};
+export const IconGlobe = (props: IconGlobeProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconGlobeSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconGlobe/IconGlobe.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconGlobe/IconGlobe.tsx
@@ -7,6 +7,6 @@ export type IconGlobeProps = IconContainerProps;
 
 export const IconGlobe = (props: IconGlobeProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconGlobeSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconGlobeSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconGrid/IconGrid.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconGrid/IconGrid.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconGridSvg } from './IconGridSvg';
 
-export type IconGridProps = UseIconProps;
+export type IconGridProps = IconContainerProps;
 
-export const IconGrid = (props: IconGridProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconGridSvg} {...iconProps} />;
-};
+export const IconGrid = (props: IconGridProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconGridSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconGrid/IconGrid.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconGrid/IconGrid.tsx
@@ -7,6 +7,6 @@ export type IconGridProps = IconContainerProps;
 
 export const IconGrid = (props: IconGridProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconGridSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconGridSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconHash/IconHash.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconHash/IconHash.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconHashSvg } from './IconHashSvg';
 
-export type IconHashProps = UseIconProps;
+export type IconHashProps = IconContainerProps;
 
-export const IconHash = (props: IconHashProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconHashSvg} {...iconProps} />;
-};
+export const IconHash = (props: IconHashProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconHashSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconHash/IconHash.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconHash/IconHash.tsx
@@ -7,6 +7,6 @@ export type IconHashProps = IconContainerProps;
 
 export const IconHash = (props: IconHashProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconHashSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconHashSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconHeart/IconHeart.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconHeart/IconHeart.tsx
@@ -10,10 +10,10 @@ export type IconHeartProps = IconContainerProps & {
 
 export const IconHeart = ({ active = false, ...props }: IconHeartProps) => (
   <IconContainer {...props}>
-    {(boxProps) => (
+    {(svgProps) => (
       <Box
         component={active ? IconHeartActiveSvg : IconHeartSvg}
-        {...boxProps}
+        {...svgProps}
       />
     )}
   </IconContainer>

--- a/packages/braid-design-system/src/lib/components/icons/IconHeart/IconHeart.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconHeart/IconHeart.tsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconHeartSvg } from './IconHeartSvg';
 import { IconHeartActiveSvg } from './IconHeartActiveSvg';
 
-export type IconHeartProps = UseIconProps & {
+export type IconHeartProps = IconContainerProps & {
   active?: boolean;
 };
 
-export const IconHeart = ({ active = false, ...props }: IconHeartProps) => {
-  const iconProps = useIcon(props);
-
-  return (
-    <Box
-      component={active ? IconHeartActiveSvg : IconHeartSvg}
-      {...iconProps}
-    />
-  );
-};
+export const IconHeart = ({ active = false, ...props }: IconHeartProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => (
+      <Box
+        component={active ? IconHeartActiveSvg : IconHeartSvg}
+        {...boxProps}
+      />
+    )}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconHelp/IconHelp.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconHelp/IconHelp.tsx
@@ -7,6 +7,6 @@ export type IconHelpProps = IconContainerProps;
 
 export const IconHelp = (props: IconHelpProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconHelpSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconHelpSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconHelp/IconHelp.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconHelp/IconHelp.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconHelpSvg } from './IconHelpSvg';
 
-export type IconHelpProps = UseIconProps;
+export type IconHelpProps = IconContainerProps;
 
-export const IconHelp = (props: IconHelpProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconHelpSvg} {...iconProps} />;
-};
+export const IconHelp = (props: IconHelpProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconHelpSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconHistory/IconHistory.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconHistory/IconHistory.tsx
@@ -7,6 +7,6 @@ export type IconHistoryProps = IconContainerProps;
 
 export const IconHistory = (props: IconHistoryProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconHistorySvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconHistorySvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconHistory/IconHistory.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconHistory/IconHistory.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconHistorySvg } from './IconHistorySvg';
 
-export type IconHistoryProps = UseIconProps;
+export type IconHistoryProps = IconContainerProps;
 
-export const IconHistory = (props: IconHistoryProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconHistorySvg} {...iconProps} />;
-};
+export const IconHistory = (props: IconHistoryProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconHistorySvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconHome/IconHome.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconHome/IconHome.tsx
@@ -7,6 +7,6 @@ export type IconHomeProps = IconContainerProps;
 
 export const IconHome = (props: IconHomeProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconHomeSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconHomeSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconHome/IconHome.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconHome/IconHome.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconHomeSvg } from './IconHomeSvg';
 
-export type IconHomeProps = UseIconProps;
+export type IconHomeProps = IconContainerProps;
 
-export const IconHome = (props: IconHomeProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconHomeSvg} {...iconProps} />;
-};
+export const IconHome = (props: IconHomeProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconHomeSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconImage/IconImage.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconImage/IconImage.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconImageSvg } from './IconImageSvg';
 
-export type IconImageProps = UseIconProps;
+export type IconImageProps = IconContainerProps;
 
-export const IconImage = (props: IconImageProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconImageSvg} {...iconProps} />;
-};
+export const IconImage = (props: IconImageProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconImageSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconImage/IconImage.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconImage/IconImage.tsx
@@ -7,6 +7,6 @@ export type IconImageProps = IconContainerProps;
 
 export const IconImage = (props: IconImageProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconImageSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconImageSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconInfo/IconInfo.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconInfo/IconInfo.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconInfoSvg } from './IconInfoSvg';
 
-export type IconInfoProps = UseIconProps;
+export type IconInfoProps = IconContainerProps;
 
-export const IconInfo = (props: IconInfoProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconInfoSvg} {...iconProps} />;
-};
+export const IconInfo = (props: IconInfoProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconInfoSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconInfo/IconInfo.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconInfo/IconInfo.tsx
@@ -7,6 +7,6 @@ export type IconInfoProps = IconContainerProps;
 
 export const IconInfo = (props: IconInfoProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconInfoSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconInfoSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconInvoice/IconInvoice.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconInvoice/IconInvoice.tsx
@@ -7,6 +7,6 @@ export type IconInvoiceProps = IconContainerProps;
 
 export const IconInvoice = (props: IconInvoiceProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconInvoiceSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconInvoiceSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconInvoice/IconInvoice.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconInvoice/IconInvoice.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconInvoiceSvg } from './IconInvoiceSvg';
 
-export type IconInvoiceProps = UseIconProps;
+export type IconInvoiceProps = IconContainerProps;
 
-export const IconInvoice = (props: IconInvoiceProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconInvoiceSvg} {...iconProps} />;
-};
+export const IconInvoice = (props: IconInvoiceProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconInvoiceSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconLanguage/IconLanguage.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconLanguage/IconLanguage.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconLanguageSvg } from './IconLanguageSvg';
 
-export type IconLanguageProps = UseIconProps;
+export type IconLanguageProps = IconContainerProps;
 
-export const IconLanguage = (props: IconLanguageProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconLanguageSvg} {...iconProps} />;
-};
+export const IconLanguage = (props: IconLanguageProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconLanguageSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconLanguage/IconLanguage.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconLanguage/IconLanguage.tsx
@@ -7,6 +7,6 @@ export type IconLanguageProps = IconContainerProps;
 
 export const IconLanguage = (props: IconLanguageProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconLanguageSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconLanguageSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconLink/IconLink.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconLink/IconLink.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconLinkSvg } from './IconLinkSvg';
 
-export type IconLinkProps = UseIconProps;
+export type IconLinkProps = IconContainerProps;
 
-export const IconLink = (props: IconLinkProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconLinkSvg} {...iconProps} />;
-};
+export const IconLink = (props: IconLinkProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconLinkSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconLink/IconLink.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconLink/IconLink.tsx
@@ -7,6 +7,6 @@ export type IconLinkProps = IconContainerProps;
 
 export const IconLink = (props: IconLinkProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconLinkSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconLinkSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconLinkBroken/IconLinkBroken.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconLinkBroken/IconLinkBroken.tsx
@@ -7,6 +7,6 @@ export type IconLinkBrokenProps = IconContainerProps;
 
 export const IconLinkBroken = (props: IconLinkBrokenProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconLinkBrokenSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconLinkBrokenSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconLinkBroken/IconLinkBroken.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconLinkBroken/IconLinkBroken.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconLinkBrokenSvg } from './IconLinkBrokenSvg';
 
-export type IconLinkBrokenProps = UseIconProps;
+export type IconLinkBrokenProps = IconContainerProps;
 
-export const IconLinkBroken = (props: IconLinkBrokenProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconLinkBrokenSvg} {...iconProps} />;
-};
+export const IconLinkBroken = (props: IconLinkBrokenProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconLinkBrokenSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconList/IconList.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconList/IconList.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconListSvg } from './IconListSvg';
 
-export type IconListProps = UseIconProps;
+export type IconListProps = IconContainerProps;
 
-export const IconList = (props: IconListProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconListSvg} {...iconProps} />;
-};
+export const IconList = (props: IconListProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconListSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconList/IconList.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconList/IconList.tsx
@@ -7,6 +7,6 @@ export type IconListProps = IconContainerProps;
 
 export const IconList = (props: IconListProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconListSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconListSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconLocation/IconLocation.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconLocation/IconLocation.tsx
@@ -7,6 +7,6 @@ export type IconLocationProps = IconContainerProps;
 
 export const IconLocation = (props: IconLocationProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconLocationSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconLocationSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconLocation/IconLocation.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconLocation/IconLocation.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconLocationSvg } from './IconLocationSvg';
 
-export type IconLocationProps = UseIconProps;
+export type IconLocationProps = IconContainerProps;
 
-export const IconLocation = (props: IconLocationProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconLocationSvg} {...iconProps} />;
-};
+export const IconLocation = (props: IconLocationProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconLocationSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconMail/IconMail.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconMail/IconMail.tsx
@@ -7,6 +7,6 @@ export type IconMailProps = IconContainerProps;
 
 export const IconMail = (props: IconMailProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconMailSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconMailSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconMail/IconMail.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconMail/IconMail.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconMailSvg } from './IconMailSvg';
 
-export type IconMailProps = UseIconProps;
+export type IconMailProps = IconContainerProps;
 
-export const IconMail = (props: IconMailProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconMailSvg} {...iconProps} />;
-};
+export const IconMail = (props: IconMailProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconMailSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconMessage/IconMessage.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconMessage/IconMessage.tsx
@@ -7,6 +7,6 @@ export type IconMessageProps = IconContainerProps;
 
 export const IconMessage = (props: IconMessageProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconMessageSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconMessageSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconMessage/IconMessage.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconMessage/IconMessage.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconMessageSvg } from './IconMessageSvg';
 
-export type IconMessageProps = UseIconProps;
+export type IconMessageProps = IconContainerProps;
 
-export const IconMessage = (props: IconMessageProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconMessageSvg} {...iconProps} />;
-};
+export const IconMessage = (props: IconMessageProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconMessageSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconMinus/IconMinus.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconMinus/IconMinus.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconMinusSvg } from './IconMinusSvg';
 
-export type IconMinusProps = UseIconProps;
+export type IconMinusProps = IconContainerProps;
 
-export const IconMinus = (props: IconMinusProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconMinusSvg} {...iconProps} />;
-};
+export const IconMinus = (props: IconMinusProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconMinusSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconMinus/IconMinus.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconMinus/IconMinus.tsx
@@ -7,6 +7,6 @@ export type IconMinusProps = IconContainerProps;
 
 export const IconMinus = (props: IconMinusProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconMinusSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconMinusSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconMobile/IconMobile.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconMobile/IconMobile.tsx
@@ -7,6 +7,6 @@ export type IconMobileProps = IconContainerProps;
 
 export const IconMobile = (props: IconMobileProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconMobileSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconMobileSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconMobile/IconMobile.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconMobile/IconMobile.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconMobileSvg } from './IconMobileSvg';
 
-export type IconMobileProps = UseIconProps;
+export type IconMobileProps = IconContainerProps;
 
-export const IconMobile = (props: IconMobileProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconMobileSvg} {...iconProps} />;
-};
+export const IconMobile = (props: IconMobileProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconMobileSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconMoney/IconMoney.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconMoney/IconMoney.tsx
@@ -7,6 +7,6 @@ export type IconMoneyProps = IconContainerProps;
 
 export const IconMoney = (props: IconMoneyProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconMoneySvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconMoneySvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconMoney/IconMoney.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconMoney/IconMoney.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconMoneySvg } from './IconMoneySvg';
 
-export type IconMoneyProps = UseIconProps;
+export type IconMoneyProps = IconContainerProps;
 
-export const IconMoney = (props: IconMoneyProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconMoneySvg} {...iconProps} />;
-};
+export const IconMoney = (props: IconMoneyProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconMoneySvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconNewWindow/IconNewWindow.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconNewWindow/IconNewWindow.tsx
@@ -7,6 +7,6 @@ export type IconNewWindowProps = IconContainerProps;
 
 export const IconNewWindow = (props: IconNewWindowProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconNewWindowSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconNewWindowSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconNewWindow/IconNewWindow.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconNewWindow/IconNewWindow.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconNewWindowSvg } from './IconNewWindowSvg';
 
-export type IconNewWindowProps = UseIconProps;
+export type IconNewWindowProps = IconContainerProps;
 
-export const IconNewWindow = (props: IconNewWindowProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconNewWindowSvg} {...iconProps} />;
-};
+export const IconNewWindow = (props: IconNewWindowProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconNewWindowSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconNote/IconNote.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconNote/IconNote.tsx
@@ -7,6 +7,6 @@ export type IconNoteProps = IconContainerProps;
 
 export const IconNote = (props: IconNoteProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconNoteSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconNoteSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconNote/IconNote.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconNote/IconNote.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconNoteSvg } from './IconNoteSvg';
 
-export type IconNoteProps = UseIconProps;
+export type IconNoteProps = IconContainerProps;
 
-export const IconNote = (props: IconNoteProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconNoteSvg} {...iconProps} />;
-};
+export const IconNote = (props: IconNoteProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconNoteSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconNotification/IconNotification.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconNotification/IconNotification.tsx
@@ -7,6 +7,6 @@ export type IconNotificationProps = IconContainerProps;
 
 export const IconNotification = (props: IconNotificationProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconNotificationSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconNotificationSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconNotification/IconNotification.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconNotification/IconNotification.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconNotificationSvg } from './IconNotificationSvg';
 
-export type IconNotificationProps = UseIconProps;
+export type IconNotificationProps = IconContainerProps;
 
-export const IconNotification = (props: IconNotificationProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconNotificationSvg} {...iconProps} />;
-};
+export const IconNotification = (props: IconNotificationProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconNotificationSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconOverflow/IconOverflow.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconOverflow/IconOverflow.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconOverflowSvg } from './IconOverflowSvg';
 
-export type IconOverflowProps = UseIconProps;
+export type IconOverflowProps = IconContainerProps;
 
-export const IconOverflow = (props: IconOverflowProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconOverflowSvg} {...iconProps} />;
-};
+export const IconOverflow = (props: IconOverflowProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconOverflowSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconOverflow/IconOverflow.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconOverflow/IconOverflow.tsx
@@ -7,6 +7,6 @@ export type IconOverflowProps = IconContainerProps;
 
 export const IconOverflow = (props: IconOverflowProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconOverflowSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconOverflowSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconPeople/IconPeople.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPeople/IconPeople.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconPeopleSvg } from './IconPeopleSvg';
 
-export type IconPeopleProps = UseIconProps;
+export type IconPeopleProps = IconContainerProps;
 
-export const IconPeople = (props: IconPeopleProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconPeopleSvg} {...iconProps} />;
-};
+export const IconPeople = (props: IconPeopleProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconPeopleSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconPeople/IconPeople.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPeople/IconPeople.tsx
@@ -7,6 +7,6 @@ export type IconPeopleProps = IconContainerProps;
 
 export const IconPeople = (props: IconPeopleProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconPeopleSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconPeopleSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconPersonAdd/IconPersonAdd.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPersonAdd/IconPersonAdd.tsx
@@ -7,6 +7,6 @@ export type IconPersonAddProps = IconContainerProps;
 
 export const IconPersonAdd = (props: IconPersonAddProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconPersonAddSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconPersonAddSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconPersonAdd/IconPersonAdd.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPersonAdd/IconPersonAdd.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconPersonAddSvg } from './IconPersonAddSvg';
 
-export type IconPersonAddProps = UseIconProps;
+export type IconPersonAddProps = IconContainerProps;
 
-export const IconPersonAdd = (props: IconPersonAddProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconPersonAddSvg} {...iconProps} />;
-};
+export const IconPersonAdd = (props: IconPersonAddProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconPersonAddSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconPersonVerified/IconPersonVerified.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPersonVerified/IconPersonVerified.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconPersonVerifiedSvg } from './IconPersonVerifiedSvg';
 
-export type IconPersonVerifiedProps = UseIconProps;
+export type IconPersonVerifiedProps = IconContainerProps;
 
-export const IconPersonVerified = (props: IconPersonVerifiedProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconPersonVerifiedSvg} {...iconProps} />;
-};
+export const IconPersonVerified = (props: IconPersonVerifiedProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconPersonVerifiedSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconPersonVerified/IconPersonVerified.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPersonVerified/IconPersonVerified.tsx
@@ -7,6 +7,6 @@ export type IconPersonVerifiedProps = IconContainerProps;
 
 export const IconPersonVerified = (props: IconPersonVerifiedProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconPersonVerifiedSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconPersonVerifiedSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconPhone/IconPhone.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPhone/IconPhone.tsx
@@ -7,6 +7,6 @@ export type IconPhoneProps = IconContainerProps;
 
 export const IconPhone = (props: IconPhoneProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconPhoneSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconPhoneSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconPhone/IconPhone.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPhone/IconPhone.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconPhoneSvg } from './IconPhoneSvg';
 
-export type IconPhoneProps = UseIconProps;
+export type IconPhoneProps = IconContainerProps;
 
-export const IconPhone = (props: IconPhoneProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconPhoneSvg} {...iconProps} />;
-};
+export const IconPhone = (props: IconPhoneProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconPhoneSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconPlatformAndroid/IconPlatformAndroid.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPlatformAndroid/IconPlatformAndroid.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconPlatformAndroidSvg } from './IconPlatformAndroidSvg';
 
-export type IconPlatformAndroidProps = UseIconProps;
+export type IconPlatformAndroidProps = IconContainerProps;
 
-export const IconPlatformAndroid = (props: IconPlatformAndroidProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconPlatformAndroidSvg} {...iconProps} />;
-};
+export const IconPlatformAndroid = (props: IconPlatformAndroidProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconPlatformAndroidSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconPlatformAndroid/IconPlatformAndroid.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPlatformAndroid/IconPlatformAndroid.tsx
@@ -7,6 +7,6 @@ export type IconPlatformAndroidProps = IconContainerProps;
 
 export const IconPlatformAndroid = (props: IconPlatformAndroidProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconPlatformAndroidSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconPlatformAndroidSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconPlatformApple/IconPlatformApple.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPlatformApple/IconPlatformApple.tsx
@@ -7,6 +7,6 @@ export type IconPlatformAppleProps = IconContainerProps;
 
 export const IconPlatformApple = (props: IconPlatformAppleProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconPlatformAppleSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconPlatformAppleSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconPlatformApple/IconPlatformApple.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPlatformApple/IconPlatformApple.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconPlatformAppleSvg } from './IconPlatformAppleSvg';
 
-export type IconPlatformAppleProps = UseIconProps;
+export type IconPlatformAppleProps = IconContainerProps;
 
-export const IconPlatformApple = (props: IconPlatformAppleProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconPlatformAppleSvg} {...iconProps} />;
-};
+export const IconPlatformApple = (props: IconPlatformAppleProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconPlatformAppleSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconPositive/IconPositive.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPositive/IconPositive.tsx
@@ -7,6 +7,6 @@ export type IconPositiveProps = IconContainerProps;
 
 export const IconPositive = (props: IconPositiveProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconPositiveSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconPositiveSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconPositive/IconPositive.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPositive/IconPositive.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconPositiveSvg } from './IconPositiveSvg';
 
-export type IconPositiveProps = UseIconProps;
+export type IconPositiveProps = IconContainerProps;
 
-export const IconPositive = (props: IconPositiveProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconPositiveSvg} {...iconProps} />;
-};
+export const IconPositive = (props: IconPositiveProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconPositiveSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconPrint/IconPrint.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPrint/IconPrint.tsx
@@ -7,6 +7,6 @@ export type IconPrintProps = IconContainerProps;
 
 export const IconPrint = (props: IconPrintProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconPrintSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconPrintSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconPrint/IconPrint.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPrint/IconPrint.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconPrintSvg } from './IconPrintSvg';
 
-export type IconPrintProps = UseIconProps;
+export type IconPrintProps = IconContainerProps;
 
-export const IconPrint = (props: IconPrintProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconPrintSvg} {...iconProps} />;
-};
+export const IconPrint = (props: IconPrintProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconPrintSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconProfile/IconProfile.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconProfile/IconProfile.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconProfileSvg } from './IconProfileSvg';
 
-export type IconProfileProps = UseIconProps;
+export type IconProfileProps = IconContainerProps;
 
-export const IconProfile = (props: IconProfileProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconProfileSvg} {...iconProps} />;
-};
+export const IconProfile = (props: IconProfileProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconProfileSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconProfile/IconProfile.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconProfile/IconProfile.tsx
@@ -7,6 +7,6 @@ export type IconProfileProps = IconContainerProps;
 
 export const IconProfile = (props: IconProfileProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconProfileSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconProfileSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconPromote/IconPromote.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPromote/IconPromote.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconPromoteSvg } from './IconPromoteSvg';
 
-export type IconPromoteProps = UseIconProps;
+export type IconPromoteProps = IconContainerProps;
 
-export const IconPromote = (props: IconPromoteProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconPromoteSvg} {...iconProps} />;
-};
+export const IconPromote = (props: IconPromoteProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconPromoteSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconPromote/IconPromote.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPromote/IconPromote.tsx
@@ -7,6 +7,6 @@ export type IconPromoteProps = IconContainerProps;
 
 export const IconPromote = (props: IconPromoteProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconPromoteSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconPromoteSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconRecommended/IconRecommended.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconRecommended/IconRecommended.tsx
@@ -7,6 +7,6 @@ export type IconRecommendedProps = IconContainerProps;
 
 export const IconRecommended = (props: IconRecommendedProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconRecommendedSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconRecommendedSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconRecommended/IconRecommended.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconRecommended/IconRecommended.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconRecommendedSvg } from './IconRecommendedSvg';
 
-export type IconRecommendedProps = UseIconProps;
+export type IconRecommendedProps = IconContainerProps;
 
-export const IconRecommended = (props: IconRecommendedProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconRecommendedSvg} {...iconProps} />;
-};
+export const IconRecommended = (props: IconRecommendedProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconRecommendedSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconRefresh/IconRefresh.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconRefresh/IconRefresh.tsx
@@ -7,6 +7,6 @@ export type IconRefreshProps = IconContainerProps;
 
 export const IconRefresh = (props: IconRefreshProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconRefreshSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconRefreshSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconRefresh/IconRefresh.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconRefresh/IconRefresh.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconRefreshSvg } from './IconRefreshSvg';
 
-export type IconRefreshProps = UseIconProps;
+export type IconRefreshProps = IconContainerProps;
 
-export const IconRefresh = (props: IconRefreshProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconRefreshSvg} {...iconProps} />;
-};
+export const IconRefresh = (props: IconRefreshProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconRefreshSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconResume/IconResume.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconResume/IconResume.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconResumeSvg } from './IconResumeSvg';
 
-export type IconResumeProps = UseIconProps;
+export type IconResumeProps = IconContainerProps;
 
-export const IconResume = (props: IconResumeProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconResumeSvg} {...iconProps} />;
-};
+export const IconResume = (props: IconResumeProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconResumeSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconResume/IconResume.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconResume/IconResume.tsx
@@ -7,6 +7,6 @@ export type IconResumeProps = IconContainerProps;
 
 export const IconResume = (props: IconResumeProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconResumeSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconResumeSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconRocket/IconRocket.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconRocket/IconRocket.tsx
@@ -7,6 +7,6 @@ export type IconRocketProps = IconContainerProps;
 
 export const IconRocket = (props: IconRocketProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconRocketSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconRocketSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconRocket/IconRocket.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconRocket/IconRocket.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconRocketSvg } from './IconRocketSvg';
 
-export type IconRocketProps = UseIconProps;
+export type IconRocketProps = IconContainerProps;
 
-export const IconRocket = (props: IconRocketProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconRocketSvg} {...iconProps} />;
-};
+export const IconRocket = (props: IconRocketProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconRocketSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSearch/IconSearch.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSearch/IconSearch.tsx
@@ -7,6 +7,6 @@ export type IconSearchProps = IconContainerProps;
 
 export const IconSearch = (props: IconSearchProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconSearchSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconSearchSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconSearch/IconSearch.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSearch/IconSearch.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconSearchSvg } from './IconSearchSvg';
 
-export type IconSearchProps = UseIconProps;
+export type IconSearchProps = IconContainerProps;
 
-export const IconSearch = (props: IconSearchProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconSearchSvg} {...iconProps} />;
-};
+export const IconSearch = (props: IconSearchProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconSearchSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSecurity/IconSecurity.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSecurity/IconSecurity.tsx
@@ -7,6 +7,6 @@ export type IconSecurityProps = IconContainerProps;
 
 export const IconSecurity = (props: IconSecurityProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconSecuritySvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconSecuritySvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconSecurity/IconSecurity.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSecurity/IconSecurity.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconSecuritySvg } from './IconSecuritySvg';
 
-export type IconSecurityProps = UseIconProps;
+export type IconSecurityProps = IconContainerProps;
 
-export const IconSecurity = (props: IconSecurityProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconSecuritySvg} {...iconProps} />;
-};
+export const IconSecurity = (props: IconSecurityProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconSecuritySvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSend/IconSend.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSend/IconSend.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconSendSvg } from './IconSendSvg';
 
-export type IconSendProps = UseIconProps;
+export type IconSendProps = IconContainerProps;
 
-export const IconSend = (props: IconSendProps) => {
-  const iconProps = useIcon(props, {
-    verticalCorrection: {
+export const IconSend = (props: IconSendProps) => (
+  <IconContainer
+    {...props}
+    verticalCorrection={{
       uppercase: 'none',
       lowercase: 'up',
-    },
-  });
-
-  return <Box component={IconSendSvg} {...iconProps} />;
-};
+    }}
+  >
+    {(boxProps) => <Box component={IconSendSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSend/IconSend.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSend/IconSend.tsx
@@ -13,6 +13,6 @@ export const IconSend = (props: IconSendProps) => (
       lowercase: 'up',
     }}
   >
-    {(boxProps) => <Box component={IconSendSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconSendSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconSent/IconSent.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSent/IconSent.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconSentSvg } from './IconSentSvg';
 
-export type IconSentProps = UseIconProps;
+export type IconSentProps = IconContainerProps;
 
-export const IconSent = (props: IconSentProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconSentSvg} {...iconProps} />;
-};
+export const IconSent = (props: IconSentProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconSentSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSent/IconSent.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSent/IconSent.tsx
@@ -7,6 +7,6 @@ export type IconSentProps = IconContainerProps;
 
 export const IconSent = (props: IconSentProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconSentSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconSentSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconSentiment/IconSentiment.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSentiment/IconSentiment.tsx
@@ -1,13 +1,13 @@
 import type React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconSentimentSvg } from './IconSentimentSvg';
 import { IconSentimentNegativeSvg } from './IconSentimentNegativeSvg';
 import { IconSentimentPositiveSvg } from './IconSentimentPositiveSvg';
 
 type Feeling = 'positive' | 'negative' | 'neutral';
 
-export type IconSentimentProps = UseIconProps & {
+export type IconSentimentProps = IconContainerProps & {
   feeling?: Feeling;
 };
 
@@ -20,13 +20,13 @@ const feelingToIcon: Record<Feeling, React.ComponentType> = {
 export const IconSentiment = ({
   feeling = 'neutral',
   ...props
-}: IconSentimentProps) => {
-  const iconProps = useIcon(props);
-
-  return (
-    <Box
-      component={feelingToIcon[feeling] || feelingToIcon.neutral}
-      {...iconProps}
-    />
-  );
-};
+}: IconSentimentProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => (
+      <Box
+        component={feelingToIcon[feeling] || feelingToIcon.neutral}
+        {...boxProps}
+      />
+    )}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSentiment/IconSentiment.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSentiment/IconSentiment.tsx
@@ -22,10 +22,10 @@ export const IconSentiment = ({
   ...props
 }: IconSentimentProps) => (
   <IconContainer {...props}>
-    {(boxProps) => (
+    {(svgProps) => (
       <Box
         component={feelingToIcon[feeling] || feelingToIcon.neutral}
-        {...boxProps}
+        {...svgProps}
       />
     )}
   </IconContainer>

--- a/packages/braid-design-system/src/lib/components/icons/IconSettings/IconSettings.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSettings/IconSettings.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconSettingsSvg } from './IconSettingsSvg';
 
-export type IconSettingsProps = UseIconProps;
+export type IconSettingsProps = IconContainerProps;
 
-export const IconSettings = (props: IconSettingsProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconSettingsSvg} {...iconProps} />;
-};
+export const IconSettings = (props: IconSettingsProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconSettingsSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSettings/IconSettings.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSettings/IconSettings.tsx
@@ -7,6 +7,6 @@ export type IconSettingsProps = IconContainerProps;
 
 export const IconSettings = (props: IconSettingsProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconSettingsSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconSettingsSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconShare/IconShare.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconShare/IconShare.tsx
@@ -7,6 +7,6 @@ export type IconShareProps = IconContainerProps;
 
 export const IconShare = (props: IconShareProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconShareSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconShareSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconShare/IconShare.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconShare/IconShare.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconShareSvg } from './IconShareSvg';
 
-export type IconShareProps = UseIconProps;
+export type IconShareProps = IconContainerProps;
 
-export const IconShare = (props: IconShareProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconShareSvg} {...iconProps} />;
-};
+export const IconShare = (props: IconShareProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconShareSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSkills/IconSkills.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSkills/IconSkills.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconSkillsSvg } from './IconSkillsSvg';
 
-export type IconSkillsProps = UseIconProps;
+export type IconSkillsProps = IconContainerProps;
 
-export const IconSkills = (props: IconSkillsProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconSkillsSvg} {...iconProps} />;
-};
+export const IconSkills = (props: IconSkillsProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconSkillsSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSkills/IconSkills.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSkills/IconSkills.tsx
@@ -7,6 +7,6 @@ export type IconSkillsProps = IconContainerProps;
 
 export const IconSkills = (props: IconSkillsProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconSkillsSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconSkillsSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialFacebook/IconSocialFacebook.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialFacebook/IconSocialFacebook.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconSocialFacebookSvg } from './IconSocialFacebookSvg';
 
-export type IconSocialFacebookProps = UseIconProps;
+export type IconSocialFacebookProps = IconContainerProps;
 
-export const IconSocialFacebook = (props: IconSocialFacebookProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconSocialFacebookSvg} {...iconProps} />;
-};
+export const IconSocialFacebook = (props: IconSocialFacebookProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconSocialFacebookSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialFacebook/IconSocialFacebook.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialFacebook/IconSocialFacebook.tsx
@@ -7,6 +7,6 @@ export type IconSocialFacebookProps = IconContainerProps;
 
 export const IconSocialFacebook = (props: IconSocialFacebookProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconSocialFacebookSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconSocialFacebookSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialGitHub/IconSocialGitHub.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialGitHub/IconSocialGitHub.tsx
@@ -7,6 +7,6 @@ export type IconSocialGitHubProps = IconContainerProps;
 
 export const IconSocialGitHub = (props: IconSocialGitHubProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconSocialGitHubSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconSocialGitHubSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialGitHub/IconSocialGitHub.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialGitHub/IconSocialGitHub.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconSocialGitHubSvg } from './IconSocialGitHubSvg';
 
-export type IconSocialGitHubProps = UseIconProps;
+export type IconSocialGitHubProps = IconContainerProps;
 
-export const IconSocialGitHub = (props: IconSocialGitHubProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconSocialGitHubSvg} {...iconProps} />;
-};
+export const IconSocialGitHub = (props: IconSocialGitHubProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconSocialGitHubSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialInstagram/IconSocialInstagram.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialInstagram/IconSocialInstagram.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconSocialInstagramSvg } from './IconSocialInstagramSvg';
 
-export type IconSocialInstagramProps = UseIconProps;
+export type IconSocialInstagramProps = IconContainerProps;
 
-export const IconSocialInstagram = (props: IconSocialInstagramProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconSocialInstagramSvg} {...iconProps} />;
-};
+export const IconSocialInstagram = (props: IconSocialInstagramProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconSocialInstagramSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialInstagram/IconSocialInstagram.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialInstagram/IconSocialInstagram.tsx
@@ -7,6 +7,6 @@ export type IconSocialInstagramProps = IconContainerProps;
 
 export const IconSocialInstagram = (props: IconSocialInstagramProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconSocialInstagramSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconSocialInstagramSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialLinkedIn/IconSocialLinkedIn.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialLinkedIn/IconSocialLinkedIn.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconSocialLinkedInSvg } from './IconSocialLinkedInSvg';
 
-export type IconSocialLinkedInProps = UseIconProps;
+export type IconSocialLinkedInProps = IconContainerProps;
 
-export const IconSocialLinkedIn = (props: IconSocialLinkedInProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconSocialLinkedInSvg} {...iconProps} />;
-};
+export const IconSocialLinkedIn = (props: IconSocialLinkedInProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconSocialLinkedInSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialLinkedIn/IconSocialLinkedIn.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialLinkedIn/IconSocialLinkedIn.tsx
@@ -7,6 +7,6 @@ export type IconSocialLinkedInProps = IconContainerProps;
 
 export const IconSocialLinkedIn = (props: IconSocialLinkedInProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconSocialLinkedInSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconSocialLinkedInSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialMedium/IconSocialMedium.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialMedium/IconSocialMedium.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconSocialMediumSvg } from './IconSocialMediumSvg';
 
-export type IconSocialMediumProps = UseIconProps;
+export type IconSocialMediumProps = IconContainerProps;
 
-export const IconSocialMedium = (props: IconSocialMediumProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconSocialMediumSvg} {...iconProps} />;
-};
+export const IconSocialMedium = (props: IconSocialMediumProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconSocialMediumSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialMedium/IconSocialMedium.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialMedium/IconSocialMedium.tsx
@@ -7,6 +7,6 @@ export type IconSocialMediumProps = IconContainerProps;
 
 export const IconSocialMedium = (props: IconSocialMediumProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconSocialMediumSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconSocialMediumSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialTwitter/IconSocialTwitter.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialTwitter/IconSocialTwitter.tsx
@@ -8,6 +8,6 @@ export type IconSocialTwitterProps = IconContainerProps;
 /** @deprecated - use IconSocialX instead */
 export const IconSocialTwitter = (props: IconSocialTwitterProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconSocialXSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconSocialXSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialTwitter/IconSocialTwitter.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialTwitter/IconSocialTwitter.tsx
@@ -1,13 +1,13 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconSocialXSvg } from '../IconSocialX/IconSocialXSvg';
 
-export type IconSocialTwitterProps = UseIconProps;
+export type IconSocialTwitterProps = IconContainerProps;
 
 /** @deprecated - use IconSocialX instead */
-export const IconSocialTwitter = (props: IconSocialTwitterProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconSocialXSvg} {...iconProps} />;
-};
+export const IconSocialTwitter = (props: IconSocialTwitterProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconSocialXSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialX/IconSocialX.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialX/IconSocialX.tsx
@@ -7,6 +7,6 @@ export type IconSocialXProps = IconContainerProps;
 
 export const IconSocialX = (props: IconSocialXProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconSocialXSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconSocialXSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialX/IconSocialX.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialX/IconSocialX.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconSocialXSvg } from './IconSocialXSvg';
 
-export type IconSocialXProps = UseIconProps;
+export type IconSocialXProps = IconContainerProps;
 
-export const IconSocialX = (props: IconSocialXProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconSocialXSvg} {...iconProps} />;
-};
+export const IconSocialX = (props: IconSocialXProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconSocialXSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialYouTube/IconSocialYouTube.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialYouTube/IconSocialYouTube.tsx
@@ -7,6 +7,6 @@ export type IconSocialYouTubeProps = IconContainerProps;
 
 export const IconSocialYouTube = (props: IconSocialYouTubeProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconSocialYouTubeSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconSocialYouTubeSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialYouTube/IconSocialYouTube.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialYouTube/IconSocialYouTube.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconSocialYouTubeSvg } from './IconSocialYouTubeSvg';
 
-export type IconSocialYouTubeProps = UseIconProps;
+export type IconSocialYouTubeProps = IconContainerProps;
 
-export const IconSocialYouTube = (props: IconSocialYouTubeProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconSocialYouTubeSvg} {...iconProps} />;
-};
+export const IconSocialYouTube = (props: IconSocialYouTubeProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconSocialYouTubeSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSort/IconSort.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSort/IconSort.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconSortSvg } from './IconSortSvg';
 
-export type IconSortProps = UseIconProps;
+export type IconSortProps = IconContainerProps;
 
-export const IconSort = (props: IconSortProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconSortSvg} {...iconProps} />;
-};
+export const IconSort = (props: IconSortProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconSortSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconSort/IconSort.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSort/IconSort.tsx
@@ -7,6 +7,6 @@ export type IconSortProps = IconContainerProps;
 
 export const IconSort = (props: IconSortProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconSortSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconSortSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconStar/IconStar.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconStar/IconStar.tsx
@@ -10,8 +10,8 @@ export type IconStarProps = IconContainerProps & {
 
 export const IconStar = ({ active = false, ...props }: IconStarProps) => (
   <IconContainer {...props}>
-    {(boxProps) => (
-      <Box component={active ? IconStarActiveSvg : IconStarSvg} {...boxProps} />
+    {(svgProps) => (
+      <Box component={active ? IconStarActiveSvg : IconStarSvg} {...svgProps} />
     )}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconStar/IconStar.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconStar/IconStar.tsx
@@ -1,17 +1,17 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconStarSvg } from './IconStarSvg';
 import { IconStarActiveSvg } from './IconStarActiveSvg';
 
-export type IconStarProps = UseIconProps & {
+export type IconStarProps = IconContainerProps & {
   active?: boolean;
 };
 
-export const IconStar = ({ active = false, ...props }: IconStarProps) => {
-  const iconProps = useIcon(props);
-
-  return (
-    <Box component={active ? IconStarActiveSvg : IconStarSvg} {...iconProps} />
-  );
-};
+export const IconStar = ({ active = false, ...props }: IconStarProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => (
+      <Box component={active ? IconStarActiveSvg : IconStarSvg} {...boxProps} />
+    )}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconStatistics/IconStatistics.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconStatistics/IconStatistics.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconStatisticsSvg } from './IconStatisticsSvg';
 
-export type IconStatisticsProps = UseIconProps;
+export type IconStatisticsProps = IconContainerProps;
 
-export const IconStatistics = (props: IconStatisticsProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconStatisticsSvg} {...iconProps} />;
-};
+export const IconStatistics = (props: IconStatisticsProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconStatisticsSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconStatistics/IconStatistics.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconStatistics/IconStatistics.tsx
@@ -7,6 +7,6 @@ export type IconStatisticsProps = IconContainerProps;
 
 export const IconStatistics = (props: IconStatisticsProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconStatisticsSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconStatisticsSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconSubCategory/IconSubCategory.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSubCategory/IconSubCategory.tsx
@@ -7,6 +7,6 @@ export type IconSubCategoryProps = IconContainerProps;
 
 export const IconSubCategory = (props: IconSubCategoryProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconSubCategorySvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconSubCategorySvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconSubCategory/IconSubCategory.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSubCategory/IconSubCategory.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconSubCategorySvg } from './IconSubCategorySvg';
 
-export type IconSubCategoryProps = UseIconProps;
+export type IconSubCategoryProps = IconContainerProps;
 
-export const IconSubCategory = (props: IconSubCategoryProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconSubCategorySvg} {...iconProps} />;
-};
+export const IconSubCategory = (props: IconSubCategoryProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconSubCategorySvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconTag/IconTag.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconTag/IconTag.tsx
@@ -7,6 +7,6 @@ export type IconTagProps = IconContainerProps;
 
 export const IconTag = (props: IconTagProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconTagSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconTagSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconTag/IconTag.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconTag/IconTag.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconTagSvg } from './IconTagSvg';
 
-export type IconTagProps = UseIconProps;
+export type IconTagProps = IconContainerProps;
 
-export const IconTag = (props: IconTagProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconTagSvg} {...iconProps} />;
-};
+export const IconTag = (props: IconTagProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconTagSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconThumb/IconThumb.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconThumb/IconThumb.tsx
@@ -10,7 +10,7 @@ export type IconThumbProps = IconContainerProps & {
 
 export const IconThumb = ({ direction = 'up', ...props }: IconThumbProps) => (
   <IconContainer {...props}>
-    {({ className, ...iconProps }) => (
+    {({ className, ...svgProps }) => (
       <Box
         component={IconThumbSvg}
         className={[
@@ -20,7 +20,7 @@ export const IconThumb = ({ direction = 'up', ...props }: IconThumbProps) => (
             [styles.down]: direction === 'down',
           },
         ]}
-        {...iconProps}
+        {...svgProps}
       />
     )}
   </IconContainer>

--- a/packages/braid-design-system/src/lib/components/icons/IconThumb/IconThumb.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconThumb/IconThumb.tsx
@@ -1,27 +1,27 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconThumbSvg } from './IconThumbSvg';
 import * as styles from './IconThumb.css';
 
-export type IconThumbProps = UseIconProps & {
+export type IconThumbProps = IconContainerProps & {
   direction?: 'up' | 'down';
 };
 
-export const IconThumb = ({ direction = 'up', ...props }: IconThumbProps) => {
-  const { className, ...iconProps } = useIcon(props);
-
-  return (
-    <Box
-      component={IconThumbSvg}
-      className={[
-        styles.root,
-        className,
-        {
-          [styles.down]: direction === 'down',
-        },
-      ]}
-      {...iconProps}
-    />
-  );
-};
+export const IconThumb = ({ direction = 'up', ...props }: IconThumbProps) => (
+  <IconContainer {...props}>
+    {({ className, ...iconProps }) => (
+      <Box
+        component={IconThumbSvg}
+        className={[
+          styles.root,
+          className,
+          {
+            [styles.down]: direction === 'down',
+          },
+        ]}
+        {...iconProps}
+      />
+    )}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconTick/IconTick.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconTick/IconTick.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconTickSvg } from './IconTickSvg';
 
-export type IconTickProps = UseIconProps;
+export type IconTickProps = IconContainerProps;
 
-export const IconTick = (props: IconTickProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconTickSvg} {...iconProps} />;
-};
+export const IconTick = (props: IconTickProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconTickSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconTick/IconTick.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconTick/IconTick.tsx
@@ -7,6 +7,6 @@ export type IconTickProps = IconContainerProps;
 
 export const IconTick = (props: IconTickProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconTickSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconTickSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconTime/IconTime.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconTime/IconTime.tsx
@@ -7,6 +7,6 @@ export type IconTimeProps = IconContainerProps;
 
 export const IconTime = (props: IconTimeProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconTimeSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconTimeSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconTime/IconTime.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconTime/IconTime.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconTimeSvg } from './IconTimeSvg';
 
-export type IconTimeProps = UseIconProps;
+export type IconTimeProps = IconContainerProps;
 
-export const IconTime = (props: IconTimeProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconTimeSvg} {...iconProps} />;
-};
+export const IconTime = (props: IconTimeProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconTimeSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconTip/IconTip.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconTip/IconTip.tsx
@@ -7,6 +7,6 @@ export type IconTipProps = IconContainerProps;
 
 export const IconTip = (props: IconTipProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconTipSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconTipSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconTip/IconTip.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconTip/IconTip.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconTipSvg } from './IconTipSvg';
 
-export type IconTipProps = UseIconProps;
+export type IconTipProps = IconContainerProps;
 
-export const IconTip = (props: IconTipProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconTipSvg} {...iconProps} />;
-};
+export const IconTip = (props: IconTipProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconTipSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconUpload/IconUpload.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconUpload/IconUpload.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconUploadSvg } from './IconUploadSvg';
 
-export type IconUploadProps = UseIconProps;
+export type IconUploadProps = IconContainerProps;
 
-export const IconUpload = (props: IconUploadProps) => {
-  const iconProps = useIcon(props, {
-    verticalCorrection: {
+export const IconUpload = (props: IconUploadProps) => (
+  <IconContainer
+    {...props}
+    verticalCorrection={{
       uppercase: 'none',
       lowercase: 'up',
-    },
-  });
-
-  return <Box component={IconUploadSvg} {...iconProps} />;
-};
+    }}
+  >
+    {(boxProps) => <Box component={IconUploadSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconUpload/IconUpload.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconUpload/IconUpload.tsx
@@ -13,6 +13,6 @@ export const IconUpload = (props: IconUploadProps) => (
       lowercase: 'up',
     }}
   >
-    {(boxProps) => <Box component={IconUploadSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconUploadSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconVideo/IconVideo.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconVideo/IconVideo.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconVideoSvg } from './IconVideoSvg';
 
-export type IconVideoProps = UseIconProps;
+export type IconVideoProps = IconContainerProps;
 
-export const IconVideo = (props: IconVideoProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconVideoSvg} {...iconProps} />;
-};
+export const IconVideo = (props: IconVideoProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconVideoSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconVideo/IconVideo.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconVideo/IconVideo.tsx
@@ -7,6 +7,6 @@ export type IconVideoProps = IconContainerProps;
 
 export const IconVideo = (props: IconVideoProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconVideoSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconVideoSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconVisibility/IconVisibility.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconVisibility/IconVisibility.tsx
@@ -10,10 +10,10 @@ export type IconVisibilityProps = IconContainerProps & {
 
 export const IconVisibility = ({ hidden, ...props }: IconVisibilityProps) => (
   <IconContainer {...props}>
-    {(boxProps) => (
+    {(svgProps) => (
       <Box
         component={hidden ? IconVisibilityHiddenSvg : IconVisibilitySvg}
-        {...boxProps}
+        {...svgProps}
       />
     )}
   </IconContainer>

--- a/packages/braid-design-system/src/lib/components/icons/IconVisibility/IconVisibility.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconVisibility/IconVisibility.tsx
@@ -1,20 +1,20 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconVisibilitySvg } from './IconVisibilitySvg';
 import { IconVisibilityHiddenSvg } from './IconVisibilityHiddenSvg';
 
-export type IconVisibilityProps = UseIconProps & {
+export type IconVisibilityProps = IconContainerProps & {
   hidden?: boolean;
 };
 
-export const IconVisibility = ({ hidden, ...props }: IconVisibilityProps) => {
-  const iconProps = useIcon(props);
-
-  return (
-    <Box
-      component={hidden ? IconVisibilityHiddenSvg : IconVisibilitySvg}
-      {...iconProps}
-    />
-  );
-};
+export const IconVisibility = ({ hidden, ...props }: IconVisibilityProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => (
+      <Box
+        component={hidden ? IconVisibilityHiddenSvg : IconVisibilitySvg}
+        {...boxProps}
+      />
+    )}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconWorkExperience/IconWorkExperience.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconWorkExperience/IconWorkExperience.tsx
@@ -1,17 +1,18 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconWorkExperienceSvg } from './IconWorkExperienceSvg';
 
-export type IconWorkExperienceProps = UseIconProps;
+export type IconWorkExperienceProps = IconContainerProps;
 
-export const IconWorkExperience = (props: IconWorkExperienceProps) => {
-  const iconProps = useIcon(props, {
-    verticalCorrection: {
+export const IconWorkExperience = (props: IconWorkExperienceProps) => (
+  <IconContainer
+    {...props}
+    verticalCorrection={{
       uppercase: 'up',
       lowercase: 'up',
-    },
-  });
-
-  return <Box component={IconWorkExperienceSvg} {...iconProps} />;
-};
+    }}
+  >
+    {(boxProps) => <Box component={IconWorkExperienceSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconWorkExperience/IconWorkExperience.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconWorkExperience/IconWorkExperience.tsx
@@ -13,6 +13,6 @@ export const IconWorkExperience = (props: IconWorkExperienceProps) => (
       lowercase: 'up',
     }}
   >
-    {(boxProps) => <Box component={IconWorkExperienceSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconWorkExperienceSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconZoomIn/IconZoomIn.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconZoomIn/IconZoomIn.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconZoomInSvg } from './IconZoomInSvg';
 
-export type IconZoomInProps = UseIconProps;
+export type IconZoomInProps = IconContainerProps;
 
-export const IconZoomIn = (props: IconZoomInProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconZoomInSvg} {...iconProps} />;
-};
+export const IconZoomIn = (props: IconZoomInProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconZoomInSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconZoomIn/IconZoomIn.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconZoomIn/IconZoomIn.tsx
@@ -7,6 +7,6 @@ export type IconZoomInProps = IconContainerProps;
 
 export const IconZoomIn = (props: IconZoomInProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconZoomInSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconZoomInSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/IconZoomOut/IconZoomOut.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconZoomOut/IconZoomOut.tsx
@@ -1,12 +1,12 @@
 import React from 'react';
 import { Box } from '../../Box/Box';
-import useIcon, { type UseIconProps } from '../../../hooks/useIcon';
+import { IconContainer, type IconContainerProps } from '../IconContainer';
 import { IconZoomOutSvg } from './IconZoomOutSvg';
 
-export type IconZoomOutProps = UseIconProps;
+export type IconZoomOutProps = IconContainerProps;
 
-export const IconZoomOut = (props: IconZoomOutProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconZoomOutSvg} {...iconProps} />;
-};
+export const IconZoomOut = (props: IconZoomOutProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconZoomOutSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/packages/braid-design-system/src/lib/components/icons/IconZoomOut/IconZoomOut.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconZoomOut/IconZoomOut.tsx
@@ -7,6 +7,6 @@ export type IconZoomOutProps = IconContainerProps;
 
 export const IconZoomOut = (props: IconZoomOutProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconZoomOutSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconZoomOutSvg} {...svgProps} />}
   </IconContainer>
 );

--- a/packages/braid-design-system/src/lib/components/icons/Icons.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/Icons.screenshots.tsx
@@ -1,6 +1,18 @@
 import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { Text, Heading, Inline, Button, Stack } from '../';
+import {
+  Text,
+  Heading,
+  Inline,
+  Button,
+  Stack,
+  Spread,
+  Box,
+  IconAI,
+  IconAdd,
+  IconArrow,
+  IconBookmark,
+} from '../';
 import type { UseIconProps } from '../../hooks/useIcon';
 import {
   heading as headingSizes,
@@ -9,6 +21,7 @@ import {
 } from '../../css/typography.css';
 
 import * as icons from './index';
+import { vars } from '../../themes/vars.css';
 
 type IconName = keyof typeof icons;
 const iconNames = Object.keys(icons).map((icon) => icon as IconName);
@@ -157,6 +170,48 @@ export const screenshots: ComponentScreenshot = {
           })}
         </Stack>
       ),
+    },
+    {
+      label:
+        'Test: inline sizing comparing `Inline` (left) to custom flex container (right)',
+      Example: () => {
+        const sizes = Object.keys(textSizes) as Array<keyof typeof textSizes>;
+
+        return (
+          <Stack space="large">
+            {sizes.map((size) => (
+              <Text size={size} key={size}>
+                <Box
+                  maxWidth="xsmall"
+                  style={{
+                    borderTop: '2px solid red',
+                    borderBottom: '2px solid red',
+                  }}
+                >
+                  <Spread space="small">
+                    <Inline space="small">
+                      <IconAI />
+                      <IconAdd />
+                      <IconArrow />
+                      <IconBookmark />
+                    </Inline>
+                    <Box
+                      display="flex"
+                      flexWrap="wrap"
+                      style={{ gap: vars.space.small }}
+                    >
+                      <IconAI />
+                      <IconAdd />
+                      <IconArrow />
+                      <IconBookmark />
+                    </Box>
+                  </Spread>
+                </Box>
+              </Text>
+            ))}
+          </Stack>
+        );
+      },
     },
   ],
 };

--- a/packages/braid-design-system/src/lib/hooks/useIcon/index.ts
+++ b/packages/braid-design-system/src/lib/hooks/useIcon/index.ts
@@ -60,7 +60,7 @@ export default (
   { verticalCorrection = defaultVerticalCorrection }: PrivateIconProps = {},
   // TODO: COLORMODE RELEASE
   // Revert to BoxProps
-): { isInline: boolean; boxProps: PublicBoxProps } => {
+): { isInline: boolean; svgProps: PublicBoxProps } => {
   const textContext = useContext(TextContext);
   const headingContext = useContext(HeadingContext);
   const resolvedTone =
@@ -89,7 +89,7 @@ export default (
   if (size === 'fill') {
     return {
       isInline: false,
-      boxProps: {
+      svgProps: {
         width: 'full',
         height: 'full',
         display: 'block',
@@ -102,7 +102,7 @@ export default (
 
   return {
     isInline,
-    boxProps: {
+    svgProps: {
       className: [
         toneClass,
         isInline

--- a/packages/braid-design-system/src/lib/hooks/useIcon/index.ts
+++ b/packages/braid-design-system/src/lib/hooks/useIcon/index.ts
@@ -60,7 +60,7 @@ export default (
   { verticalCorrection = defaultVerticalCorrection }: PrivateIconProps = {},
   // TODO: COLORMODE RELEASE
   // Revert to BoxProps
-): PublicBoxProps => {
+): { isInline: boolean; boxProps: PublicBoxProps } => {
   const textContext = useContext(TextContext);
   const headingContext = useContext(HeadingContext);
   const resolvedTone =
@@ -88,33 +88,39 @@ export default (
 
   if (size === 'fill') {
     return {
-      width: 'full',
-      height: 'full',
-      display: 'block',
-      className: toneClass,
-      ...buildDataAttributes({ data, validateRestProps: restProps }),
-      ...a11yProps,
+      isInline: false,
+      boxProps: {
+        width: 'full',
+        height: 'full',
+        display: 'block',
+        className: toneClass,
+        ...buildDataAttributes({ data, validateRestProps: restProps }),
+        ...a11yProps,
+      },
     };
   }
 
   return {
-    className: [
-      toneClass,
-      isInline
-        ? [
-            iconInlineSize({
-              alignY: alignY || 'uppercase',
-              verticalCorrection: verticalCorrection[alignY || 'uppercase'],
-            }),
-          ]
-        : [
-            atoms({
-              display: 'block',
-            }),
-            iconContainerSize(size),
-          ],
-    ],
-    ...buildDataAttributes({ data, validateRestProps: restProps }),
-    ...a11yProps,
+    isInline,
+    boxProps: {
+      className: [
+        toneClass,
+        isInline
+          ? [
+              iconInlineSize({
+                alignY: alignY || 'uppercase',
+                verticalCorrection: verticalCorrection[alignY || 'uppercase'],
+              }),
+            ]
+          : [
+              atoms({
+                display: 'block',
+              }),
+              iconContainerSize(size),
+            ],
+      ],
+      ...buildDataAttributes({ data, validateRestProps: restProps }),
+      ...a11yProps,
+    },
   };
 };

--- a/site/src/App/routes/gallery/Gallery.tsx
+++ b/site/src/App/routes/gallery/Gallery.tsx
@@ -69,7 +69,10 @@ import {
   controller as controllerState,
 } from './galleryState';
 import { GalleryPanel } from './GalleryPanel';
-import useIcon, { type UseIconProps } from 'braid-src/lib/hooks/useIcon';
+import {
+  IconContainer,
+  type IconContainerProps,
+} from 'braid-src/lib/components/icons/IconContainer';
 import type { SVGProps } from 'braid-src/lib/components/icons/SVGTypes';
 import { Logo } from '../../Logo/Logo';
 
@@ -767,8 +770,8 @@ const IconFitToScreenSvg = ({ title, titleId, ...props }: SVGProps) => (
   </svg>
 );
 
-const IconFitToScreen = (props: UseIconProps) => {
-  const iconProps = useIcon(props);
-
-  return <Box component={IconFitToScreenSvg} {...iconProps} />;
-};
+const IconFitToScreen = (props: IconContainerProps) => (
+  <IconContainer {...props}>
+    {(boxProps) => <Box component={IconFitToScreenSvg} {...boxProps} />}
+  </IconContainer>
+);

--- a/site/src/App/routes/gallery/Gallery.tsx
+++ b/site/src/App/routes/gallery/Gallery.tsx
@@ -772,6 +772,6 @@ const IconFitToScreenSvg = ({ title, titleId, ...props }: SVGProps) => (
 
 const IconFitToScreen = (props: IconContainerProps) => (
   <IconContainer {...props}>
-    {(boxProps) => <Box component={IconFitToScreenSvg} {...boxProps} />}
+    {(svgProps) => <Box component={IconFitToScreenSvg} {...svgProps} />}
   </IconContainer>
 );


### PR DESCRIPTION
When rendering our icons with [inline sizing], i.e. inside of `Text` or `Heading` components, they use negative margins and specific height and width values to improve alignment with the surrounding text. However, if when used as a direct child in a flex container, the values behave differently.

This PR wraps the icon in a `inline-block` element (when using [inline sizing]) to ensure predictable sizing and spacing when used in our layout components or as a flex item.

[inline sizing]: https://seek-oss.github.io/braid-design-system/foundations/iconography/#size-inline