### PR TITLE
docs: Remove broken link and fix typo on Stepper

### DIFF
--- a/packages/braid-design-system/src/lib/components/Stepper/Stepper.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Stepper/Stepper.docs.tsx
@@ -42,7 +42,7 @@ const docs: ComponentDocs = {
         <TextLink href="https://www.w3.org/WAI/ARIA/apg/practices/landmark-regions/#x4-2-general-principles-of-landmark-design">
           General Principles of Landmark Design
         </TextLink>{' '}
-        it is neccessary for it to have an <Strong>aria-label</Strong>.
+        it is necessary for it to have an <Strong>aria-label</Strong>.
       </Text>
       <Text tone="promote" id="translations">
         <IconLanguage title="Translation hint" titleId="translations" /> The{' '}
@@ -265,11 +265,7 @@ const docs: ComponentDocs = {
           </Text>
           <Text>
             This makes the highlight colour follow the default text colour,
-            including{' '}
-            <TextLink href="#contextual-design">
-              inverting on dark surfaces
-            </TextLink>{' '}
-            to improve contrast.
+            including inverting on dark surfaces to improve contrast.
           </Text>
         </>
       ),


### PR DESCRIPTION
Just noticed the Contextual Design section never existed for this component, so removing the link to the heading. Also fix typo