### PR TITLE
BraidTestProvider: Provide `scrollIntoView` stub function for jsdom

### DIFF
--- a/.changeset/bright-squids-ring.md
+++ b/.changeset/bright-squids-ring.md
@@ -1,0 +1,15 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - BraidTestProvider
+---
+
+**BraidTestProvider:** Provide `scrollIntoView` stub function for jsdom
+
+Fixes an issue where `scrollIntoView` is not defined in jsdom, causing tests to fail with the following error:
+```
+Error: Uncaught [TypeError: highlightedItem?.scrollIntoView is not a function]
+```

--- a/jest/setupTests.ts
+++ b/jest/setupTests.ts
@@ -6,9 +6,6 @@ import { format, TextEncoder, TextDecoder } from 'util';
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
 
-// Mocking for `jsdom`
-window.HTMLElement.prototype.scrollIntoView = function () {};
-
 const error = global.console.error;
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true;

--- a/packages/braid-design-system/src/lib/components/BraidTestProvider/BraidTestProvider.tsx
+++ b/packages/braid-design-system/src/lib/components/BraidTestProvider/BraidTestProvider.tsx
@@ -8,6 +8,21 @@ import {
 import { BraidTestProviderContext } from './BraidTestProviderContext';
 import { breakpointContext } from '../BraidProvider/BreakpointContext';
 
+/**
+ * Mocking for `jsdom` which doesn't support `scrollIntoView`.
+ * Can remove this if/when `jsdom` adds a stub for `scrollIntoView`.
+ *
+ * GitHub issue: https://github.com/jsdom/jsdom/issues/1695
+ * Pull request: https://github.com/jsdom/jsdom/pull/3639
+ */
+if (
+  typeof navigator !== 'undefined' &&
+  navigator?.userAgent?.includes('jsdom')
+) {
+  window.HTMLElement.prototype.scrollIntoView =
+    window.HTMLElement.prototype.scrollIntoView || (() => {});
+}
+
 interface BraidTestProviderProps
   extends Omit<BraidProviderProps, 'theme' | 'styleBody'> {
   themeName?: keyof typeof themes;


### PR DESCRIPTION
In an earlier [PR] the `Autosuggest` moved from using a custom scrolling function over to the native [scrollIntoView API].
Due to [jsdom not supporting it], we stubbed it for *our tests*, but this has resulted in the following error:
```
Error: Uncaught [TypeError: highlightedItem?.scrollIntoView is not a function]
```

Moving the stubs to a side effect of importing `BraidTestProvider` to solve it in all Braid consumers test environments.

[PR]: https://github.com/seek-oss/braid-design-system/pull/1571/files
[scrollIntoView API]: https://caniuse.com/mdn-api_element_scrollintoview
[jsdom not supporting it]: https://github.com/jsdom/jsdom/issues/1695