### PR TITLE
MenuRenderer, OverflowMenu: add `small` size

### DIFF
--- a/.changeset/wicked-dancers-end.md
+++ b/.changeset/wicked-dancers-end.md
@@ -1,0 +1,18 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - MenuRenderer
+---
+
+**MenuRenderer:** Add `small` size.
+
+Introduce a new `small` size for the `MenuRenderer` component.
+This is available via the `size` prop, which supports the existing `standard` (default) and `small`.
+
+**EXAMPLE USAGE:**
+```jsx
+<MenuRenderer size="small" ... />
+```

--- a/.changeset/wicked-dancers-end.md
+++ b/.changeset/wicked-dancers-end.md
@@ -5,11 +5,12 @@
 ---
 updated:
   - MenuRenderer
+  - OverflowMenu
 ---
 
-**MenuRenderer:** Add `small` size.
+**MenuRenderer, OverflowMenu:** Add `small` size.
 
-Introduce a new `small` size for the `MenuRenderer` component.
+Introduce a new `small` size for `MenuRenderer` and `OverflowMenu`.
 This is available via the `size` prop, which supports the existing `standard` (default) and `small`.
 
 **EXAMPLE USAGE:**

--- a/packages/braid-design-system/src/lib/components/Badge/Badge.tsx
+++ b/packages/braid-design-system/src/lib/components/Badge/Badge.tsx
@@ -10,6 +10,7 @@ import { DefaultTextPropsProvider } from '../private/defaultTextProps';
 import { TextContext } from '../Text/TextContext';
 import HeadingContext from '../Heading/HeadingContext';
 import * as styles from './Badge.css';
+import { useDefaultBadgeProps } from './defaultBadgeProps';
 
 type ValueOrArray<T> = T | T[];
 
@@ -61,7 +62,7 @@ export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
     {
       tone = 'info',
       weight = 'regular',
-      bleedY = false,
+      bleedY: bleedYProp,
       title,
       children,
       id,
@@ -87,6 +88,8 @@ export const Badge = forwardRef<HTMLSpanElement, BadgeProps>(
     const textContext = useContext(TextContext);
     const headingContext = useContext(HeadingContext);
     const isInline = Boolean(textContext || headingContext);
+
+    const { bleedY } = useDefaultBadgeProps({ bleedY: bleedYProp });
 
     assert(
       !isInline || (isInline && bleedY === false),

--- a/packages/braid-design-system/src/lib/components/Badge/defaultBadgeProps.tsx
+++ b/packages/braid-design-system/src/lib/components/Badge/defaultBadgeProps.tsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, useMemo, type ReactNode } from 'react';
+import type { BadgeProps } from './Badge';
+
+interface DefaultBadgeProps {
+  bleedY: BadgeProps['bleedY'];
+}
+
+const DefaultBadgePropsContext = createContext<DefaultBadgeProps>({
+  bleedY: undefined,
+});
+
+interface DefaultBadgePropsProviderProps extends DefaultBadgeProps {
+  children: ReactNode;
+}
+
+export const DefaultBadgePropsProvider = ({
+  bleedY,
+  children,
+}: DefaultBadgePropsProviderProps) => {
+  const defaultBadgeProps = useMemo(
+    () => ({
+      bleedY,
+    }),
+    [bleedY],
+  );
+
+  return (
+    <DefaultBadgePropsContext.Provider value={defaultBadgeProps}>
+      {children}
+    </DefaultBadgePropsContext.Provider>
+  );
+};
+
+export const useDefaultBadgeProps = ({
+  bleedY: bleedYProp,
+}: DefaultBadgeProps) => {
+  const { bleedY } = useContext(DefaultBadgePropsContext);
+
+  return {
+    bleedY: bleedYProp ?? bleedY ?? false,
+  };
+};

--- a/packages/braid-design-system/src/lib/components/MenuItem/MenuItem.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItem/MenuItem.screenshots.tsx
@@ -8,6 +8,7 @@ import {
   IconBookmark,
   IconStar,
   IconThumb,
+  Inline,
 } from '../';
 import { Menu } from '../MenuRenderer/MenuRenderer';
 
@@ -31,261 +32,528 @@ export const screenshots: ComponentScreenshot = {
     {
       label: 'Default',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps}>
-            <MenuItem onClick={() => {}}>Button</MenuItem>
-            <MenuItemLink href="#">Link</MenuItemLink>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps}>
+              <MenuItem onClick={() => {}}>Button</MenuItem>
+              <MenuItemLink href="#">Link</MenuItemLink>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} size="small">
+              <MenuItem onClick={() => {}}>Button</MenuItem>
+              <MenuItemLink href="#">Link</MenuItemLink>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Highlighted button',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={0}>
-            <MenuItem onClick={() => {}}>Button</MenuItem>
-            <MenuItemLink href="#">Link</MenuItemLink>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={0}>
+              <MenuItem onClick={() => {}}>Button</MenuItem>
+              <MenuItemLink href="#">Link</MenuItemLink>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={0} size="small">
+              <MenuItem onClick={() => {}}>Button</MenuItem>
+              <MenuItemLink href="#">Link</MenuItemLink>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Highlighted link',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={1}>
-            <MenuItem onClick={() => {}}>Button</MenuItem>
-            <MenuItemLink href="#">Link</MenuItemLink>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1}>
+              <MenuItem onClick={() => {}}>Button</MenuItem>
+              <MenuItemLink href="#">Link</MenuItemLink>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1} size="small">
+              <MenuItem onClick={() => {}}>Button</MenuItem>
+              <MenuItemLink href="#">Link</MenuItemLink>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Critical',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps}>
-            <MenuItem onClick={() => {}}>Default</MenuItem>
-            <MenuItem onClick={() => {}} tone="critical">
-              Button
-            </MenuItem>
-            <MenuItemLink href="#" tone="critical">
-              Link
-            </MenuItemLink>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps}>
+              <MenuItem onClick={() => {}}>Default</MenuItem>
+              <MenuItem onClick={() => {}} tone="critical">
+                Button
+              </MenuItem>
+              <MenuItemLink href="#" tone="critical">
+                Link
+              </MenuItemLink>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} size="small">
+              <MenuItem onClick={() => {}}>Default</MenuItem>
+              <MenuItem onClick={() => {}} tone="critical">
+                Button
+              </MenuItem>
+              <MenuItemLink href="#" tone="critical">
+                Link
+              </MenuItemLink>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Highlighted critical button',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={0}>
-            <MenuItem onClick={() => {}} tone="critical">
-              Button
-            </MenuItem>
-            <MenuItemLink href="#">Link</MenuItemLink>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={0}>
+              <MenuItem onClick={() => {}} tone="critical">
+                Button
+              </MenuItem>
+              <MenuItemLink href="#">Link</MenuItemLink>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={0} size="small">
+              <MenuItem onClick={() => {}} tone="critical">
+                Button
+              </MenuItem>
+              <MenuItemLink href="#">Link</MenuItemLink>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Highlighted critical link',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={1}>
-            <MenuItem onClick={() => {}}>Button</MenuItem>
-            <MenuItemLink href="#" tone="critical">
-              Link
-            </MenuItemLink>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1}>
+              <MenuItem onClick={() => {}}>Button</MenuItem>
+              <MenuItemLink href="#" tone="critical">
+                Link
+              </MenuItemLink>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1} size="small">
+              <MenuItem onClick={() => {}}>Button</MenuItem>
+              <MenuItemLink href="#" tone="critical">
+                Link
+              </MenuItemLink>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'With icon',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={1}>
-            <MenuItem onClick={() => {}} icon={<IconStar />}>
-              Button
-            </MenuItem>
-            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-              Button
-            </MenuItem>
-            <MenuItemLink href="#" icon={<IconThumb />}>
-              Link
-            </MenuItemLink>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1}>
+              <MenuItem onClick={() => {}} icon={<IconStar />}>
+                Button
+              </MenuItem>
+              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+                Button
+              </MenuItem>
+              <MenuItemLink href="#" icon={<IconThumb />}>
+                Link
+              </MenuItemLink>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1} size="small">
+              <MenuItem onClick={() => {}} icon={<IconStar />}>
+                Button
+              </MenuItem>
+              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+                Button
+              </MenuItem>
+              <MenuItemLink href="#" icon={<IconThumb />}>
+                Link
+              </MenuItemLink>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'With icon and reserving icon space',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={1} reserveIconSpace>
-            <MenuItem onClick={() => {}} icon={<IconStar />}>
-              Button
-            </MenuItem>
-            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-              Button
-            </MenuItem>
-            <MenuItemLink href="#">Link</MenuItemLink>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1} reserveIconSpace>
+              <MenuItem onClick={() => {}} icon={<IconStar />}>
+                Button
+              </MenuItem>
+              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+                Button
+              </MenuItem>
+              <MenuItemLink href="#">Link</MenuItemLink>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu
+              {...defaultProps}
+              highlightIndex={1}
+              reserveIconSpace
+              size="small"
+            >
+              <MenuItem onClick={() => {}} icon={<IconStar />}>
+                Button
+              </MenuItem>
+              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+                Button
+              </MenuItem>
+              <MenuItemLink href="#">Link</MenuItemLink>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'With icon and critical',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={1}>
-            <MenuItem onClick={() => {}} icon={<IconStar />}>
-              Button
-            </MenuItem>
-            <MenuItem
-              onClick={() => {}}
-              icon={<IconBookmark />}
-              tone="critical"
-            >
-              Button
-            </MenuItem>
-            <MenuItemLink href="#" icon={<IconThumb />} tone="critical">
-              Link
-            </MenuItemLink>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1}>
+              <MenuItem onClick={() => {}} icon={<IconStar />}>
+                Button
+              </MenuItem>
+              <MenuItem
+                onClick={() => {}}
+                icon={<IconBookmark />}
+                tone="critical"
+              >
+                Button
+              </MenuItem>
+              <MenuItemLink href="#" icon={<IconThumb />} tone="critical">
+                Link
+              </MenuItemLink>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1} size="small">
+              <MenuItem onClick={() => {}} icon={<IconStar />}>
+                Button
+              </MenuItem>
+              <MenuItem
+                onClick={() => {}}
+                icon={<IconBookmark />}
+                tone="critical"
+              >
+                Button
+              </MenuItem>
+              <MenuItemLink href="#" icon={<IconThumb />} tone="critical">
+                Link
+              </MenuItemLink>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'With badge',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={1}>
-            <MenuItem
-              onClick={() => {}}
-              badge={<Badge weight="strong">Badge</Badge>}
-            >
-              Button
-            </MenuItem>
-            <MenuItem
-              onClick={() => {}}
-              icon={<IconBookmark />}
-              badge={<Badge weight="strong">Badge</Badge>}
-            >
-              Button
-            </MenuItem>
-            <MenuItemLink
-              href="#"
-              icon={<IconThumb />}
-              badge={<Badge weight="strong">Badge</Badge>}
-            >
-              Link
-            </MenuItemLink>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1}>
+              <MenuItem
+                onClick={() => {}}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Button
+              </MenuItem>
+              <MenuItem
+                onClick={() => {}}
+                icon={<IconBookmark />}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Button
+              </MenuItem>
+              <MenuItemLink
+                href="#"
+                icon={<IconThumb />}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Link
+              </MenuItemLink>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1} size="small">
+              <MenuItem
+                onClick={() => {}}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Button
+              </MenuItem>
+              <MenuItem
+                onClick={() => {}}
+                icon={<IconBookmark />}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Button
+              </MenuItem>
+              <MenuItemLink
+                href="#"
+                icon={<IconThumb />}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Link
+              </MenuItemLink>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Overflow tests in content width menu (no truncation)',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={1} width="content">
-            <MenuItem onClick={() => {}}>
-              Really long menu item text that should truncate
-            </MenuItem>
-            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-              Really long menu item text that should truncate
-            </MenuItem>
-            <MenuItemLink href="#" badge={<Badge weight="strong">Badge</Badge>}>
-              Really long menu item text that should truncate
-            </MenuItemLink>
-            <MenuItemLink
-              href="#"
-              icon={<IconBookmark />}
-              badge={<Badge weight="strong">Badge</Badge>}
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1} width="content">
+              <MenuItem onClick={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItem>
+              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+                Really long menu item text that should truncate
+              </MenuItem>
+              <MenuItemLink
+                href="#"
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemLink>
+              <MenuItemLink
+                href="#"
+                icon={<IconBookmark />}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemLink>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu
+              {...defaultProps}
+              highlightIndex={1}
+              width="content"
+              size="small"
             >
-              Really long menu item text that should truncate
-            </MenuItemLink>
-          </Menu>
-        </Box>
+              <MenuItem onClick={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItem>
+              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+                Really long menu item text that should truncate
+              </MenuItem>
+              <MenuItemLink
+                href="#"
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemLink>
+              <MenuItemLink
+                href="#"
+                icon={<IconBookmark />}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemLink>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Overflow tests in small width menu',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={1} width="small">
-            <MenuItem onClick={() => {}}>
-              Really long menu item text that should truncate
-            </MenuItem>
-            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-              Really long menu item text that should truncate
-            </MenuItem>
-            <MenuItemLink href="#" badge={<Badge weight="strong">Badge</Badge>}>
-              Really long menu item text that should truncate
-            </MenuItemLink>
-            <MenuItemLink
-              href="#"
-              icon={<IconBookmark />}
-              badge={<Badge weight="strong">Badge</Badge>}
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1} width="small">
+              <MenuItem onClick={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItem>
+              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+                Really long menu item text that should truncate
+              </MenuItem>
+              <MenuItemLink
+                href="#"
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemLink>
+              <MenuItemLink
+                href="#"
+                icon={<IconBookmark />}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemLink>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu
+              {...defaultProps}
+              highlightIndex={1}
+              width="small"
+              size="small"
             >
-              Really long menu item text that should truncate
-            </MenuItemLink>
-          </Menu>
-        </Box>
+              <MenuItem onClick={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItem>
+              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+                Really long menu item text that should truncate
+              </MenuItem>
+              <MenuItemLink
+                href="#"
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemLink>
+              <MenuItemLink
+                href="#"
+                icon={<IconBookmark />}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemLink>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Overflow tests in medium width menu',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={1} width="medium">
-            <MenuItem onClick={() => {}}>
-              Really long menu item text that should truncate
-            </MenuItem>
-            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-              Really long menu item text that should truncate
-            </MenuItem>
-            <MenuItemLink href="#" badge={<Badge weight="strong">Badge</Badge>}>
-              Really long menu item text that should truncate
-            </MenuItemLink>
-            <MenuItemLink
-              href="#"
-              icon={<IconBookmark />}
-              badge={<Badge weight="strong">Badge</Badge>}
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1} width="medium">
+              <MenuItem onClick={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItem>
+              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+                Really long menu item text that should truncate
+              </MenuItem>
+              <MenuItemLink
+                href="#"
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemLink>
+              <MenuItemLink
+                href="#"
+                icon={<IconBookmark />}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemLink>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu
+              {...defaultProps}
+              highlightIndex={1}
+              width="medium"
+              size="small"
             >
-              Really long menu item text that should truncate
-            </MenuItemLink>
-          </Menu>
-        </Box>
+              <MenuItem onClick={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItem>
+              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+                Really long menu item text that should truncate
+              </MenuItem>
+              <MenuItemLink
+                href="#"
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemLink>
+              <MenuItemLink
+                href="#"
+                icon={<IconBookmark />}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemLink>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Overflow tests in large width menu',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={1} width="large">
-            <MenuItem onClick={() => {}}>
-              Really long menu item text that should truncate
-            </MenuItem>
-            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-              Really long menu item text that should truncate
-            </MenuItem>
-            <MenuItemLink href="#" badge={<Badge weight="strong">Badge</Badge>}>
-              Really long menu item text that should truncate
-            </MenuItemLink>
-            <MenuItemLink
-              href="#"
-              icon={<IconBookmark />}
-              badge={<Badge weight="strong">Badge</Badge>}
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1} width="large">
+              <MenuItem onClick={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItem>
+              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+                Really long menu item text that should truncate
+              </MenuItem>
+              <MenuItemLink
+                href="#"
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemLink>
+              <MenuItemLink
+                href="#"
+                icon={<IconBookmark />}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemLink>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu
+              {...defaultProps}
+              highlightIndex={1}
+              width="large"
+              size="small"
             >
-              Really long menu item text that should truncate
-            </MenuItemLink>
-          </Menu>
-        </Box>
+              <MenuItem onClick={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItem>
+              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+                Really long menu item text that should truncate
+              </MenuItem>
+              <MenuItemLink
+                href="#"
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemLink>
+              <MenuItemLink
+                href="#"
+                icon={<IconBookmark />}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemLink>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/MenuItem/MenuItem.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItem/MenuItem.screenshots.tsx
@@ -2,7 +2,6 @@ import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
 import {
   Badge,
-  Box,
   MenuItem,
   MenuItemLink,
   IconBookmark,
@@ -33,18 +32,14 @@ export const screenshots: ComponentScreenshot = {
       label: 'Default',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps}>
-              <MenuItem onClick={() => {}}>Button</MenuItem>
-              <MenuItemLink href="#">Link</MenuItemLink>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} size="small">
-              <MenuItem onClick={() => {}}>Button</MenuItem>
-              <MenuItemLink href="#">Link</MenuItemLink>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps}>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItemLink href="#">Link</MenuItemLink>
+          </Menu>
+          <Menu {...defaultProps} size="small">
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItemLink href="#">Link</MenuItemLink>
+          </Menu>
         </Inline>
       ),
     },
@@ -52,18 +47,14 @@ export const screenshots: ComponentScreenshot = {
       label: 'Highlighted button',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={0}>
-              <MenuItem onClick={() => {}}>Button</MenuItem>
-              <MenuItemLink href="#">Link</MenuItemLink>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={0} size="small">
-              <MenuItem onClick={() => {}}>Button</MenuItem>
-              <MenuItemLink href="#">Link</MenuItemLink>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps} highlightIndex={0}>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItemLink href="#">Link</MenuItemLink>
+          </Menu>
+          <Menu {...defaultProps} highlightIndex={0} size="small">
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItemLink href="#">Link</MenuItemLink>
+          </Menu>
         </Inline>
       ),
     },
@@ -71,18 +62,14 @@ export const screenshots: ComponentScreenshot = {
       label: 'Highlighted link',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1}>
-              <MenuItem onClick={() => {}}>Button</MenuItem>
-              <MenuItemLink href="#">Link</MenuItemLink>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1} size="small">
-              <MenuItem onClick={() => {}}>Button</MenuItem>
-              <MenuItemLink href="#">Link</MenuItemLink>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps} highlightIndex={1}>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItemLink href="#">Link</MenuItemLink>
+          </Menu>
+          <Menu {...defaultProps} highlightIndex={1} size="small">
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItemLink href="#">Link</MenuItemLink>
+          </Menu>
         </Inline>
       ),
     },
@@ -90,28 +77,24 @@ export const screenshots: ComponentScreenshot = {
       label: 'Critical',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps}>
-              <MenuItem onClick={() => {}}>Default</MenuItem>
-              <MenuItem onClick={() => {}} tone="critical">
-                Button
-              </MenuItem>
-              <MenuItemLink href="#" tone="critical">
-                Link
-              </MenuItemLink>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} size="small">
-              <MenuItem onClick={() => {}}>Default</MenuItem>
-              <MenuItem onClick={() => {}} tone="critical">
-                Button
-              </MenuItem>
-              <MenuItemLink href="#" tone="critical">
-                Link
-              </MenuItemLink>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps}>
+            <MenuItem onClick={() => {}}>Default</MenuItem>
+            <MenuItem onClick={() => {}} tone="critical">
+              Button
+            </MenuItem>
+            <MenuItemLink href="#" tone="critical">
+              Link
+            </MenuItemLink>
+          </Menu>
+          <Menu {...defaultProps} size="small">
+            <MenuItem onClick={() => {}}>Default</MenuItem>
+            <MenuItem onClick={() => {}} tone="critical">
+              Button
+            </MenuItem>
+            <MenuItemLink href="#" tone="critical">
+              Link
+            </MenuItemLink>
+          </Menu>
         </Inline>
       ),
     },
@@ -119,22 +102,18 @@ export const screenshots: ComponentScreenshot = {
       label: 'Highlighted critical button',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={0}>
-              <MenuItem onClick={() => {}} tone="critical">
-                Button
-              </MenuItem>
-              <MenuItemLink href="#">Link</MenuItemLink>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={0} size="small">
-              <MenuItem onClick={() => {}} tone="critical">
-                Button
-              </MenuItem>
-              <MenuItemLink href="#">Link</MenuItemLink>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps} highlightIndex={0}>
+            <MenuItem onClick={() => {}} tone="critical">
+              Button
+            </MenuItem>
+            <MenuItemLink href="#">Link</MenuItemLink>
+          </Menu>
+          <Menu {...defaultProps} highlightIndex={0} size="small">
+            <MenuItem onClick={() => {}} tone="critical">
+              Button
+            </MenuItem>
+            <MenuItemLink href="#">Link</MenuItemLink>
+          </Menu>
         </Inline>
       ),
     },
@@ -142,22 +121,18 @@ export const screenshots: ComponentScreenshot = {
       label: 'Highlighted critical link',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1}>
-              <MenuItem onClick={() => {}}>Button</MenuItem>
-              <MenuItemLink href="#" tone="critical">
-                Link
-              </MenuItemLink>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1} size="small">
-              <MenuItem onClick={() => {}}>Button</MenuItem>
-              <MenuItemLink href="#" tone="critical">
-                Link
-              </MenuItemLink>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps} highlightIndex={1}>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItemLink href="#" tone="critical">
+              Link
+            </MenuItemLink>
+          </Menu>
+          <Menu {...defaultProps} highlightIndex={1} size="small">
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItemLink href="#" tone="critical">
+              Link
+            </MenuItemLink>
+          </Menu>
         </Inline>
       ),
     },
@@ -165,32 +140,28 @@ export const screenshots: ComponentScreenshot = {
       label: 'With icon',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1}>
-              <MenuItem onClick={() => {}} icon={<IconStar />}>
-                Button
-              </MenuItem>
-              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-                Button
-              </MenuItem>
-              <MenuItemLink href="#" icon={<IconThumb />}>
-                Link
-              </MenuItemLink>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1} size="small">
-              <MenuItem onClick={() => {}} icon={<IconStar />}>
-                Button
-              </MenuItem>
-              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-                Button
-              </MenuItem>
-              <MenuItemLink href="#" icon={<IconThumb />}>
-                Link
-              </MenuItemLink>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps} highlightIndex={1}>
+            <MenuItem onClick={() => {}} icon={<IconStar />}>
+              Button
+            </MenuItem>
+            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+              Button
+            </MenuItem>
+            <MenuItemLink href="#" icon={<IconThumb />}>
+              Link
+            </MenuItemLink>
+          </Menu>
+          <Menu {...defaultProps} highlightIndex={1} size="small">
+            <MenuItem onClick={() => {}} icon={<IconStar />}>
+              Button
+            </MenuItem>
+            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+              Button
+            </MenuItem>
+            <MenuItemLink href="#" icon={<IconThumb />}>
+              Link
+            </MenuItemLink>
+          </Menu>
         </Inline>
       ),
     },
@@ -198,33 +169,29 @@ export const screenshots: ComponentScreenshot = {
       label: 'With icon and reserving icon space',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1} reserveIconSpace>
-              <MenuItem onClick={() => {}} icon={<IconStar />}>
-                Button
-              </MenuItem>
-              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-                Button
-              </MenuItem>
-              <MenuItemLink href="#">Link</MenuItemLink>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu
-              {...defaultProps}
-              highlightIndex={1}
-              reserveIconSpace
-              size="small"
-            >
-              <MenuItem onClick={() => {}} icon={<IconStar />}>
-                Button
-              </MenuItem>
-              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-                Button
-              </MenuItem>
-              <MenuItemLink href="#">Link</MenuItemLink>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps} highlightIndex={1} reserveIconSpace>
+            <MenuItem onClick={() => {}} icon={<IconStar />}>
+              Button
+            </MenuItem>
+            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+              Button
+            </MenuItem>
+            <MenuItemLink href="#">Link</MenuItemLink>
+          </Menu>
+          <Menu
+            {...defaultProps}
+            highlightIndex={1}
+            reserveIconSpace
+            size="small"
+          >
+            <MenuItem onClick={() => {}} icon={<IconStar />}>
+              Button
+            </MenuItem>
+            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+              Button
+            </MenuItem>
+            <MenuItemLink href="#">Link</MenuItemLink>
+          </Menu>
         </Inline>
       ),
     },
@@ -232,40 +199,36 @@ export const screenshots: ComponentScreenshot = {
       label: 'With icon and critical',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1}>
-              <MenuItem onClick={() => {}} icon={<IconStar />}>
-                Button
-              </MenuItem>
-              <MenuItem
-                onClick={() => {}}
-                icon={<IconBookmark />}
-                tone="critical"
-              >
-                Button
-              </MenuItem>
-              <MenuItemLink href="#" icon={<IconThumb />} tone="critical">
-                Link
-              </MenuItemLink>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1} size="small">
-              <MenuItem onClick={() => {}} icon={<IconStar />}>
-                Button
-              </MenuItem>
-              <MenuItem
-                onClick={() => {}}
-                icon={<IconBookmark />}
-                tone="critical"
-              >
-                Button
-              </MenuItem>
-              <MenuItemLink href="#" icon={<IconThumb />} tone="critical">
-                Link
-              </MenuItemLink>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps} highlightIndex={1}>
+            <MenuItem onClick={() => {}} icon={<IconStar />}>
+              Button
+            </MenuItem>
+            <MenuItem
+              onClick={() => {}}
+              icon={<IconBookmark />}
+              tone="critical"
+            >
+              Button
+            </MenuItem>
+            <MenuItemLink href="#" icon={<IconThumb />} tone="critical">
+              Link
+            </MenuItemLink>
+          </Menu>
+          <Menu {...defaultProps} highlightIndex={1} size="small">
+            <MenuItem onClick={() => {}} icon={<IconStar />}>
+              Button
+            </MenuItem>
+            <MenuItem
+              onClick={() => {}}
+              icon={<IconBookmark />}
+              tone="critical"
+            >
+              Button
+            </MenuItem>
+            <MenuItemLink href="#" icon={<IconThumb />} tone="critical">
+              Link
+            </MenuItemLink>
+          </Menu>
         </Inline>
       ),
     },
@@ -273,54 +236,50 @@ export const screenshots: ComponentScreenshot = {
       label: 'With badge',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1}>
-              <MenuItem
-                onClick={() => {}}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Button
-              </MenuItem>
-              <MenuItem
-                onClick={() => {}}
-                icon={<IconBookmark />}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Button
-              </MenuItem>
-              <MenuItemLink
-                href="#"
-                icon={<IconThumb />}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Link
-              </MenuItemLink>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1} size="small">
-              <MenuItem
-                onClick={() => {}}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Button
-              </MenuItem>
-              <MenuItem
-                onClick={() => {}}
-                icon={<IconBookmark />}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Button
-              </MenuItem>
-              <MenuItemLink
-                href="#"
-                icon={<IconThumb />}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Link
-              </MenuItemLink>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps} highlightIndex={1}>
+            <MenuItem
+              onClick={() => {}}
+              badge={<Badge weight="strong">Badge</Badge>}
+            >
+              Button
+            </MenuItem>
+            <MenuItem
+              onClick={() => {}}
+              icon={<IconBookmark />}
+              badge={<Badge weight="strong">Badge</Badge>}
+            >
+              Button
+            </MenuItem>
+            <MenuItemLink
+              href="#"
+              icon={<IconThumb />}
+              badge={<Badge weight="strong">Badge</Badge>}
+            >
+              Link
+            </MenuItemLink>
+          </Menu>
+          <Menu {...defaultProps} highlightIndex={1} size="small">
+            <MenuItem
+              onClick={() => {}}
+              badge={<Badge weight="strong">Badge</Badge>}
+            >
+              Button
+            </MenuItem>
+            <MenuItem
+              onClick={() => {}}
+              icon={<IconBookmark />}
+              badge={<Badge weight="strong">Badge</Badge>}
+            >
+              Button
+            </MenuItem>
+            <MenuItemLink
+              href="#"
+              icon={<IconThumb />}
+              badge={<Badge weight="strong">Badge</Badge>}
+            >
+              Link
+            </MenuItemLink>
+          </Menu>
         </Inline>
       ),
     },
@@ -328,57 +287,47 @@ export const screenshots: ComponentScreenshot = {
       label: 'Overflow tests in content width menu (no truncation)',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1} width="content">
-              <MenuItem onClick={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItem>
-              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-                Really long menu item text that should truncate
-              </MenuItem>
-              <MenuItemLink
-                href="#"
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemLink>
-              <MenuItemLink
-                href="#"
-                icon={<IconBookmark />}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemLink>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu
-              {...defaultProps}
-              highlightIndex={1}
-              width="content"
-              size="small"
+          <Menu {...defaultProps} highlightIndex={1} width="content">
+            <MenuItem onClick={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItem>
+            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+              Really long menu item text that should truncate
+            </MenuItem>
+            <MenuItemLink href="#" badge={<Badge weight="strong">Badge</Badge>}>
+              Really long menu item text that should truncate
+            </MenuItemLink>
+            <MenuItemLink
+              href="#"
+              icon={<IconBookmark />}
+              badge={<Badge weight="strong">Badge</Badge>}
             >
-              <MenuItem onClick={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItem>
-              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-                Really long menu item text that should truncate
-              </MenuItem>
-              <MenuItemLink
-                href="#"
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemLink>
-              <MenuItemLink
-                href="#"
-                icon={<IconBookmark />}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemLink>
-            </Menu>
-          </Box>
+              Really long menu item text that should truncate
+            </MenuItemLink>
+          </Menu>
+          <Menu
+            {...defaultProps}
+            highlightIndex={1}
+            width="content"
+            size="small"
+          >
+            <MenuItem onClick={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItem>
+            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+              Really long menu item text that should truncate
+            </MenuItem>
+            <MenuItemLink href="#" badge={<Badge weight="strong">Badge</Badge>}>
+              Really long menu item text that should truncate
+            </MenuItemLink>
+            <MenuItemLink
+              href="#"
+              icon={<IconBookmark />}
+              badge={<Badge weight="strong">Badge</Badge>}
+            >
+              Really long menu item text that should truncate
+            </MenuItemLink>
+          </Menu>
         </Inline>
       ),
     },
@@ -386,57 +335,42 @@ export const screenshots: ComponentScreenshot = {
       label: 'Overflow tests in small width menu',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1} width="small">
-              <MenuItem onClick={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItem>
-              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-                Really long menu item text that should truncate
-              </MenuItem>
-              <MenuItemLink
-                href="#"
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemLink>
-              <MenuItemLink
-                href="#"
-                icon={<IconBookmark />}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemLink>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu
-              {...defaultProps}
-              highlightIndex={1}
-              width="small"
-              size="small"
+          <Menu {...defaultProps} highlightIndex={1} width="small">
+            <MenuItem onClick={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItem>
+            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+              Really long menu item text that should truncate
+            </MenuItem>
+            <MenuItemLink href="#" badge={<Badge weight="strong">Badge</Badge>}>
+              Really long menu item text that should truncate
+            </MenuItemLink>
+            <MenuItemLink
+              href="#"
+              icon={<IconBookmark />}
+              badge={<Badge weight="strong">Badge</Badge>}
             >
-              <MenuItem onClick={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItem>
-              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-                Really long menu item text that should truncate
-              </MenuItem>
-              <MenuItemLink
-                href="#"
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemLink>
-              <MenuItemLink
-                href="#"
-                icon={<IconBookmark />}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemLink>
-            </Menu>
-          </Box>
+              Really long menu item text that should truncate
+            </MenuItemLink>
+          </Menu>
+          <Menu {...defaultProps} highlightIndex={1} width="small" size="small">
+            <MenuItem onClick={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItem>
+            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+              Really long menu item text that should truncate
+            </MenuItem>
+            <MenuItemLink href="#" badge={<Badge weight="strong">Badge</Badge>}>
+              Really long menu item text that should truncate
+            </MenuItemLink>
+            <MenuItemLink
+              href="#"
+              icon={<IconBookmark />}
+              badge={<Badge weight="strong">Badge</Badge>}
+            >
+              Really long menu item text that should truncate
+            </MenuItemLink>
+          </Menu>
         </Inline>
       ),
     },
@@ -444,57 +378,47 @@ export const screenshots: ComponentScreenshot = {
       label: 'Overflow tests in medium width menu',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1} width="medium">
-              <MenuItem onClick={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItem>
-              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-                Really long menu item text that should truncate
-              </MenuItem>
-              <MenuItemLink
-                href="#"
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemLink>
-              <MenuItemLink
-                href="#"
-                icon={<IconBookmark />}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemLink>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu
-              {...defaultProps}
-              highlightIndex={1}
-              width="medium"
-              size="small"
+          <Menu {...defaultProps} highlightIndex={1} width="medium">
+            <MenuItem onClick={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItem>
+            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+              Really long menu item text that should truncate
+            </MenuItem>
+            <MenuItemLink href="#" badge={<Badge weight="strong">Badge</Badge>}>
+              Really long menu item text that should truncate
+            </MenuItemLink>
+            <MenuItemLink
+              href="#"
+              icon={<IconBookmark />}
+              badge={<Badge weight="strong">Badge</Badge>}
             >
-              <MenuItem onClick={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItem>
-              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-                Really long menu item text that should truncate
-              </MenuItem>
-              <MenuItemLink
-                href="#"
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemLink>
-              <MenuItemLink
-                href="#"
-                icon={<IconBookmark />}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemLink>
-            </Menu>
-          </Box>
+              Really long menu item text that should truncate
+            </MenuItemLink>
+          </Menu>
+          <Menu
+            {...defaultProps}
+            highlightIndex={1}
+            width="medium"
+            size="small"
+          >
+            <MenuItem onClick={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItem>
+            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+              Really long menu item text that should truncate
+            </MenuItem>
+            <MenuItemLink href="#" badge={<Badge weight="strong">Badge</Badge>}>
+              Really long menu item text that should truncate
+            </MenuItemLink>
+            <MenuItemLink
+              href="#"
+              icon={<IconBookmark />}
+              badge={<Badge weight="strong">Badge</Badge>}
+            >
+              Really long menu item text that should truncate
+            </MenuItemLink>
+          </Menu>
         </Inline>
       ),
     },
@@ -502,57 +426,42 @@ export const screenshots: ComponentScreenshot = {
       label: 'Overflow tests in large width menu',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1} width="large">
-              <MenuItem onClick={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItem>
-              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-                Really long menu item text that should truncate
-              </MenuItem>
-              <MenuItemLink
-                href="#"
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemLink>
-              <MenuItemLink
-                href="#"
-                icon={<IconBookmark />}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemLink>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu
-              {...defaultProps}
-              highlightIndex={1}
-              width="large"
-              size="small"
+          <Menu {...defaultProps} highlightIndex={1} width="large">
+            <MenuItem onClick={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItem>
+            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+              Really long menu item text that should truncate
+            </MenuItem>
+            <MenuItemLink href="#" badge={<Badge weight="strong">Badge</Badge>}>
+              Really long menu item text that should truncate
+            </MenuItemLink>
+            <MenuItemLink
+              href="#"
+              icon={<IconBookmark />}
+              badge={<Badge weight="strong">Badge</Badge>}
             >
-              <MenuItem onClick={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItem>
-              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-                Really long menu item text that should truncate
-              </MenuItem>
-              <MenuItemLink
-                href="#"
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemLink>
-              <MenuItemLink
-                href="#"
-                icon={<IconBookmark />}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemLink>
-            </Menu>
-          </Box>
+              Really long menu item text that should truncate
+            </MenuItemLink>
+          </Menu>
+          <Menu {...defaultProps} highlightIndex={1} width="large" size="small">
+            <MenuItem onClick={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItem>
+            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+              Really long menu item text that should truncate
+            </MenuItem>
+            <MenuItemLink href="#" badge={<Badge weight="strong">Badge</Badge>}>
+              Really long menu item text that should truncate
+            </MenuItemLink>
+            <MenuItemLink
+              href="#"
+              icon={<IconBookmark />}
+              badge={<Badge weight="strong">Badge</Badge>}
+            >
+              Really long menu item text that should truncate
+            </MenuItemLink>
+          </Menu>
         </Inline>
       ),
     },

--- a/packages/braid-design-system/src/lib/components/MenuItem/MenuItem.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItem/MenuItem.screenshots.tsx
@@ -14,6 +14,7 @@ import { Menu } from '../MenuRenderer/MenuRenderer';
 const defaultProps = {
   offsetSpace: 'none',
   align: 'left',
+  size: 'standard',
   width: 'content',
   highlightIndex: -1,
   open: true,

--- a/packages/braid-design-system/src/lib/components/MenuItem/MenuItem.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItem/MenuItem.tsx
@@ -10,7 +10,7 @@ export interface MenuItemProps
   extends Pick<UseMenuItemProps, 'tone' | 'onClick' | 'data' | 'id'> {
   children: ReactNode;
   badge?: MenuItemChildrenProps['badge'];
-  icon?: MenuItemChildrenProps['icon'];
+  icon?: MenuItemChildrenProps['leftSlot'];
 }
 export const MenuItem = ({
   children,
@@ -30,7 +30,7 @@ export const MenuItem = ({
 
   return (
     <Box {...menuItemProps} component="button" type="button">
-      <MenuItemChildren tone={tone} icon={icon} badge={badge}>
+      <MenuItemChildren tone={tone} leftSlot={icon} badge={badge}>
         {children}
       </MenuItemChildren>
     </Box>

--- a/packages/braid-design-system/src/lib/components/MenuItem/MenuItemLink.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItem/MenuItemLink.tsx
@@ -36,7 +36,7 @@ export const MenuItemLink = ({
       target={target}
       rel={rel}
     >
-      <MenuItemChildren tone={tone} icon={icon} badge={badge}>
+      <MenuItemChildren tone={tone} leftSlot={icon} badge={badge}>
         {children}
       </MenuItemChildren>
     </Box>

--- a/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.css.ts
+++ b/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.css.ts
@@ -9,5 +9,5 @@ export const menuItem = style({
 });
 
 export const menuItemLeftSlot = style({
-  height: '0px',
+  height: '0px', // Prevents the slot from affecting the height of the MenuItem
 });

--- a/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.css.ts
+++ b/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.css.ts
@@ -7,3 +7,7 @@ export const menuItem = style({
     },
   },
 });
+
+export const menuItemLeftSlot = style({
+  height: '0px',
+});

--- a/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.tsx
@@ -160,7 +160,7 @@ export function useMenuItem<MenuItemElement extends HTMLElement>({
           display: 'flex',
           alignItems: 'center',
           width: 'full',
-          paddingX: size === 'standard' ? 'small' : 'small', // todo - with 'small' size - small or xsmall?
+          paddingX: size === 'standard' ? 'small' : 'small',
           paddingY: size === 'standard' ? undefined : 'xsmall',
           height: size === 'standard' ? 'touchable' : undefined,
           cursor: 'pointer',
@@ -171,6 +171,39 @@ export function useMenuItem<MenuItemElement extends HTMLElement>({
       ...buildDataAttributes({ data, validateRestProps: restProps }),
     } as BoxProps,
   } as const;
+}
+
+export function MenuItemLeftSlot({ children }: { children?: ReactNode }) {
+  const menuRendererContext = useContext(MenuRendererContext);
+
+  assert(
+    menuRendererContext !== null,
+    `MenuItem must be rendered as an immediate child of a menu. See the documentation for correct usage: https://seek-oss.github.io/braid-design-system/components/MenuItem`,
+  );
+
+  const { size } = menuRendererContext;
+  const iconSpace = useBraidTheme().legacy ? 'small' : iconSlotSpace;
+  return (
+    <Box
+      component="span"
+      paddingRight={iconSpace}
+      flexShrink={0}
+      minWidth={0}
+      position="relative"
+      display="flex"
+      alignItems="center"
+      className={styles.menuItemLeftSlot}
+    >
+      <Box component="span" display="block" className={iconSize({ size })}>
+        &nbsp;
+      </Box>
+      {children ? (
+        <Box position="absolute" display="flex">
+          {children}
+        </Box>
+      ) : null}
+    </Box>
+  );
 }
 
 export interface MenuItemChildrenProps {
@@ -188,9 +221,7 @@ function MenuItemChildren({
   formElement = false,
 }: MenuItemChildrenProps) {
   const menuRendererContext = useContext(MenuRendererContext);
-  const legacy = useBraidTheme().legacy;
-  const iconSpace = legacy ? 'small' : iconSlotSpace;
-  const badgeSpace = legacy ? 'small' : badgeSlotSpace;
+  const badgeSpace = useBraidTheme().legacy ? 'small' : badgeSlotSpace;
 
   assert(
     menuRendererContext !== null,
@@ -205,28 +236,17 @@ function MenuItemChildren({
 
   const { size, reserveIconSpace } = menuRendererContext;
 
-  const leftSlot =
-    !formElement && (icon || reserveIconSpace) ? (
-      <Text size={size} tone={tone === 'critical' ? tone : undefined}>
-        {icon || (
-          <Box component="span" display="block" className={iconSize({ size })}>
-            &nbsp;
-          </Box>
-        )}
-      </Text>
-    ) : null;
-
   return (
     <Box component="span" display="flex" alignItems="center" minWidth={0}>
-      {leftSlot ? (
-        <Box
-          component="span"
-          paddingRight={iconSpace}
-          flexShrink={0}
-          minWidth={0}
-        >
-          {leftSlot}
-        </Box>
+      {!formElement && (icon || reserveIconSpace) ? (
+        <MenuItemLeftSlot>
+          <Text
+            size={size}
+            tone={tone && tone === 'critical' ? tone : undefined}
+          >
+            {icon}
+          </Text>
+        </MenuItemLeftSlot>
       ) : null}
       <Box component="span" minWidth={0}>
         <Text

--- a/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.tsx
@@ -26,6 +26,7 @@ import { iconSlotSpace } from '../private/iconSlotSpace';
 import { badgeSlotSpace } from '../private/badgeSlotSpace';
 import { virtualTouchable } from '../private/touchable/virtualTouchable.css';
 import { DefaultBadgePropsProvider } from '../Badge/defaultBadgeProps';
+import { Inline } from '../Inline/Inline';
 
 const {
   MENU_ITEM_UP,
@@ -161,7 +162,7 @@ export function useMenuItem<MenuItemElement extends HTMLElement>({
           display: 'flex',
           alignItems: 'center',
           width: 'full',
-          paddingX: size === 'standard' ? 'small' : 'small',
+          paddingX: 'small',
           paddingY: size === 'standard' ? undefined : 'xsmall',
           height: size === 'standard' ? 'touchable' : undefined,
           cursor: 'pointer',
@@ -176,33 +177,23 @@ export function useMenuItem<MenuItemElement extends HTMLElement>({
 
 export function MenuItemLeftSlot({ children }: { children?: ReactNode }) {
   const menuRendererContext = useContext(MenuRendererContext);
-
-  assert(
-    menuRendererContext !== null,
-    `MenuItem must be rendered as an immediate child of a menu. See the documentation for correct usage: https://seek-oss.github.io/braid-design-system/components/MenuItem`,
-  );
-
-  const { size } = menuRendererContext;
+  const size = menuRendererContext?.size;
   const iconSpace = useBraidTheme().legacy ? 'small' : iconSlotSpace;
+
   return (
-    <Box
-      component="span"
-      paddingRight={iconSpace}
-      flexShrink={0}
-      minWidth={0}
-      position="relative"
-      display="flex"
-      alignItems="center"
-      className={styles.menuItemLeftSlot}
-    >
-      <Box component="span" display="block" className={iconSize({ size })}>
-        &nbsp;
-      </Box>
-      {children ? (
-        <Box position="absolute" display="flex">
-          {children}
+    <Box position="relative" paddingRight={iconSpace}>
+      <Inline component="span" alignY="center" space="none">
+        <Box className={styles.menuItemLeftSlot}>
+          <Box component="span" display="block" className={iconSize({ size })}>
+            &nbsp;
+          </Box>
         </Box>
-      ) : null}
+        {children ? (
+          <Box position="absolute" display="flex">
+            {children}
+          </Box>
+        ) : null}
+      </Inline>
     </Box>
   );
 }
@@ -238,7 +229,7 @@ function MenuItemChildren({
   const { size, reserveIconSpace } = menuRendererContext;
 
   return (
-    <Box component="span" display="flex" alignItems="center" minWidth={0}>
+    <Inline component="span" alignY="center" space="none">
       {!formElement && (icon || reserveIconSpace) ? (
         <MenuItemLeftSlot>
           <Text
@@ -268,6 +259,6 @@ function MenuItemChildren({
           <DefaultBadgePropsProvider bleedY>{badge}</DefaultBadgePropsProvider>
         </Box>
       ) : null}
-    </Box>
+    </Inline>
   );
 }

--- a/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.tsx
@@ -174,51 +174,23 @@ export function useMenuItem<MenuItemElement extends HTMLElement>({
   } as const;
 }
 
-export function MenuItemLeftSlot({ children }: { children?: ReactNode }) {
-  const menuRendererContext = useContext(MenuRendererContext);
-  const size = menuRendererContext?.size;
-  const iconSpace = useBraidTheme().legacy ? 'small' : iconSlotSpace;
-
-  return (
-    <Box
-      component="span"
-      position="relative"
-      display="flex"
-      alignItems="center"
-      paddingRight={iconSpace}
-    >
-      <Box
-        component="span"
-        display="block"
-        className={[iconSize({ size }), styles.menuItemLeftSlot]}
-      >
-        &nbsp;
-      </Box>
-      {children ? (
-        <Box component="span" position="absolute" display="flex">
-          {children}
-        </Box>
-      ) : null}
-    </Box>
-  );
-}
-
 export interface MenuItemChildrenProps {
   children: ReactNode;
   tone: MenuItemTone;
   badge: ReactElement<BadgeProps> | undefined;
-  icon: ReactNode | undefined;
-  formElement?: boolean;
+  leftSlot: ReactNode | undefined;
+  isCheckbox?: boolean;
 }
 function MenuItemChildren({
-  icon,
+  leftSlot,
   tone,
   children,
   badge,
-  formElement = false,
+  isCheckbox = false,
 }: MenuItemChildrenProps) {
   const menuRendererContext = useContext(MenuRendererContext);
   const badgeSpace = useBraidTheme().legacy ? 'small' : badgeSlotSpace;
+  const iconSpace = useBraidTheme().legacy ? 'small' : iconSlotSpace;
 
   assert(
     menuRendererContext !== null,
@@ -235,15 +207,36 @@ function MenuItemChildren({
 
   return (
     <Box component="span" display="flex" alignItems="center" minWidth={0}>
-      {!formElement && (icon || reserveIconSpace) ? (
-        <MenuItemLeftSlot>
-          <Text
-            size={size}
-            tone={tone && tone === 'critical' ? tone : undefined}
+      {leftSlot || reserveIconSpace ? (
+        <Box
+          component="span"
+          position="relative"
+          display="flex"
+          alignItems="center"
+          paddingRight={iconSpace}
+        >
+          <Box
+            component="span"
+            display="block"
+            className={[iconSize({ size }), styles.menuItemLeftSlot]}
           >
-            {icon}
-          </Text>
-        </MenuItemLeftSlot>
+            &nbsp;
+          </Box>
+          {leftSlot ? (
+            <Box component="span" position="absolute">
+              {isCheckbox ? (
+                leftSlot
+              ) : (
+                <Text
+                  size={size}
+                  tone={tone && tone === 'critical' ? tone : undefined}
+                >
+                  {leftSlot}
+                </Text>
+              )}
+            </Box>
+          ) : null}
+        </Box>
       ) : null}
       <Box component="span" minWidth={0}>
         <Text

--- a/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.tsx
@@ -26,7 +26,6 @@ import { iconSlotSpace } from '../private/iconSlotSpace';
 import { badgeSlotSpace } from '../private/badgeSlotSpace';
 import { virtualTouchable } from '../private/touchable/virtualTouchable.css';
 import { DefaultBadgePropsProvider } from '../Badge/defaultBadgeProps';
-import { Inline } from '../Inline/Inline';
 
 const {
   MENU_ITEM_UP,
@@ -181,19 +180,25 @@ export function MenuItemLeftSlot({ children }: { children?: ReactNode }) {
   const iconSpace = useBraidTheme().legacy ? 'small' : iconSlotSpace;
 
   return (
-    <Box position="relative" paddingRight={iconSpace}>
-      <Inline component="span" alignY="center" space="none">
-        <Box className={styles.menuItemLeftSlot}>
-          <Box component="span" display="block" className={iconSize({ size })}>
-            &nbsp;
-          </Box>
+    <Box
+      component="span"
+      position="relative"
+      display="flex"
+      alignItems="center"
+      paddingRight={iconSpace}
+    >
+      <Box
+        component="span"
+        display="block"
+        className={[iconSize({ size }), styles.menuItemLeftSlot]}
+      >
+        &nbsp;
+      </Box>
+      {children ? (
+        <Box component="span" position="absolute" display="flex">
+          {children}
         </Box>
-        {children ? (
-          <Box position="absolute" display="flex">
-            {children}
-          </Box>
-        ) : null}
-      </Inline>
+      ) : null}
     </Box>
   );
 }
@@ -229,7 +234,7 @@ function MenuItemChildren({
   const { size, reserveIconSpace } = menuRendererContext;
 
   return (
-    <Inline component="span" alignY="center" space="none">
+    <Box component="span" display="flex" alignItems="center" minWidth={0}>
       {!formElement && (icon || reserveIconSpace) ? (
         <MenuItemLeftSlot>
           <Text
@@ -259,6 +264,6 @@ function MenuItemChildren({
           <DefaultBadgePropsProvider bleedY>{badge}</DefaultBadgePropsProvider>
         </Box>
       ) : null}
-    </Inline>
+    </Box>
   );
 }

--- a/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.tsx
@@ -25,6 +25,7 @@ import { useBraidTheme } from '../BraidProvider/BraidThemeContext';
 import { iconSlotSpace } from '../private/iconSlotSpace';
 import { badgeSlotSpace } from '../private/badgeSlotSpace';
 import { virtualTouchable } from '../private/touchable/virtualTouchable.css';
+import { DefaultBadgePropsProvider } from '../Badge/defaultBadgeProps';
 
 const {
   MENU_ITEM_UP,
@@ -264,7 +265,7 @@ function MenuItemChildren({
           flexShrink={0}
           minWidth={0}
         >
-          {badge}
+          <DefaultBadgePropsProvider bleedY>{badge}</DefaultBadgePropsProvider>
         </Box>
       ) : null}
     </Box>

--- a/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.screenshots.tsx
@@ -6,6 +6,7 @@ import { Menu } from '../MenuRenderer/MenuRenderer';
 const defaultProps = {
   offsetSpace: 'none',
   align: 'left',
+  size: 'standard',
   width: 'content',
   highlightIndex: -1,
   open: true,

--- a/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.screenshots.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { Badge, Box, Inline, MenuItemCheckbox } from '../';
+import { Badge, Inline, MenuItemCheckbox } from '../';
 import { Menu } from '../MenuRenderer/MenuRenderer';
 
 const defaultProps = {
@@ -24,26 +24,22 @@ export const screenshots: ComponentScreenshot = {
       label: 'Default',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps}>
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Checkbox
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Checkbox
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} size="small">
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Checkbox
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Checkbox
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps}>
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Checkbox
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Checkbox
+            </MenuItemCheckbox>
+          </Menu>
+          <Menu {...defaultProps} size="small">
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Checkbox
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Checkbox
+            </MenuItemCheckbox>
+          </Menu>
         </Inline>
       ),
     },
@@ -51,26 +47,22 @@ export const screenshots: ComponentScreenshot = {
       label: 'Highlighted',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={0}>
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Checkbox
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Checkbox
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={0} size="small">
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Checkbox
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Checkbox
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps} highlightIndex={0}>
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Checkbox
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Checkbox
+            </MenuItemCheckbox>
+          </Menu>
+          <Menu {...defaultProps} highlightIndex={0} size="small">
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Checkbox
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Checkbox
+            </MenuItemCheckbox>
+          </Menu>
         </Inline>
       ),
     },
@@ -78,34 +70,30 @@ export const screenshots: ComponentScreenshot = {
       label: 'With badge',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1}>
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Checkbox
-              </MenuItemCheckbox>
-              <MenuItemCheckbox
-                checked={true}
-                onChange={() => {}}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Checkbox
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1} size="small">
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Checkbox
-              </MenuItemCheckbox>
-              <MenuItemCheckbox
-                checked={true}
-                onChange={() => {}}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Checkbox
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps} highlightIndex={1}>
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Checkbox
+            </MenuItemCheckbox>
+            <MenuItemCheckbox
+              checked={true}
+              onChange={() => {}}
+              badge={<Badge weight="strong">Badge</Badge>}
+            >
+              Checkbox
+            </MenuItemCheckbox>
+          </Menu>
+          <Menu {...defaultProps} highlightIndex={1} size="small">
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Checkbox
+            </MenuItemCheckbox>
+            <MenuItemCheckbox
+              checked={true}
+              onChange={() => {}}
+              badge={<Badge weight="strong">Badge</Badge>}
+            >
+              Checkbox
+            </MenuItemCheckbox>
+          </Menu>
         </Inline>
       ),
     },
@@ -113,45 +101,41 @@ export const screenshots: ComponentScreenshot = {
       label: 'Overflow tests in content width menu (no truncation)',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1} width="content">
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-              <MenuItemCheckbox
-                checked={true}
-                onChange={() => {}}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu
-              {...defaultProps}
-              highlightIndex={1}
-              width="content"
-              size="small"
+          <Menu {...defaultProps} highlightIndex={1} width="content">
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+            <MenuItemCheckbox
+              checked={true}
+              onChange={() => {}}
+              badge={<Badge weight="strong">Badge</Badge>}
             >
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-              <MenuItemCheckbox
-                checked={true}
-                onChange={() => {}}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+          </Menu>
+          <Menu
+            {...defaultProps}
+            highlightIndex={1}
+            width="content"
+            size="small"
+          >
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+            <MenuItemCheckbox
+              checked={true}
+              onChange={() => {}}
+              badge={<Badge weight="strong">Badge</Badge>}
+            >
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+          </Menu>
         </Inline>
       ),
     },
@@ -159,45 +143,36 @@ export const screenshots: ComponentScreenshot = {
       label: 'Overflow tests in small width menu',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1} width="small">
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-              <MenuItemCheckbox
-                checked={true}
-                onChange={() => {}}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu
-              {...defaultProps}
-              highlightIndex={1}
-              width="small"
-              size="small"
+          <Menu {...defaultProps} highlightIndex={1} width="small">
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+            <MenuItemCheckbox
+              checked={true}
+              onChange={() => {}}
+              badge={<Badge weight="strong">Badge</Badge>}
             >
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-              <MenuItemCheckbox
-                checked={true}
-                onChange={() => {}}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+          </Menu>
+          <Menu {...defaultProps} highlightIndex={1} width="small" size="small">
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+            <MenuItemCheckbox
+              checked={true}
+              onChange={() => {}}
+              badge={<Badge weight="strong">Badge</Badge>}
+            >
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+          </Menu>
         </Inline>
       ),
     },
@@ -205,45 +180,41 @@ export const screenshots: ComponentScreenshot = {
       label: 'Overflow tests in medium width menu',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1} width="medium">
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-              <MenuItemCheckbox
-                checked={true}
-                onChange={() => {}}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu
-              {...defaultProps}
-              highlightIndex={1}
-              width="medium"
-              size="small"
+          <Menu {...defaultProps} highlightIndex={1} width="medium">
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+            <MenuItemCheckbox
+              checked={true}
+              onChange={() => {}}
+              badge={<Badge weight="strong">Badge</Badge>}
             >
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-              <MenuItemCheckbox
-                checked={true}
-                onChange={() => {}}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+          </Menu>
+          <Menu
+            {...defaultProps}
+            highlightIndex={1}
+            width="medium"
+            size="small"
+          >
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+            <MenuItemCheckbox
+              checked={true}
+              onChange={() => {}}
+              badge={<Badge weight="strong">Badge</Badge>}
+            >
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+          </Menu>
         </Inline>
       ),
     },
@@ -251,45 +222,36 @@ export const screenshots: ComponentScreenshot = {
       label: 'Overflow tests in large width menu',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1} width="large">
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-              <MenuItemCheckbox
-                checked={true}
-                onChange={() => {}}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu
-              {...defaultProps}
-              highlightIndex={1}
-              width="large"
-              size="small"
+          <Menu {...defaultProps} highlightIndex={1} width="large">
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+            <MenuItemCheckbox
+              checked={true}
+              onChange={() => {}}
+              badge={<Badge weight="strong">Badge</Badge>}
             >
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-              <MenuItemCheckbox
-                checked={true}
-                onChange={() => {}}
-                badge={<Badge weight="strong">Badge</Badge>}
-              >
-                Really long menu item text that should truncate
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+          </Menu>
+          <Menu {...defaultProps} highlightIndex={1} width="large" size="small">
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+            <MenuItemCheckbox
+              checked={true}
+              onChange={() => {}}
+              badge={<Badge weight="strong">Badge</Badge>}
+            >
+              Really long menu item text that should truncate
+            </MenuItemCheckbox>
+          </Menu>
         </Inline>
       ),
     },

--- a/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.screenshots.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { Badge, Box, MenuItemCheckbox } from '../';
+import { Badge, Box, Inline, MenuItemCheckbox } from '../';
 import { Menu } from '../MenuRenderer/MenuRenderer';
 
 const defaultProps = {
@@ -23,138 +23,274 @@ export const screenshots: ComponentScreenshot = {
     {
       label: 'Default',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps}>
-            <MenuItemCheckbox checked={false} onChange={() => {}}>
-              Checkbox
-            </MenuItemCheckbox>
-            <MenuItemCheckbox checked={true} onChange={() => {}}>
-              Checkbox
-            </MenuItemCheckbox>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps}>
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Checkbox
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Checkbox
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} size="small">
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Checkbox
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Checkbox
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Highlighted',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={0}>
-            <MenuItemCheckbox checked={false} onChange={() => {}}>
-              Checkbox
-            </MenuItemCheckbox>
-            <MenuItemCheckbox checked={true} onChange={() => {}}>
-              Checkbox
-            </MenuItemCheckbox>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={0}>
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Checkbox
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Checkbox
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={0} size="small">
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Checkbox
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Checkbox
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'With badge',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={1}>
-            <MenuItemCheckbox checked={false} onChange={() => {}}>
-              Checkbox
-            </MenuItemCheckbox>
-            <MenuItemCheckbox
-              checked={true}
-              onChange={() => {}}
-              badge={<Badge weight="strong">Badge</Badge>}
-            >
-              Checkbox
-            </MenuItemCheckbox>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1}>
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Checkbox
+              </MenuItemCheckbox>
+              <MenuItemCheckbox
+                checked={true}
+                onChange={() => {}}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Checkbox
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1} size="small">
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Checkbox
+              </MenuItemCheckbox>
+              <MenuItemCheckbox
+                checked={true}
+                onChange={() => {}}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Checkbox
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Overflow tests in content width menu (no truncation)',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={1} width="content">
-            <MenuItemCheckbox checked={false} onChange={() => {}}>
-              Really long menu item text that should truncate
-            </MenuItemCheckbox>
-            <MenuItemCheckbox checked={true} onChange={() => {}}>
-              Really long menu item text that should truncate
-            </MenuItemCheckbox>
-            <MenuItemCheckbox
-              checked={true}
-              onChange={() => {}}
-              badge={<Badge weight="strong">Badge</Badge>}
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1} width="content">
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+              <MenuItemCheckbox
+                checked={true}
+                onChange={() => {}}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu
+              {...defaultProps}
+              highlightIndex={1}
+              width="content"
+              size="small"
             >
-              Really long menu item text that should truncate
-            </MenuItemCheckbox>
-          </Menu>
-        </Box>
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+              <MenuItemCheckbox
+                checked={true}
+                onChange={() => {}}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Overflow tests in small width menu',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={1} width="small">
-            <MenuItemCheckbox checked={false} onChange={() => {}}>
-              Really long menu item text that should truncate
-            </MenuItemCheckbox>
-            <MenuItemCheckbox checked={true} onChange={() => {}}>
-              Really long menu item text that should truncate
-            </MenuItemCheckbox>
-            <MenuItemCheckbox
-              checked={true}
-              onChange={() => {}}
-              badge={<Badge weight="strong">Badge</Badge>}
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1} width="small">
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+              <MenuItemCheckbox
+                checked={true}
+                onChange={() => {}}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu
+              {...defaultProps}
+              highlightIndex={1}
+              width="small"
+              size="small"
             >
-              Really long menu item text that should truncate
-            </MenuItemCheckbox>
-          </Menu>
-        </Box>
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+              <MenuItemCheckbox
+                checked={true}
+                onChange={() => {}}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Overflow tests in medium width menu',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={1} width="medium">
-            <MenuItemCheckbox checked={false} onChange={() => {}}>
-              Really long menu item text that should truncate
-            </MenuItemCheckbox>
-            <MenuItemCheckbox checked={true} onChange={() => {}}>
-              Really long menu item text that should truncate
-            </MenuItemCheckbox>
-            <MenuItemCheckbox
-              checked={true}
-              onChange={() => {}}
-              badge={<Badge weight="strong">Badge</Badge>}
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1} width="medium">
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+              <MenuItemCheckbox
+                checked={true}
+                onChange={() => {}}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu
+              {...defaultProps}
+              highlightIndex={1}
+              width="medium"
+              size="small"
             >
-              Really long menu item text that should truncate
-            </MenuItemCheckbox>
-          </Menu>
-        </Box>
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+              <MenuItemCheckbox
+                checked={true}
+                onChange={() => {}}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Overflow tests in large width menu',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={1} width="large">
-            <MenuItemCheckbox checked={false} onChange={() => {}}>
-              Really long menu item text that should truncate
-            </MenuItemCheckbox>
-            <MenuItemCheckbox checked={true} onChange={() => {}}>
-              Really long menu item text that should truncate
-            </MenuItemCheckbox>
-            <MenuItemCheckbox
-              checked={true}
-              onChange={() => {}}
-              badge={<Badge weight="strong">Badge</Badge>}
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1} width="large">
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+              <MenuItemCheckbox
+                checked={true}
+                onChange={() => {}}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu
+              {...defaultProps}
+              highlightIndex={1}
+              width="large"
+              size="small"
             >
-              Really long menu item text that should truncate
-            </MenuItemCheckbox>
-          </Menu>
-        </Box>
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+              <MenuItemCheckbox
+                checked={true}
+                onChange={() => {}}
+                badge={<Badge weight="strong">Badge</Badge>}
+              >
+                Really long menu item text that should truncate
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.tsx
@@ -2,7 +2,7 @@ import React, { type ReactNode } from 'react';
 import { Box } from '../Box/Box';
 import { IconTick } from '../icons/IconTick/IconTick';
 import type { MenuItemProps } from '../MenuItem/MenuItem';
-import { MenuItemLeftSlot, useMenuItem } from '../MenuItem/useMenuItem';
+import { useMenuItem } from '../MenuItem/useMenuItem';
 
 import * as styles from './MenuItemCheckbox.css';
 
@@ -37,34 +37,34 @@ export const MenuItemCheckbox = ({
       display="flex"
       alignItems="center"
     >
-      <MenuItemLeftSlot>
-        <Box
-          component="span"
-          borderRadius="standard"
-          boxShadow="borderField"
-          position="relative"
-          background={{ lightMode: 'surface' }}
-          flexShrink={0}
-          className={styles.checkboxSize}
-        >
-          <Box
-            component="span"
-            position="absolute"
-            inset={0}
-            background="formAccent"
-            borderRadius="standard"
-            transition="fast"
-            opacity={checked ? undefined : 0}
-          >
-            <IconTick size="fill" />
-          </Box>
-        </Box>
-      </MenuItemLeftSlot>
       <MenuItemChildren
         tone={undefined}
-        icon={undefined}
+        leftSlot={
+          <Box
+            component="span"
+            display="block"
+            borderRadius="standard"
+            boxShadow="borderField"
+            position="relative"
+            background={{ lightMode: 'surface' }}
+            flexShrink={0}
+            className={styles.checkboxSize}
+          >
+            <Box
+              component="span"
+              position="absolute"
+              inset={0}
+              background="formAccent"
+              borderRadius="standard"
+              transition="fast"
+              opacity={checked ? undefined : 0}
+            >
+              <IconTick size="fill" />
+            </Box>
+          </Box>
+        }
         badge={badge}
-        formElement={true}
+        isCheckbox={true}
       >
         {children}
       </MenuItemChildren>

--- a/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.tsx
@@ -2,9 +2,7 @@ import React, { type ReactNode } from 'react';
 import { Box } from '../Box/Box';
 import { IconTick } from '../icons/IconTick/IconTick';
 import type { MenuItemProps } from '../MenuItem/MenuItem';
-import { useMenuItem } from '../MenuItem/useMenuItem';
-import { iconSlotSpace } from '../private/iconSlotSpace';
-import { useBraidTheme } from '../BraidProvider/BraidThemeContext';
+import { MenuItemLeftSlot, useMenuItem } from '../MenuItem/useMenuItem';
 
 import * as styles from './MenuItemCheckbox.css';
 
@@ -28,8 +26,6 @@ export const MenuItemCheckbox = ({
     data,
     id,
   });
-  const legacy = useBraidTheme().legacy;
-  const iconSpace = legacy ? 'xsmall' : iconSlotSpace;
 
   return (
     <Box
@@ -41,28 +37,29 @@ export const MenuItemCheckbox = ({
       display="flex"
       alignItems="center"
     >
-      <Box
-        component="span"
-        borderRadius="standard"
-        boxShadow="borderField"
-        position="relative"
-        background={{ lightMode: 'surface' }}
-        marginRight={iconSpace}
-        flexShrink={0}
-        className={styles.checkboxSize}
-      >
+      <MenuItemLeftSlot>
         <Box
           component="span"
-          position="absolute"
-          inset={0}
-          background="formAccent"
           borderRadius="standard"
-          transition="fast"
-          opacity={checked ? undefined : 0}
+          boxShadow="borderField"
+          position="relative"
+          background={{ lightMode: 'surface' }}
+          flexShrink={0}
+          className={styles.checkboxSize}
         >
-          <IconTick size="fill" />
+          <Box
+            component="span"
+            position="absolute"
+            inset={0}
+            background="formAccent"
+            borderRadius="standard"
+            transition="fast"
+            opacity={checked ? undefined : 0}
+          >
+            <IconTick size="fill" />
+          </Box>
         </Box>
-      </Box>
+      </MenuItemLeftSlot>
       <MenuItemChildren
         tone={undefined}
         icon={undefined}

--- a/packages/braid-design-system/src/lib/components/MenuItemDivider/MenuItemDivider.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItemDivider/MenuItemDivider.screenshots.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { Box, MenuItem, MenuItemCheckbox, MenuItemDivider } from '../';
+import { Box, Inline, MenuItem, MenuItemCheckbox, MenuItemDivider } from '../';
 import { Menu } from '../MenuRenderer/MenuRenderer';
 
 const defaultProps = {
@@ -23,55 +23,100 @@ export const screenshots: ComponentScreenshot = {
     {
       label: 'Default',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps}>
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-            <MenuItemDivider />
-            <MenuItemCheckbox checked={false} onChange={() => {}}>
-              Item
-            </MenuItemCheckbox>
-            <MenuItemCheckbox checked={true} onChange={() => {}}>
-              Item
-            </MenuItemCheckbox>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps}>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItemDivider />
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} size="small">
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItemDivider />
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Highlighted before divider',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={1}>
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-            <MenuItemDivider />
-            <MenuItemCheckbox checked={false} onChange={() => {}}>
-              Item
-            </MenuItemCheckbox>
-            <MenuItemCheckbox checked={true} onChange={() => {}}>
-              Item
-            </MenuItemCheckbox>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={1}>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItemDivider />
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} size="small" highlightIndex={1}>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItemDivider />
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
-      label: 'Highlighted before divider',
+      label: 'Highlighted after divider',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} highlightIndex={2}>
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-            <MenuItemDivider />
-            <MenuItemCheckbox checked={false} onChange={() => {}}>
-              Item
-            </MenuItemCheckbox>
-            <MenuItemCheckbox checked={true} onChange={() => {}}>
-              Item
-            </MenuItemCheckbox>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} highlightIndex={2}>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItemDivider />
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} size="small" highlightIndex={2}>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItemDivider />
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/MenuItemDivider/MenuItemDivider.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItemDivider/MenuItemDivider.screenshots.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import type { ComponentScreenshot } from 'site/types';
-import { Box, Inline, MenuItem, MenuItemCheckbox, MenuItemDivider } from '../';
+import { Inline, MenuItem, MenuItemCheckbox, MenuItemDivider } from '../';
 import { Menu } from '../MenuRenderer/MenuRenderer';
 
 const defaultProps = {
@@ -24,32 +24,28 @@ export const screenshots: ComponentScreenshot = {
       label: 'Default',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps}>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItemDivider />
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} size="small">
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItemDivider />
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps}>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItemDivider />
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+          </Menu>
+          <Menu {...defaultProps} size="small">
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItemDivider />
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+          </Menu>
         </Inline>
       ),
     },
@@ -57,32 +53,28 @@ export const screenshots: ComponentScreenshot = {
       label: 'Highlighted before divider',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={1}>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItemDivider />
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} size="small" highlightIndex={1}>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItemDivider />
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps} highlightIndex={1}>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItemDivider />
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+          </Menu>
+          <Menu {...defaultProps} size="small" highlightIndex={1}>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItemDivider />
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+          </Menu>
         </Inline>
       ),
     },
@@ -90,32 +82,28 @@ export const screenshots: ComponentScreenshot = {
       label: 'Highlighted after divider',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} highlightIndex={2}>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItemDivider />
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} size="small" highlightIndex={2}>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItemDivider />
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps} highlightIndex={2}>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItemDivider />
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+          </Menu>
+          <Menu {...defaultProps} size="small" highlightIndex={2}>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItemDivider />
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+          </Menu>
         </Inline>
       ),
     },

--- a/packages/braid-design-system/src/lib/components/MenuItemDivider/MenuItemDivider.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItemDivider/MenuItemDivider.screenshots.tsx
@@ -6,6 +6,7 @@ import { Menu } from '../MenuRenderer/MenuRenderer';
 const defaultProps = {
   offsetSpace: 'none',
   align: 'left',
+  size: 'standard',
   width: 'content',
   highlightIndex: -1,
   open: true,

--- a/packages/braid-design-system/src/lib/components/MenuItemDivider/MenuItemDivider.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItemDivider/MenuItemDivider.tsx
@@ -3,6 +3,7 @@ import React, { useContext } from 'react';
 import { Box } from '../Box/Box';
 import { Divider } from '../Divider/Divider';
 import { MenuRendererContext } from '../MenuRenderer/MenuRendererContext';
+import { menuYPadding } from '../MenuRenderer/MenuRenderer.css';
 
 export const MenuItemDivider = () => {
   assert(
@@ -11,7 +12,7 @@ export const MenuItemDivider = () => {
   );
 
   return (
-    <Box paddingY="xxsmall">
+    <Box paddingY={menuYPadding}>
       <Divider />
     </Box>
   );

--- a/packages/braid-design-system/src/lib/components/MenuItemDivider/MenuItemDivider.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItemDivider/MenuItemDivider.tsx
@@ -3,7 +3,6 @@ import React, { useContext } from 'react';
 import { Box } from '../Box/Box';
 import { Divider } from '../Divider/Divider';
 import { MenuRendererContext } from '../MenuRenderer/MenuRendererContext';
-import { menuYPadding } from '../MenuRenderer/MenuRenderer.css';
 
 export const MenuItemDivider = () => {
   assert(
@@ -12,7 +11,7 @@ export const MenuItemDivider = () => {
   );
 
   return (
-    <Box paddingY={menuYPadding}>
+    <Box paddingY="xxsmall">
       <Divider />
     </Box>
   );

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.css.ts
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.css.ts
@@ -7,6 +7,8 @@ import {
 import { calc } from '@vanilla-extract/css-utils';
 import { vars } from '../../themes/vars.css';
 
+export const menuYPadding = 'xxsmall';
+
 export const backdrop = style({
   width: '100vw',
   height: '100vh',
@@ -48,5 +50,8 @@ export const width = styleVariants({ small, medium, large }, (w) => [
 ]);
 
 export const menuHeightLimit = style({
-  maxHeight: calc(vars.touchableSize).multiply(9.5).toString(),
+  maxHeight: calc(vars.touchableSize)
+    .multiply(9.5)
+    .add(calc(vars.space[menuYPadding]).multiply(2))
+    .toString(),
 });

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.css.ts
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.css.ts
@@ -7,7 +7,7 @@ import {
 import { calc } from '@vanilla-extract/css-utils';
 import { vars } from '../../themes/vars.css';
 
-export const menuYPadding = 'xxsmall';
+export const menuYPadding = createVar();
 
 export const backdrop = style({
   width: '100vw',
@@ -52,6 +52,6 @@ export const width = styleVariants({ small, medium, large }, (w) => [
 export const menuHeightLimit = style({
   maxHeight: calc(vars.touchableSize)
     .multiply(9.5)
-    .add(calc(vars.space[menuYPadding]).multiply(2))
+    .add(calc(menuYPadding).multiply(2))
     .toString(),
 });

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.docs.tsx
@@ -179,8 +179,8 @@ const docs: ComponentDocs = {
         <Text>
           You can customise the size of the menu via the <Strong>size</Strong>{' '}
           prop, which accepts either <Strong>standard</Strong> or{' '}
-          <Strong>small</Strong>. <Strong>small</Strong> menus are recommended
-          when using a small trigger.
+          <Strong>small</Strong>. When using a small trigger,{' '}
+          <Strong>small</Strong> menus are recommended.
         </Text>
       ),
       Example: () =>

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.docs.tsx
@@ -174,6 +174,61 @@ const docs: ComponentDocs = {
         ),
     },
     {
+      label: 'Sizes',
+      description: (
+        <Text>
+          You can customise the size of the menu via the <Strong>size</Strong>{' '}
+          prop, which accepts either <Strong>standard</Strong> or{' '}
+          <Strong>small</Strong>. <Strong>small</Strong> menus are recommended
+          when using a small trigger.
+        </Text>
+      ),
+      Example: () =>
+        source(
+          <Stack space="large">
+            <Inline space="none">
+              <MenuRenderer
+                offsetSpace="small"
+                trigger={(triggerProps, { open }) => (
+                  <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                    <Text>
+                      Standard trigger{' '}
+                      <IconChevron
+                        direction={open ? 'up' : 'down'}
+                        alignY="lowercase"
+                      />
+                    </Text>
+                  </Box>
+                )}
+              >
+                <MenuItem onClick={() => {}}>Button</MenuItem>
+                <MenuItemLink href="#">Link</MenuItemLink>
+              </MenuRenderer>
+            </Inline>
+            <Inline space="none">
+              <MenuRenderer
+                size="small"
+                offsetSpace="xsmall"
+                trigger={(triggerProps, { open }) => (
+                  <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                    <Text size="small">
+                      Small trigger{' '}
+                      <IconChevron
+                        direction={open ? 'up' : 'down'}
+                        alignY="lowercase"
+                      />
+                    </Text>
+                  </Box>
+                )}
+              >
+                <MenuItem onClick={() => {}}>Button</MenuItem>
+                <MenuItemLink href="#">Link</MenuItemLink>
+              </MenuRenderer>
+            </Inline>
+          </Stack>,
+        ),
+    },
+    {
       label: 'Width',
       description: (
         <>

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.gallery.tsx
@@ -12,6 +12,7 @@ import {
   IconProfile,
   IconBookmark,
   MenuItemDivider,
+  Stack,
 } from '..';
 import source from '@braid-design-system/source.macro';
 
@@ -115,6 +116,53 @@ export const galleryItems: GalleryComponent = {
               <MenuItemLink href="#">Link</MenuItemLink>
             </MenuRenderer>
           </Inline>,
+        ),
+    },
+    {
+      label: 'Sizes',
+      Example: () =>
+        source(
+          <Stack space="large">
+            <Inline space="none">
+              <MenuRenderer
+                offsetSpace="small"
+                trigger={(triggerProps, { open }) => (
+                  <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                    <Text>
+                      Standard{' '}
+                      <IconChevron
+                        direction={open ? 'up' : 'down'}
+                        alignY="lowercase"
+                      />
+                    </Text>
+                  </Box>
+                )}
+              >
+                <MenuItem onClick={() => {}}>Button</MenuItem>
+                <MenuItemLink href="#">Link</MenuItemLink>
+              </MenuRenderer>
+            </Inline>
+            <Inline space="none">
+              <MenuRenderer
+                size="small"
+                offsetSpace="xsmall"
+                trigger={(triggerProps, { open }) => (
+                  <Box userSelect="none" cursor="pointer" {...triggerProps}>
+                    <Text size="small">
+                      Small{' '}
+                      <IconChevron
+                        direction={open ? 'up' : 'down'}
+                        alignY="lowercase"
+                      />
+                    </Text>
+                  </Box>
+                )}
+              >
+                <MenuItem onClick={() => {}}>Button</MenuItem>
+                <MenuItemLink href="#">Link</MenuItemLink>
+              </MenuRenderer>
+            </Inline>
+          </Stack>,
         ),
     },
     {

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.screenshots.tsx
@@ -100,24 +100,28 @@ export const screenshots: ComponentScreenshot = {
     {
       label: 'Placement bottom',
       Example: () => (
-        <Box position="relative">
-          <Placeholder height={triggerHeight} label="Menu trigger" />
-          <Menu {...defaultProps} placement="bottom">
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-          </Menu>
+        <Box display="flex">
+          <Box position="relative">
+            <Placeholder height={triggerHeight} label="Menu trigger" />
+            <Menu {...defaultProps} placement="bottom">
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+            </Menu>
+          </Box>
         </Box>
       ),
     },
     {
       label: 'Placement bottom with small offset',
       Example: () => (
-        <Box position="relative">
-          <Placeholder height={triggerHeight} label="Menu trigger" />
-          <Menu {...defaultProps} placement="bottom" offsetSpace="small">
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-          </Menu>
+        <Box display="flex">
+          <Box position="relative">
+            <Placeholder height={triggerHeight} label="Menu trigger" />
+            <Menu {...defaultProps} placement="bottom" offsetSpace="small">
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+            </Menu>
+          </Box>
         </Box>
       ),
     },

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.screenshots.tsx
@@ -9,11 +9,13 @@ import {
   MenuItemCheckbox,
   IconBookmark,
   IconProfile,
+  Inline,
 } from '../';
 import { Placeholder } from '../private/Placeholder/Placeholder';
 import { Menu } from './MenuRenderer';
 import { vars } from '../../../entries/css';
 import { calc } from '@vanilla-extract/css-utils';
+import { debugTouchableAttrForDataProp } from '../private/touchable/debugTouchable';
 
 const defaultProps = {
   offsetSpace: 'none',
@@ -173,10 +175,10 @@ export const screenshots: ComponentScreenshot = {
       ),
     },
     {
-      label: 'Width content',
+      label: 'Small size (virtual touch target)',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} width="content">
+        <Box display="flex" data={{ [debugTouchableAttrForDataProp]: '' }}>
+          <Menu {...defaultProps} width="content" size="small">
             <MenuItem onClick={() => {}}>Item</MenuItem>
             <MenuItem onClick={() => {}}>Item</MenuItem>
             <MenuItemDivider />
@@ -188,88 +190,191 @@ export const screenshots: ComponentScreenshot = {
             </MenuItemCheckbox>
           </Menu>
         </Box>
+      ),
+    },
+    {
+      label: 'Width content',
+      Example: () => (
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} width="content">
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItemDivider />
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} width="content" size="small">
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItemDivider />
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Width small',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} width="small">
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-            <MenuItemDivider />
-            <MenuItemCheckbox checked={true} onChange={() => {}}>
-              Item
-            </MenuItemCheckbox>
-            <MenuItemCheckbox checked={false} onChange={() => {}}>
-              Item
-            </MenuItemCheckbox>
-            <MenuItemDivider />
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} width="small">
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItemDivider />
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemDivider />
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} width="small" size="small">
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItemDivider />
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemDivider />
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Width medium',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} width="medium">
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-            <MenuItemDivider />
-            <MenuItemCheckbox checked={true} onChange={() => {}}>
-              Item
-            </MenuItemCheckbox>
-            <MenuItemCheckbox checked={false} onChange={() => {}}>
-              Item
-            </MenuItemCheckbox>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} width="medium">
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItemDivider />
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} width="medium" size="small">
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItemDivider />
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Width large',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} width="large">
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-            <MenuItemDivider />
-            <MenuItemCheckbox checked={true} onChange={() => {}}>
-              Item
-            </MenuItemCheckbox>
-            <MenuItemCheckbox checked={false} onChange={() => {}}>
-              Item
-            </MenuItemCheckbox>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} width="large">
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItemDivider />
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} width="large" size="small">
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItemDivider />
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
     {
       label: 'Reserve icon space',
       Example: () => (
-        <Box display="flex">
-          <Menu {...defaultProps} reserveIconSpace>
-            <MenuItem onClick={() => {}} icon={<IconProfile />}>
-              Item
-            </MenuItem>
-            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-              Item
-            </MenuItem>
-            <MenuItemDivider />
-            <MenuItemCheckbox checked={true} onChange={() => {}}>
-              Item
-            </MenuItemCheckbox>
-            <MenuItemCheckbox checked={false} onChange={() => {}}>
-              Item
-            </MenuItemCheckbox>
-            <MenuItemDivider />
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-            <MenuItem onClick={() => {}}>Item</MenuItem>
-          </Menu>
-        </Box>
+        <Inline space="medium">
+          <Box display="flex">
+            <Menu {...defaultProps} reserveIconSpace>
+              <MenuItem onClick={() => {}} icon={<IconProfile />}>
+                Item
+              </MenuItem>
+              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+                Item
+              </MenuItem>
+              <MenuItemDivider />
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemDivider />
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+            </Menu>
+          </Box>
+          <Box display="flex">
+            <Menu {...defaultProps} reserveIconSpace size="small">
+              <MenuItem onClick={() => {}} icon={<IconProfile />}>
+                Item
+              </MenuItem>
+              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+                Item
+              </MenuItem>
+              <MenuItemDivider />
+              <MenuItemCheckbox checked={true} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemCheckbox checked={false} onChange={() => {}}>
+                Item
+              </MenuItemCheckbox>
+              <MenuItemDivider />
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+              <MenuItem onClick={() => {}}>Item</MenuItem>
+            </Menu>
+          </Box>
+        </Inline>
       ),
     },
   ],

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.screenshots.tsx
@@ -18,6 +18,7 @@ import { calc } from '@vanilla-extract/css-utils';
 const defaultProps = {
   offsetSpace: 'none',
   align: 'left',
+  size: 'standard',
   width: 'content',
   highlightIndex: -1,
   open: true,

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.screenshots.tsx
@@ -100,28 +100,24 @@ export const screenshots: ComponentScreenshot = {
     {
       label: 'Placement bottom',
       Example: () => (
-        <Box display="flex">
-          <Box position="relative">
-            <Placeholder height={triggerHeight} label="Menu trigger" />
-            <Menu {...defaultProps} placement="bottom">
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-            </Menu>
-          </Box>
+        <Box position="relative">
+          <Placeholder height={triggerHeight} label="Menu trigger" />
+          <Menu {...defaultProps} placement="bottom">
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+          </Menu>
         </Box>
       ),
     },
     {
       label: 'Placement bottom with small offset',
       Example: () => (
-        <Box display="flex">
-          <Box position="relative">
-            <Placeholder height={triggerHeight} label="Menu trigger" />
-            <Menu {...defaultProps} placement="bottom" offsetSpace="small">
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-            </Menu>
-          </Box>
+        <Box position="relative">
+          <Placeholder height={triggerHeight} label="Menu trigger" />
+          <Menu {...defaultProps} placement="bottom" offsetSpace="small">
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+          </Menu>
         </Box>
       ),
     },
@@ -196,32 +192,28 @@ export const screenshots: ComponentScreenshot = {
       label: 'Width content',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} width="content">
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItemDivider />
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} width="content" size="small">
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItemDivider />
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps} width="content">
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItemDivider />
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+          </Menu>
+          <Menu {...defaultProps} width="content" size="small">
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItemDivider />
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+          </Menu>
         </Inline>
       ),
     },
@@ -229,38 +221,34 @@ export const screenshots: ComponentScreenshot = {
       label: 'Width small',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} width="small">
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItemDivider />
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemDivider />
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} width="small" size="small">
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItemDivider />
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemDivider />
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps} width="small">
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItemDivider />
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemDivider />
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+          </Menu>
+          <Menu {...defaultProps} width="small" size="small">
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItemDivider />
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemDivider />
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+          </Menu>
         </Inline>
       ),
     },
@@ -268,32 +256,28 @@ export const screenshots: ComponentScreenshot = {
       label: 'Width medium',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} width="medium">
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItemDivider />
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} width="medium" size="small">
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItemDivider />
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps} width="medium">
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItemDivider />
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+          </Menu>
+          <Menu {...defaultProps} width="medium" size="small">
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItemDivider />
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+          </Menu>
         </Inline>
       ),
     },
@@ -301,32 +285,28 @@ export const screenshots: ComponentScreenshot = {
       label: 'Width large',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} width="large">
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItemDivider />
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} width="large" size="small">
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItemDivider />
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps} width="large">
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItemDivider />
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+          </Menu>
+          <Menu {...defaultProps} width="large" size="small">
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItemDivider />
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+          </Menu>
         </Inline>
       ),
     },
@@ -334,46 +314,42 @@ export const screenshots: ComponentScreenshot = {
       label: 'Reserve icon space',
       Example: () => (
         <Inline space="medium">
-          <Box display="flex">
-            <Menu {...defaultProps} reserveIconSpace>
-              <MenuItem onClick={() => {}} icon={<IconProfile />}>
-                Item
-              </MenuItem>
-              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-                Item
-              </MenuItem>
-              <MenuItemDivider />
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemDivider />
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-            </Menu>
-          </Box>
-          <Box display="flex">
-            <Menu {...defaultProps} reserveIconSpace size="small">
-              <MenuItem onClick={() => {}} icon={<IconProfile />}>
-                Item
-              </MenuItem>
-              <MenuItem onClick={() => {}} icon={<IconBookmark />}>
-                Item
-              </MenuItem>
-              <MenuItemDivider />
-              <MenuItemCheckbox checked={true} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemCheckbox checked={false} onChange={() => {}}>
-                Item
-              </MenuItemCheckbox>
-              <MenuItemDivider />
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-              <MenuItem onClick={() => {}}>Item</MenuItem>
-            </Menu>
-          </Box>
+          <Menu {...defaultProps} reserveIconSpace>
+            <MenuItem onClick={() => {}} icon={<IconProfile />}>
+              Item
+            </MenuItem>
+            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+              Item
+            </MenuItem>
+            <MenuItemDivider />
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemDivider />
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+          </Menu>
+          <Menu {...defaultProps} reserveIconSpace size="small">
+            <MenuItem onClick={() => {}} icon={<IconProfile />}>
+              Item
+            </MenuItem>
+            <MenuItem onClick={() => {}} icon={<IconBookmark />}>
+              Item
+            </MenuItem>
+            <MenuItemDivider />
+            <MenuItemCheckbox checked={true} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemCheckbox checked={false} onChange={() => {}}>
+              Item
+            </MenuItemCheckbox>
+            <MenuItemDivider />
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+            <MenuItem onClick={() => {}}>Item</MenuItem>
+          </Menu>
         </Inline>
       ),
     },

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.snippets.tsx
@@ -8,9 +8,9 @@ import {
   IconChevron,
   Placeholder,
   IconList,
+  ButtonIcon,
 } from '../../playroom/components';
 import source from '@braid-design-system/source.macro';
-import { ButtonIcon } from '../ButtonIcon/ButtonIcon';
 
 export const snippets: Snippets = [
   {

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.snippets.tsx
@@ -14,7 +14,7 @@ import source from '@braid-design-system/source.macro';
 
 export const snippets: Snippets = [
   {
-    name: 'Text trigger',
+    name: 'Standard',
     code: source(
       <MenuRenderer
         offsetSpace="small"
@@ -36,7 +36,7 @@ export const snippets: Snippets = [
     ),
   },
   {
-    name: 'Small Text trigger',
+    name: 'Small',
     code: source(
       <MenuRenderer
         size="small"
@@ -59,7 +59,7 @@ export const snippets: Snippets = [
     ),
   },
   {
-    name: 'ButtonIcon trigger',
+    name: 'With ButtonIcon',
     code: source(
       <MenuRenderer
         offsetSpace="small"
@@ -78,7 +78,7 @@ export const snippets: Snippets = [
     ),
   },
   {
-    name: 'Small ButtonIcon trigger',
+    name: 'Small with ButtonIcon',
     code: source(
       <MenuRenderer
         size="small"
@@ -100,7 +100,7 @@ export const snippets: Snippets = [
     ),
   },
   {
-    name: 'Placeholder trigger',
+    name: 'With Placeholder',
     code: source(
       <MenuRenderer
         offsetSpace="small"

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.snippets.tsx
@@ -1,0 +1,120 @@
+import type { Snippets } from '../private/Snippets';
+import {
+  MenuRenderer,
+  MenuItem,
+  MenuItemLink,
+  Box,
+  Text,
+  IconChevron,
+  Placeholder,
+  IconList,
+} from '../../playroom/components';
+import source from '@braid-design-system/source.macro';
+import { ButtonIcon } from '../ButtonIcon/ButtonIcon';
+
+export const snippets: Snippets = [
+  {
+    name: 'Text trigger',
+    code: source(
+      <MenuRenderer
+        offsetSpace="small"
+        trigger={(triggerProps, { open }) => (
+          <Box userSelect="none" cursor="pointer" {...triggerProps}>
+            <Text>
+              Menu{' '}
+              <IconChevron
+                direction={open ? 'up' : 'down'}
+                alignY="lowercase"
+              />
+            </Text>
+          </Box>
+        )}
+      >
+        <MenuItem onClick={() => {}}>Button</MenuItem>
+        <MenuItemLink href="#">Link</MenuItemLink>
+      </MenuRenderer>,
+    ),
+  },
+  {
+    name: 'Small Text trigger',
+    code: source(
+      <MenuRenderer
+        size="small"
+        offsetSpace="xsmall"
+        trigger={(triggerProps, { open }) => (
+          <Box userSelect="none" cursor="pointer" {...triggerProps}>
+            <Text size="small">
+              Menu{' '}
+              <IconChevron
+                direction={open ? 'up' : 'down'}
+                alignY="lowercase"
+              />
+            </Text>
+          </Box>
+        )}
+      >
+        <MenuItem onClick={() => {}}>Button</MenuItem>
+        <MenuItemLink href="#">Link</MenuItemLink>
+      </MenuRenderer>,
+    ),
+  },
+  {
+    name: 'ButtonIcon trigger',
+    code: source(
+      <MenuRenderer
+        offsetSpace="small"
+        trigger={(triggerProps) => (
+          <Box userSelect="none" cursor="pointer" {...triggerProps}>
+            <ButtonIcon
+              icon={<IconList />}
+              id="buttonicon-menurenderer"
+              label="Menu"
+            />
+          </Box>
+        )}
+      >
+        <MenuItem onClick={() => {}}>Button</MenuItem>
+        <MenuItemLink href="#">Link</MenuItemLink>
+      </MenuRenderer>,
+    ),
+  },
+  {
+    name: 'Small ButtonIcon trigger',
+    code: source(
+      <MenuRenderer
+        size="small"
+        offsetSpace="xxsmall"
+        trigger={(triggerProps) => (
+          <Box userSelect="none" cursor="pointer" {...triggerProps}>
+            <ButtonIcon
+              size="small"
+              icon={<IconList />}
+              id="buttonicon-menurenderer"
+              label="Menu"
+            />
+          </Box>
+        )}
+      >
+        <MenuItem onClick={() => {}}>Button</MenuItem>
+        <MenuItemLink href="#">Link</MenuItemLink>
+      </MenuRenderer>,
+    ),
+  },
+  {
+    name: 'Placeholder trigger',
+    code: source(
+      <MenuRenderer
+        size="small"
+        offsetSpace="xsmall"
+        trigger={(triggerProps) => (
+          <Box userSelect="none" cursor="pointer" {...triggerProps}>
+            <Placeholder height={50} label="Menu Trigger" />
+          </Box>
+        )}
+      >
+        <MenuItem onClick={() => {}}>Button</MenuItem>
+        <MenuItemLink href="#">Link</MenuItemLink>
+      </MenuRenderer>,
+    ),
+  },
+];

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.snippets.tsx
@@ -64,13 +64,12 @@ export const snippets: Snippets = [
       <MenuRenderer
         offsetSpace="small"
         trigger={(triggerProps) => (
-          <Box userSelect="none" cursor="pointer" {...triggerProps}>
-            <ButtonIcon
-              icon={<IconList />}
-              id="buttonicon-menurenderer"
-              label="Menu"
-            />
-          </Box>
+          <ButtonIcon
+            icon={<IconList />}
+            id="buttonicon-menurenderer"
+            label="Menu"
+            {...triggerProps}
+          />
         )}
       >
         <MenuItem onClick={() => {}}>Button</MenuItem>
@@ -85,14 +84,13 @@ export const snippets: Snippets = [
         size="small"
         offsetSpace="xxsmall"
         trigger={(triggerProps) => (
-          <Box userSelect="none" cursor="pointer" {...triggerProps}>
-            <ButtonIcon
-              size="small"
-              icon={<IconList />}
-              id="buttonicon-menurenderer"
-              label="Menu"
-            />
-          </Box>
+          <ButtonIcon
+            size="small"
+            icon={<IconList />}
+            id="buttonicon-menurenderer"
+            label="Menu"
+            {...triggerProps}
+          />
         )}
       >
         <MenuItem onClick={() => {}}>Button</MenuItem>
@@ -104,8 +102,7 @@ export const snippets: Snippets = [
     name: 'Placeholder trigger',
     code: source(
       <MenuRenderer
-        size="small"
-        offsetSpace="xsmall"
+        offsetSpace="small"
         trigger={(triggerProps) => (
           <Box userSelect="none" cursor="pointer" {...triggerProps}>
             <Placeholder height={50} label="Menu Trigger" />

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.snippets.tsx
@@ -7,8 +7,8 @@ import {
   Text,
   IconChevron,
   Placeholder,
-  IconList,
   ButtonIcon,
+  IconEdit,
 } from '../../playroom/components';
 import source from '@braid-design-system/source.macro';
 
@@ -65,7 +65,7 @@ export const snippets: Snippets = [
         offsetSpace="small"
         trigger={(triggerProps) => (
           <ButtonIcon
-            icon={<IconList />}
+            icon={<IconEdit />}
             id="buttonicon-menurenderer"
             label="Menu"
             {...triggerProps}
@@ -87,7 +87,7 @@ export const snippets: Snippets = [
           <Box userSelect="none" cursor="pointer" {...triggerProps}>
             <ButtonIcon
               size="small"
-              icon={<IconList />}
+              icon={<IconEdit />}
               id="small-buttonicon-menurenderer"
               label="Menu"
             />

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.snippets.tsx
@@ -84,13 +84,14 @@ export const snippets: Snippets = [
         size="small"
         offsetSpace="xxsmall"
         trigger={(triggerProps) => (
-          <ButtonIcon
-            size="small"
-            icon={<IconList />}
-            id="buttonicon-menurenderer"
-            label="Menu"
-            {...triggerProps}
-          />
+          <Box userSelect="none" cursor="pointer" {...triggerProps}>
+            <ButtonIcon
+              size="small"
+              icon={<IconList />}
+              id="small-buttonicon-menurenderer"
+              label="Menu"
+            />
+          </Box>
         )}
       >
         <MenuItem onClick={() => {}}>Button</MenuItem>

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
@@ -26,7 +26,6 @@ import buildDataAttributes, {
 import * as styles from './MenuRenderer.css';
 import { BraidPortal } from '../BraidPortal/BraidPortal';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
-import type { MenuSize } from './MenuRendererTypes';
 import { useBraidTheme } from '../BraidProvider/BraidThemeContext';
 import { vars } from '../../themes/vars.css';
 
@@ -49,6 +48,7 @@ interface CloseReasonSelection {
   index: number;
   id?: string;
 }
+export type MenuSize = 'standard' | 'small';
 type CloseReason = CloseReasonSelection | CloseReasonExit;
 export interface MenuRendererProps {
   trigger: (props: TriggerProps, state: TriggerState) => ReactNode;

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
@@ -27,6 +27,8 @@ import * as styles from './MenuRenderer.css';
 import { BraidPortal } from '../BraidPortal/BraidPortal';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import type { MenuSize } from './MenuRendererTypes';
+import { useBraidTheme } from '../BraidProvider/BraidThemeContext';
+import { vars } from '../../themes/vars.css';
 
 interface TriggerProps {
   'aria-haspopup': boolean;
@@ -417,12 +419,16 @@ export function Menu({
 }: MenuProps) {
   let dividerCount = 0;
 
-  const inlineVars =
-    triggerPosition &&
-    assignInlineVars({
+  const menuYPadding =
+    useBraidTheme().legacy && size === 'small' ? 'xsmall' : 'xxsmall';
+
+  const inlineVars = assignInlineVars({
+    ...(triggerPosition && {
       [styles.triggerVars[placement]]: `${triggerPosition[placement]}px`,
       [styles.triggerVars[align]]: `${triggerPosition[align]}px`,
-    });
+    }),
+    [styles.menuYPadding]: vars.space[menuYPadding],
+  });
 
   return (
     <MenuRendererContext.Provider value={{ size, reserveIconSpace }}>
@@ -444,11 +450,11 @@ export function Menu({
           width !== 'content' && styles.width[width],
         ]}
       >
-        <ScrollContainer direction="vertical" fadeSize="medium">
-          <Box
-            paddingY={styles.menuYPadding}
-            className={styles.menuHeightLimit}
-          >
+        <ScrollContainer
+          direction="vertical"
+          fadeSize={size === 'standard' ? 'medium' : 'small'}
+        >
+          <Box paddingY={menuYPadding}>
             {Children.map(children, (item, i) => {
               if (isDivider(item)) {
                 dividerCount++;

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
@@ -26,6 +26,7 @@ import buildDataAttributes, {
 import * as styles from './MenuRenderer.css';
 import { BraidPortal } from '../BraidPortal/BraidPortal';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
+import type { MenuSize } from './MenuRendererTypes';
 
 interface TriggerProps {
   'aria-haspopup': boolean;
@@ -51,6 +52,7 @@ export interface MenuRendererProps {
   trigger: (props: TriggerProps, state: TriggerState) => ReactNode;
   align?: 'left' | 'right';
   offsetSpace?: ResponsiveSpace;
+  size?: MenuSize;
   width?: keyof typeof styles.width | 'content';
   placement?: 'top' | 'bottom';
   onOpen?: () => void;
@@ -118,6 +120,7 @@ export const MenuRenderer = ({
   onOpen,
   onClose,
   trigger,
+  size = 'standard',
   width = 'content',
   align = 'left',
   offsetSpace = 'none',
@@ -344,6 +347,7 @@ export const MenuRenderer = ({
           <BraidPortal>
             <Menu
               align={align}
+              size={size}
               width={width}
               placement={placement}
               offsetSpace={offsetSpace}
@@ -385,6 +389,7 @@ const borderRadius = 'large';
 interface MenuProps {
   offsetSpace: NonNullable<MenuRendererProps['offsetSpace']>;
   align: NonNullable<MenuRendererProps['align']>;
+  size: NonNullable<MenuRendererProps['size']>;
   width: NonNullable<MenuRendererProps['width']>;
   placement: NonNullable<MenuRendererProps['placement']>;
   reserveIconSpace: NonNullable<MenuRendererProps['reserveIconSpace']>;
@@ -399,6 +404,7 @@ interface MenuProps {
 export function Menu({
   offsetSpace,
   align,
+  size,
   width,
   placement,
   children,
@@ -419,7 +425,7 @@ export function Menu({
     });
 
   return (
-    <MenuRendererContext.Provider value={{ reserveIconSpace }}>
+    <MenuRendererContext.Provider value={{ size, reserveIconSpace }}>
       <Box
         role="menu"
         position={position}
@@ -427,7 +433,6 @@ export function Menu({
         boxShadow={placement === 'top' ? 'small' : 'medium'}
         borderRadius={borderRadius}
         background="surface"
-        paddingY="xxsmall"
         marginTop={placement === 'bottom' ? offsetSpace : undefined}
         marginBottom={placement === 'top' ? offsetSpace : undefined}
         transition="fast"
@@ -439,8 +444,11 @@ export function Menu({
           width !== 'content' && styles.width[width],
         ]}
       >
-        <ScrollContainer direction="vertical" fadeSize="small">
-          <Box className={styles.menuHeightLimit}>
+        <ScrollContainer direction="vertical" fadeSize="medium">
+          <Box
+            paddingY={styles.menuYPadding}
+            className={styles.menuHeightLimit}
+          >
             {Children.map(children, (item, i) => {
               if (isDivider(item)) {
                 dividerCount++;

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRendererContext.ts
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRendererContext.ts
@@ -1,6 +1,8 @@
 import { createContext } from 'react';
+import type { MenuSize } from './MenuRendererTypes';
 
 interface MenuRendererValues {
+  size: MenuSize;
   reserveIconSpace: boolean;
 }
 

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRendererContext.ts
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRendererContext.ts
@@ -1,5 +1,5 @@
 import { createContext } from 'react';
-import type { MenuSize } from './MenuRendererTypes';
+import type { MenuSize } from './MenuRenderer';
 
 interface MenuRendererValues {
   size: MenuSize;

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRendererTypes.ts
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRendererTypes.ts
@@ -1,2 +1,0 @@
-// todo - move to existing file
-export type MenuSize = 'standard' | 'small';

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRendererTypes.ts
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRendererTypes.ts
@@ -1,0 +1,2 @@
+// todo - move to existing file
+export type MenuSize = 'standard' | 'small';

--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.docs.tsx
@@ -191,6 +191,49 @@ const docs: ComponentDocs = {
         ),
     },
     {
+      label: 'Sizes',
+      description: (
+        <Text>
+          You can customise the size of the menu via the <Strong>size</Strong>{' '}
+          prop, which accepts either <Strong>standard</Strong> or{' '}
+          <Strong>small</Strong>.
+        </Text>
+      ),
+      Example: () =>
+        source(
+          <Stack space="medium">
+            <Inline alignY="center" space="medium">
+              <Text>Standard</Text>
+              <OverflowMenu size="standard" label="Options" id="example">
+                <MenuItem id="menuItem1" onClick={() => {}}>
+                  Item 1
+                </MenuItem>
+                <MenuItem id="menuItem2" onClick={() => {}}>
+                  Item 2
+                </MenuItem>
+                <MenuItem id="menuItem3" onClick={() => {}}>
+                  Item 3
+                </MenuItem>
+              </OverflowMenu>
+            </Inline>
+            <Inline alignY="center" space="medium">
+              <Text size="small">Small</Text>
+              <OverflowMenu size="small" label="Options" id="example">
+                <MenuItem id="menuItem1" onClick={() => {}}>
+                  Item 1
+                </MenuItem>
+                <MenuItem id="menuItem2" onClick={() => {}}>
+                  Item 2
+                </MenuItem>
+                <MenuItem id="menuItem3" onClick={() => {}}>
+                  Item 3
+                </MenuItem>
+              </OverflowMenu>
+            </Inline>
+          </Stack>,
+        ),
+    },
+    {
       label: 'Development considerations',
       description: (
         <Text>

--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.docs.tsx
@@ -204,7 +204,7 @@ const docs: ComponentDocs = {
           <Stack space="medium">
             <Inline alignY="center" space="medium">
               <Text>Standard</Text>
-              <OverflowMenu size="standard" label="Options" id="example">
+              <OverflowMenu size="standard" label="Options" id="size-standard">
                 <MenuItem id="menuItem1" onClick={() => {}}>
                   Item 1
                 </MenuItem>
@@ -218,7 +218,7 @@ const docs: ComponentDocs = {
             </Inline>
             <Inline alignY="center" space="medium">
               <Text size="small">Small</Text>
-              <OverflowMenu size="small" label="Options" id="example">
+              <OverflowMenu size="small" label="Options" id="size-small">
                 <MenuItem id="menuItem1" onClick={() => {}}>
                   Item 1
                 </MenuItem>

--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.screenshots.tsx
@@ -19,5 +19,19 @@ export const screenshots: ComponentScreenshot = {
         </Box>
       ),
     },
+    {
+      label: 'Small',
+      background: 'surface',
+      Example: ({ handler }) => (
+        <Box style={{ maxWidth: '100px' }}>
+          <OverflowMenu size="small" label="Options">
+            <MenuItem onClick={handler}>Button</MenuItem>
+            <MenuItemLink href="#" onClick={handler}>
+              Link
+            </MenuItemLink>
+          </OverflowMenu>
+        </Box>
+      ),
+    },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.snippets.tsx
@@ -1,4 +1,3 @@
-import React from 'react';
 import type { Snippets } from '../private/Snippets';
 import { OverflowMenu, MenuItem } from '../../playroom/components';
 import source from '@braid-design-system/source.macro';
@@ -8,6 +7,15 @@ export const snippets: Snippets = [
     name: 'Standard',
     code: source(
       <OverflowMenu label="Options">
+        <MenuItem>Option</MenuItem>
+        <MenuItem>Option</MenuItem>
+      </OverflowMenu>,
+    ),
+  },
+  {
+    name: 'Small',
+    code: source(
+      <OverflowMenu size="small" label="Options">
         <MenuItem>Option</MenuItem>
         <MenuItem>Option</MenuItem>
       </OverflowMenu>,

--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.tsx
@@ -9,7 +9,10 @@ import { Box } from '../Box/Box';
 import * as styles from './OverflowMenu.css';
 
 export interface OverflowMenuProps
-  extends Omit<MenuRendererProps, 'trigger' | 'align' | 'offsetSpace'> {
+  extends Omit<
+    MenuRendererProps,
+    'size' | 'trigger' | 'align' | 'offsetSpace'
+  > {
   label: string;
   id?: string;
 }

--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.tsx
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.tsx
@@ -9,15 +9,13 @@ import { Box } from '../Box/Box';
 import * as styles from './OverflowMenu.css';
 
 export interface OverflowMenuProps
-  extends Omit<
-    MenuRendererProps,
-    'size' | 'trigger' | 'align' | 'offsetSpace'
-  > {
+  extends Omit<MenuRendererProps, 'trigger' | 'align' | 'offsetSpace'> {
   label: string;
   id?: string;
 }
 
 export const OverflowMenu = ({
+  size,
   label,
   children,
   id,
@@ -34,6 +32,7 @@ export const OverflowMenu = ({
           // @ts-expect-error With no id, ButtonIcon will fallback from Tooltip to title internally.
           // ID will no longer be required when React 18 has sufficient adoption and we can safely `useId()`
           id={id}
+          size={size}
           icon={<IconOverflow />}
           variant="transparent"
           label={label}
@@ -41,7 +40,8 @@ export const OverflowMenu = ({
         />
       )}
       align="right"
-      offsetSpace="small"
+      size={size}
+      offsetSpace={size === 'standard' ? 'small' : 'xsmall'}
       {...menuProps}
     >
       {children}

--- a/packages/braid-design-system/src/lib/playroom/snippets.ts
+++ b/packages/braid-design-system/src/lib/playroom/snippets.ts
@@ -21,6 +21,7 @@ import { snippets as Heading } from './snippets/Heading';
 import { snippets as Inline } from './snippets/Inline';
 import { snippets as List } from './snippets/List';
 import { snippets as Loader } from './snippets/Loader';
+import { snippets as MenuRenderer } from './snippets/MenuRenderer';
 import { snippets as MonthPicker } from './snippets/MonthPicker';
 import { snippets as Notice } from './snippets/Notice';
 import { snippets as OverflowMenu } from './snippets/OverflowMenu';
@@ -70,6 +71,7 @@ export default Object.entries({
   Inline,
   List,
   Loader,
+  MenuRenderer,
   MonthPicker,
   Notice,
   OverflowMenu,

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -7498,6 +7498,9 @@ exports[`OverflowMenu 1`] = `
         | "bottom"
         | "top"
     reserveIconSpace?: boolean
+    size?: 
+        | "small"
+        | "standard"
     width?: 
         | "content"
         | "large"

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -7418,6 +7418,9 @@ exports[`MenuRenderer 1`] = `
         | "bottom"
         | "top"
     reserveIconSpace?: boolean
+    size?: 
+        | "small"
+        | "standard"
     trigger: (props: TriggerProps, state: TriggerState) => ReactNode
     width?: 
         | "content"


### PR DESCRIPTION
Introduce a new `small` size for the `MenuRenderer` component.
This is available via the `size` prop, which supports the existing `standard` (default) and `small`.

**EXAMPLE USAGE:**
```jsx
<MenuRenderer size="small" ... />
```

**NB**:

In small menus, `ScrollContainer` is causing some issues in non-production themes (docs, wireframe). This is due to their small value for `xsmall` padding, being too small to accommodate for the excess space created by the `virtualTouchable` box around each `MenuItem`. Potentially, the space scale of these themes could be revisited? I'm not sure another way around this problem.