### PR TITLE
Button, ButtonLink: Ensure inner label is full width

### DIFF
--- a/.changeset/four-cups-live.md
+++ b/.changeset/four-cups-live.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Button
+  - ButtonLink
+---
+
+**Button, ButtonLink:** Ensure inner label is full width
+
+Ensuring the inner label element is full width to maintain backwards compatibility with previous block layout.

--- a/packages/braid-design-system/src/lib/components/Button/Button.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.screenshots.tsx
@@ -518,5 +518,34 @@ export const screenshots: ComponentScreenshot = {
         </Stack>
       ),
     },
+    {
+      label:
+        'Ensure inner label element is full width (red dots should touch horizontal edges)',
+      Example: () => (
+        <Button>
+          <Box position="absolute" left={0}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              height={24}
+              width={24}
+            >
+              <circle cx="12" cy="12" r="10" fill="red" />
+            </svg>
+          </Box>
+          <Box position="absolute" right={0}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              height={24}
+              width={24}
+            >
+              <circle cx="12" cy="12" r="10" fill="red" />
+            </svg>
+          </Box>
+          Label
+        </Button>
+      ),
+    },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/Button/Button.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.tsx
@@ -361,6 +361,7 @@ export const ButtonText = ({
       position="relative"
       display="flex"
       justifyContent="center"
+      flexGrow={1}
       flexWrap="wrap"
       overflow="hidden"
       pointerEvents="none"

--- a/packages/braid-design-system/src/lib/components/ButtonLink/ButtonLink.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonLink/ButtonLink.screenshots.tsx
@@ -325,5 +325,34 @@ export const screenshots: ComponentScreenshot = {
         </Stack>
       ),
     },
+    {
+      label:
+        'Ensure inner label element is full width (red dots should touch horizontal edges)',
+      Example: () => (
+        <ButtonLink href="#">
+          <Box position="absolute" left={0}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              height={24}
+              width={24}
+            >
+              <circle cx="12" cy="12" r="10" fill="red" />
+            </svg>
+          </Box>
+          <Box position="absolute" right={0}>
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              viewBox="0 0 24 24"
+              height={24}
+              width={24}
+            >
+              <circle cx="12" cy="12" r="10" fill="red" />
+            </svg>
+          </Box>
+          Label
+        </ButtonLink>
+      ),
+    },
   ],
 };


### PR DESCRIPTION
Ensuring the inner label element is full width to maintain backwards compatibility with previous block layout.