### PR TITLE
docs-ui: Bump Braid peer dependency to v33

### DIFF
--- a/.changeset/yellow-mirrors-hear.md
+++ b/.changeset/yellow-mirrors-hear.md
@@ -1,0 +1,5 @@
+---
+'@braid-design-system/docs-ui': major
+---
+
+Bump Braid peer dependency to v33


### PR DESCRIPTION
Adding changeset to capture the Braid peer dep change in the `docs-ui` package Changelog