### PR TITLE
Tiles: Prevent hydration error

### DIFF
--- a/.changeset/clever-seahorses-yell.md
+++ b/.changeset/clever-seahorses-yell.md
@@ -1,0 +1,10 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Tiles
+---
+
+**Tiles**: Optimise layout implementation to prevent hydration error.

--- a/.changeset/clever-seahorses-yell.md
+++ b/.changeset/clever-seahorses-yell.md
@@ -7,4 +7,7 @@ updated:
   - Tiles
 ---
 
-**Tiles**: Optimise layout implementation to prevent hydration error.
+**Tiles**: Fixes a bug where nested `Tiles` components could calculate their columns incorrectly.
+
+Previously, when using a `Tiles` component inside another `Tiles` component, the responsive column calculation could be incorrect in certain scenarios. 
+This change ensures nested `Tiles` elements always calculate their columns correctly.

--- a/packages/braid-design-system/src/lib/components/Tiles/Tiles.css.ts
+++ b/packages/braid-design-system/src/lib/components/Tiles/Tiles.css.ts
@@ -1,9 +1,4 @@
-import {
-  createVar,
-  fallbackVar,
-  globalStyle,
-  style,
-} from '@vanilla-extract/css';
+import { createVar, globalStyle, style } from '@vanilla-extract/css';
 import { responsiveStyle } from '../../css/responsiveStyle';
 
 const columns = createVar();
@@ -25,26 +20,17 @@ export const tiles = style([
     },
     tablet: {
       vars: {
-        [columns]: fallbackVar(tabletColumnsVar, mobileColumnsVar),
+        [columns]: tabletColumnsVar,
       },
     },
     desktop: {
       vars: {
-        [columns]: fallbackVar(
-          desktopColumnsVar,
-          tabletColumnsVar,
-          mobileColumnsVar,
-        ),
+        [columns]: desktopColumnsVar,
       },
     },
     wide: {
       vars: {
-        [columns]: fallbackVar(
-          wideColumnsVar,
-          desktopColumnsVar,
-          tabletColumnsVar,
-          mobileColumnsVar,
-        ),
+        [columns]: wideColumnsVar,
       },
     },
   }),

--- a/packages/braid-design-system/src/lib/components/Tiles/Tiles.tsx
+++ b/packages/braid-design-system/src/lib/components/Tiles/Tiles.tsx
@@ -26,19 +26,11 @@ export const Tiles = ({
   data,
   ...restProps
 }: TilesProps) => {
-  /**
-   * Defaulting the normalised column values to empty strings so that when
-   * parsed to strings for `assignInlineVars`, they are correctly omitted
-   * from the style attribute when not defined.
-   *
-   * Without this, `undefined` would be parsed to the string "undefined",
-   * requiring additional logic to omit them manually from the style attribute.
-   */
   const {
-    mobile: mobileColumns = '',
-    tablet: tabletColumns = '',
-    desktop: desktopColumns = '',
-    wide: wideColumns = '',
+    mobile: mobileColumns = '1',
+    tablet: tabletColumns = mobileColumns,
+    desktop: desktopColumns = tabletColumns,
+    wide: wideColumns = desktopColumns,
   } = normalizeResponsiveValue(columns);
 
   return (
@@ -46,10 +38,10 @@ export const Tiles = ({
       gap={space}
       className={styles.tiles}
       style={assignInlineVars({
-        [styles.mobileColumnsVar]: String(mobileColumns) || undefined,
-        [styles.tabletColumnsVar]: String(tabletColumns) || undefined,
-        [styles.desktopColumnsVar]: String(desktopColumns) || undefined,
-        [styles.wideColumnsVar]: String(wideColumns) || undefined,
+        [styles.mobileColumnsVar]: String(mobileColumns),
+        [styles.tabletColumnsVar]: String(tabletColumns),
+        [styles.desktopColumnsVar]: String(desktopColumns),
+        [styles.wideColumnsVar]: String(wideColumns),
       })}
       {...buildDataAttributes({ data, validateRestProps: restProps })}
     >

--- a/packages/braid-design-system/src/lib/components/Tiles/Tiles.tsx
+++ b/packages/braid-design-system/src/lib/components/Tiles/Tiles.tsx
@@ -26,12 +26,13 @@ export const Tiles = ({
   data,
   ...restProps
 }: TilesProps) => {
+  const normalizedResponsiveColumns = normalizeResponsiveValue(columns);
   const {
     mobile: mobileColumns = '1',
     tablet: tabletColumns = mobileColumns,
     desktop: desktopColumns = tabletColumns,
     wide: wideColumns = desktopColumns,
-  } = normalizeResponsiveValue(columns);
+  } = normalizedResponsiveColumns;
 
   return (
     <Box

--- a/packages/braid-design-system/src/lib/components/Tiles/Tiles.tsx
+++ b/packages/braid-design-system/src/lib/components/Tiles/Tiles.tsx
@@ -46,10 +46,10 @@ export const Tiles = ({
       gap={space}
       className={styles.tiles}
       style={assignInlineVars({
-        [styles.mobileColumnsVar]: String(mobileColumns),
-        [styles.tabletColumnsVar]: String(tabletColumns),
-        [styles.desktopColumnsVar]: String(desktopColumns),
-        [styles.wideColumnsVar]: String(wideColumns),
+        [styles.mobileColumnsVar]: String(mobileColumns) || undefined,
+        [styles.tabletColumnsVar]: String(tabletColumns) || undefined,
+        [styles.desktopColumnsVar]: String(desktopColumns) || undefined,
+        [styles.wideColumnsVar]: String(wideColumns) || undefined,
       })}
       {...buildDataAttributes({ data, validateRestProps: restProps })}
     >


### PR DESCRIPTION
Optimise layout implementation to prevent hydration error.

The hydration error was:
```
Warning: Prop `style` did not match.
Server: "--mobileColumnsVar__3trpbp1:3"
Client: "--mobileColumnsVar__3trpbp1:3;--tabletColumnsVar__3trpbp2:;--desktopColumnsVar__3trpbp3:;--wideColumnsVar__3trpbp4:" Error Component Stack
```

This meant that on the client, setting a CSS var to an empty string did not result it in being omitted from the inline style (but strangely not on the server 🤔).

This change sets the var to undefined instead of empty string (when it is not explicitly set), which ensures it is always omitted from the inline style, preventing the hydration error.

Edit: This change now always sets explicit column values at different breakpoints to ensure nested `Tiles` with responsive columns work as expected.