### PR TITLE
playroom: Fix Stack and Inline `component` prop

### DIFF
--- a/packages/braid-design-system/src/lib/components/Inline/Inline.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/Inline/Inline.playroom.tsx
@@ -2,13 +2,7 @@ import React from 'react';
 import { cleanSpaceValue } from '../../playroom/cleanSpaceValue';
 import { type InlineProps, Inline as BraidInline } from './Inline';
 
-export const Inline = ({
-  space,
-  align,
-  alignY,
-  component,
-  ...restProps
-}: InlineProps) => (
+export const Inline = ({ space, align, alignY, ...restProps }: InlineProps) => (
   <BraidInline
     space={cleanSpaceValue(space) || 'none'}
     align={typeof align !== 'boolean' ? align : undefined}

--- a/packages/braid-design-system/src/lib/components/Stack/Stack.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/Stack/Stack.playroom.tsx
@@ -2,12 +2,7 @@ import React from 'react';
 import { cleanSpaceValue } from '../../playroom/cleanSpaceValue';
 import { type StackProps, Stack as BraidStack } from './Stack';
 
-export const Stack = ({
-  space,
-  align,
-  component,
-  ...restProps
-}: StackProps) => (
+export const Stack = ({ space, align, ...restProps }: StackProps) => (
   <BraidStack
     space={cleanSpaceValue(space) || 'none'}
     align={typeof align !== 'boolean' ? align : undefined}


### PR DESCRIPTION
Missed this when we removed the `component` validation, and by destructuring it we would never set the right component in Playroom (most notably, list items would always have the default style)