### PR TITLE
Preserve preview sites on master release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -50,3 +50,8 @@ jobs:
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           folder: ./site/dist
+          # Preserve the preview deployment folder and custom grad-connection site
+          clean-exclude: |
+            preview/*
+            grad-connection/*
+          single-commit: true


### PR DESCRIPTION
Whitelisting the `preview` (and `grad-connection`) folders to prevent the release of the docs site from cleaning the output directory and blowing them away.

Also opting into `single-commit` as an optimisation as we have no need to git history on the `gh-pages` branch.