### PR TITLE
site: Add `component` and missing `reverse` docs

### DIFF
--- a/packages/braid-design-system/src/lib/components/Column/Column.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Column/Column.screenshots.tsx
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react';
+import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
 import { Columns, Column, Box, Stack } from '../';
 import { Placeholder } from '../private/Placeholder/Placeholder';
@@ -49,77 +49,70 @@ export const screenshots: ComponentScreenshot = {
     {
       label: 'Gutter align',
       Example: () => (
-        <Fragment>
-          <Box marginBottom="medium">
-            <Columns space="small">
-              <Column>
-                <Placeholder height={60} label="Fluid" />
-              </Column>
-              <Column>
-                <Placeholder height={60} label="Fluid" />
-              </Column>
-            </Columns>
-          </Box>
-          <Box marginBottom="medium">
-            <Columns space="small">
-              <Column width="1/2">
-                <Placeholder height={60} label="&#189;" />
-              </Column>
-              <Column>
-                <Placeholder height={60} label="Fluid" />
-              </Column>
-            </Columns>
-          </Box>
-          <Box marginBottom="medium">
-            <Columns space="small">
-              <Column width="1/2">
-                <Placeholder height={60} label="&#189;" />
-              </Column>
-              <Column width="1/2">
-                <Placeholder height={60} label="&#189;" />
-              </Column>
-            </Columns>
-          </Box>
-          <Box marginBottom="medium">
-            <Columns space="small">
-              <Column width="1/4">
-                <Placeholder height={60} label="&#188;" />
-              </Column>
-              <Column width="1/4">
-                <Placeholder height={60} label="&#188;" />
-              </Column>
-              <Column>
-                <Placeholder height={60} label="Fluid" />
-              </Column>
-            </Columns>
-          </Box>
-          <Box marginBottom="medium">
-            <Columns space="small">
-              <Column width="1/3">
-                <Placeholder height={60} label="&#8531;" />
-              </Column>
-              <Column width="1/4">
-                <Placeholder height={60} label="&#188;" />
-              </Column>
-              <Column width="content">
-                <Placeholder height={60} label="Content" />
-              </Column>
-            </Columns>
-          </Box>
-          <Box marginBottom="medium">
-            <Columns space="small" reverse>
-              <Column width="1/3">
-                <Placeholder height={60} label="&#8531;" />
-              </Column>
-              <Column width="1/4">
-                <Placeholder height={60} label="&#188;" />
-              </Column>
-              <Column width="content">
-                <Placeholder height={60} label="Content" />
-              </Column>
-            </Columns>
-          </Box>
-        </Fragment>
+        <Stack space="medium">
+          <Columns space="small">
+            <Column>
+              <Placeholder height={60} label="Fluid" />
+            </Column>
+            <Column>
+              <Placeholder height={60} label="Fluid" />
+            </Column>
+          </Columns>
+
+          <Columns space="small">
+            <Column width="1/2">
+              <Placeholder height={60} label="&#189;" />
+            </Column>
+            <Column>
+              <Placeholder height={60} label="Fluid" />
+            </Column>
+          </Columns>
+
+          <Columns space="small">
+            <Column width="1/2">
+              <Placeholder height={60} label="&#189;" />
+            </Column>
+            <Column width="1/2">
+              <Placeholder height={60} label="&#189;" />
+            </Column>
+          </Columns>
+
+          <Columns space="small">
+            <Column width="1/4">
+              <Placeholder height={60} label="&#188;" />
+            </Column>
+            <Column width="1/4">
+              <Placeholder height={60} label="&#188;" />
+            </Column>
+            <Column>
+              <Placeholder height={60} label="Fluid" />
+            </Column>
+          </Columns>
+
+          <Columns space="small">
+            <Column width="1/3">
+              <Placeholder height={60} label="&#8531;" />
+            </Column>
+            <Column width="1/4">
+              <Placeholder height={60} label="&#188;" />
+            </Column>
+            <Column width="content">
+              <Placeholder height={60} label="Content" />
+            </Column>
+          </Columns>
+
+          <Columns space="small" reverse>
+            <Column width="1/3">
+              <Placeholder height={60} label="&#8531;" />
+            </Column>
+            <Column width="1/4">
+              <Placeholder height={60} label="&#188;" />
+            </Column>
+            <Column width="content">
+              <Placeholder height={60} label="Content" />
+            </Column>
+          </Columns>
+        </Stack>
       ),
     },
     {

--- a/packages/braid-design-system/src/lib/components/Columns/Columns.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Columns/Columns.docs.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
 import type { ComponentDocs } from 'site/types';
 import { Placeholder } from '../private/Placeholder/Placeholder';
-import { Columns, Column, Strong, Text, Stack, Tiles, Divider } from '../';
+import {
+  Columns,
+  Column,
+  Strong,
+  Text,
+  Stack,
+  Tiles,
+  Divider,
+  Notice,
+} from '../';
 import source from '@braid-design-system/source.macro';
 import { TextLink } from '../TextLink/TextLink';
 
@@ -425,15 +434,53 @@ const docs: ComponentDocs = {
     {
       label: 'Reversing the column order',
       description: (
-        <Text>
-          By default, columns are rendered in document order, which also doubles
-          as the screen reader order. If you need the columns to be visually
-          reversed, you can provide the <Strong>reverse</Strong> prop.
-        </Text>
+        <>
+          <Text>
+            By default, Columns are rendered in document order, which also
+            doubles as the screen reader order. If you need the columns to be
+            visually reversed, you can provide the <Strong>reverse</Strong>{' '}
+            prop.
+          </Text>
+          <Notice>
+            <Text>
+              Reverse should only be applied in combination with the{' '}
+              <Strong>collapseBelow</Strong> prop to ensure the columns are
+              reversed on the same row, but follow the document order when
+              collapsed.
+            </Text>
+          </Notice>
+        </>
       ),
-      Example: () =>
-        source(
-          <Columns space="small" reverse>
+      Example: () => {
+        const { value: visual } = source(
+          <Tiles space="xlarge" columns={[1, 2]}>
+            <Stack space="small">
+              <Text tone="secondary" size="small">
+                On “tablet” and above
+              </Text>
+              <Columns space="small">
+                <Column>
+                  <Placeholder height={60} label="Second" />
+                </Column>
+                <Column width="1/4">
+                  <Placeholder height={60} label="First" />
+                </Column>
+              </Columns>
+            </Stack>
+            <Stack space="small">
+              <Text tone="secondary" size="small">
+                Below “tablet”
+              </Text>
+              <Stack space="small">
+                <Placeholder height={60} label="First" />
+                <Placeholder height={60} label="Second" />
+              </Stack>
+            </Stack>
+          </Tiles>,
+        );
+
+        const { code: codeDemo } = source(
+          <Columns space="small" collapseBelow="tablet" reverse>
             <Column width="1/5">
               <Placeholder height={60} label="First" />
             </Column>
@@ -441,7 +488,32 @@ const docs: ComponentDocs = {
               <Placeholder height={60} label="Second" />
             </Column>
           </Columns>,
-        ),
+        );
+
+        return {
+          code: codeDemo,
+          value: visual,
+        };
+      },
+    },
+    {
+      label: 'Semantic elements',
+      description: (
+        <Text>
+          By default, Columns renders a <Strong>div</Strong> element. You can
+          customise this via the <Strong>component</Strong> prop.
+        </Text>
+      ),
+      code: source(
+        <Columns space="small" component="span">
+          <Column>
+            <Placeholder height={40} />
+          </Column>
+          <Column>
+            <Placeholder height={40} />
+          </Column>
+        </Columns>,
+      ).code,
     },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/Inline/Inline.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Inline/Inline.docs.tsx
@@ -223,8 +223,8 @@ const docs: ComponentDocs = {
           <Text>
             This is useful when navigating forward within a flow, where the
             primary action is on the right when inline, and on top when
-            collapsed. For this reason, the default horizontal alignment
-            when reversed is to the <Strong>right</Strong>.
+            collapsed. For this reason, the default horizontal alignment when
+            reversed is to the <Strong>right</Strong>.
           </Text>
           <Notice>
             <Text>

--- a/packages/braid-design-system/src/lib/components/Inline/Inline.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Inline/Inline.docs.tsx
@@ -1,7 +1,16 @@
 import React from 'react';
 import type { ComponentDocs } from 'site/types';
 import { Placeholder } from '../private/Placeholder/Placeholder';
-import { Divider, Inline, Stack, Strong, Text, TextLink, Tiles } from '../';
+import {
+  Divider,
+  Inline,
+  Notice,
+  Stack,
+  Strong,
+  Text,
+  TextLink,
+  Tiles,
+} from '../';
 import source from '@braid-design-system/source.macro';
 
 const docs: ComponentDocs = {
@@ -180,9 +189,9 @@ const docs: ComponentDocs = {
                 Below “tablet”
               </Text>
               <Stack space="small">
-                <Placeholder width={48} height={48} />
-                <Placeholder width={48} height={48} />
-                <Placeholder width={48} height={48} />
+                <Placeholder height={48} />
+                <Placeholder height={48} />
+                <Placeholder height={48} />
               </Stack>
             </Stack>
           </Tiles>,
@@ -201,6 +210,83 @@ const docs: ComponentDocs = {
           value: visual,
         };
       },
+    },
+    {
+      label: 'Reversing the order',
+      description: (
+        <>
+          <Text>
+            By default, Inline renders its content in document order, which also
+            doubles as the screen reader order. The visual order can be flipped
+            using the <Strong>reverse</Strong> prop.
+          </Text>
+          <Text>
+            This is useful when navigating forward within a flow, where the
+            primary action is on the right when inline, and on top when
+            collapsed. For this reason, the default the horizontal alignment
+            when reversed is to the <Strong>right</Strong>.
+          </Text>
+          <Notice>
+            <Text>
+              Reverse should only be applied in combination with the{' '}
+              <Strong>collapseBelow</Strong> prop to ensure the content is
+              reversed on the same row, but follows the document order when
+              collapsed.
+            </Text>
+          </Notice>
+        </>
+      ),
+      Example: () => {
+        const { value: visual } = source(
+          <Tiles space="xlarge" columns={[1, 2]}>
+            <Stack space="small">
+              <Text tone="secondary" size="small">
+                On “tablet” and above
+              </Text>
+              <Inline space="small" align="right">
+                <Placeholder height={48} label="Second" />
+                <Placeholder height={48} label="First" />
+              </Inline>
+            </Stack>
+            <Stack space="small">
+              <Text tone="secondary" size="small">
+                Below “tablet”
+              </Text>
+              <Stack space="small">
+                <Placeholder height={48} label="First" />
+                <Placeholder height={48} label="Second" />
+              </Stack>
+            </Stack>
+          </Tiles>,
+        );
+
+        const { code: codeDemo } = source(
+          <Inline space="small" collapseBelow="tablet" reverse>
+            <Placeholder height={48} label="First" />
+            <Placeholder height={48} label="Second" />
+          </Inline>,
+        );
+
+        return {
+          code: codeDemo,
+          value: visual,
+        };
+      },
+    },
+    {
+      label: 'Semantic elements',
+      description: (
+        <Text>
+          By default, Inline renders a <Strong>div</Strong> element. You can
+          customise this via the <Strong>component</Strong> prop.
+        </Text>
+      ),
+      code: source(
+        <Inline component="span" space="small">
+          <Placeholder width={40} height={40} />
+          <Placeholder width={40} height={40} />
+        </Inline>,
+      ).code,
     },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/Inline/Inline.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Inline/Inline.docs.tsx
@@ -223,7 +223,7 @@ const docs: ComponentDocs = {
           <Text>
             This is useful when navigating forward within a flow, where the
             primary action is on the right when inline, and on top when
-            collapsed. For this reason, the default the horizontal alignment
+            collapsed. For this reason, the default horizontal alignment
             when reversed is to the <Strong>right</Strong>.
           </Text>
           <Notice>

--- a/packages/braid-design-system/src/lib/components/Spread/Spread.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Spread/Spread.docs.tsx
@@ -125,6 +125,21 @@ const docs: ComponentDocs = {
           </Tiles>,
         ),
     },
+    {
+      label: 'Semantic elements',
+      description: (
+        <Text>
+          By default, Spread renders a <Strong>div</Strong> element. You can
+          customise this via the <Strong>component</Strong> prop.
+        </Text>
+      ),
+      code: source(
+        <Spread component="span" space="small">
+          <Placeholder height={40} />
+          <Placeholder height={40} />
+        </Spread>,
+      ).code,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Stack/Stack.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Stack/Stack.docs.tsx
@@ -144,6 +144,21 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
+    {
+      label: 'Semantic elements',
+      description: (
+        <Text>
+          By default, Stack renders a <Strong>div</Strong> element. You can
+          customise this via the <Strong>component</Strong> prop.
+        </Text>
+      ),
+      code: source(
+        <Stack component="span" space="small">
+          <Placeholder height={40} />
+          <Placeholder height={40} />
+        </Stack>,
+      ).code,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Stack/Stack.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/Stack/Stack.snippets.tsx
@@ -23,6 +23,15 @@ export const snippets: Snippets = [
     ),
   },
   {
+    name: 'Titled content',
+    code: source(
+      <Stack space="small">
+        <Heading level="4">Heading</Heading>
+        <Text>Standard Text</Text>
+      </Stack>,
+    ),
+  },
+  {
     name: 'Content groups',
     code: source(
       <Stack space="medium">


### PR DESCRIPTION
Adding some missing "Semantic elements" documentation to document the `component` prop.

Also adding the missing `reverse` documentation from the `Inline` component.