### PR TITLE
List: Add tests for semantic markup

### DIFF
--- a/packages/braid-design-system/src/lib/components/List/List.test.tsx
+++ b/packages/braid-design-system/src/lib/components/List/List.test.tsx
@@ -1,0 +1,106 @@
+import '@testing-library/jest-dom';
+import 'html-validate/jest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { render } from '@testing-library/react';
+import { BraidTestProvider } from '../../../entries/test';
+import { IconTick, List, Text } from '..';
+
+describe('List', () => {
+  it('should render valid html structure', () => {
+    expect(
+      renderToStaticMarkup(
+        <BraidTestProvider>
+          {(['bullet', 'icon', 'alpha', 'number', 'roman'] as const).map(
+            (type) =>
+              type === 'icon' ? (
+                <List type={type} icon={<IconTick />} space="small" key={type}>
+                  <Text>1</Text>
+                  <Text>2</Text>
+                  <Text>3</Text>
+                </List>
+              ) : (
+                <List type={type} space="small" key={type}>
+                  <Text>1</Text>
+                  <Text>2</Text>
+                  <Text>3</Text>
+                </List>
+              ),
+          )}
+        </BraidTestProvider>,
+      ),
+    ).toHTMLValidate({
+      extends: ['html-validate:recommended'],
+    });
+  });
+
+  it('should render a valid unordered list when "type" is "bullet"', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <List type="bullet" space="small">
+          <Text>1</Text>
+          <Text>2</Text>
+          <Text>3</Text>
+        </List>
+      </BraidTestProvider>,
+    );
+
+    expect(getByRole('list').nodeName).toBe('UL');
+  });
+
+  it('should render a valid unordered list when "type" is "icon"', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <List type="icon" icon={<IconTick />} space="small">
+          <Text>1</Text>
+          <Text>2</Text>
+          <Text>3</Text>
+        </List>
+      </BraidTestProvider>,
+    );
+
+    expect(getByRole('list').nodeName).toBe('UL');
+  });
+
+  it('should render a valid ordered list when "type" is "alpha"', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <List type="alpha" space="small">
+          <Text>1</Text>
+          <Text>2</Text>
+          <Text>3</Text>
+        </List>
+      </BraidTestProvider>,
+    );
+
+    expect(getByRole('list').nodeName).toBe('OL');
+  });
+
+  it('should render a valid ordered list when "type" is "number"', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <List type="number" space="small">
+          <Text>1</Text>
+          <Text>2</Text>
+          <Text>3</Text>
+        </List>
+      </BraidTestProvider>,
+    );
+
+    expect(getByRole('list').nodeName).toBe('OL');
+  });
+
+  it('should render a valid ordered list when "type" is "roman"', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <List type="roman" space="small">
+          <Text>1</Text>
+          <Text>2</Text>
+          <Text>3</Text>
+        </List>
+      </BraidTestProvider>,
+    );
+
+    expect(getByRole('list').nodeName).toBe('OL');
+  });
+});


### PR DESCRIPTION
Adding tests to `List` component to ensure semantic markup.

This was previously implicitly tested by `Stack`, but with an upcoming change to our layout components, this should be explicitly tested by `List`.