### PR TITLE
ci: Update GitHub pages clean up workflow

### DIFF
--- a/.github/workflows/clean-up-previews.yml
+++ b/.github/workflows/clean-up-previews.yml
@@ -9,16 +9,16 @@ jobs:
     env:
       CI: true
       PREVIEW_DIR: preview
-      DAYS_OLD: -1
+      DAYS_OLD: 7
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
         with:
-          ref: gh-pages-test
+          ref: gh-pages
 
       - name: Delete old preview directories
         run: |
-          for i in `find ${{ env.PREVIEW_DIR }} -mindepth 1 -maxdepth 1 -type d -mtime ${{ env.DAYS_OLD }} -print`; do echo -e "Deleting directory $i";rm -rf $i; done
+          for i in `find ${{ env.PREVIEW_DIR }} -mindepth 1 -maxdepth 1 -type d -mtime +${{ env.DAYS_OLD }} -print`; do echo -e "Deleting directory $i";rm -rf $i; done
           if [[ $(git status --porcelain --untracked-files=no | wc -l) -eq 0 ]]; then echo "No directories to clean up";exit 0; fi
           git config --local user.name 'GitHub Actions'
           git config --local user.email 'actions@github.com'

--- a/.github/workflows/clean-up-previews.yml
+++ b/.github/workflows/clean-up-previews.yml
@@ -8,8 +8,8 @@ jobs:
     runs-on: ubuntu-latest
     env:
       CI: true
-      PREVIEW_DIR: preview/
-      DAYS_OLD: 1
+      PREVIEW_DIR: preview
+      DAYS_OLD: -1
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
@@ -18,7 +18,7 @@ jobs:
 
       - name: Delete old preview directories
         run: |
-          for i in `find ${{ env.PREVIEW_DIR }} -mindepth 1 -maxdepth 1 -type d -mtime +${{ env.DAYS_OLD }} -print`; do echo -e "Deleting directory $i";rm -rf $i; done
+          for i in `find ${{ env.PREVIEW_DIR }} -mindepth 1 -maxdepth 1 -type d -mtime ${{ env.DAYS_OLD }} -print`; do echo -e "Deleting directory $i";rm -rf $i; done
           if [[ $(git status --porcelain --untracked-files=no | wc -l) -eq 0 ]]; then echo "No directories to clean up";exit 0; fi
           git config --local user.name 'GitHub Actions'
           git config --local user.email 'actions@github.com'

--- a/.github/workflows/clean-up-previews.yml
+++ b/.github/workflows/clean-up-previews.yml
@@ -13,14 +13,15 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-        ref: gh-pages-test
+        with:
+          ref: gh-pages-test
 
       - name: Delete old preview directories
         run: |
           for i in `find ${{ env.PREVIEW_DIR }} -mindepth 1 -maxdepth 1 -type d -mtime +${{ env.DAYS_OLD }} -print`; do echo -e "Deleting directory $i";rm -rf $i; done
           if [[ $(git status --porcelain --untracked-files=no | wc -l) -eq 0 ]]; then echo "No directories to clean up";exit 0; fi
-          git config --global user.name 'GitHub Actions'
-          git config --global user.email 'actions@github.com'
+          git config --local user.name 'GitHub Actions'
+          git config --local user.email 'actions@github.com'
           git add ${{ env.PREVIEW_DIR }}
           git commit --quiet -m "Clean up old preview directories"
           git push

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "generate:icons": "nx run braid-design-system:generate:icons",
     "generate:snippets": "nx run braid-design-system:generate:snippets",
     "generate:component-docs": "nx run site:generate:component-docs",
-    "deploy": "node scripts/deploy.js",
     "post-commit-status": "node scripts/postCommitStatus.js",
     "release": "pnpm prepare-publish && changeset publish",
     "prepare-publish": "pnpm build && tsx scripts/copyReadme.cts",


### PR DESCRIPTION
Pointing the clean up workflow at the real `gh-pages` branch, and setting to 7 day max age.

Leaving the trigger to be manual for the moment, but can set the cron cadence and max age as a follow up.


(Also removing unused `deploy` command pointing to a script that no longer exists)