### PR TITLE
MenuRenderer, OverflowMenu: Ensure max height

### DIFF
--- a/.changeset/friendly-trains-explain.md
+++ b/.changeset/friendly-trains-explain.md
@@ -8,4 +8,4 @@ updated:
   - OverflowMenu
 ---
 
-**MenuRenderer, OverflowMenu**: Fix bug, ensure the `Menu` size is limited by a maximum height.
+**MenuRenderer, OverflowMenu**: Ensure the menu has a maximum height.

--- a/.changeset/friendly-trains-explain.md
+++ b/.changeset/friendly-trains-explain.md
@@ -1,0 +1,11 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - MenuRenderer
+  - OverflowMenu
+---
+
+**MenuRenderer, OverflowMenu**: Fix bug, ensure the `Menu` size is limited by a maximum height.

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.screenshots.tsx
@@ -357,5 +357,54 @@ export const screenshots: ComponentScreenshot = {
         </Inline>
       ),
     },
+    {
+      label: 'Height limit',
+      Example: () => (
+        <Inline space="medium">
+          <Menu {...defaultProps}>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+          </Menu>
+          <Menu {...defaultProps} size="small">
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+            <MenuItem onClick={() => {}}>Button</MenuItem>
+          </Menu>
+        </Inline>
+      ),
+    },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
@@ -454,7 +454,7 @@ export function Menu({
           direction="vertical"
           fadeSize={size === 'standard' ? 'medium' : 'small'}
         >
-          <Box paddingY={menuYPadding}>
+          <Box paddingY={menuYPadding} className={styles.menuHeightLimit}>
             {Children.map(children, (item, i) => {
               if (isDivider(item)) {
                 dividerCount++;


### PR DESCRIPTION
This limit was mistakenly removed in https://github.com/seek-oss/braid-design-system/pull/1675

Added some screenshot tests to prevent the issue. In legacy themes, the max height of small and standard Menus is different due to the padding workaround, but this does not impact `seekJobs` theme