### PR TITLE
Accordion: Fix `data` prop parsing

### DIFF
--- a/.changeset/green-dots-warn.md
+++ b/.changeset/green-dots-warn.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Accordion
+---
+
+**Accordion**: Fix `data` prop parsing
+
+Ensure the `data` prop is correctly passed through to `Stack` internally, and validate `data-*` attributes are not being passed in incorrectly.
+

--- a/packages/braid-design-system/src/lib/components/Accordion/Accordion.tsx
+++ b/packages/braid-design-system/src/lib/components/Accordion/Accordion.tsx
@@ -81,6 +81,14 @@ export const Accordion = ({
       .join(', ')}`,
   );
 
+  if (process.env.NODE_ENV !== 'production') {
+    /**
+     * Validate that consumers are not passing `data-*`props,
+     * which will not work and are not validated by TypeScript.
+     */
+    buildDataAttributes({ data, validateRestProps: restProps });
+  }
+
   const contextValue = useMemo(
     () => ({ size, tone, weight }),
     [size, tone, weight],
@@ -91,10 +99,7 @@ export const Accordion = ({
 
   return (
     <AccordionContext.Provider value={contextValue}>
-      <Stack
-        space={space}
-        {...buildDataAttributes({ data, validateRestProps: restProps })}
-      >
+      <Stack space={space} data={data}>
         {!dividers ? (
           children
         ) : (

--- a/packages/braid-design-system/src/lib/components/Accordion/AccordionItem.tsx
+++ b/packages/braid-design-system/src/lib/components/Accordion/AccordionItem.tsx
@@ -20,7 +20,9 @@ import { type TextProps, Text } from '../Text/Text';
 import { IconChevron } from '../icons';
 import { Overlay } from '../private/Overlay/Overlay';
 import { badgeSlotSpace } from '../private/badgeSlotSpace';
-import type { DataAttributeMap } from '../private/buildDataAttributes';
+import buildDataAttributes, {
+  type DataAttributeMap,
+} from '../private/buildDataAttributes';
 import { hideFocusRingsClassName } from '../private/hideFocusRings/hideFocusRings';
 
 import { defaultSize } from './Accordion';
@@ -124,6 +126,14 @@ export const AccordionItem = ({
           onToggle: restProps.onToggle,
         }),
   });
+
+  if (process.env.NODE_ENV !== 'production') {
+    /**
+     * Validate that consumers are not passing `data-*`props,
+     * which will not work and are not validated by TypeScript.
+     */
+    buildDataAttributes({ data, validateRestProps: restProps });
+  }
 
   return (
     <Stack space={itemSpace} data={data}>


### PR DESCRIPTION
Ensure the `data` prop is correctly passed through to `Stack` internally, and validate `data-*` attributes are not being passed in incorrectly.

This was broken in part of the [v33 refactor].

[v33 refactor]: https://github.com/seek-oss/braid-design-system/pull/1602/files#diff-7f76bf257112052ee42c8d0cf0399f455ed33c7a3eca90b36040b6f8043ce226L85-L89 