### PR TITLE
Columns, Inline: Only respect `reverse` with `collapseBelow`

### DIFF
--- a/.changeset/selfish-terms-shake.md
+++ b/.changeset/selfish-terms-shake.md
@@ -1,0 +1,16 @@
+---
+'braid-design-system': major
+---
+
+---
+updated:
+  - Columns
+  - Inline
+---
+
+**Columns, Inline:** Only respect `reverse` in combination with `collapseBelow`
+
+The `reverse` prop is only respected in combination with `collapseBelow`.
+This ensures the content is reversed on the same row, but follows the document order when collapsed.
+
+If content needs to be reversed without `collapseBelow` then it should be reversed in the document/source order directly.

--- a/packages/braid-design-system/src/lib/components/Column/Column.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Column/Column.screenshots.tsx
@@ -101,7 +101,7 @@ export const screenshots: ComponentScreenshot = {
             </Column>
           </Columns>
 
-          <Columns space="small" reverse>
+          <Columns space="small" collapseBelow="tablet" reverse>
             <Column width="1/3">
               <Placeholder height={60} label="&#8531;" />
             </Column>

--- a/packages/braid-design-system/src/lib/components/Columns/Columns.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Columns/Columns.docs.tsx
@@ -443,7 +443,7 @@ const docs: ComponentDocs = {
           </Text>
           <Notice>
             <Text>
-              Reverse should only be applied in combination with the{' '}
+              Reverse is only applied in combination with the{' '}
               <Strong>collapseBelow</Strong> prop to ensure the columns are
               reversed on the same row, but follow the document order when
               collapsed.

--- a/packages/braid-design-system/src/lib/components/Columns/Columns.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Columns/Columns.gallery.tsx
@@ -97,12 +97,11 @@ export const galleryItems: GalleryComponent = {
           </Stack>,
         ),
     },
-
     {
       label: 'Reversing the column order',
       Example: () =>
         source(
-          <Columns space="small" reverse>
+          <Columns space="small" collapseBelow="tablet" reverse>
             <Column width="1/5">
               <Placeholder height={60} label="First" />
             </Column>

--- a/packages/braid-design-system/src/lib/components/Columns/Columns.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Columns/Columns.screenshots.tsx
@@ -343,7 +343,7 @@ export const screenshots: ComponentScreenshot = {
     {
       label: 'Reverse',
       Example: () => (
-        <Columns space="small" reverse>
+        <Columns space="small" collapseBelow="tablet" reverse>
           <Column>
             <Placeholder height={60} label="First" />
           </Column>

--- a/packages/braid-design-system/src/lib/components/Columns/Columns.tsx
+++ b/packages/braid-design-system/src/lib/components/Columns/Columns.tsx
@@ -44,7 +44,7 @@ export const Columns = ({
 
   assert(
     !reverse || (reverse && collapseBelow),
-    'The `reverse` prop should only be applied in combination with the `collapseBelow` prop.\nIf you do not want to collapse responsively, it is recommended to reorder the order of the content directly.\n\nSee documentation for details: https://seek-oss.github.io/braid-design-system/components/Columns#reversing-the-column-order',
+    'The `reverse` prop should only be applied in combination with the `collapseBelow` prop.\nIf you do not want to collapse responsively, it is recommended to reorder the content directly.\n\nSee documentation for details: https://seek-oss.github.io/braid-design-system/components/Columns#reversing-the-column-order',
   );
 
   const normalizedSpace = normalizeResponsiveValue(space);

--- a/packages/braid-design-system/src/lib/components/Columns/Columns.tsx
+++ b/packages/braid-design-system/src/lib/components/Columns/Columns.tsx
@@ -14,7 +14,7 @@ import buildDataAttributes, {
 } from '../private/buildDataAttributes';
 import { ColumnsContext, validColumnsComponents } from './ColumnsContext';
 
-export interface ColumnsProps extends CollapsibleAlignmentProps {
+export type ColumnsProps = CollapsibleAlignmentProps & {
   space: ResponsiveSpace;
   children:
     | Array<ReactElement<ColumnProps> | null>
@@ -22,7 +22,7 @@ export interface ColumnsProps extends CollapsibleAlignmentProps {
     | null;
   component?: (typeof validColumnsComponents)[number];
   data?: DataAttributeMap;
-}
+};
 
 export const Columns = ({
   children,
@@ -40,6 +40,11 @@ export const Columns = ({
     `Invalid Columns component: '${component}'. Should be one of [${validColumnsComponents
       .map((c) => `'${c}'`)
       .join(', ')}]`,
+  );
+
+  assert(
+    !reverse || (reverse && collapseBelow),
+    'The `reverse` prop should only be applied in combination with the `collapseBelow` prop.\nIf you do not want to collapse responsively, it is recommended to reorder the order of the content directly.\n\nSee documentation for details: https://seek-oss.github.io/braid-design-system/components/Columns#reversing-the-column-order',
   );
 
   const normalizedSpace = normalizeResponsiveValue(space);

--- a/packages/braid-design-system/src/lib/components/Inline/Inline.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Inline/Inline.docs.tsx
@@ -228,7 +228,7 @@ const docs: ComponentDocs = {
           </Text>
           <Notice>
             <Text>
-              Reverse should only be applied in combination with the{' '}
+              Reverse is only applied in combination with the{' '}
               <Strong>collapseBelow</Strong> prop to ensure the content is
               reversed on the same row, but follows the document order when
               collapsed.

--- a/packages/braid-design-system/src/lib/components/Inline/Inline.tsx
+++ b/packages/braid-design-system/src/lib/components/Inline/Inline.tsx
@@ -43,7 +43,7 @@ export const Inline = ({
 
   assert(
     !reverse || (reverse && collapseBelow),
-    'The `reverse` prop should only be applied in combination with the `collapseBelow` prop.\nIf you do not want to collapse responsively, it is recommended to reorder the order of the content directly.\n\nSee documentation for details: https://seek-oss.github.io/braid-design-system/components/Inline#reversing-the-order',
+    'The `reverse` prop should only be applied in combination with the `collapseBelow` prop.\nIf you do not want to collapse responsively, it is recommended to reorder the content directly.\n\nSee documentation for details: https://seek-oss.github.io/braid-design-system/components/Inline#reversing-the-order',
   );
 
   const isList = component === 'ol' || component === 'ul';

--- a/packages/braid-design-system/src/lib/components/Inline/Inline.tsx
+++ b/packages/braid-design-system/src/lib/components/Inline/Inline.tsx
@@ -16,19 +16,19 @@ import buildDataAttributes, {
 
 export const validInlineComponents = ['div', 'span', 'ol', 'ul'] as const;
 
-export interface InlineProps extends CollapsibleAlignmentProps {
+export type InlineProps = CollapsibleAlignmentProps & {
   space: ResponsiveSpace;
   component?: (typeof validInlineComponents)[number];
   data?: DataAttributeMap;
   children: ReactNodeNoStrings;
-}
+};
 
 export const Inline = ({
   space = 'none',
   align,
   alignY,
   collapseBelow,
-  reverse,
+  reverse = false,
   component = 'div',
   data,
   children,
@@ -39,6 +39,11 @@ export const Inline = ({
     `Invalid Inline component: '${component}'. Should be one of [${validInlineComponents
       .map((c) => `'${c}'`)
       .join(', ')}]`,
+  );
+
+  assert(
+    !reverse || (reverse && collapseBelow),
+    'The `reverse` prop should only be applied in combination with the `collapseBelow` prop.\nIf you do not want to collapse responsively, it is recommended to reorder the order of the content directly.\n\nSee documentation for details: https://seek-oss.github.io/braid-design-system/components/Inline#reversing-the-order',
   );
 
   const isList = component === 'ol' || component === 'ul';

--- a/packages/braid-design-system/src/lib/utils/collapsibleAlignmentProps.ts
+++ b/packages/braid-design-system/src/lib/utils/collapsibleAlignmentProps.ts
@@ -27,12 +27,19 @@ function invertAlignment<Alignment extends string>(alignment: Alignment) {
   return alignment;
 }
 
-export interface CollapsibleAlignmentProps {
-  collapseBelow?: ResponsiveRangeProps['below'];
+export type CollapsibleAlignmentProps = {
   align?: OptionalResponsiveValue<Align>;
   alignY?: OptionalResponsiveValue<AlignY>;
-  reverse?: boolean;
-}
+} & (
+  | {
+      reverse?: never;
+      collapseBelow?: ResponsiveRangeProps['below'];
+    }
+  | {
+      reverse: boolean;
+      collapseBelow: ResponsiveRangeProps['below'];
+    }
+);
 
 export function resolveCollapsibleAlignmentProps({
   align,


### PR DESCRIPTION
The `reverse` prop is only respected in combination with `collapseBelow`.
This ensures the content is reversed on the same row, but follows the document order when collapsed.

If content needs to be reversed without `collapseBelow` then it should be reversed in the document/source order directly.