### PR TITLE
useColor: Align `background` tokens with `Box` and `vars`

### DIFF
--- a/.changeset/lucky-bottles-relate.md
+++ b/.changeset/lucky-bottles-relate.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': major
+---
+
+---
+updated:
+  - useColor
+---
+
+**useColor:** Align `background` tokens with `Box` and `vars`
+
+Align the available `background` tokens between `Box`, `vars`, and the `useColor` Hook.
+Removes the `surfaceDark` and `bodyDark` tokens that were mistakenly exposed in the `useColor` Hook.

--- a/packages/braid-design-system/src/lib/components/useColor/useColor.ts
+++ b/packages/braid-design-system/src/lib/components/useColor/useColor.ts
@@ -1,3 +1,15 @@
 import { useBraidTheme } from '../BraidProvider/BraidThemeContext';
 
-export const useColor = () => useBraidTheme().color;
+export const useColor = () => {
+  const {
+    foreground,
+    // TODO: COLORMODE RELEASE
+    // Release new backgrounds
+    background: { surfaceDark: _, bodyDark: __, ...background },
+  } = useBraidTheme().color;
+
+  return {
+    foreground,
+    background,
+  };
+};


### PR DESCRIPTION
Align the available `background` tokens between `Box`, `vars`, and the `useColor` Hook.
Removes the `surfaceDark` and `bodyDark` tokens that were mistakenly exposed in the `useColor` Hook.