### PR TITLE
OverflowMenu: fix layout issue

### DIFF
--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.css.ts
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.css.ts
@@ -2,5 +2,4 @@ import { style } from '@vanilla-extract/css';
 
 export const wrapperPositioning = style({
   margin: '-1px -6px',
-  width: 'fit-content',
 });

--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.css.ts
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.css.ts
@@ -3,5 +3,4 @@ import { style } from '@vanilla-extract/css';
 export const wrapperPositioning = style({
   margin: '-1px -6px',
   width: 'fit-content',
-  justifySelf: 'flex-end',
 });

--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.tsx
@@ -20,26 +20,28 @@ export const OverflowMenu = ({
   id,
   ...menuProps
 }: OverflowMenuProps) => (
-  <Box display="flex" justifyContent="flexEnd">
-    <Box className={styles.wrapperPositioning}>
-      <MenuRenderer
-        trigger={(triggerProps) => (
-          <ButtonIcon
-            // @ts-expect-error With no id, ButtonIcon will fallback from Tooltip to title internally.
-            // ID will no longer be required when React 18 has sufficient adoption and we can safely `useId()`
-            id={id}
-            icon={<IconOverflow />}
-            variant="transparent"
-            label={label}
-            {...triggerProps}
-          />
-        )}
-        align="right"
-        offsetSpace="small"
-        {...menuProps}
-      >
-        {children}
-      </MenuRenderer>
-    </Box>
+  <Box
+    className={styles.wrapperPositioning}
+    display="flex"
+    justifyContent="flexEnd"
+  >
+    <MenuRenderer
+      trigger={(triggerProps) => (
+        <ButtonIcon
+          // @ts-expect-error With no id, ButtonIcon will fallback from Tooltip to title internally.
+          // ID will no longer be required when React 18 has sufficient adoption and we can safely `useId()`
+          id={id}
+          icon={<IconOverflow />}
+          variant="transparent"
+          label={label}
+          {...triggerProps}
+        />
+      )}
+      align="right"
+      offsetSpace="small"
+      {...menuProps}
+    >
+      {children}
+    </MenuRenderer>
   </Box>
 );

--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.tsx
@@ -20,24 +20,26 @@ export const OverflowMenu = ({
   id,
   ...menuProps
 }: OverflowMenuProps) => (
-  <Box display="flex" className={styles.wrapperPositioning}>
-    <MenuRenderer
-      trigger={(triggerProps) => (
-        <ButtonIcon
-          // @ts-expect-error With no id, ButtonIcon will fallback from Tooltip to title internally.
-          // ID will no longer be required when React 18 has sufficient adoption and we can safely `useId()`
-          id={id}
-          icon={<IconOverflow />}
-          variant="transparent"
-          label={label}
-          {...triggerProps}
-        />
-      )}
-      align="right"
-      offsetSpace="small"
-      {...menuProps}
-    >
-      {children}
-    </MenuRenderer>
+  <Box display="flex" justifyContent="flexEnd">
+    <Box className={styles.wrapperPositioning}>
+      <MenuRenderer
+        trigger={(triggerProps) => (
+          <ButtonIcon
+            // @ts-expect-error With no id, ButtonIcon will fallback from Tooltip to title internally.
+            // ID will no longer be required when React 18 has sufficient adoption and we can safely `useId()`
+            id={id}
+            icon={<IconOverflow />}
+            variant="transparent"
+            label={label}
+            {...triggerProps}
+          />
+        )}
+        align="right"
+        offsetSpace="small"
+        {...menuProps}
+      >
+        {children}
+      </MenuRenderer>
+    </Box>
   </Box>
 );


### PR DESCRIPTION
https://github.com/seek-oss/braid-design-system/pull/1658 introduced `justifySelf: 'flex-end'` on `OverflowMenu` to simplify its internal structure and ensure it would right align in its parent container regardless of the display property used.

It looks like `justifySelf` for block level boxes is only supported in [Chrome 130+](https://chromium-review.googlesource.com/c/chromium/src/+/5838707). Setting `display="flex"` appears to make no difference.

This [Playroom](https://seek-oss.github.io/braid-design-system/playroom/#?code=N4Igxg9gJgpiBcIA8AhCAPABFAlgZwAcAbAQwE8BeAHRADMiZ0bM8AXMhi4YTAKwFc2OWmQDKMIrXiYa9RgFoYAOyjMAvmoB8VJZkxIAKo1abRrEipIAnKJlbGkAeiPoTOp2nTalIADQhWAAsYAFsYPAQAbRA8GBgAawApCAAjCIBdfwB3HCggiPhIgHYANgAOdLUgA) will currently right align the content in Chromium browsers with version 130+ but not Safari or Firefox.

This change reintroduces a wrapper Box to ensure right alignment and no breaking change. It can be revisted in the future for a possible more elegant solution.

No changeset added because the change hasn't been published.