### PR TITLE
useToast: Ensure content is left aligned

### DIFF
--- a/.changeset/loud-wasps-tickle.md
+++ b/.changeset/loud-wasps-tickle.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - useToast
+---
+
+**useToast**: Ensure content is left aligned
+
+Applies left alignment to `Toast` content to ensure intended alignment, regardless of other styles applied.

--- a/packages/braid-design-system/src/lib/components/useToast/Toast.tsx
+++ b/packages/braid-design-system/src/lib/components/useToast/Toast.tsx
@@ -138,6 +138,7 @@ const Toast = React.forwardRef<HTMLDivElement, ToastProps>(
       <Box
         display="flex"
         justifyContent="center"
+        textAlign="left"
         role="alert"
         ref={ref}
         onMouseEnter={stopTimeout}


### PR DESCRIPTION
Applies left alignment to `Toast` content to ensure intended alignment, regardless of other styles applied.