### PR TITLE
Columns: Ensure component occupies available height

### DIFF
--- a/.changeset/orange-kiwis-laugh.md
+++ b/.changeset/orange-kiwis-laugh.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Columns
+---
+
+**Columns:** Ensure component occupies available height
+
+Enables `Columns` content to occupy the available height of the parent container.

--- a/packages/braid-design-system/src/lib/components/Columns/Columns.tsx
+++ b/packages/braid-design-system/src/lib/components/Columns/Columns.tsx
@@ -65,6 +65,7 @@ export const Columns = ({
     <Box
       component={component}
       {...collapsibleAlignmentProps}
+      height="full"
       className={negativeMargin('left', {
         mobile: collapseMobile ? 'none' : mobileSpace,
         tablet: collapseTablet ? 'none' : tabletSpace,


### PR DESCRIPTION
Enables `Columns` content to occupy the available height of the parent container.