### PR TITLE
Inline, Tiles: Enable truncated items

### DIFF
--- a/packages/braid-design-system/src/lib/components/Inline/Inline.css.ts
+++ b/packages/braid-design-system/src/lib/components/Inline/Inline.css.ts
@@ -9,6 +9,7 @@ export const fitContentWide = style({});
 const fitContentStyleRule = {
   flexBasis: 'auto',
   width: 'auto',
+  minWidth: 0,
 };
 
 globalStyle(`${fitContentMobile} > *`, fitContentStyleRule);

--- a/packages/braid-design-system/src/lib/components/Inline/Inline.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Inline/Inline.screenshots.tsx
@@ -343,8 +343,7 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label:
-        'Test - truncation should be visible on all examples below',
+      label: 'Test - truncation should be visible on all examples below',
       Container,
       Example: () => (
         <Inline space="small">

--- a/packages/braid-design-system/src/lib/components/Inline/Inline.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Inline/Inline.screenshots.tsx
@@ -344,7 +344,7 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label:
-        'Test - truncation should work an (all examples should truncate below)',
+        'Test - truncation should be visible on all examples below',
       Container,
       Example: () => (
         <Inline space="small">

--- a/packages/braid-design-system/src/lib/components/Inline/Inline.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Inline/Inline.screenshots.tsx
@@ -342,5 +342,40 @@ export const screenshots: ComponentScreenshot = {
         </Inline>
       ),
     },
+    {
+      label:
+        'Test - truncation should work an (all examples should truncate below)',
+      Container,
+      Example: () => (
+        <Inline space="small">
+          <Box
+            style={{
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            Consequat quis anim anim officia voluptate. Ex in ut ipsum tempor
+            occaecat enim laboris ex incididunt sunt non est reprehenderit. Id
+            proident deserunt excepteur esse mollit aliquip. Aute ut tempor ex
+            officia quis magna occaecat nostrud.
+          </Box>
+          <Box>
+            <Box
+              style={{
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              Consequat quis anim anim officia voluptate. Ex in ut ipsum tempor
+              occaecat enim laboris ex incididunt sunt non est reprehenderit. Id
+              proident deserunt excepteur esse mollit aliquip. Aute ut tempor ex
+              officia quis magna occaecat nostrud.
+            </Box>
+          </Box>
+        </Inline>
+      ),
+    },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/Tiles/Tiles.css.ts
+++ b/packages/braid-design-system/src/lib/components/Tiles/Tiles.css.ts
@@ -1,4 +1,9 @@
-import { createVar, fallbackVar, style } from '@vanilla-extract/css';
+import {
+  createVar,
+  fallbackVar,
+  globalStyle,
+  style,
+} from '@vanilla-extract/css';
 import { responsiveStyle } from '../../css/responsiveStyle';
 
 const columns = createVar();
@@ -44,3 +49,7 @@ export const tiles = style([
     },
   }),
 ]);
+
+globalStyle(`${tiles} > *`, {
+  minWidth: 0,
+});

--- a/packages/braid-design-system/src/lib/components/Tiles/Tiles.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Tiles/Tiles.screenshots.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { Tiles } from '../';
+import { Box, Tiles } from '../';
 import { Placeholder } from '../private/Placeholder/Placeholder';
 
 const exampleRows = 3;
@@ -26,6 +26,40 @@ export const screenshots: ComponentScreenshot = {
           {[...new Array(4 * exampleRows)].map((_, i) => (
             <Placeholder key={i} height={40} />
           ))}
+        </Tiles>
+      ),
+    },
+    {
+      label:
+        'Test - truncation should work and showing two equal tiles with truncated text',
+      Example: () => (
+        <Tiles space="small" columns={2}>
+          <Box
+            style={{
+              whiteSpace: 'nowrap',
+              overflow: 'hidden',
+              textOverflow: 'ellipsis',
+            }}
+          >
+            Consequat quis anim anim officia voluptate. Ex in ut ipsum tempor
+            occaecat enim laboris ex incididunt sunt non est reprehenderit. Id
+            proident deserunt excepteur esse mollit aliquip. Aute ut tempor ex
+            officia quis magna occaecat nostrud.
+          </Box>
+          <Box>
+            <Box
+              style={{
+                whiteSpace: 'nowrap',
+                overflow: 'hidden',
+                textOverflow: 'ellipsis',
+              }}
+            >
+              Consequat quis anim anim officia voluptate. Ex in ut ipsum tempor
+              occaecat enim laboris ex incididunt sunt non est reprehenderit. Id
+              proident deserunt excepteur esse mollit aliquip. Aute ut tempor ex
+              officia quis magna occaecat nostrud.
+            </Box>
+          </Box>
         </Tiles>
       ),
     },

--- a/packages/braid-design-system/src/lib/components/Tiles/Tiles.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Tiles/Tiles.screenshots.tsx
@@ -31,7 +31,7 @@ export const screenshots: ComponentScreenshot = {
     },
     {
       label:
-        'Test - truncation should work and showing two equal tiles with truncated text',
+        'Test - truncation should be visible on both tiles below, as well as both tiles being equally sized',
       Example: () => (
         <Tiles space="small" columns={2}>
           <Box


### PR DESCRIPTION
Identified an issue where truncated items (more explicitly, elements with `white-space: nowrap`) within an `Inline` or `Tiles` would not truncate correctly, and break the boundaries of the parent container.

The fix is to ensure children of these components apply the `min-width: 0` so flex and grid infer their width and correctly truncate.

There is no changeset as this is a refactor on the CSS gap updates already in the `next` branch