### PR TITLE
Accordion, AccordionItem: improve default space values

### DIFF
--- a/.changeset/tidy-cooks-fly.md
+++ b/.changeset/tidy-cooks-fly.md
@@ -1,0 +1,10 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - AccordionItem
+---
+
+**AccordionItem**: Simplify internal layout.

--- a/.changeset/wise-guests-bow.md
+++ b/.changeset/wise-guests-bow.md
@@ -8,9 +8,9 @@ updated:
   - AccordionItem
 ---
 
-**Accordion, AccordionItem**: Improve default spacing values and simplify internal layout.
+**Accordion, AccordionItem**: Adjust spacing values for improved visual balance.
 
-This change reduces the default spacing within `Accordion` and `AccordionItem` components at certain sizes to improve its visual balance, ensuring the content is better associated with the correct `AccordionItem`.
+This change reduces the default spacing within `Accordion` and `AccordionItem` components at certain sizes, ensuring the content is better associated with the correct `AccordionItem`.
 
 Within the `Accordion` component, the default space between `AccordionItem` components has been reduced for size `large` with dividers, and sizes `small` and `xsmall` without dividers.
 Within the `AccordionItem` component, the space between the `label` and content has been reduced for sizes `large` and `small`.

--- a/.changeset/wise-guests-bow.md
+++ b/.changeset/wise-guests-bow.md
@@ -1,0 +1,16 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Accordion
+  - AccordionItem
+---
+
+**Accordion, AccordionItem**: Improve default spacing values and simplify internal layout.
+
+This change reduces the default spacing within `Accordion` and `AccordionItem` components at certain sizes to improve its visual balance, ensuring the content is better associated with the correct `AccordionItem`.
+
+Within the `Accordion` component, the default space between `AccordionItem` components has been reduced for size `large` with dividers, and sizes `small` and `xsmall` without dividers.
+Within the `AccordionItem` component, the space between the `label` and content has been reduced for sizes `large` and `small`.

--- a/packages/braid-design-system/src/lib/components/Accordion/Accordion.tsx
+++ b/packages/braid-design-system/src/lib/components/Accordion/Accordion.tsx
@@ -13,10 +13,10 @@ import { Divider } from '../Divider/Divider';
 import {
   type AccordionContextValue,
   AccordionContext,
-  type validSizeValues,
   validTones,
 } from './AccordionContext';
 import flattenChildren from '../../utils/flattenChildren';
+import type { TextProps } from '../Text/Text';
 
 export const validSpaceValues = ['medium', 'large', 'xlarge'] as const;
 
@@ -47,7 +47,7 @@ const defaultSpaceForSize = {
   },
 } satisfies Record<
   'divided' | 'undivided',
-  Record<NonNullable<validSizeValues>, (typeof validSpaceValues)[number]>
+  Record<NonNullable<TextProps['size']>, (typeof validSpaceValues)[number]>
 >;
 
 export const Accordion = ({

--- a/packages/braid-design-system/src/lib/components/Accordion/Accordion.tsx
+++ b/packages/braid-design-system/src/lib/components/Accordion/Accordion.tsx
@@ -13,6 +13,7 @@ import { Divider } from '../Divider/Divider';
 import {
   type AccordionContextValue,
   AccordionContext,
+  type validSizeValues,
   validTones,
 } from './AccordionContext';
 import flattenChildren from '../../utils/flattenChildren';
@@ -29,24 +30,29 @@ export interface AccordionProps {
   data?: DataAttributeMap;
 }
 
+export const defaultSize = 'large';
+
 const defaultSpaceForSize = {
   divided: {
     xsmall: 'medium',
     small: 'medium',
     standard: 'medium',
-    large: 'large',
+    large: 'medium',
   },
   undivided: {
-    xsmall: 'large',
-    small: 'large',
+    xsmall: 'medium',
+    small: 'medium',
     standard: 'large',
     large: 'large',
   },
-} as const;
+} satisfies Record<
+  'divided' | 'undivided',
+  Record<NonNullable<validSizeValues>, (typeof validSpaceValues)[number]>
+>;
 
 export const Accordion = ({
   children,
-  size = 'large',
+  size = defaultSize,
   tone,
   weight,
   space: spaceProp,

--- a/packages/braid-design-system/src/lib/components/Accordion/AccordionContext.ts
+++ b/packages/braid-design-system/src/lib/components/Accordion/AccordionContext.ts
@@ -1,10 +1,11 @@
 import { createContext } from 'react';
 import type { TextProps } from '../Text/Text';
 
+export type validSizeValues = TextProps['size'];
 export const validTones = ['neutral', 'secondary'] as const;
 
 export interface AccordionContextValue {
-  size?: TextProps['size'];
+  size?: validSizeValues;
   tone?: (typeof validTones)[number];
   weight?: TextProps['weight'];
 }

--- a/packages/braid-design-system/src/lib/components/Accordion/AccordionContext.ts
+++ b/packages/braid-design-system/src/lib/components/Accordion/AccordionContext.ts
@@ -1,11 +1,10 @@
 import { createContext } from 'react';
 import type { TextProps } from '../Text/Text';
 
-export type validSizeValues = TextProps['size'];
 export const validTones = ['neutral', 'secondary'] as const;
 
 export interface AccordionContextValue {
-  size?: validSizeValues;
+  size?: TextProps['size'];
   tone?: (typeof validTones)[number];
   weight?: TextProps['weight'];
 }

--- a/packages/braid-design-system/src/lib/components/Accordion/AccordionItem.tsx
+++ b/packages/braid-design-system/src/lib/components/Accordion/AccordionItem.tsx
@@ -7,8 +7,6 @@ import React, {
 import assert from 'assert';
 import { Box } from '../Box/Box';
 import { type TextProps, Text } from '../Text/Text';
-import { Columns } from '../Columns/Columns';
-import { Column } from '../Column/Column';
 import type { BadgeProps } from '../Badge/Badge';
 import { IconChevron } from '../icons';
 import {
@@ -29,12 +27,14 @@ import buildDataAttributes, {
 } from '../private/buildDataAttributes';
 import { badgeSlotSpace } from '../private/badgeSlotSpace';
 import * as styles from './AccordionItem.css';
+import { Spread } from '../Spread/Spread';
+import { defaultSize } from './Accordion';
 
 const itemSpaceForSize = {
   xsmall: 'small',
-  small: 'medium',
+  small: 'small',
   standard: 'medium',
-  large: 'large',
+  large: 'medium',
 } as const;
 
 export interface AccordionItemBaseProps {
@@ -101,7 +101,7 @@ export const AccordionItem = ({
     "Icons cannot set the 'size' or 'tone' prop when passed to an AccordionItem component",
   );
 
-  const size = accordionContext?.size ?? sizeProp ?? 'large';
+  const size = accordionContext?.size ?? sizeProp ?? defaultSize;
   const tone = accordionContext?.tone ?? toneProp ?? 'neutral';
   const weight = accordionContext?.weight ?? weightProp ?? 'medium';
   const itemSpace = itemSpaceForSize[size] ?? 'none';
@@ -124,7 +124,12 @@ export const AccordionItem = ({
   });
 
   return (
-    <Box {...buildDataAttributes({ data, validateRestProps: restProps })}>
+    <Box
+      {...buildDataAttributes({ data, validateRestProps: restProps })}
+      display="flex"
+      flexDirection="column"
+      gap={itemSpace}
+    >
       <Box position="relative" display="flex">
         <Box
           component="button"
@@ -142,29 +147,25 @@ export const AccordionItem = ({
             https://stackoverflow.com/questions/41100273/overflowing-button-text-is-being-clipped-in-safari
           */}
           <Box component="span" position="relative">
-            <Columns component="span" space={itemSpace}>
-              <Column>
-                <Text size={size} weight={weight} tone={tone} icon={icon}>
-                  {badge ? (
-                    <Box component="span" paddingRight={badgeSlotSpace}>
-                      {label}
-                    </Box>
-                  ) : (
-                    label
-                  )}
-                  {badge ? cloneElement(badge, {}) : null}
-                </Text>
-              </Column>
-              <Column width="content">
-                <Text
-                  size={size}
-                  weight={weight}
-                  tone={tone === 'neutral' ? 'secondary' : tone}
-                >
-                  <IconChevron direction={expanded ? 'up' : 'down'} />
-                </Text>
-              </Column>
-            </Columns>
+            <Spread component="span" space={itemSpace}>
+              <Text size={size} weight={weight} tone={tone} icon={icon}>
+                {badge ? (
+                  <Box component="span" paddingRight={badgeSlotSpace}>
+                    {label}
+                  </Box>
+                ) : (
+                  label
+                )}
+                {badge ? cloneElement(badge, {}) : null}
+              </Text>
+              <Text
+                size={size}
+                weight={weight}
+                tone={tone === 'neutral' ? 'secondary' : tone}
+              >
+                <IconChevron direction={expanded ? 'up' : 'down'} />
+              </Text>
+            </Spread>
           </Box>
         </Box>
         <Overlay
@@ -174,11 +175,7 @@ export const AccordionItem = ({
           className={[styles.focusRing, hideFocusRingsClassName]}
         />
       </Box>
-      <Box
-        paddingTop={itemSpace}
-        display={expanded ? 'block' : 'none'}
-        {...contentProps}
-      >
+      <Box display={expanded ? 'block' : 'none'} {...contentProps}>
         {children}
       </Box>
     </Box>

--- a/packages/braid-design-system/src/lib/components/Accordion/AccordionItem.tsx
+++ b/packages/braid-design-system/src/lib/components/Accordion/AccordionItem.tsx
@@ -29,6 +29,7 @@ import { badgeSlotSpace } from '../private/badgeSlotSpace';
 import * as styles from './AccordionItem.css';
 import { Spread } from '../Spread/Spread';
 import { defaultSize } from './Accordion';
+import { Stack } from '../Stack/Stack';
 
 const itemSpaceForSize = {
   xsmall: 'small',
@@ -124,11 +125,9 @@ export const AccordionItem = ({
   });
 
   return (
-    <Box
+    <Stack
+      space={itemSpace}
       {...buildDataAttributes({ data, validateRestProps: restProps })}
-      display="flex"
-      flexDirection="column"
-      gap={itemSpace}
     >
       <Box position="relative" display="flex">
         <Box
@@ -178,6 +177,6 @@ export const AccordionItem = ({
       <Box display={expanded ? 'block' : 'none'} {...contentProps}>
         {children}
       </Box>
-    </Box>
+    </Stack>
   );
 };


### PR DESCRIPTION
Improve default spacing values and simplify internal layout.

This change reduces the default spacing within `Accordion` and `AccordionItem` components at certain sizes to improve its visual balance, ensuring the content is better associated with the correct `AccordionItem`.

Within the `Accordion` component, the default space between `AccordionItem` components has been reduced for size `large` with dividers, and sizes `small` and `xsmall` without dividers.
Within the `AccordionItem` component, the space between the `label` and content has been reduced for sizes `large` and `small`.