### PR TITLE
Update playroom config to mjs

### DIFF
--- a/site/playroom.config.mjs
+++ b/site/playroom.config.mjs
@@ -1,13 +1,18 @@
-const path = require('path');
+import { createRequire } from 'node:module';
+import path from 'node:path';
 
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const SkuWebpackPlugin = require('sku/webpack-plugin');
-const { DefinePlugin } = require('webpack');
+import MiniCssExtractPlugin from 'mini-css-extract-plugin';
+import SkuWebpackPlugin from 'sku/webpack-plugin';
+import webpackPkg from 'webpack';
 
-const braidSrc = path.join(__dirname, '../packages/braid-design-system/src');
+const { DefinePlugin } = webpackPkg;
+
+const require = createRequire(import.meta.url);
+
+const braidSrc = path.join(import.meta.dirname, '../packages/braid-design-system/src');
 const resolveFromBraid = (p) => require.resolve(path.join(braidSrc, p));
 
-module.exports = {
+export default {
   outputPath: './dist/playroom',
   components: require.resolve('./src/playroom.components.ts'),
   snippets: resolveFromBraid('entries/playroom/snippets.ts'),

--- a/site/playroom.config.mjs
+++ b/site/playroom.config.mjs
@@ -9,7 +9,10 @@ const { DefinePlugin } = webpackPkg;
 
 const require = createRequire(import.meta.url);
 
-const braidSrc = path.join(import.meta.dirname, '../packages/braid-design-system/src');
+const braidSrc = path.join(
+  import.meta.dirname,
+  '../packages/braid-design-system/src',
+);
 const resolveFromBraid = (p) => require.resolve(path.join(braidSrc, p));
 
 export default {

--- a/site/project.json
+++ b/site/project.json
@@ -16,7 +16,7 @@
       }
     },
     "start:playroom": {
-      "dependsOn": ["generate"],
+      "dependsOn": ["generate", "^dev"],
       "executor": "nx:run-script",
       "options": {
         "script": "start:playroom"
@@ -36,7 +36,7 @@
       }
     },
     "build:playroom": {
-      "dependsOn": ["generate"],
+      "dependsOn": ["generate", "^dev"],
       "inputs": ["^default"],
       "outputs": ["dist/playroom"],
       "executor": "nx:run-script",


### PR DESCRIPTION
## Changes

- Change `playroom.config.js` into `mjs`.
- Add `"^dev"` as a dependency in `project.json` for the playroom commands.

Turning the playroom config into `mjs` is in preparation for an upcoming release of `sku` which is going to be esm only.