### PR TITLE
Disclosure: Add `size` support

### DIFF
--- a/.changeset/wet-bananas-end.md
+++ b/.changeset/wet-bananas-end.md
@@ -1,0 +1,21 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Disclosure
+---
+
+**Disclosure:** Add `size` support
+
+Introduce the `size` prop to the `Disclosure` component, providing the same options as the `Text` component.
+
+**EXAMPLE USAGE:**
+```jsx
+<Disclosure
+  size="small"
+>
+  ...
+</Disclosure>
+```

--- a/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.docs.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { ComponentDocs } from 'site/types';
-import { Disclosure, Text, TextLink, Strong } from '..';
+import { Disclosure, Text, TextLink, Strong, Stack, Notice } from '..';
 import source from '@braid-design-system/source.macro';
 
 const docs: ComponentDocs = {
@@ -43,32 +43,6 @@ const docs: ComponentDocs = {
   ],
   additional: [
     {
-      label: 'Custom space',
-      description: (
-        <Text>
-          The space between the disclosure label and content can be customised
-          via the <Strong>space</Strong> prop.
-        </Text>
-      ),
-      Example: ({ id, setDefaultState, getState, setState }) =>
-        source(
-          <>
-            {setDefaultState('expanded', true)}
-
-            <Disclosure
-              id={id}
-              expandLabel="Show content"
-              collapseLabel="Hide content"
-              expanded={getState('expanded')}
-              onToggle={setState('expanded')}
-              space="small"
-            >
-              <Text>Content</Text>
-            </Disclosure>
-          </>,
-        ),
-    },
-    {
       label: 'Visual weight',
       description: (
         <Text>
@@ -90,6 +64,102 @@ const docs: ComponentDocs = {
               collapseLabel="Hide content"
               expanded={getState('expanded')}
               onToggle={setState('expanded')}
+            >
+              <Text>Content</Text>
+            </Disclosure>
+          </>,
+        ),
+    },
+    {
+      label: 'Sizing',
+      description: (
+        <>
+          <Text>
+            The size can be customised via the <Strong>size</Strong> prop, which
+            accepts the same sizes as the{' '}
+            <TextLink href="/components/Text">Text</TextLink> component.
+          </Text>
+          <Notice>
+            <Text>
+              The provided <Strong>size</Strong> will also be used as the
+              default size for <TextLink href="/components/Text">Text</TextLink>{' '}
+              components within the content of the disclosure.
+            </Text>
+          </Notice>
+        </>
+      ),
+      Example: ({ id, handler }) =>
+        source(
+          <Stack space="large">
+            <Disclosure
+              id={`${id}_1`}
+              expandLabel="Large size"
+              size="large"
+              expanded={true}
+              onToggle={handler}
+            >
+              <Text>
+                Defaults to <Strong>large</Strong> text size
+              </Text>
+            </Disclosure>
+            <Disclosure
+              id={`${id}_2`}
+              expandLabel="Standard size"
+              size="standard"
+              expanded={true}
+              onToggle={handler}
+            >
+              <Text>
+                Defaults to <Strong>standard</Strong> text size
+              </Text>
+            </Disclosure>
+            <Disclosure
+              id={`${id}_3`}
+              expandLabel="Small size"
+              size="small"
+              expanded={true}
+              onToggle={handler}
+            >
+              <Text>
+                Defaults to <Strong>small</Strong> text size
+              </Text>
+            </Disclosure>
+            <Disclosure
+              id={`${id}_4`}
+              expandLabel="Xsmall size"
+              size="xsmall"
+              expanded={true}
+              onToggle={handler}
+            >
+              <Text>
+                Defaults to <Strong>xsmall</Strong> text size
+              </Text>
+            </Disclosure>
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Custom space',
+      description: (
+        <Text>
+          The default space between the disclosure label and content will be
+          determined by the <TextLink href="#sizing">size</TextLink>.
+          Alternatively, this can be customised via the <Strong>space</Strong>{' '}
+          prop.
+        </Text>
+      ),
+      Example: ({ id, setDefaultState, getState, setState }) =>
+        source(
+          <>
+            {setDefaultState('expanded', true)}
+
+            <Disclosure
+              id={id}
+              expandLabel="Show content"
+              collapseLabel="Hide content"
+              expanded={getState('expanded')}
+              onToggle={setState('expanded')}
+              space="large"
             >
               <Text>Content</Text>
             </Disclosure>

--- a/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.gallery.tsx
@@ -1,12 +1,13 @@
 import React from 'react';
 import type { GalleryComponent } from 'site/types';
-import { Disclosure } from '..';
+import { Disclosure, Stack, Strong, Text } from '..';
 import source from '@braid-design-system/source.macro';
 import { Placeholder } from '../../playroom/components';
 
 export const galleryItems: GalleryComponent = {
   examples: [
     {
+      label: 'Standard',
       Example: ({ id }) =>
         source(
           <Disclosure
@@ -16,6 +17,81 @@ export const galleryItems: GalleryComponent = {
           >
             <Placeholder height={100} />
           </Disclosure>,
+        ),
+    },
+    {
+      label: 'Visual weight',
+      Example: ({ id }) =>
+        source(
+          <Stack space="large">
+            <Disclosure
+              id={`${id}_1`}
+              expandLabel="Regular weight"
+              weight="regular"
+            >
+              <Placeholder height={100} />
+            </Disclosure>
+            <Disclosure
+              id={`${id}_2`}
+              expandLabel="Weak weight"
+              size="standard"
+              weight="weak"
+            >
+              <Placeholder height={100} />
+            </Disclosure>
+          </Stack>,
+        ),
+    },
+    {
+      label: 'Sizing',
+      Example: ({ id, handler }) =>
+        source(
+          <Stack space="large">
+            <Disclosure
+              id={`${id}_1`}
+              expandLabel="Large size"
+              size="large"
+              expanded={true}
+              onToggle={handler}
+            >
+              <Text>
+                Defaults to <Strong>large</Strong> text size
+              </Text>
+            </Disclosure>
+            <Disclosure
+              id={`${id}_2`}
+              expandLabel="Standard size"
+              size="standard"
+              expanded={true}
+              onToggle={handler}
+            >
+              <Text>
+                Defaults to <Strong>standard</Strong> text size
+              </Text>
+            </Disclosure>
+            <Disclosure
+              id={`${id}_3`}
+              expandLabel="Small size"
+              size="small"
+              expanded={true}
+              onToggle={handler}
+            >
+              <Text>
+                Defaults to <Strong>small</Strong> text size
+              </Text>
+            </Disclosure>
+            <Disclosure
+              id={`${id}_4`}
+              expandLabel="Xsmall size"
+              size="xsmall"
+              expanded={true}
+              onToggle={handler}
+            >
+              <Text>
+                Defaults to <Strong>xsmall</Strong> text size
+              </Text>
+            </Disclosure>
+          </Stack>,
         ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.screenshots.tsx
@@ -1,11 +1,16 @@
 import React, { type ReactNode } from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { Disclosure, Text } from '../';
+import { Disclosure, Stack, Text } from '../';
 import { Box } from '../Box/Box';
+import { textSizeUntrimmed } from '../../css/typography.css';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <Box style={{ maxWidth: 250 }}>{children}</Box>
 );
+
+const textSizes = Object.keys(textSizeUntrimmed) as Array<
+  keyof typeof textSizeUntrimmed
+>;
 
 export const screenshots: ComponentScreenshot = {
   screenshotWidths: [320],
@@ -180,6 +185,47 @@ export const screenshots: ComponentScreenshot = {
           vel nunc auctor facilisis. Quisque neque sapien, aliquam eget eros id,
           facilisis sodales nisl.
         </Text>
+      ),
+    },
+    {
+      label: 'Sizes and default spacing',
+      Example: ({ id, handler }) => (
+        <Stack space="large">
+          {textSizes.map((size) => (
+            <Disclosure
+              key={size}
+              id={`${id}_${size}`}
+              expandLabel={`${size.charAt(0).toUpperCase()}${size.slice(
+                1,
+              )} size`}
+              size={size}
+              expanded={true}
+              onToggle={handler}
+            >
+              <Text>Defaults to {size} text size</Text>
+            </Disclosure>
+          ))}
+        </Stack>
+      ),
+    },
+    {
+      label: 'Inline: Sizes and default spacing',
+      Example: ({ id, handler }) => (
+        <Stack space="large">
+          {textSizes.map((size) => (
+            <Text size={size} key={size}>
+              Inline disclosure in{' '}
+              <Disclosure
+                id={`${id}_${size}`}
+                expandLabel={`${size} size`}
+                expanded={true}
+                onToggle={handler}
+              >
+                Defaults to {size} text size
+              </Disclosure>
+            </Text>
+          ))}
+        </Stack>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.snippets.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { Snippets } from '../private/Snippets';
-import { Disclosure, Stack, Text } from '../../playroom/components';
+import { Disclosure, Text } from '../../playroom/components';
 import source from '@braid-design-system/source.macro';
 
 export const snippets: Snippets = [
@@ -8,9 +8,7 @@ export const snippets: Snippets = [
     name: 'Standard',
     code: source(
       <Disclosure expandLabel="Show" collapseLabel="Hide">
-        <Stack space="large">
-          <Text>Content</Text>
-        </Stack>
+        <Text>Content</Text>
       </Disclosure>,
     ),
   },

--- a/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.tsx
+++ b/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.tsx
@@ -86,8 +86,8 @@ export const Disclosure = ({
   const size = sizeProp ?? textContext?.size ?? 'standard';
   const defaultSpace = isInline
     ? /*
-       * If inline, only use `xxsmall` as the space between the trigger
-       * and the content will include the line height of the text
+       * If inline, only use `xxsmall` space between the trigger and the content
+       * to compensate for the additional space created by the line height of text.
        */
       'xxsmall'
     : defaultSpaceForSize[size];

--- a/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.tsx
+++ b/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.tsx
@@ -66,7 +66,7 @@ export const Disclosure = ({
 
   assert(
     typeof sizeProp === 'undefined' || !isInline,
-    `Specifying a custom \`size\` for an \`Disclosure\` inside the context of a \`<${
+    `Specifying a custom \`size\` for a \`Disclosure\` inside the context of a \`<${
       textContext ? 'Text' : 'Heading'
     }>\` component is invalid. See the documentation for correct usage: https://seek-oss.github.io/braid-design-system/components/Disclosure`,
   );

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -2952,6 +2952,11 @@ exports[`Disclosure 1`] = `
     expanded?: boolean
     id: string
     onToggle?: (expanded: boolean) => void
+    size?: 
+        | "large"
+        | "small"
+        | "standard"
+        | "xsmall"
     space?: 
         | "gutter"
         | "large"


### PR DESCRIPTION
Introduce the `size` prop to the `Disclosure` component, providing the same options as the `Text` component.

**EXAMPLE USAGE:**
```jsx
<Disclosure
  size="small"
>
  ...
</Disclosure>
```