### PR TITLE
Stack: Set default text alignment based on `align`

### DIFF
--- a/.changeset/red-ladybugs-doubt.md
+++ b/.changeset/red-ladybugs-doubt.md
@@ -11,4 +11,4 @@ updated:
 
 As a convenience, the `align` prop sets the text alignment for the container, meaning any nested `Text` or `Heading` components will inherit this alignment by default.
 
-This can be overriden by setting the alignment explicitly on the relevant `Text` or `Heading` component.
+This can be overridden by setting the alignment explicitly on the relevant `Text` or `Heading` component.

--- a/.changeset/red-ladybugs-doubt.md
+++ b/.changeset/red-ladybugs-doubt.md
@@ -1,0 +1,14 @@
+---
+'braid-design-system': major
+---
+
+---
+updated:
+  - Stack
+---
+
+**Stack:** Set default text alignment based on `align`
+
+As a convenience, the `align` prop sets the text alignment for the container, meaning any nested `Text` or `Heading` components will inherit this alignment by default.
+
+This can be overriden by setting the alignment explicitly on the relevant `Text` or `Heading` component.

--- a/packages/braid-design-system/src/lib/components/Stack/Stack.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Stack/Stack.docs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { ComponentDocs } from 'site/types';
-import { Stack, Text, TextLink, Strong, Divider } from '../';
+import { Stack, Text, TextLink, Strong, Divider, Notice } from '../';
 import { Placeholder } from '../private/Placeholder/Placeholder';
 import source from '@braid-design-system/source.macro';
 
@@ -66,11 +66,23 @@ const docs: ComponentDocs = {
     {
       label: 'Horizontal alignment',
       description: (
-        <Text>
-          Items can be aligned horizontally using the <Strong>align</Strong>{' '}
-          prop. Responsive values are supported, e.g.{' '}
-          <Strong>{"align={{ mobile: 'center', tablet: 'left' }}"}</Strong>
-        </Text>
+        <>
+          <Text>
+            Items can be aligned horizontally using the <Strong>align</Strong>{' '}
+            prop. Responsive values are supported, e.g.{' '}
+            <Strong>{"align={{ mobile: 'center', tablet: 'left' }}"}</Strong>
+          </Text>
+          <Notice>
+            <Text>
+              As a convenience, the <Strong>align</Strong> prop also sets the
+              text alignment for the container. This can be overridden by
+              setting alignment explicitly on the relevant{' '}
+              <TextLink href="/components/Text#alignment">Text</TextLink> or{' '}
+              <TextLink href="/components/Heading#alignment">Heading</TextLink>{' '}
+              component.
+            </Text>
+          </Notice>
+        </>
       ),
       Example: () =>
         source(

--- a/packages/braid-design-system/src/lib/components/Stack/Stack.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Stack/Stack.screenshots.tsx
@@ -1,6 +1,6 @@
 import React, { type ReactNode, Fragment } from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { Box, Stack, Hidden } from '../';
+import { Box, Stack, Hidden, Heading, Text, Strong } from '../';
 import { Placeholder } from '../private/Placeholder/Placeholder';
 import { spaces } from '../../utils/docsHelpers';
 
@@ -158,6 +158,57 @@ export const screenshots: ComponentScreenshot = {
           <Placeholder height={40} width={40} />
           <Placeholder height={40} width={60} />
           <Placeholder height={40} width={80} />
+        </Stack>
+      ),
+    },
+    {
+      label: 'Test - Default text alignment (left)',
+      Container,
+      Example: () => (
+        <Stack space="large" align="left">
+          <Heading level="3">Default heading alignment (left).</Heading>
+          <Text>
+            <Strong>Default text alignment (left).</Strong> Est quis incididunt
+            do laboris eiusmod et..
+          </Text>
+          <Text align="right">
+            <Strong>Explicit right alignment.</Strong> Pariatur ad aute esse
+            esse sunt aliqua.
+          </Text>
+        </Stack>
+      ),
+    },
+    {
+      label: 'Test - Default text alignment (center)',
+      Container,
+      Example: () => (
+        <Stack space="large" align="center">
+          <Heading level="3">Default heading alignment (center).</Heading>
+          <Text>
+            <Strong>Default text alignment (center).</Strong> Est quis
+            incididunt do laboris eiusmod et..
+          </Text>
+          <Text align="right">
+            <Strong>Explicit right alignment.</Strong> Pariatur ad aute esse
+            esse sunt aliqua.
+          </Text>
+        </Stack>
+      ),
+    },
+    {
+      label: 'Test - Default text alignment (right)',
+      Container,
+      Example: () => (
+        <Stack space="large" align="right">
+          <Heading level="3">Default heading alignment (right).</Heading>
+          <Text>
+            <Strong>Default text alignment (right).</Strong> Est quis incididunt
+            do laboris eiusmod et..
+          </Text>
+          <Text align="center">
+            <Strong>Explicit center alignment.</Strong> Pariatur ad aute esse
+            esse sunt aliqua.
+          </Text>
         </Stack>
       ),
     },

--- a/packages/braid-design-system/src/lib/components/Stack/Stack.tsx
+++ b/packages/braid-design-system/src/lib/components/Stack/Stack.tsx
@@ -39,18 +39,28 @@ export const Stack = ({
   component = 'div',
   children,
   space = 'none',
-  align = 'left',
+  align: alignProp,
   data,
   ...restProps
-}: StackProps) => (
-  <Box
-    component={component}
-    display="flex"
-    flexDirection="column"
-    gap={space}
-    alignItems={align !== 'left' ? alignToFlexAlign(align) : undefined}
-    {...buildDataAttributes({ data, validateRestProps: restProps })}
-  >
-    {children}
-  </Box>
-);
+}: StackProps) => {
+  /**
+   * Creating a seam between the provided prop and the default value
+   * to enable only setting the text alignment when the `align` prop
+   * is provided — not when it's defaulted.
+   */
+  const align = alignProp || 'left';
+
+  return (
+    <Box
+      component={component}
+      display="flex"
+      flexDirection="column"
+      gap={space}
+      alignItems={align !== 'left' ? alignToFlexAlign(align) : undefined}
+      textAlign={alignProp}
+      {...buildDataAttributes({ data, validateRestProps: restProps })}
+    >
+      {children}
+    </Box>
+  );
+};


### PR DESCRIPTION
As a convenience, the `align` prop sets the text alignment for the container, meaning any nested `Text` or `Heading` components will inherit this alignment by default.

This can be overridden by setting the alignment explicitly on the relevant `Text` or `Heading` component.