### PR TITLE
seekJobs: Reduce size of `gutter` token

### DIFF
--- a/.changeset/heavy-radios-remain.md
+++ b/.changeset/heavy-radios-remain.md
@@ -9,5 +9,5 @@ updated:
 
 **seekJobs:** Reduce size of `gutter` token
 
-The size of the `gutter` token on the `seekJobs` theme will be reduce from `large` (i.e. 32px), to `medium` (i.e. 24px).
+The size of the `gutter` token on the `seekJobs` theme will be reduced from `large` (i.e. 32px), to `medium` (i.e. 24px).
 This is a semantic token that runs through many system components, and consumers are encouraged to perform a visual design audit to ensure experiences are laid out as intended.

--- a/.changeset/heavy-radios-remain.md
+++ b/.changeset/heavy-radios-remain.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - seekJobs
+---
+
+**seekJobs:** Reduce size of `gutter` token
+
+The size of the `gutter` token on the `seekJobs` theme will be reduce from `large` (i.e. 32px), to `medium` (i.e. 24px).
+This is a semantic token that runs through many system components, and consumers are encouraged to perform a visual design audit to ensure experiences are laid out as intended.

--- a/packages/braid-design-system/src/lib/themes/seekJobs/tokens.ts
+++ b/packages/braid-design-system/src/lib/themes/seekJobs/tokens.ts
@@ -125,7 +125,7 @@ export default makeTokens({
       },
     },
     space: {
-      gutter: 8,
+      gutter: 6,
       xxsmall: 2,
       xsmall: 3,
       small: 4,


### PR DESCRIPTION
The size of the `gutter` token on the `seekJobs` theme will be reduce from `large` (i.e. 32px), to `medium` (i.e. 24px).
This is a semantic token that runs through many system components, and consumers are encouraged to perform a visual design audit to ensure experiences are laid out as intended.