### PR TITLE
ci: Add clean up workflow

### DIFF
--- a/.github/workflows/clean-up-previews.yml
+++ b/.github/workflows/clean-up-previews.yml
@@ -1,0 +1,29 @@
+name: Clean up preview site
+
+on: workflow_dispatch
+
+jobs:
+  delete:
+    name: Clean up preview site
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+      PREVIEW_DIR: preview/
+      DAYS_OLD: 1
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        ref: gh-pages-test
+
+      - name: Delete old preview directories
+        run: |
+          for i in `find ${{ env.PREVIEW_DIR }} -mindepth 1 -maxdepth 1 -type d -mtime +${{ env.DAYS_OLD }} -print`; do echo -e "Deleting directory $i";rm -rf $i; done
+          if [[ $(git status --porcelain --untracked-files=no | wc -l) -eq 0 ]]; then echo "No directories to clean up";exit 0; fi
+          git config --global user.name 'GitHub Actions'
+          git config --global user.email 'actions@github.com'
+          git add ${{ env.PREVIEW_DIR }}
+          git commit --quiet -m "Clean up old preview directories"
+          git push
+        shell: bash
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,4 +57,3 @@ jobs:
           clean-exclude: |
             /preview/*
             /grad-connection/*
-          single-commit: true


### PR DESCRIPTION
Introduces a clean up workflow to delete old preview deployments to stop hitting the size limit of GitHub pages.

Initially script has some debugging:
- dispatches manually, will be a cron
- targets a test branch, will checkout `gh-pages` 
- finds deployed files older than a day, will be a higher number (tbd)

Also removing the `single-commit` config on the release workflow as that re-writes the preview folder which clashes with this new workflow.