### PR TITLE
theme: Expose web fonts `href` on runtime tokens

### DIFF
--- a/.changeset/green-wasps-fail.md
+++ b/.changeset/green-wasps-fail.md
@@ -1,0 +1,22 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - theme
+---
+
+**theme:** Expose web fonts `href` on runtime tokens
+
+Extend the `webFonts` runtime token to include the `href` property containing the web font URL.
+This enables custom handling of web fonts beyond injecting the pre-constructed `link` tag(s).
+
+**EXAMPLE USAGE:**
+```jsx
+import seekJobs from 'braid-design-system/themes/seekJobs';
+
+const webFontHrefs = seekJobs.webFonts.map(({ href }) => href);
+
+// => [ "https://www.seek.com.au/static/shared-web/seeksans.css" ]
+```

--- a/packages/braid-design-system/src/lib/themes/makeRuntimeTokens.ts
+++ b/packages/braid-design-system/src/lib/themes/makeRuntimeTokens.ts
@@ -8,7 +8,9 @@ const makeWebFonts = (webFont: BraidTokens['typography']['webFont']) => {
     return [];
   }
 
-  return [{ linkTag: `<link href="${webFont}" rel="stylesheet" />` }];
+  return [
+    { linkTag: `<link href="${webFont}" rel="stylesheet" />`, href: webFont },
+  ];
 };
 
 export const makeRuntimeTokens = (tokens: BraidTokens) => ({

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -2032,7 +2032,7 @@ exports[`BraidProvider 1`] = `
         | FunctionComponent<LinkComponentProps>
         | { readonly __forwardRef__: ForwardRefExoticComponent<LinkComponentProps & RefAttributes<HTMLAnchorElement>>; }
     styleBody?: boolean
-    theme: { vanillaTheme: string; name: string; displayName: string; legacy: boolean; background: { lightMode: string; darkMode: string; }; webFonts: { linkTag: string; }[]; space: { grid: number; space: { gutter: number; ... 7 more ...; xxxlarge: number; }; }; color: { ...; }; backgroundLightness: Record<...>; }
+    theme: { vanillaTheme: string; name: string; displayName: string; legacy: boolean; background: { lightMode: string; darkMode: string; }; webFonts: { linkTag: string; href: string; }[]; space: { grid: number; space: { ...; }; }; color: { ...; }; backgroundLightness: Record<...>; }
 },
 }
 `;
@@ -7935,6 +7935,16 @@ exports[`TableFooter 1`] = `
 }
 `;
 
+exports[`TableHeader 1`] = `
+{
+  exportType: component,
+  props: {
+    children: ReactNode
+    data?: DataAttributeMap
+},
+}
+`;
+
 exports[`TableHeaderCell 1`] = `
 {
   exportType: component,
@@ -7961,16 +7971,6 @@ exports[`TableHeaderCell 1`] = `
         | "content"
         | \`\${number}%\`
     wrap?: boolean
-},
-}
-`;
-
-exports[`TableHeader 1`] = `
-{
-  exportType: component,
-  props: {
-    children: ReactNode
-    data?: DataAttributeMap
 },
 }
 `;


### PR DESCRIPTION
Extend the `webFonts` runtime token to include the `href` property containing the web font URL. This enables custom handling of web fonts beyond injecting the pre-constructed `link` tag(s).

**EXAMPLE USAGE:**
```jsx
import seekJobs from 'braid-design-system/themes/seekJobs';

const webFontHrefs = seekJobs.webFonts.map(({ href }) => href);

// => [ "https://www.seek.com.au/static/shared-web/seeksans.css" ]
```