### PR TITLE
MenuRenderer, OverflowMenu: Ensure menus work in Modal components

### DIFF
--- a/.changeset/tender-olives-sell.md
+++ b/.changeset/tender-olives-sell.md
@@ -1,0 +1,11 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - MenuRenderer
+  - OverflowMenu
+---
+
+**MenuRenderer, OverflowMenu:** Fixes a bug where menus could be obscured when rendered inside a `Dialog` or `Drawer` component.

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
@@ -363,7 +363,7 @@ export const MenuRenderer = ({
               dispatch({ type: BACKDROP_CLICK });
             }}
             position="fixed"
-            zIndex="dropdownBackdrop"
+            zIndex="modal"
             top={0}
             left={0}
             className={styles.backdrop}
@@ -423,7 +423,7 @@ export function Menu({
       <Box
         role="menu"
         position={position}
-        zIndex="dropdown"
+        zIndex="modal"
         boxShadow={placement === 'top' ? 'small' : 'medium'}
         borderRadius={borderRadius}
         background="surface"


### PR DESCRIPTION
Fixes a bug where menus could be obscured when rendered inside a `Dialog` or `Drawer` component.

`MenuRenderer` and Modals are both in separate Braid portals, which are in the same stacking context. Hence, their `zIndex` values are compared. `MenuRenderer` previously had a lower `zIndex` value than Modals, and hence if one was used in a `Model` it would be stacked incorrectly. As they now have the same `zIndex` value, the element later in the DOM is stacked above, which works correctly for `Menus` in and out of `Modals`.

In this solution, the `zIndex` value for `MenuRenderer` is not semantically accurate. This should likely be revisited in the future to address this issue.