### PR TITLE
site: Improve definition of preview path, fix double slash on root

### DIFF
--- a/.github/workflows/preview-site.yml
+++ b/.github/workflows/preview-site.yml
@@ -11,6 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI: true
+      SITE_PREVIEW_PATH: preview/${{ github.sha }}
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -37,7 +38,7 @@ jobs:
       - name: Build
         run: pnpm build:site
         env:
-          BASE_NAME: /braid-design-system/preview/${{ github.sha }}
+          BASE_NAME: /braid-design-system/${{ env.SITE_PREVIEW_PATH }}
           BRANCH_NAME: ${{ github.ref_name }}
           HEAD_BRANCH_NAME: ${{ github.head_ref }}
 
@@ -46,11 +47,11 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           folder: ./site/dist
-          target-folder: preview/${{ github.sha }}
+          target-folder: ${{ env.SITE_PREVIEW_PATH }}
           commit-message: Preview of `${{ github.ref_name }}`
 
       - name: Update PR status
         run: pnpm post-commit-status
         env:
-          BASE_NAME: /braid-design-system/preview/${{ github.sha }}
+          BASE_NAME: /braid-design-system/${{ env.SITE_PREVIEW_PATH }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/site/src/App/Navigation/Navigation.tsx
+++ b/site/src/App/Navigation/Navigation.tsx
@@ -105,9 +105,7 @@ const PreviewBranchPanel = () => {
             )}
           >
             <MenuItemLink
-              href={`https://seek-oss.github.io/braid-design-system${pathname}${
-                !pathname.endsWith('/') ? '/' : ''
-              }${hash}`}
+              href={`https://seek-oss.github.io/braid-design-system${pathname}${hash}`}
               target="_blank"
               icon={<IconNewWindow />}
             >

--- a/site/src/App/Navigation/Navigation.tsx
+++ b/site/src/App/Navigation/Navigation.tsx
@@ -105,7 +105,9 @@ const PreviewBranchPanel = () => {
             )}
           >
             <MenuItemLink
-              href={`https://seek-oss.github.io/braid-design-system${pathname}/${hash}`}
+              href={`https://seek-oss.github.io/braid-design-system${pathname}${
+                !pathname.endsWith('/') ? '/' : ''
+              }${hash}`}
               target="_blank"
               icon={<IconNewWindow />}
             >


### PR DESCRIPTION
Centralising the definition of the preview path for deployments to a single env var. This makes it easier to update the path once centrally (e.g. the custom grad-connection site we maintain).

Also fixing a double slash on the production site link when on the root page.