### PR TITLE
docs-ui: Fix build workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "nx run-many --target=dev",
     "start": "nx run site:start",
     "start:playroom": "nx run site:start:playroom",
-    "build": "nx run braid-design-system:build",
+    "build": "pnpm build:braid && pnpm build:docs-ui",
+    "build:braid": "nx run braid-design-system:build",
     "build:docs-ui": "nx run docs-ui:build",
     "build:site": "nx run site:build",
     "postbuild": "concurrently --group 'pnpm:test:integration' 'pnpm:validate'",
@@ -32,7 +33,7 @@
     "deploy": "node scripts/deploy.js",
     "post-commit-status": "node scripts/postCommitStatus.js",
     "release": "pnpm prepare-publish && changeset publish",
-    "prepare-publish": "pnpm build && pnpm build:docs-ui && tsx scripts/copyReadme.cts",
+    "prepare-publish": "pnpm build && tsx scripts/copyReadme.cts",
     "version": "changeset version && tsx scripts/versionComponentUpdates.cts && pnpm install --lockfile-only",
     "changeset": "EDITOR=scripts/writeBraidFrontMatter.js ./node_modules/.bin/changeset add --open"
   },

--- a/packages/docs-ui/package.json
+++ b/packages/docs-ui/package.json
@@ -36,6 +36,7 @@
     "@vanilla-extract/css": "^1.9.2"
   },
   "devDependencies": {
+    "@types/react": "^18.3.18",
     "braid-design-system": "workspace:*",
     "react": "^18.3.1"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -449,6 +449,9 @@ importers:
         specifier: ^1.9.2
         version: 1.17.0(babel-plugin-macros@3.1.0)
     devDependencies:
+      '@types/react':
+        specifier: ^18.3.18
+        version: 18.3.18
       braid-design-system:
         specifier: workspace:*
         version: link:../braid-design-system


### PR DESCRIPTION
The removal of the default React export exposed a missing types dependency in dev for the `docs-ui` package. This was not picked up until the build on `master` due to a mistake in the workflow that only runs the `docs-ui` as part of the `prepare-publish` step.

The workflow fix is to run `build:braid` and `build:docs-ui` as part of the `validate` step to ensure we catch this earlier.