### PR TITLE
Autosuggest: Ensure dropdown content is left aligned

### DIFF
--- a/.changeset/yellow-frogs-wait.md
+++ b/.changeset/yellow-frogs-wait.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Autosuggest
+---
+
+**Autosuggest**: Ensure content is left aligned
+
+Applies left alignment to `Autosuggest` dropdown content to ensure consistent alignment, even when inside centered layout containers.

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.tsx
@@ -766,6 +766,7 @@ export const Autosuggest = forwardRef(function <Value>(
                 {/* MenuRef gets forwarded down to UL by RemoveScroll by `forwardProps`. */}
                 <RemoveScroll ref={menuRef} enabled={isOpen} forwardProps>
                   <Box
+                    textAlign="left"
                     component="ul"
                     display={isOpen ? 'block' : 'none'}
                     position="absolute"


### PR DESCRIPTION
Applies left alignment to `Autosuggest` dropdown content to ensure consistent alignment, even when inside centered layout containers.