### PR TITLE
Add `tabIndex` to all form fields

### DIFF
--- a/.changeset/tidy-jars-arrive.md
+++ b/.changeset/tidy-jars-arrive.md
@@ -1,0 +1,30 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Autosuggest
+  - Checkbox
+  - CheckboxStandalone
+  - Dropdown
+  - MonthPicker
+  - PasswordField
+  - RadioGroup
+  - TextDropdown
+  - TextField
+  - Textarea
+---
+
+Add `tabIndex` support to all form fields
+
+Ensure the `tabIndex` prop is available on all form fields, enabling greater control over which elements appear in the keyboard navigation flow.
+
+In line with [MDN guidance], the only supported values are `0` and `-1` to ensure best practice for keyboard navigation and assistive technologies.
+
+**EXAMPLE USAGE:**
+```jsx
+<TextField tabIndex={-1} />
+```
+
+[MDN guidance]: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex#:~:text=only%20use%200%20and%20%2D1%20as%20tabindex%20values

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.playroom.tsx
@@ -2,6 +2,7 @@ import type { Optional } from 'utility-types';
 
 import { type StateProp, useFallbackState } from '../../playroom/playroomState';
 import { useFallbackId } from '../../playroom/utils';
+import { validTabIndexes } from '../private/validateTabIndex';
 
 import {
   type AutosuggestBaseProps,
@@ -19,6 +20,7 @@ export function Autosuggest<Value>({
   value,
   onChange,
   onClear,
+  tabIndex,
   ...restProps
 }: PlayroomAutosuggestProps<Value>) {
   const fallbackId = useFallbackId();
@@ -39,6 +41,7 @@ export function Autosuggest<Value>({
         handleChange(blankValue);
         onClear?.();
       }}
+      tabIndex={validTabIndexes.includes(tabIndex!) ? tabIndex : undefined}
       {...restProps}
     />
   );

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.test.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.test.tsx
@@ -16,11 +16,17 @@ function renderAutosuggest<Value>({
   value: initialValue,
   suggestions: suggestionsProp,
   automaticSelection,
+  tabIndex,
   onFocus,
   onBlur,
 }: Pick<
   AutosuggestProps<Value>,
-  'value' | 'suggestions' | 'automaticSelection' | 'onFocus' | 'onBlur'
+  | 'value'
+  | 'suggestions'
+  | 'automaticSelection'
+  | 'onFocus'
+  | 'onBlur'
+  | 'tabIndex'
 >) {
   const changeHandler = jest.fn();
 
@@ -48,6 +54,7 @@ function renderAutosuggest<Value>({
             changeHandler(...args);
           }}
           suggestions={suggestions}
+          tabIndex={tabIndex}
           onFocus={onFocus}
           onBlur={onBlur}
         />
@@ -565,6 +572,81 @@ describe('Autosuggest', () => {
   });
 
   describe('keyboard access', () => {
+    it('should not be accessible with tabindex of -1', async () => {
+      renderAutosuggest({
+        value: { text: '' },
+        suggestions: [
+          {
+            text: 'Apples',
+            value: 'apples',
+            highlights: [{ start: 0, end: 4 }],
+          },
+          {
+            text: 'Bananas',
+            value: 'bananas',
+            highlights: [{ start: 0, end: 4 }],
+          },
+        ],
+        tabIndex: -1,
+      });
+
+      expect(document.body).toHaveFocus();
+
+      await userEvent.tab();
+
+      expect(document.body).toHaveFocus();
+    });
+
+    it('should be accessible with tabindex of 0', async () => {
+      const { input } = renderAutosuggest({
+        value: { text: '' },
+        suggestions: [
+          {
+            text: 'Apples',
+            value: 'apples',
+            highlights: [{ start: 0, end: 4 }],
+          },
+          {
+            text: 'Bananas',
+            value: 'bananas',
+            highlights: [{ start: 0, end: 4 }],
+          },
+        ],
+        tabIndex: 0,
+      });
+
+      expect(document.body).toHaveFocus();
+
+      await userEvent.tab();
+
+      expect(input).toHaveFocus();
+    });
+
+    it('should be accessible with a tabindex of undefined', async () => {
+      const { input } = renderAutosuggest({
+        value: { text: '' },
+        suggestions: [
+          {
+            text: 'Apples',
+            value: 'apples',
+            highlights: [{ start: 0, end: 4 }],
+          },
+          {
+            text: 'Bananas',
+            value: 'bananas',
+            highlights: [{ start: 0, end: 4 }],
+          },
+        ],
+        tabIndex: undefined,
+      });
+
+      expect(document.body).toHaveFocus();
+
+      await userEvent.tab();
+
+      expect(input).toHaveFocus();
+    });
+
     it("shouldn't select anything and close the list on enter if the user hasn't navigated the list", async () => {
       const { input, changeHandler, getInputValue, queryByLabelText } =
         renderAutosuggest({

--- a/packages/braid-design-system/src/lib/components/Checkbox/Checkbox.tsx
+++ b/packages/braid-design-system/src/lib/components/Checkbox/Checkbox.tsx
@@ -5,6 +5,7 @@ import {
   InlineField,
 } from '../private/InlineField/InlineField';
 import type { CheckboxChecked } from '../private/InlineField/StyledInput';
+import { validTabIndexes } from '../private/validateTabIndex';
 
 import { resolveCheckedGroup } from './resolveCheckedGroup';
 
@@ -13,7 +14,7 @@ export interface CheckboxProps extends Omit<InlineFieldProps, 'checked'> {
 }
 
 export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
-  ({ checked, ...restProps }, ref) => {
+  ({ checked, tabIndex, ...restProps }, ref) => {
     const calculatedChecked = Array.isArray(checked)
       ? resolveCheckedGroup(checked)
       : checked;
@@ -21,6 +22,7 @@ export const Checkbox = forwardRef<HTMLInputElement, CheckboxProps>(
     return (
       <InlineField
         {...restProps}
+        tabIndex={validTabIndexes.includes(tabIndex!) ? tabIndex : undefined}
         checked={calculatedChecked}
         type="checkbox"
         ref={ref}

--- a/packages/braid-design-system/src/lib/components/Checkbox/CheckboxStandalone.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/Checkbox/CheckboxStandalone.playroom.tsx
@@ -2,6 +2,7 @@ import type { Optional } from 'utility-types';
 
 import { type StateProp, useFallbackState } from '../../playroom/playroomState';
 import { useFallbackId } from '../../playroom/utils';
+import { validTabIndexes } from '../private/validateTabIndex';
 
 import {
   type CheckboxStandaloneProps,
@@ -16,6 +17,7 @@ export const CheckboxStandalone = ({
   stateName,
   checked,
   onChange,
+  tabIndex,
   'aria-label': ariaLabel,
   ...restProps
 }: PlayroomCheckboxStandaloneProps) => {
@@ -33,6 +35,7 @@ export const CheckboxStandalone = ({
       checked={state}
       onChange={handleChange}
       aria-label={ariaLabel ?? ''}
+      tabIndex={validTabIndexes.includes(tabIndex!) ? tabIndex : undefined}
       {...restProps}
     />
   );

--- a/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.playroom.tsx
@@ -2,6 +2,7 @@ import type { Optional } from 'utility-types';
 
 import { type StateProp, useFallbackState } from '../../playroom/playroomState';
 import { useFallbackId } from '../../playroom/utils';
+import { validTabIndexes } from '../private/validateTabIndex';
 
 import {
   type DropdownBaseProps,
@@ -18,6 +19,7 @@ export const Dropdown = ({
   stateName,
   value,
   onChange,
+  tabIndex,
   ...restProps
 }: PlayroomDropdownProps) => {
   const fallbackId = useFallbackId();
@@ -33,6 +35,7 @@ export const Dropdown = ({
       id={id ?? fallbackId}
       value={state}
       onChange={handleChange}
+      tabIndex={validTabIndexes.includes(tabIndex!) ? tabIndex : undefined}
       {...restProps}
     />
   );

--- a/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.test.tsx
+++ b/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { Dropdown } from '..';
 import { BraidTestProvider } from '../../../entries/test';
@@ -239,5 +240,71 @@ describe('Dropdown', () => {
     expect(select.selectedIndex).toBe(0);
     expect(select.options.length).toEqual(1);
     expect(select.options[0].text).toEqual('1');
+  });
+
+  it('field should not be accessible with tabindex of -1', async () => {
+    render(
+      <BraidTestProvider>
+        <Dropdown
+          id="field"
+          label="My dropdown"
+          value="1"
+          onChange={() => {}}
+          tabIndex={-1}
+        >
+          <option>1</option>
+        </Dropdown>
+      </BraidTestProvider>,
+    );
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(document.body).toHaveFocus();
+  });
+
+  it('field should be accessible with tabindex of 0', async () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <Dropdown
+          id="field"
+          label="My dropdown"
+          value="1"
+          onChange={() => {}}
+          tabIndex={0}
+        >
+          <option>1</option>
+        </Dropdown>
+      </BraidTestProvider>,
+    );
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(getByRole('combobox')).toHaveFocus();
+  });
+
+  it('field should be accessible with a tabindex of undefined', async () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <Dropdown
+          id="field"
+          label="My dropdown"
+          value="1"
+          onChange={() => {}}
+          tabIndex={undefined}
+        >
+          <option>1</option>
+        </Dropdown>
+      </BraidTestProvider>,
+    );
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(getByRole('combobox')).toHaveFocus();
   });
 });

--- a/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.playroom.tsx
@@ -2,6 +2,7 @@ import type { Optional } from 'utility-types';
 
 import { type StateProp, useFallbackState } from '../../playroom/playroomState';
 import { useFallbackId } from '../../playroom/utils';
+import { validTabIndexes } from '../private/validateTabIndex';
 
 import {
   type MonthPickerBaseProps,
@@ -18,6 +19,7 @@ export const MonthPicker = ({
   stateName,
   value,
   onChange,
+  tabIndex,
   ...restProps
 }: PlayroomMonthPickerProps) => {
   const fallbackId = useFallbackId();
@@ -33,6 +35,7 @@ export const MonthPicker = ({
       id={id ?? fallbackId}
       value={state}
       onChange={handleChange}
+      tabIndex={validTabIndexes.includes(tabIndex!) ? tabIndex : undefined}
       {...restProps}
     />
   );

--- a/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.test.tsx
+++ b/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { render, getAllByRole } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { MonthPicker } from '..';
 import { BraidTestProvider } from '../../../entries/test';
@@ -270,5 +271,91 @@ describe('MonthPicker (Double dropdown)', () => {
     );
 
     expect(getByLabelText('Year').getAttribute('aria-describedby')).toBeNull();
+  });
+
+  it('fields should not be accessible with tabindex of -1', async () => {
+    render(
+      <BraidTestProvider>
+        <MonthPicker
+          id="month-picker"
+          label="Start"
+          monthLabel="Month"
+          yearLabel="Year"
+          value={{}}
+          onChange={() => {}}
+          tabIndex={-1}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(document.body).toHaveFocus();
+  });
+
+  it('fields should be accessible with tabindex of 0', async () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <MonthPicker
+          id="month-picker"
+          label="Start"
+          monthLabel="Month"
+          yearLabel="Year"
+          value={{}}
+          onChange={() => {}}
+          tabIndex={0}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(getByLabelText('Month')).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(getByLabelText('Year')).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(document.body).toHaveFocus();
+  });
+
+  it('field should be accessible with a tabindex of undefined', async () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <MonthPicker
+          id="month-picker"
+          label="Start"
+          monthLabel="Month"
+          yearLabel="Year"
+          value={{}}
+          onChange={() => {}}
+          tabIndex={undefined}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(getByLabelText('Month')).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(getByLabelText('Year')).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(document.body).toHaveFocus();
   });
 });

--- a/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.tsx
+++ b/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.tsx
@@ -147,6 +147,7 @@ const MonthPicker = ({
   ascendingYears = false,
   monthLabel = 'Month',
   yearLabel = 'Year',
+  tabIndex,
   monthNames = defaultMonthNames,
   ...restProps
 }: MonthPickerProps) => {
@@ -200,6 +201,7 @@ const MonthPicker = ({
       value={customValueToString(currentValue)}
       {...restProps}
       componentName="MonthPicker"
+      tabIndex={tabIndex}
       icon={undefined}
       prefix={undefined}
       name={undefined}
@@ -230,6 +232,7 @@ const MonthPicker = ({
       id={id}
       tone={tone}
       disabled={disabled}
+      tabIndex={tabIndex}
       componentName="MonthPicker"
       {...restProps}
     >

--- a/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.playroom.tsx
@@ -2,6 +2,7 @@ import type { Optional } from 'utility-types';
 
 import { type StateProp, useFallbackState } from '../../playroom/playroomState';
 import { useFallbackId } from '../../playroom/utils';
+import { validTabIndexes } from '../private/validateTabIndex';
 
 import {
   type PasswordFieldBaseProps,
@@ -18,6 +19,7 @@ export const PasswordField = ({
   stateName,
   value,
   onChange,
+  tabIndex,
   ...restProps
 }: PlayroomPasswordFieldProps) => {
   const fallbackId = useFallbackId();
@@ -34,6 +36,7 @@ export const PasswordField = ({
       value={state}
       onChange={handleChange}
       autoComplete="off"
+      tabIndex={validTabIndexes.includes(tabIndex!) ? tabIndex : undefined}
       {...restProps}
     />
   );

--- a/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.test.tsx
+++ b/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.test.tsx
@@ -237,4 +237,64 @@ describe('PasswordField', () => {
 
     expect(getByLabelText('My field')).toHaveAttribute('disabled');
   });
+
+  it('field should not be accessible with tabindex of -1', async () => {
+    render(
+      <BraidTestProvider>
+        <PasswordField
+          id="password"
+          label="Password"
+          value=""
+          onChange={() => {}}
+          tabIndex={-1}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(document.body).toHaveFocus();
+  });
+
+  it('field should be accessible with tabindex of 0', async () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <PasswordField
+          id="password"
+          label="Password"
+          value=""
+          onChange={() => {}}
+          tabIndex={0}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(getByLabelText('Password')).toHaveFocus();
+  });
+
+  it('field should be accessible with a tabindex of undefined', async () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <PasswordField
+          id="password"
+          label="Password"
+          value=""
+          onChange={() => {}}
+          tabIndex={undefined}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(getByLabelText('Password')).toHaveFocus();
+  });
 });

--- a/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.tsx
+++ b/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.tsx
@@ -47,6 +47,7 @@ export const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
       onVisibilityToggle,
       visibilityToggleLabel = 'Toggle password visibility',
       id,
+      tabIndex,
       ...restProps
     },
     forwardedRef,
@@ -81,6 +82,7 @@ export const PasswordField = forwardRef<HTMLInputElement, PasswordFieldProps>(
         componentName="PasswordField"
         id={id}
         value={value}
+        tabIndex={tabIndex}
         icon={undefined}
         prefix={undefined}
         disabled={disabled}

--- a/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.playroom.tsx
@@ -2,6 +2,7 @@ import type { Optional } from 'utility-types';
 
 import { type StateProp, useFallbackState } from '../../playroom/playroomState';
 import { useFallbackId } from '../../playroom/utils';
+import { validTabIndexes } from '../private/validateTabIndex';
 
 import {
   type RadioGroupBaseProps,
@@ -19,6 +20,7 @@ export const RadioGroup = ({
   value,
   onChange,
   children,
+  tabIndex,
   ...restProps
 }: PlayroomRadioProps) => {
   const fallbackId = useFallbackId();
@@ -30,6 +32,7 @@ export const RadioGroup = ({
       id={id ?? fallbackId}
       value={state}
       onChange={handleChange}
+      tabIndex={validTabIndexes.includes(tabIndex!) ? tabIndex : undefined}
     >
       {children}
     </BraidRadioGroup>

--- a/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.test.tsx
+++ b/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.test.tsx
@@ -248,4 +248,114 @@ describe('RadioGroup', () => {
     await userEvent.tab({ shift: true });
     expect(option2).toHaveFocus();
   });
+
+  it('should not be accessible with tabindex of -1', async () => {
+    render(
+      <BraidTestProvider>
+        <RadioGroup
+          id="options"
+          value=""
+          onChange={() => {}}
+          label="Options"
+          tabIndex={-1}
+        >
+          <RadioItem label="Option 1" value="1" />
+          <RadioItem label="Option 2" value="2" />
+        </RadioGroup>
+      </BraidTestProvider>,
+    );
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(document.body).toHaveFocus();
+  });
+
+  it('should be accessible with tabindex of 0 with no checked items', async () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <RadioGroup
+          id="options"
+          value=""
+          onChange={() => {}}
+          label="Options"
+          tabIndex={0}
+        >
+          <RadioItem label="Option 1" value="1" />
+          <RadioItem label="Option 2" value="2" />
+        </RadioGroup>
+      </BraidTestProvider>,
+    );
+
+    const option1 = getByLabelText('Option 1') as HTMLInputElement;
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(option1).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(document.body).toHaveFocus();
+  });
+
+  it('should be accessible with tabindex of 0 with a checked item', async () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <RadioGroup
+          id="options"
+          value="2"
+          onChange={() => {}}
+          label="Options"
+          tabIndex={0}
+        >
+          <RadioItem label="Option 1" value="1" />
+          <RadioItem label="Option 2" value="2" />
+        </RadioGroup>
+      </BraidTestProvider>,
+    );
+
+    const option2 = getByLabelText('Option 2') as HTMLInputElement;
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(option2).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(document.body).toHaveFocus();
+  });
+
+  it('should be accessible with a tabindex of undefined', async () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <RadioGroup
+          id="options"
+          value=""
+          onChange={() => {}}
+          label="Options"
+          tabIndex={undefined}
+        >
+          <RadioItem label="Option 1" value="1" />
+          <RadioItem label="Option 2" value="2" />
+        </RadioGroup>
+      </BraidTestProvider>,
+    );
+
+    const option1 = getByLabelText('Option 1') as HTMLInputElement;
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(option1).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(document.body).toHaveFocus();
+  });
 });

--- a/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroupContext.ts
+++ b/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroupContext.ts
@@ -9,6 +9,7 @@ interface RadioGroupContextValues {
   disabled?: boolean;
   tone?: RadioGroupProps['tone'];
   size?: RadioGroupProps['size'];
+  tabIndex?: RadioGroupProps['tabIndex'];
   'aria-describedby'?: string;
   onChange: RadioGroupProps['onChange'];
 }

--- a/packages/braid-design-system/src/lib/components/RadioGroup/RadioItem.tsx
+++ b/packages/braid-design-system/src/lib/components/RadioGroup/RadioItem.tsx
@@ -22,6 +22,7 @@ export interface RadioItemProps
     | 'id'
     | 'tone'
     | 'size'
+    | 'tabIndex'
   > {
   value: NonNullable<InlineFieldProps['value']>;
 }
@@ -62,7 +63,7 @@ export const RadioItem = forwardRef<HTMLInputElement, RadioItemProps>(
         size={radioGroupContext.size}
         disabled={radioGroupContext.disabled || props.disabled}
         aria-describedby={radioGroupContext['aria-describedby']}
-        tabIndex={tababble ? 0 : -1}
+        tabIndex={tababble && radioGroupContext.tabIndex !== -1 ? 0 : -1}
         inList={true}
         type="radio"
         message={null}

--- a/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.playroom.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import type { Optional } from 'utility-types';
 
 import { useFallbackId } from '../../playroom/utils';
+import { validTabIndexes } from '../private/validateTabIndex';
 
 import {
   type TextDropdownProps,
@@ -43,6 +44,7 @@ export function TextDropdown<Value>({
   label,
   onChange,
   options = fallbackOptions,
+  tabIndex,
   ...restProps
 }: PlayroomTextDropdownProps<Value | string>) {
   const fallbackId = useFallbackId();
@@ -67,6 +69,7 @@ export function TextDropdown<Value>({
       value={internalValue}
       options={internalOptions}
       onChange={onChange ? onChange : setInternalValue}
+      tabIndex={validTabIndexes.includes(tabIndex!) ? tabIndex : undefined}
       {...restProps}
     />
   );

--- a/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.test.tsx
+++ b/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { render, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 import { useState } from 'react';
 
 import { Text, TextDropdown } from '..';
@@ -31,5 +32,74 @@ describe('TextDropdown', () => {
     expect(dropdown.options[dropdown.selectedIndex].value).toEqual('Two');
     fireEvent.change(dropdown, { target: { selectedIndex: 2 } });
     expect(dropdown.options[dropdown.selectedIndex].value).toEqual('Third');
+  });
+
+  it('should not be accessible with tabindex of -1', async () => {
+    render(
+      <BraidTestProvider>
+        <Text>
+          <TextDropdown
+            id="content"
+            label="Label"
+            value="One"
+            onChange={() => {}}
+            options={['One', 'Two', 'Third']}
+            tabIndex={-1}
+          />
+        </Text>
+      </BraidTestProvider>,
+    );
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(document.body).toHaveFocus();
+  });
+
+  it('should be accessible with tabindex of 0', async () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <Text>
+          <TextDropdown
+            id="content"
+            label="Label"
+            value="One"
+            onChange={() => {}}
+            options={['One', 'Two', 'Third']}
+            tabIndex={0}
+          />
+        </Text>
+      </BraidTestProvider>,
+    );
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(getByRole('combobox')).toHaveFocus();
+  });
+
+  it('should be accessible with a tabindex of undefined', async () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <Text>
+          <TextDropdown
+            id="content"
+            label="Label"
+            value="One"
+            onChange={() => {}}
+            options={['One', 'Two', 'Third']}
+            tabIndex={undefined}
+          />
+        </Text>
+      </BraidTestProvider>,
+    );
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(getByRole('combobox')).toHaveFocus();
   });
 });

--- a/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.tsx
+++ b/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.tsx
@@ -10,6 +10,7 @@ import { Overlay } from '../private/Overlay/Overlay';
 import buildDataAttributes, {
   type DataAttributeMap,
 } from '../private/buildDataAttributes';
+import { validateTabIndex } from '../private/validateTabIndex';
 
 import * as styles from './TextDropdown.css';
 
@@ -27,6 +28,7 @@ export interface TextDropdownProps<Value> {
   options: Array<TextDropdownValue<Value>>;
   label: string;
   data?: DataAttributeMap;
+  tabIndex?: 0 | -1;
 }
 
 export function parseSimpleToComplexOption<Value>(
@@ -48,6 +50,7 @@ export function TextDropdown<Value>({
   options,
   label,
   data,
+  tabIndex,
   ...restProps
 }: TextDropdownProps<Value>) {
   assert(
@@ -61,6 +64,10 @@ export function TextDropdown<Value>({
     })(),
     'TextDropdown components must be rendered within a Text or Heading component. See the documentation for correct usage: https://seek-oss.github.io/braid-design-system/components/TextDropdown',
   );
+
+  if (process.env.NODE_ENV !== 'production') {
+    validateTabIndex(tabIndex);
+  }
 
   const parsedOptions = options.map(parseSimpleToComplexOption);
   const [currentText] = parsedOptions.filter((o) => value === o.value);
@@ -91,6 +98,7 @@ export function TextDropdown<Value>({
         aria-label={label}
         title={label}
         id={id}
+        tabIndex={tabIndex}
         value={String(value)}
         onChange={(ev: FormEvent<HTMLSelectElement>) => {
           if (typeof onChange === 'function') {

--- a/packages/braid-design-system/src/lib/components/TextField/TextField.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/TextField/TextField.playroom.tsx
@@ -2,6 +2,7 @@ import type { Optional } from 'utility-types';
 
 import { type StateProp, useFallbackState } from '../../playroom/playroomState';
 import { useFallbackId } from '../../playroom/utils';
+import { validTabIndexes } from '../private/validateTabIndex';
 
 import {
   type TextFieldBaseProps,
@@ -21,6 +22,7 @@ export const TextField = ({
   value,
   onChange,
   onClear,
+  tabIndex,
   ...restProps
 }: PlayroomTextFieldProps) => {
   const fallbackId = useFallbackId();
@@ -41,6 +43,7 @@ export const TextField = ({
         onClear?.();
       }}
       autoComplete="off"
+      tabIndex={validTabIndexes.includes(tabIndex!) ? tabIndex : undefined}
       {...restProps}
     />
   );

--- a/packages/braid-design-system/src/lib/components/TextField/TextField.test.tsx
+++ b/packages/braid-design-system/src/lib/components/TextField/TextField.test.tsx
@@ -1,5 +1,6 @@
 import '@testing-library/jest-dom';
 import { render } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
 
 import { TextField } from '..';
 import { BraidTestProvider } from '../../../entries/test';
@@ -130,5 +131,65 @@ describe('TextField', () => {
     expect(
       getByLabelText('My field').getAttribute('aria-describedby'),
     ).toBeNull();
+  });
+
+  it('field should not be accessible with tabindex of -1', async () => {
+    render(
+      <BraidTestProvider>
+        <TextField
+          id="field"
+          label="My field"
+          value=""
+          onChange={() => {}}
+          tabIndex={-1}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(document.body).toHaveFocus();
+  });
+
+  it('field should be accessible with tabindex of 0', async () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <TextField
+          id="field"
+          label="My field"
+          value=""
+          onChange={() => {}}
+          tabIndex={0}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(getByRole('textbox')).toHaveFocus();
+  });
+
+  it('field should be accessible with a tabindex of undefined', async () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <TextField
+          id="field"
+          label="My field"
+          value=""
+          onChange={() => {}}
+          tabIndex={undefined}
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(document.body).toHaveFocus();
+
+    await userEvent.tab();
+
+    expect(getByRole('textbox')).toHaveFocus();
   });
 });

--- a/packages/braid-design-system/src/lib/components/private/Field/Field.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Field/Field.tsx
@@ -19,6 +19,7 @@ import buildDataAttributes, {
   type DataAttributeMap,
 } from '../buildDataAttributes';
 import { mergeIds } from '../mergeIds';
+import { validateTabIndex } from '../validateTabIndex';
 
 import * as styles from './Field.css';
 import { touchableText } from '../../../css/typography.css';
@@ -59,6 +60,7 @@ export interface FieldBaseProps {
   icon?: ReactNode;
   prefix?: string;
   required?: boolean;
+  tabIndex?: 0 | -1;
 }
 
 type PassthroughProps =
@@ -66,7 +68,8 @@ type PassthroughProps =
   | 'name'
   | 'disabled'
   | 'autoComplete'
-  | 'autoFocus';
+  | 'autoFocus'
+  | 'tabIndex';
 interface FieldRenderProps extends Pick<FieldBaseProps, PassthroughProps> {
   background: BoxProps['background'];
   borderRadius: BoxProps['borderRadius'];
@@ -115,6 +118,7 @@ export const Field = ({
   icon,
   prefix,
   required,
+  tabIndex,
   componentName,
   ...restProps
 }: InternalFieldProps) => {
@@ -141,6 +145,8 @@ export const Field = ({
         `,
       );
     }
+
+    validateTabIndex(tabIndex);
   }
 
   const messageId = `${id}-message`;
@@ -229,6 +235,7 @@ export const Field = ({
               disabled,
               autoComplete,
               autoFocus,
+              tabIndex,
               ...buildDataAttributes({ data, validateRestProps: restProps }),
               className: clsx(
                 styles.field,

--- a/packages/braid-design-system/src/lib/components/private/FieldGroup/FieldGroup.tsx
+++ b/packages/braid-design-system/src/lib/components/private/FieldGroup/FieldGroup.tsx
@@ -13,6 +13,7 @@ import buildDataAttributes, {
   type DataAttributeMap,
 } from '../buildDataAttributes';
 import { mergeIds } from '../mergeIds';
+import { validateTabIndex } from '../validateTabIndex';
 
 type FormElementProps = AllHTMLAttributes<HTMLFormElement>;
 
@@ -41,12 +42,14 @@ export interface FieldGroupBaseProps {
   reserveMessageSpace?: FieldMessageProps['reserveMessageSpace'];
   tone?: FieldMessageProps['tone'];
   required?: boolean;
+  tabIndex?: 0 | -1;
   data?: DataAttributeMap;
 }
 
 interface FieldGroupRenderProps {
   disabled?: FieldGroupBaseProps['disabled'];
   'aria-describedby'?: string;
+  tabIndex?: 0 | -1;
 }
 
 type InternalFieldGroupProps = FieldGroupBaseProps &
@@ -70,6 +73,7 @@ export const FieldGroup = ({
   tone,
   required,
   role,
+  tabIndex,
   data,
   componentName,
   ...restProps
@@ -106,6 +110,8 @@ export const FieldGroup = ({
         `,
       );
     }
+
+    validateTabIndex(tabIndex);
   }
 
   return (
@@ -137,6 +143,7 @@ export const FieldGroup = ({
         <Stack space={messageSpace}>
           {children({
             disabled,
+            tabIndex,
             'aria-describedby': mergeIds(
               message ? messageId : undefined,
               descriptionId,

--- a/packages/braid-design-system/src/lib/components/private/InlineField/StyledInput.tsx
+++ b/packages/braid-design-system/src/lib/components/private/InlineField/StyledInput.tsx
@@ -13,6 +13,7 @@ import { FieldOverlay } from '../FieldOverlay/FieldOverlay';
 import buildDataAttributes, {
   type DataAttributeMap,
 } from '../buildDataAttributes';
+import { validateTabIndex } from '../validateTabIndex';
 
 import * as styles from './InlineField.css';
 import type { Size } from './InlineField.css';
@@ -38,12 +39,12 @@ export interface StyledInputProps {
   data?: DataAttributeMap;
   required?: boolean;
   size?: Size;
+  tabIndex?: 0 | -1;
 }
 
 export type PrivateStyledInputProps = StyledInputProps & {
   type: 'radio' | 'checkbox';
   checked: CheckboxChecked;
-  tabIndex?: number;
 };
 
 const Indicator = ({
@@ -138,6 +139,10 @@ export const StyledInput = forwardRef<
 
     if (tones.indexOf(tone) === -1) {
       throw new Error(`Invalid tone: ${tone}`);
+    }
+
+    if (process.env.NODE_ENV !== 'production') {
+      validateTabIndex(tabIndex);
     }
 
     const isCheckbox = type === 'checkbox';

--- a/packages/braid-design-system/src/lib/components/private/validateTabIndex.ts
+++ b/packages/braid-design-system/src/lib/components/private/validateTabIndex.ts
@@ -1,0 +1,16 @@
+import dedent from 'dedent';
+
+export const validTabIndexes = [0, -1];
+
+export const validateTabIndex = (tabIndex: number | undefined) => {
+  if (tabIndex && !validTabIndexes.includes(tabIndex)) {
+    throw new Error(dedent`
+      Braid only supports “tabIndex” values of 0 and -1.
+
+      Avoid using tabindex values greater than 0 and CSS properties that can change the order
+      of focusable HTML elements.
+
+      Read more: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex#:~:text=only%20use%200%20and%20%2D1%20as%20tabindex%20values
+    `);
+  }
+};

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -132,6 +132,9 @@ exports[`Autosuggest 1`] = `
     suggestions: 
         | (value: AutosuggestValue<Value>) => Suggestions<Value>
         | Suggestions<Value>
+    tabIndex?: 
+        | -1
+        | 0
     tertiaryLabel?: ReactNode
     tone?: 
         | "caution"
@@ -2787,6 +2790,9 @@ exports[`Checkbox 1`] = `
     size?: 
         | "small"
         | "standard"
+    tabIndex?: 
+        | -1
+        | 0
     tone?: 
         | "critical"
         | "neutral"
@@ -2823,6 +2829,9 @@ exports[`CheckboxStandalone 1`] = `
     size?: 
         | "small"
         | "standard"
+    tabIndex?: 
+        | -1
+        | 0
     tone?: 
         | "critical"
         | "neutral"
@@ -3072,6 +3081,9 @@ exports[`Dropdown 1`] = `
     required?: boolean
     reserveMessageSpace?: boolean
     secondaryLabel?: ReactNode
+    tabIndex?: 
+        | -1
+        | 0
     tertiaryLabel?: ReactNode
     tone?: 
         | "caution"
@@ -7499,6 +7511,9 @@ exports[`MonthPicker 1`] = `
     required?: boolean
     reserveMessageSpace?: boolean
     secondaryLabel?: ReactNode
+    tabIndex?: 
+        | -1
+        | 0
     tertiaryLabel?: ReactNode
     tone?: 
         | "caution"
@@ -7634,6 +7649,9 @@ exports[`PasswordField 1`] = `
     required?: boolean
     reserveMessageSpace?: boolean
     secondaryLabel?: ReactNode
+    tabIndex?: 
+        | -1
+        | 0
     tertiaryLabel?: ReactNode
     tone?: 
         | "caution"
@@ -7670,6 +7688,9 @@ exports[`RadioGroup 1`] = `
     size?: 
         | "small"
         | "standard"
+    tabIndex?: 
+        | -1
+        | 0
     tertiaryLabel?: ReactNode
     tone?: 
         | "critical"
@@ -8330,6 +8351,9 @@ exports[`TextDropdown 1`] = `
     onBlur?: () => void
     onChange: (value: Value) => void
     options: TextDropdownValue<Value>[]
+    tabIndex?: 
+        | -1
+        | 0
     value: NonNullable<Value>
 },
 }
@@ -8379,6 +8403,9 @@ exports[`TextField 1`] = `
     step?: 
         | number
         | string
+    tabIndex?: 
+        | -1
+        | 0
     tertiaryLabel?: ReactNode
     tone?: 
         | "caution"
@@ -9002,6 +9029,9 @@ exports[`Textarea 1`] = `
         | "true"
         | false
         | true
+    tabIndex?: 
+        | -1
+        | 0
     tertiaryLabel?: ReactNode
     tone?: 
         | "caution"


### PR DESCRIPTION
Ensure the `tabIndex` prop is available on all form fields, enabling greater control over which elements appear in the keyboard navigation flow.

In line with [MDN guidance], the only supported values are `0` and `-1` to ensure best practice for keyboard navigation and assistive technologies.

**EXAMPLE USAGE:**
```jsx
<TextField tabIndex={-1} />
```

[MDN guidance]: https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/tabindex#:~:text=only%20use%200%20and%20%2D1%20as%20tabindex%20values