### PR TITLE
site: Add `data` prop docs

### DIFF
--- a/packages/braid-design-system/scripts/generateIcons.cts
+++ b/packages/braid-design-system/scripts/generateIcons.cts
@@ -153,6 +153,7 @@ const svgrConfig = {
         import { IconContainer, type IconContainerProps } from '${relative(
           `${baseDir}/src/lib/components/icons/IconContainer`,
         )}';
+
         import { ${svgComponentName} } from '${relative(`${iconDir}/${svgComponentName}`)}';
 
         export type ${iconName}Props = IconContainerProps;
@@ -169,10 +170,11 @@ const svgrConfig = {
     await templateFileIfMissing(
       `${iconName}.docs.tsx`,
       dedent/* ts */ `
-        import type { ComponentDocs } from 'site/types';
-        import { iconDocumentation } from '${relative(`${iconComponentsDir}/iconCommon.docs`)}';
         import source from '@braid-design-system/source.macro';
+        import type { ComponentDocs } from 'site/types';
+
         import { ${iconName}, Heading, Stack } from '${relative(`${baseDir}/src/lib/components`)}';
+        import { iconDocumentation } from '${relative(`${iconComponentsDir}/iconCommon.docs`)}';
 
         const docs: ComponentDocs = {
           category: 'Icon',
@@ -185,7 +187,7 @@ const svgrConfig = {
               </Stack>,
             ),
           alternatives: [],
-          additional: [iconDocumentation],
+          additional: [...iconDocumentation],
         };
 
         export default docs;

--- a/packages/braid-design-system/src/lib/components/Accordion/Accordion.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Accordion/Accordion.docs.tsx
@@ -220,6 +220,36 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Accordion
+          data={{ testid: 'accordion-1' }}
+          // => data-testid="accordion-1"
+        >
+          <AccordionItem
+            data={{ testid: 'accordion-item-1' }}
+            // => data-testid="accordion-item-1"
+          >
+            ...
+          </AccordionItem>
+        </Accordion>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Accordion/Accordion.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Accordion/Accordion.docs.tsx
@@ -12,6 +12,7 @@ import {
   IconImage,
 } from '../';
 import { Placeholder } from '../../playroom/components';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 import { validSpaceValues } from './Accordion';
 
@@ -220,22 +221,7 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Accordion
           data={{ testid: 'accordion-1' }}
@@ -249,7 +235,8 @@ const docs: ComponentDocs = {
           </AccordionItem>
         </Accordion>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Actions/Actions.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Actions/Actions.docs.tsx
@@ -129,6 +129,31 @@ const docs: ComponentDocs = {
           </Tiles>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Actions
+          data={{ testid: 'actions-1' }}
+          // => data-testid="actions-1"
+        >
+          ...
+        </Actions>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Actions/Actions.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Actions/Actions.docs.tsx
@@ -12,6 +12,7 @@ import {
   Tiles,
   Inline,
 } from '../';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 import { actionsSpace } from './Actions';
 
@@ -129,22 +130,7 @@ const docs: ComponentDocs = {
           </Tiles>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Actions
           data={{ testid: 'actions-1' }}
@@ -153,7 +139,8 @@ const docs: ComponentDocs = {
           ...
         </Actions>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Alert/Alert.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Alert/Alert.docs.tsx
@@ -3,6 +3,7 @@ import type { ComponentDocs } from 'site/types';
 
 import { Alert, Card, Text, Strong, Stack, TextLink, List, Notice } from '../';
 import { IconLanguage } from '../icons';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -168,22 +169,7 @@ const docs: ComponentDocs = {
           </Card>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Alert
           data={{ testid: 'alert-1' }}
@@ -192,7 +178,8 @@ const docs: ComponentDocs = {
           ...
         </Alert>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Alert/Alert.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Alert/Alert.docs.tsx
@@ -168,6 +168,31 @@ const docs: ComponentDocs = {
           </Card>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Alert
+          data={{ testid: 'alert-1' }}
+          // => data-testid="alert-1"
+        >
+          ...
+        </Alert>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.docs.tsx
@@ -811,6 +811,29 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Autosuggest
+          data={{ testid: 'autosuggest-1' }}
+          // => data-testid="autosuggest-1"
+        />
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.docs.tsx
@@ -17,6 +17,7 @@ import {
   TextField,
 } from '../';
 import { IconHelp, IconLanguage } from '../icons';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 import { highlightSuggestions } from './Autosuggest';
 
@@ -811,29 +812,15 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Autosuggest
           data={{ testid: 'autosuggest-1' }}
           // => data-testid="autosuggest-1"
         />
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Badge/Badge.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Badge/Badge.docs.tsx
@@ -146,8 +146,8 @@ const docs: ComponentDocs = {
               />
               <Stack space="medium">
                 <Divider />
-                {new Array(3).fill('').map(() => (
-                  <>
+                {new Array(3).fill('').map((_, index) => (
+                  <Fragment key={index}>
                     <Box boxShadow="borderCriticalLight">
                       <Columns space="medium" alignY="center">
                         <Column width="content">
@@ -172,12 +172,37 @@ const docs: ComponentDocs = {
                       </Columns>
                     </Box>
                     <Divider />
-                  </>
+                  </Fragment>
                 ))}
               </Stack>
             </Stack>
           </>,
         ),
+    },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Badge
+          data={{ testid: 'badge-1' }}
+          // => data-testid="badge-1"
+        >
+          ...
+        </Badge>
+      `,
     },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/Badge/Badge.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Badge/Badge.docs.tsx
@@ -17,6 +17,7 @@ import {
   IconOverflow,
   Divider,
 } from '../';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -179,22 +180,7 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Badge
           data={{ testid: 'badge-1' }}
@@ -203,7 +189,8 @@ const docs: ComponentDocs = {
           ...
         </Badge>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Bleed/Bleed.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Bleed/Bleed.docs.tsx
@@ -3,6 +3,7 @@ import type { ComponentDocs } from 'site/types';
 
 import { Box, Bleed, Stack, Text, Strong, TextLink, Tiles, Toggle } from '../';
 import { Placeholder } from '../../playroom/components';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 import { vars } from '../../themes/vars.css';
 
@@ -251,22 +252,7 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Bleed
           data={{ testid: 'bleed-1' }}
@@ -275,7 +261,8 @@ const docs: ComponentDocs = {
           ...
         </Bleed>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Bleed/Bleed.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Bleed/Bleed.docs.tsx
@@ -251,6 +251,31 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Bleed
+          data={{ testid: 'bleed-1' }}
+          // => data-testid="bleed-1"
+        >
+          ...
+        </Bleed>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Box/Box.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Box/Box.docs.tsx
@@ -26,7 +26,7 @@ import {
   unresponsiveProperties,
   pseudoProperties,
 } from '../../css/atoms/atomicProperties';
-import { Notice } from '../Notice/Notice';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 // TODO: COLORMODE RELEASE
 // Use public import
@@ -131,43 +131,20 @@ const docs: ComponentDocs = {
         </>
       ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-          <Notice>
-            <Text>
-              While Box does support the native HTML syntax, it also supports
-              the <Strong>data</Strong> prop for consistency.
-            </Text>
-          </Notice>
-          <Code playroom={false}>
-            {
-              source(
-                <Box
-                  data={{
-                    testid: 'customIdentifier',
-                  }}
-                  // => data-testid="customIdentifier"
-                >
-                  ...
-                </Box>,
-              ).code
-            }
-          </Code>
-        </>
-      ),
-    },
+    dataAttributeDocs({
+      code: `
+        <Box
+          data={{
+            testid: 'customIdentifier',
+          }}
+          // => data-testid="customIdentifier"
+        >
+          ...
+        </Box>
+      `,
+      supportsNativeSyntax: true,
+      componentName: 'Box',
+    }),
     {
       label: 'CSS utilities',
       description: (

--- a/packages/braid-design-system/src/lib/components/Button/Button.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.docs.tsx
@@ -610,6 +610,31 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Button
+          data={{ testid: 'button-1' }}
+          // => data-testid="button-1"
+        >
+          ...
+        </Button>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Button/Button.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.docs.tsx
@@ -16,6 +16,7 @@ import {
   Toggle,
   IconArrow,
 } from '../';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const choosingRightButtonDoc = [
   {
@@ -610,22 +611,7 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Button
           data={{ testid: 'button-1' }}
@@ -634,7 +620,8 @@ const docs: ComponentDocs = {
           ...
         </Button>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.docs.tsx
@@ -21,6 +21,7 @@ import {
   IconAdd,
   IconArrow,
 } from '..';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -302,29 +303,15 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <ButtonIcon
           data={{ testid: 'button-icon-1' }}
           // => data-testid="button-icon-1"
         />
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.docs.tsx
@@ -302,6 +302,29 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <ButtonIcon
+          data={{ testid: 'button-icon-1' }}
+          // => data-testid="button-icon-1"
+        />
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Card/Card.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Card/Card.docs.tsx
@@ -2,7 +2,17 @@ import source from '@braid-design-system/source.macro';
 import { Fragment } from 'react';
 import type { ComponentDocs } from 'site/types';
 
-import { Box, Stack, Card, Text, Tiles, Strong, Columns, Column } from '../';
+import {
+  Box,
+  Stack,
+  Card,
+  Text,
+  Tiles,
+  Strong,
+  Columns,
+  Column,
+  TextLink,
+} from '../';
 import { Placeholder } from '../../playroom/components';
 
 import { validCardComponents } from './Card';
@@ -161,6 +171,31 @@ const docs: ComponentDocs = {
           })}
         </Text>
       ),
+    },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Card
+          data={{ testid: 'card-1' }}
+          // => data-testid="card-1"
+        >
+          ...
+        </Card>
+      `,
     },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/Card/Card.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Card/Card.docs.tsx
@@ -2,18 +2,9 @@ import source from '@braid-design-system/source.macro';
 import { Fragment } from 'react';
 import type { ComponentDocs } from 'site/types';
 
-import {
-  Box,
-  Stack,
-  Card,
-  Text,
-  Tiles,
-  Strong,
-  Columns,
-  Column,
-  TextLink,
-} from '../';
+import { Box, Stack, Card, Text, Tiles, Strong, Columns, Column } from '../';
 import { Placeholder } from '../../playroom/components';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 import { validCardComponents } from './Card';
 
@@ -172,22 +163,7 @@ const docs: ComponentDocs = {
         </Text>
       ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Card
           data={{ testid: 'card-1' }}
@@ -196,7 +172,8 @@ const docs: ComponentDocs = {
           ...
         </Card>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Checkbox/Checkbox.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Checkbox/Checkbox.docs.tsx
@@ -324,6 +324,31 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Checkbox
+          data={{ testid: 'checkbox-1' }}
+          // => data-testid="checkbox-1"
+        >
+          ...
+        </Checkbox>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Checkbox/Checkbox.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Checkbox/Checkbox.docs.tsx
@@ -14,6 +14,7 @@ import {
   Divider,
 } from '../';
 import { Placeholder } from '../../playroom/components';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -324,22 +325,7 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Checkbox
           data={{ testid: 'checkbox-1' }}
@@ -348,7 +334,8 @@ const docs: ComponentDocs = {
           ...
         </Checkbox>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Columns/Columns.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Columns/Columns.docs.tsx
@@ -527,6 +527,36 @@ const docs: ComponentDocs = {
         </Columns>,
       ).code,
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Columns
+          data={{ testid: 'columns-1' }}
+          // => data-testid="columns-1"
+          >
+          <Column
+            data={{ testid: 'column-1' }}
+            // => data-testid="column-1"
+          >
+            ...
+          </Column>
+        </Columns>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Columns/Columns.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Columns/Columns.docs.tsx
@@ -13,6 +13,7 @@ import {
 } from '../';
 import { TextLink } from '../TextLink/TextLink';
 import { Placeholder } from '../private/Placeholder/Placeholder';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Layout',
@@ -527,22 +528,7 @@ const docs: ComponentDocs = {
         </Columns>,
       ).code,
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Columns
           data={{ testid: 'columns-1' }}
@@ -556,7 +542,8 @@ const docs: ComponentDocs = {
           </Column>
         </Columns>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/ContentBlock/ContentBlock.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/ContentBlock/ContentBlock.docs.tsx
@@ -1,10 +1,11 @@
 import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
-import { ContentBlock, Stack, TextLink } from '../';
+import { ContentBlock, Stack } from '../';
 import { Strong } from '../Strong/Strong';
 import { Text } from '../Text/Text';
 import { Placeholder } from '../private/Placeholder/Placeholder';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Layout',
@@ -59,22 +60,7 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <ContentBlock
           data={{ testid: 'content-block-1' }}
@@ -83,7 +69,8 @@ const docs: ComponentDocs = {
           ...
         </ContentBlock>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/ContentBlock/ContentBlock.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/ContentBlock/ContentBlock.docs.tsx
@@ -1,7 +1,7 @@
 import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
-import { ContentBlock, Stack } from '../';
+import { ContentBlock, Stack, TextLink } from '../';
 import { Strong } from '../Strong/Strong';
 import { Text } from '../Text/Text';
 import { Placeholder } from '../private/Placeholder/Placeholder';
@@ -58,6 +58,31 @@ const docs: ComponentDocs = {
             </ContentBlock>
           </Stack>,
         ),
+    },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <ContentBlock
+          data={{ testid: 'content-block-1' }}
+          // => data-testid="content-block-1"
+        >
+          ...
+        </ContentBlock>
+      `,
     },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/Dialog/Dialog.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Dialog/Dialog.docs.tsx
@@ -18,6 +18,7 @@ import {
   TextDropdown,
 } from '../';
 import { Placeholder } from '../../playroom/components';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 import { DialogContent } from './Dialog';
 import { DialogPreview } from './Dialog.screenshots';
@@ -459,22 +460,7 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Dialog
           data={{ testid: 'dialog-1' }}
@@ -483,7 +469,8 @@ const docs: ComponentDocs = {
           ...
         </Dialog>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Dialog/Dialog.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Dialog/Dialog.docs.tsx
@@ -459,6 +459,31 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Dialog
+          data={{ testid: 'dialog-1' }}
+          // => data-testid="dialog-1"
+        >
+          ...
+        </Dialog>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.docs.tsx
@@ -2,6 +2,7 @@ import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
 import { Disclosure, Text, TextLink, Strong, Stack, Notice } from '..';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -223,22 +224,7 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Disclosure
           data={{ testid: 'disclosure-1' }}
@@ -247,7 +233,8 @@ const docs: ComponentDocs = {
           ...
         </Disclosure>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.docs.tsx
@@ -223,6 +223,31 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Disclosure
+          data={{ testid: 'disclosure-1' }}
+          // => data-testid="disclosure-1"
+        >
+          ...
+        </Disclosure>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Drawer/Drawer.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Drawer/Drawer.docs.tsx
@@ -406,6 +406,31 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Drawer
+          data={{ testid: 'drawer-1' }}
+          // => data-testid="drawer-1"
+        >
+          ...
+        </Drawer>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Drawer/Drawer.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Drawer/Drawer.docs.tsx
@@ -15,6 +15,7 @@ import {
   Box,
 } from '../';
 import { Placeholder } from '../../playroom/components';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 import { DrawerContent } from './Drawer';
 import { DrawerPreview } from './Drawer.screenshots';
@@ -406,22 +407,7 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Drawer
           data={{ testid: 'drawer-1' }}
@@ -430,7 +416,8 @@ const docs: ComponentDocs = {
           ...
         </Drawer>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.docs.tsx
@@ -13,6 +13,7 @@ import {
   Heading,
   Notice,
 } from '../';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -324,22 +325,7 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Dropdown
           data={{ testid: 'dropdown-1' }}
@@ -348,7 +334,8 @@ const docs: ComponentDocs = {
           ...
         </Dropdown>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Dropdown/Dropdown.docs.tsx
@@ -324,6 +324,31 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Dropdown
+          data={{ testid: 'dropdown-1' }}
+          // => data-testid="dropdown-1"
+        >
+          ...
+        </Dropdown>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/FieldLabel/FieldLabel.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/FieldLabel/FieldLabel.docs.tsx
@@ -14,6 +14,7 @@ import {
   Notice,
 } from '../';
 import { Placeholder } from '../../playroom/components';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const Container = ({ children }: { children: ReactNode }) => (
   <Box maxWidth="xsmall">{children}</Box>
@@ -206,29 +207,15 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <FieldLabel
           data={{ testid: 'field-label-1' }}
           // => data-testid="field-label-1"
         />
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/FieldLabel/FieldLabel.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/FieldLabel/FieldLabel.docs.tsx
@@ -206,6 +206,29 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <FieldLabel
+          data={{ testid: 'field-label-1' }}
+          // => data-testid="field-label-1"
+        />
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/FieldMessage/FieldMessage.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/FieldMessage/FieldMessage.docs.tsx
@@ -14,6 +14,7 @@ import {
   Button,
   Notice,
 } from '../';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -277,29 +278,15 @@ const docs: ComponentDocs = {
           </Tiles>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <FieldMessage
           data={{ testid: 'field-message-1' }}
           // => data-testid="field-message-1"
         />
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Heading/Heading.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Heading/Heading.docs.tsx
@@ -183,6 +183,31 @@ const docs: ComponentDocs = {
           </Box>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Heading
+          data={{ testid: 'heading-1' }}
+          // => data-testid="heading-1"
+        >
+          ...
+        </Heading>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Heading/Heading.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Heading/Heading.docs.tsx
@@ -11,6 +11,7 @@ import {
   IconImage,
   Divider,
 } from '../';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -183,22 +184,7 @@ const docs: ComponentDocs = {
           </Box>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Heading
           data={{ testid: 'heading-1' }}
@@ -207,7 +193,8 @@ const docs: ComponentDocs = {
           ...
         </Heading>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Hidden/Hidden.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Hidden/Hidden.docs.tsx
@@ -1,13 +1,8 @@
 import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
+import { Hidden, Stack, Strong, Text, TextLink, Tiles } from '../';
 import { Placeholder } from '../../playroom/components';
-import { Stack } from '../Stack/Stack';
-import { Strong } from '../Strong/Strong';
-import { Text } from '../Text/Text';
-import { Tiles } from '../Tiles/Tiles';
-
-import { Hidden } from './Hidden';
 
 const docs: ComponentDocs = {
   category: 'Layout',
@@ -116,6 +111,31 @@ const docs: ComponentDocs = {
             <Placeholder label="Hidden on print" height={60} />
           </Hidden>,
         ),
+    },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Hidden
+          data={{ testid: 'hidden-1' }}
+          // => data-testid="hidden-1"
+        >
+          ...
+        </Hidden>
+      `,
     },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/Hidden/Hidden.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Hidden/Hidden.docs.tsx
@@ -1,8 +1,9 @@
 import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
-import { Hidden, Stack, Strong, Text, TextLink, Tiles } from '../';
+import { Hidden, Stack, Strong, Text, Tiles } from '../';
 import { Placeholder } from '../../playroom/components';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Layout',
@@ -112,22 +113,7 @@ const docs: ComponentDocs = {
           </Hidden>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Hidden
           data={{ testid: 'hidden-1' }}
@@ -136,7 +122,8 @@ const docs: ComponentDocs = {
           ...
         </Hidden>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/HiddenVisually/HiddenVisually.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/HiddenVisually/HiddenVisually.docs.tsx
@@ -1,7 +1,8 @@
 import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
-import { HiddenVisually, Strong, Text, TextLink } from '../';
+import { HiddenVisually, Text } from '../';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Layout',
@@ -20,22 +21,7 @@ const docs: ComponentDocs = {
     </Text>
   ),
   additional: [
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <HiddenVisually
           data={{ testid: 'hidden-visually-1' }}
@@ -44,7 +30,8 @@ const docs: ComponentDocs = {
           ...
         </HiddenVisually>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/HiddenVisually/HiddenVisually.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/HiddenVisually/HiddenVisually.docs.tsx
@@ -1,9 +1,7 @@
 import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
-import { Text } from '../Text/Text';
-
-import { HiddenVisually } from './HiddenVisually';
+import { HiddenVisually, Strong, Text, TextLink } from '../';
 
 const docs: ComponentDocs = {
   category: 'Layout',
@@ -21,6 +19,33 @@ const docs: ComponentDocs = {
       screen.
     </Text>
   ),
+  additional: [
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <HiddenVisually
+          data={{ testid: 'hidden-visually-1' }}
+          // => data-testid="hidden-visually-1"
+        >
+          ...
+        </HiddenVisually>
+      `,
+    },
+  ],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/Inline/Inline.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Inline/Inline.docs.tsx
@@ -12,6 +12,7 @@ import {
   Tiles,
 } from '../';
 import { Placeholder } from '../private/Placeholder/Placeholder';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Layout',
@@ -288,22 +289,7 @@ const docs: ComponentDocs = {
         </Inline>,
       ).code,
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Inline
           data={{ testid: 'inline-1' }}
@@ -312,7 +298,8 @@ const docs: ComponentDocs = {
           ...
         </Inline>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Inline/Inline.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Inline/Inline.docs.tsx
@@ -288,6 +288,31 @@ const docs: ComponentDocs = {
         </Inline>,
       ).code,
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Inline
+          data={{ testid: 'inline-1' }}
+          // => data-testid="inline-1"
+        >
+          ...
+        </Inline>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Link/Link.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Link/Link.docs.tsx
@@ -1,8 +1,9 @@
 import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
-import { Link, Notice, Strong, Text, TextLink } from '..';
+import { Link, Text, TextLink } from '..';
 import { Placeholder } from '../../playroom/components';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Logic',
@@ -30,28 +31,7 @@ const docs: ComponentDocs = {
         </Text>
       ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-          <Notice>
-            <Text>
-              While Link does support the native HTML syntax, it also supports
-              the <Strong>data</Strong> prop for consistency.
-            </Text>
-          </Notice>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Link
           data={{ testid: 'link-1' }}
@@ -60,7 +40,9 @@ const docs: ComponentDocs = {
           ...
         </Link>
       `,
-    },
+      supportsNativeSyntax: true,
+      componentName: 'Link',
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Link/Link.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Link/Link.docs.tsx
@@ -1,7 +1,7 @@
 import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
-import { Link, Text, TextLink } from '..';
+import { Link, Notice, Strong, Text, TextLink } from '..';
 import { Placeholder } from '../../playroom/components';
 
 const docs: ComponentDocs = {
@@ -29,6 +29,37 @@ const docs: ComponentDocs = {
           <TextLink href="/components/BraidProvider">BraidProvider</TextLink>.
         </Text>
       ),
+    },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+          <Notice>
+            <Text>
+              While Link does support the native HTML syntax, it also supports
+              the <Strong>data</Strong> prop for consistency.
+            </Text>
+          </Notice>
+        </>
+      ),
+      code: `
+        <Link
+          data={{ testid: 'link-1' }}
+          // => data-testid="link-1"
+        >
+          ...
+        </Link>
+      `,
     },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/List/List.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/List/List.docs.tsx
@@ -3,6 +3,7 @@ import type { ComponentDocs } from 'site/types';
 
 import { List, Text, TextLink, Stack, Column, Columns } from '..';
 import { IconTick, Strong } from '../../playroom/components';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -280,22 +281,7 @@ const docs: ComponentDocs = {
           </Columns>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <List
           data={{ testid: 'list-1' }}
@@ -304,7 +290,8 @@ const docs: ComponentDocs = {
           ...
         </List>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/List/List.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/List/List.docs.tsx
@@ -280,6 +280,31 @@ const docs: ComponentDocs = {
           </Columns>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <List
+          data={{ testid: 'list-1' }}
+          // => data-testid="list-1"
+        >
+          ...
+        </List>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Loader/Loader.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Loader/Loader.docs.tsx
@@ -14,6 +14,7 @@ import {
   Divider,
 } from '../';
 import { IconLanguage } from '../icons';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 import { animationDelayValueInMs } from './Loader.css';
 
@@ -124,29 +125,15 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Loader
           data={{ testid: 'loader-1' }}
           // => data-testid="loader-1"
         />
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Loader/Loader.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Loader/Loader.docs.tsx
@@ -124,6 +124,29 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Loader
+          data={{ testid: 'loader-1' }}
+          // => data-testid="loader-1"
+        />
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/MenuItem/MenuItem.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItem/MenuItem.docs.tsx
@@ -254,6 +254,31 @@ const docs: ComponentDocs = {
           </Inline>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <MenuItem
+          data={{ testid: 'menu-item-1' }}
+          // => data-testid="menu-item-1"
+        >
+          ...
+        </MenuItem>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/MenuItem/MenuItem.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItem/MenuItem.docs.tsx
@@ -22,6 +22,7 @@ import {
   IconBookmark,
   Inline,
 } from '..';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -254,22 +255,7 @@ const docs: ComponentDocs = {
           </Inline>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <MenuItem
           data={{ testid: 'menu-item-1' }}
@@ -278,7 +264,8 @@ const docs: ComponentDocs = {
           ...
         </MenuItem>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.docs.tsx
@@ -131,6 +131,31 @@ const docs: ComponentDocs = {
           </Inline>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <MenuItemCheckbox
+          data={{ testid: 'menu-item-checkbox-1' }}
+          // => data-testid="menu-item-checkbox-1"
+        >
+          ...
+        </MenuItemCheckbox>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItemCheckbox/MenuItemCheckbox.docs.tsx
@@ -12,6 +12,7 @@ import {
   Inline,
   IconChevron,
 } from '..';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -131,22 +132,7 @@ const docs: ComponentDocs = {
           </Inline>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <MenuItemCheckbox
           data={{ testid: 'menu-item-checkbox-1' }}
@@ -155,7 +141,8 @@ const docs: ComponentDocs = {
           ...
         </MenuItemCheckbox>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.docs.tsx
@@ -23,6 +23,7 @@ import {
   Badge,
   List,
 } from '..';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -518,22 +519,7 @@ const docs: ComponentDocs = {
         </>
       ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <MenuRenderer
           data={{ testid: 'menu-1' }}
@@ -542,7 +528,8 @@ const docs: ComponentDocs = {
           ...
         </MenuRenderer>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.docs.tsx
@@ -518,6 +518,31 @@ const docs: ComponentDocs = {
         </>
       ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <MenuRenderer
+          data={{ testid: 'menu-1' }}
+          // => data-testid="menu-1"
+        >
+          ...
+        </MenuRenderer>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.docs.tsx
@@ -289,6 +289,29 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <MonthPicker
+          data={{ testid: 'month-picker-1' }}
+          // => data-testid="month-picker-1"
+        />
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.docs.tsx
@@ -12,6 +12,7 @@ import {
   Heading,
 } from '../';
 import { IconLanguage } from '../icons';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -289,29 +290,15 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <MonthPicker
           data={{ testid: 'month-picker-1' }}
           // => data-testid="month-picker-1"
         />
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Notice/Notice.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Notice/Notice.docs.tsx
@@ -93,6 +93,31 @@ const docs: ComponentDocs = {
           </Notice>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Notice
+          data={{ testid: 'Notice-1' }}
+          // => data-testid="Notice-1"
+        >
+          ...
+        </Notice>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Notice/Notice.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Notice/Notice.docs.tsx
@@ -2,6 +2,7 @@ import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
 import { Notice, Text, Strong, Stack, TextLink, List } from '../';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -93,22 +94,7 @@ const docs: ComponentDocs = {
           </Notice>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Notice
           data={{ testid: 'Notice-1' }}
@@ -117,7 +103,8 @@ const docs: ComponentDocs = {
           ...
         </Notice>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.docs.tsx
@@ -19,6 +19,7 @@ import {
   Inline,
   List,
 } from '../';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -250,22 +251,7 @@ const docs: ComponentDocs = {
         </Text>
       ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <OverflowMenu
           data={{ testid: 'overflow-menu-1' }}
@@ -274,7 +260,8 @@ const docs: ComponentDocs = {
           ...
         </OverflowMenu>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.docs.tsx
@@ -250,6 +250,31 @@ const docs: ComponentDocs = {
         </Text>
       ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <OverflowMenu
+          data={{ testid: 'overflow-menu-1' }}
+          // => data-testid="overflow-menu-1"
+        >
+          ...
+        </OverflowMenu>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Page/Page.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Page/Page.docs.tsx
@@ -163,6 +163,31 @@ const docs: ComponentDocs = {
           </Page>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Page
+          data={{ testid: 'page-1' }}
+          // => data-testid="page-1"
+        >
+          ...
+        </Page>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Page/Page.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Page/Page.docs.tsx
@@ -6,6 +6,7 @@ import type { ComponentDocs } from 'site/types';
 
 import { Box, Notice, Stack, Strong, Text, TextLink, Tiles } from '..';
 import { Placeholder } from '../private/Placeholder/Placeholder';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 import { Page } from './Page';
 
@@ -163,22 +164,7 @@ const docs: ComponentDocs = {
           </Page>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Page
           data={{ testid: 'page-1' }}
@@ -187,7 +173,8 @@ const docs: ComponentDocs = {
           ...
         </Page>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/PageBlock/PageBlock.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/PageBlock/PageBlock.docs.tsx
@@ -143,6 +143,31 @@ const docs: ComponentDocs = {
         </Text>
       ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <PageBlock
+          data={{ testid: 'page-block-1' }}
+          // => data-testid="page-block-1"
+        >
+          ...
+        </PageBlock>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/PageBlock/PageBlock.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/PageBlock/PageBlock.docs.tsx
@@ -6,6 +6,7 @@ import { Box, ContentBlock, PageBlock, Stack, TextLink } from '../';
 import { Strong } from '../Strong/Strong';
 import { Text } from '../Text/Text';
 import { Placeholder } from '../private/Placeholder/Placeholder';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 import { gutters, validPageBlockComponents } from './PageBlock';
 
@@ -143,22 +144,7 @@ const docs: ComponentDocs = {
         </Text>
       ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <PageBlock
           data={{ testid: 'page-block-1' }}
@@ -167,7 +153,8 @@ const docs: ComponentDocs = {
           ...
         </PageBlock>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Pagination/Pagination.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Pagination/Pagination.docs.tsx
@@ -6,6 +6,7 @@ import { Strong } from '../Strong/Strong';
 import { Text } from '../Text/Text';
 import { TextLink } from '../TextLink/TextLink';
 import { IconLanguage } from '../icons';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 import { defaultPageLimit } from './Pagination';
 
@@ -217,29 +218,15 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Pagination
           data={{ testid: 'pagination-1' }}
           // => data-testid="pagination-1"
         />
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Pagination/Pagination.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Pagination/Pagination.docs.tsx
@@ -217,6 +217,29 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Pagination
+          data={{ testid: 'pagination-1' }}
+          // => data-testid="pagination-1"
+        />
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.docs.tsx
@@ -236,6 +236,29 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <PasswordField
+          data={{ testid: 'password-field-1' }}
+          // => data-testid="password-field-1"
+        />
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/PasswordField/PasswordField.docs.tsx
@@ -11,6 +11,7 @@ import {
   Heading,
 } from '../';
 import { IconLanguage } from '../icons';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -236,29 +237,15 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <PasswordField
           data={{ testid: 'password-field-1' }}
           // => data-testid="password-field-1"
         />
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.docs.tsx
@@ -13,6 +13,7 @@ import {
 import { Placeholder } from '../../playroom/components';
 import { Heading } from '../Heading/Heading';
 import { Stack } from '../Stack/Stack';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -352,22 +353,7 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <RadioGroup
           data={{ testid: 'radio-group-1' }}
@@ -379,7 +365,8 @@ const docs: ComponentDocs = {
           />
         </RadioGroup>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.docs.tsx
@@ -352,6 +352,34 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <RadioGroup
+          data={{ testid: 'radio-group-1' }}
+          // => data-testid="radio-group-1"
+        >
+          <RadioItem
+            data={{ testid: 'radio-item-1' }}
+            // => data-testid="radio-item-1"
+          />
+        </RadioGroup>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Rating/Rating.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Rating/Rating.docs.tsx
@@ -150,6 +150,29 @@ const docs: ComponentDocs = {
       ),
       Example: () => source(<Rating rating={3.2} tone="neutral" />),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Rating
+          data={{ testid: 'rating-1' }}
+          // => data-testid="rating-1"
+        />
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Rating/Rating.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Rating/Rating.docs.tsx
@@ -3,6 +3,7 @@ import type { ComponentDocs } from 'site/types';
 
 import { Rating, Stack, Inline, Text, Strong, TextLink, Notice } from '../';
 import { IconLanguage } from '../icons';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -150,29 +151,15 @@ const docs: ComponentDocs = {
       ),
       Example: () => source(<Rating rating={3.2} tone="neutral" />),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Rating
           data={{ testid: 'rating-1' }}
           // => data-testid="rating-1"
         />
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Secondary/Secondary.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Secondary/Secondary.docs.tsx
@@ -1,7 +1,7 @@
 import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
-import { Secondary, Text, TextLink } from '../';
+import { Secondary, Strong, Text, TextLink } from '../';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -24,6 +24,31 @@ const docs: ComponentDocs = {
           <TextLink href="/components/Heading">Heading</TextLink> component.
         </Text>
       ),
+    },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Secondary
+          data={{ testid: 'secondary-1' }}
+          // => data-testid="secondary-1"
+        >
+          ...
+        </Secondary>
+      `,
     },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/Secondary/Secondary.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Secondary/Secondary.docs.tsx
@@ -1,7 +1,8 @@
 import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
-import { Secondary, Strong, Text, TextLink } from '../';
+import { Secondary, Text, TextLink } from '../';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -25,22 +26,7 @@ const docs: ComponentDocs = {
         </Text>
       ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Secondary
           data={{ testid: 'secondary-1' }}
@@ -49,7 +35,8 @@ const docs: ComponentDocs = {
           ...
         </Secondary>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Spread/Spread.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Spread/Spread.docs.tsx
@@ -1,8 +1,9 @@
 import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
-import { Divider, Spread, Stack, Strong, Text, TextLink, Tiles } from '../';
+import { Divider, Spread, Stack, Strong, Text, Tiles } from '../';
 import { Placeholder } from '../private/Placeholder/Placeholder';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Layout',
@@ -140,22 +141,7 @@ const docs: ComponentDocs = {
         </Spread>,
       ).code,
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Spread
           data={{ testid: 'spread-1' }}
@@ -164,7 +150,8 @@ const docs: ComponentDocs = {
           ...
         </Spread>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Spread/Spread.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Spread/Spread.docs.tsx
@@ -1,7 +1,7 @@
 import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
-import { Divider, Spread, Stack, Strong, Text, Tiles } from '../';
+import { Divider, Spread, Stack, Strong, Text, TextLink, Tiles } from '../';
 import { Placeholder } from '../private/Placeholder/Placeholder';
 
 const docs: ComponentDocs = {
@@ -139,6 +139,31 @@ const docs: ComponentDocs = {
           <Placeholder height={40} />
         </Spread>,
       ).code,
+    },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Spread
+          data={{ testid: 'spread-1' }}
+          // => data-testid="spread-1"
+        >
+          ...
+        </Spread>
+      `,
     },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/Stack/Stack.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Stack/Stack.docs.tsx
@@ -3,6 +3,7 @@ import type { ComponentDocs } from 'site/types';
 
 import { Stack, Text, TextLink, Strong, Divider, Notice } from '../';
 import { Placeholder } from '../private/Placeholder/Placeholder';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Layout',
@@ -122,22 +123,7 @@ const docs: ComponentDocs = {
         </Stack>,
       ).code,
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Stack
           data={{ testid: 'stack-1' }}
@@ -146,7 +132,8 @@ const docs: ComponentDocs = {
           ...
         </Stack>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Stack/Stack.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Stack/Stack.docs.tsx
@@ -122,6 +122,31 @@ const docs: ComponentDocs = {
         </Stack>,
       ).code,
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Stack
+          data={{ testid: 'stack-1' }}
+          // => data-testid="stack-1"
+        >
+          ...
+        </Stack>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Stepper/Stepper.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Stepper/Stepper.docs.tsx
@@ -304,6 +304,31 @@ const docs: ComponentDocs = {
           </Stepper>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Stepper
+          data={{ testid: 'stepper-1' }}
+          // => data-testid="stepper-1"
+        >
+          ...
+        </Stepper>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Stepper/Stepper.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Stepper/Stepper.docs.tsx
@@ -14,6 +14,7 @@ import {
   Text,
   TextLink,
 } from '..';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 import { Step } from './Step';
 import { Stepper } from './Stepper';
@@ -304,22 +305,7 @@ const docs: ComponentDocs = {
           </Stepper>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Stepper
           data={{ testid: 'stepper-1' }}
@@ -328,7 +314,8 @@ const docs: ComponentDocs = {
           ...
         </Stepper>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Strong/Strong.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Strong/Strong.docs.tsx
@@ -25,6 +25,31 @@ const docs: ComponentDocs = {
         </Text>
       ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Strong
+          data={{ testid: 'strong-1' }}
+          // => data-testid="strong-1"
+        >
+          ...
+        </Strong>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Strong/Strong.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Strong/Strong.docs.tsx
@@ -2,6 +2,7 @@ import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
 import { Strong, Text, TextLink } from '../';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -25,22 +26,7 @@ const docs: ComponentDocs = {
         </Text>
       ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Strong
           data={{ testid: 'strong-1' }}
@@ -49,7 +35,8 @@ const docs: ComponentDocs = {
           ...
         </Strong>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Table/Table.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Table/Table.docs.tsx
@@ -1183,6 +1183,47 @@ const docs: ComponentDocs = {
           ),
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Table
+          data={{ testid: 'table-1' }}
+          // => data-testid="table-1"
+        >
+          <TableHeader data={{ testid: 'table-header-1' }}>
+            <TableRow data={{ testid: 'table-row-1' }}>
+              <TableHeaderCell data={{ testid: 'table-header-cell-1' }}>
+                ...
+              </TableHeaderCell>
+            </TableRow>
+          </TableHeader>
+          <TableBody data={{ testid: 'table-body-1' }}>
+            <TableRow>
+              <TableCell data={{ testid: 'table-cell-1' }}>
+                ...
+              </TableCell>
+            </TableRow>
+          </TableBody>
+          <TableFooter data={{ testid: 'table-footer-1' }}>
+            ...
+          </TableFooter>
+        </Table>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Table/Table.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Table/Table.docs.tsx
@@ -24,6 +24,7 @@ import {
 import { palette } from '../../color/palette';
 import type { StackProps } from '../Stack/Stack';
 import { ScrollContainer } from '../private/ScrollContainer/ScrollContainer';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 import { stripTypeAnyFromCode } from './stripTypeAnyFromCode';
 
@@ -1183,22 +1184,7 @@ const docs: ComponentDocs = {
           ),
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Table
           data={{ testid: 'table-1' }}
@@ -1223,7 +1209,8 @@ const docs: ComponentDocs = {
           </TableFooter>
         </Table>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Tabs/Tabs.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Tabs/Tabs.docs.tsx
@@ -423,6 +423,40 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <TabsProvider>
+          <Tabs
+            data={{ testid: 'tabs-1' }}
+            // => data-testid="tabs-1"
+          >
+            <Tab data={{ testid: 'tab-1' }}>
+              ...
+            </Tab>
+          </Tabs>
+          <TabPanels>
+            <TabPanel data={{ testid: 'tab-panel-1' }}>
+              ...
+            </TabPanel>
+          </TabPanels>
+        </TabsProvider>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Tabs/Tabs.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Tabs/Tabs.docs.tsx
@@ -20,6 +20,7 @@ import {
   IconRecommended,
 } from '..';
 import { Placeholder } from '../../playroom/components';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -423,22 +424,7 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <TabsProvider>
           <Tabs
@@ -456,7 +442,8 @@ const docs: ComponentDocs = {
           </TabPanels>
         </TabsProvider>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Tag/Tag.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Tag/Tag.docs.tsx
@@ -11,6 +11,7 @@ import {
   IconLanguage,
   IconTag,
 } from '../';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -174,29 +175,15 @@ const docs: ComponentDocs = {
           </Inline>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Tag
           data={{ testid: 'tag-1' }}
           // => data-testid="tag-1"
         />
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Tag/Tag.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Tag/Tag.docs.tsx
@@ -174,6 +174,29 @@ const docs: ComponentDocs = {
           </Inline>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Tag
+          data={{ testid: 'tag-1' }}
+          // => data-testid="tag-1"
+        />
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Text/Text.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Text/Text.docs.tsx
@@ -283,6 +283,31 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Text
+          data={{ testid: 'text-1' }}
+          // => data-testid="text-1"
+        >
+          ...
+        </Text>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Text/Text.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Text/Text.docs.tsx
@@ -12,6 +12,7 @@ import {
   IconImage,
   Divider,
 } from '../';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -283,22 +284,7 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Text
           data={{ testid: 'text-1' }}
@@ -307,7 +293,8 @@ const docs: ComponentDocs = {
           ...
         </Text>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.docs.tsx
@@ -2,6 +2,7 @@ import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
 import { Stack, Strong, Text, TextLink, TextDropdown, Notice } from '..';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -103,22 +104,7 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <TextDropdown
           data={{ testid: 'text-dropdown-1' }}
@@ -127,7 +113,8 @@ const docs: ComponentDocs = {
           ...
         </TextDropdown>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.docs.tsx
@@ -103,6 +103,31 @@ const docs: ComponentDocs = {
           </>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <TextDropdown
+          data={{ testid: 'text-dropdown-1' }}
+          // => data-testid="text-dropdown-1"
+        >
+          ...
+        </TextDropdown>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/TextField/TextField.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/TextField/TextField.docs.tsx
@@ -390,6 +390,29 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <TextField
+          data={{ testid: 'text-field-1' }}
+          // => data-testid="text-field-1"
+        />
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/TextField/TextField.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/TextField/TextField.docs.tsx
@@ -14,6 +14,7 @@ import {
   IconLanguage,
   TextDropdown,
 } from '../';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -390,29 +391,15 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <TextField
           data={{ testid: 'text-field-1' }}
           // => data-testid="text-field-1"
         />
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/TextLink/TextLink.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/TextLink/TextLink.docs.tsx
@@ -247,6 +247,31 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <TextLink
+          data={{ testid: 'text-link-1' }}
+          // => data-testid="text-link-1"
+        >
+          ...
+        </TextLink>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/TextLink/TextLink.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/TextLink/TextLink.docs.tsx
@@ -11,6 +11,7 @@ import {
   IconLink,
   IconArrow,
 } from '../';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -247,22 +248,7 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <TextLink
           data={{ testid: 'text-link-1' }}
@@ -271,7 +257,8 @@ const docs: ComponentDocs = {
           ...
         </TextLink>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/TextLinkButton/TextLinkButton.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/TextLinkButton/TextLinkButton.docs.tsx
@@ -2,6 +2,7 @@ import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
 import { Text, TextLink, TextLinkButton, Strong, IconLink } from '..';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -64,22 +65,7 @@ const docs: ComponentDocs = {
           </Text>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <TextLinkButton
           data={{ testid: 'text-link-button-1' }}
@@ -88,7 +74,8 @@ const docs: ComponentDocs = {
           ...
         </TextLinkButton>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/TextLinkButton/TextLinkButton.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/TextLinkButton/TextLinkButton.docs.tsx
@@ -64,6 +64,31 @@ const docs: ComponentDocs = {
           </Text>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <TextLinkButton
+          data={{ testid: 'text-link-button-1' }}
+          // => data-testid="text-link-button-1"
+        >
+          ...
+        </TextLinkButton>
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.docs.tsx
@@ -347,6 +347,29 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Textarea
+          data={{ testid: 'textarea-1' }}
+          // => data-testid="textarea-1"
+        />
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.docs.tsx
@@ -12,6 +12,7 @@ import {
   Heading,
   Alert,
 } from '../';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -347,29 +348,15 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Textarea
           data={{ testid: 'textarea-1' }}
           // => data-testid="textarea-1"
         />
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Tiles/Tiles.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Tiles/Tiles.docs.tsx
@@ -1,9 +1,10 @@
 import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
-import { Tiles, Text, TextLink } from '../';
+import { Tiles, Text } from '../';
 import { Strong } from '../Strong/Strong';
 import { Placeholder } from '../private/Placeholder/Placeholder';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Layout',
@@ -101,22 +102,7 @@ const docs: ComponentDocs = {
           </Tiles>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Tiles
           data={{ testid: 'tiles-1' }}
@@ -125,7 +111,8 @@ const docs: ComponentDocs = {
           ...
         </Tiles>
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Tiles/Tiles.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Tiles/Tiles.docs.tsx
@@ -1,7 +1,7 @@
 import source from '@braid-design-system/source.macro';
 import type { ComponentDocs } from 'site/types';
 
-import { Tiles, Text } from '../';
+import { Tiles, Text, TextLink } from '../';
 import { Strong } from '../Strong/Strong';
 import { Placeholder } from '../private/Placeholder/Placeholder';
 
@@ -100,6 +100,31 @@ const docs: ComponentDocs = {
             <Placeholder height={40} />
           </Tiles>,
         ),
+    },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Tiles
+          data={{ testid: 'tiles-1' }}
+          // => data-testid="tiles-1"
+        >
+          ...
+        </Tiles>
+      `,
     },
   ],
 };

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
@@ -6,6 +6,7 @@ import { Alert, Box, Divider, TextLink, Toggle } from '../';
 import { Stack } from '../Stack/Stack';
 import { Strong } from '../Strong/Strong';
 import { Text } from '../Text/Text';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
@@ -183,29 +184,15 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
-    {
-      label: 'Data attributes',
-      description: (
-        <>
-          <Text>
-            Braid components are very explicit about the properties they accept,
-            which makes providing arbitrary{' '}
-            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-              data attributes
-            </TextLink>{' '}
-            not possible. Instead, all Braid components accept a{' '}
-            <Strong>data</Strong> prop, allowing a single collection of data
-            attributes to be provided.
-          </Text>
-        </>
-      ),
+    dataAttributeDocs({
       code: `
         <Toggle
           data={{ testid: 'toggle-1' }}
           // => data-testid="toggle-1"
         />
       `,
-    },
+      supportsNativeSyntax: false,
+    }),
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Toggle/Toggle.docs.tsx
@@ -183,6 +183,29 @@ const docs: ComponentDocs = {
           </Stack>,
         ),
     },
+    {
+      label: 'Data attributes',
+      description: (
+        <>
+          <Text>
+            Braid components are very explicit about the properties they accept,
+            which makes providing arbitrary{' '}
+            <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+              data attributes
+            </TextLink>{' '}
+            not possible. Instead, all Braid components accept a{' '}
+            <Strong>data</Strong> prop, allowing a single collection of data
+            attributes to be provided.
+          </Text>
+        </>
+      ),
+      code: `
+        <Toggle
+          data={{ testid: 'toggle-1' }}
+          // => data-testid="toggle-1"
+        />
+      `,
+    },
   ],
 };
 

--- a/packages/braid-design-system/src/lib/components/icons/IconAI/IconAI.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconAI/IconAI.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconAdd/IconAdd.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconAdd/IconAdd.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconAttachment/IconAttachment.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconAttachment/IconAttachment.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconBluetooth/IconBluetooth.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconBluetooth/IconBluetooth.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconCategory/IconCategory.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCategory/IconCategory.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconCaution/IconCaution.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCaution/IconCaution.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconChecklist/IconChecklist.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconChecklist/IconChecklist.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconClear/IconClear.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconClear/IconClear.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconCompany/IconCompany.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCompany/IconCompany.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconCompose/IconCompose.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCompose/IconCompose.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconCopy/IconCopy.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCopy/IconCopy.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconCoverLetter/IconCoverLetter.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCoverLetter/IconCoverLetter.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconCreditCard/IconCreditCard.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCreditCard/IconCreditCard.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconCritical/IconCritical.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconCritical/IconCritical.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconDate/IconDate.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDate/IconDate.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconDelete/IconDelete.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDelete/IconDelete.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconDesktop/IconDesktop.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDesktop/IconDesktop.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconDisallow/IconDisallow.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDisallow/IconDisallow.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconDocument/IconDocument.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDocument/IconDocument.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconDocumentBroken/IconDocumentBroken.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDocumentBroken/IconDocumentBroken.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconDownload/IconDownload.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconDownload/IconDownload.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconEdit/IconEdit.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconEdit/IconEdit.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconEducation/IconEducation.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconEducation/IconEducation.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconExperience/IconExperience.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconExperience/IconExperience.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconFilter/IconFilter.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconFilter/IconFilter.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconFlag/IconFlag.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconFlag/IconFlag.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconGift/IconGift.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconGift/IconGift.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconGlobe/IconGlobe.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconGlobe/IconGlobe.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconGrid/IconGrid.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconGrid/IconGrid.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconHash/IconHash.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconHash/IconHash.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconHelp/IconHelp.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconHelp/IconHelp.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconHistory/IconHistory.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconHistory/IconHistory.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconHome/IconHome.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconHome/IconHome.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconImage/IconImage.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconImage/IconImage.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconInfo/IconInfo.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconInfo/IconInfo.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconInvoice/IconInvoice.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconInvoice/IconInvoice.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconLanguage/IconLanguage.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconLanguage/IconLanguage.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconLicence/IconLicence.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconLicence/IconLicence.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconLink/IconLink.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconLink/IconLink.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconLinkBroken/IconLinkBroken.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconLinkBroken/IconLinkBroken.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconList/IconList.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconList/IconList.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconLocation/IconLocation.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconLocation/IconLocation.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconMail/IconMail.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconMail/IconMail.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconMessage/IconMessage.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconMessage/IconMessage.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconMinus/IconMinus.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconMinus/IconMinus.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconMobile/IconMobile.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconMobile/IconMobile.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconMoney/IconMoney.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconMoney/IconMoney.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconNewWindow/IconNewWindow.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconNewWindow/IconNewWindow.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconNote/IconNote.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconNote/IconNote.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconNotification/IconNotification.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconNotification/IconNotification.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconOverflow/IconOverflow.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconOverflow/IconOverflow.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconPeople/IconPeople.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPeople/IconPeople.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconPersonAdd/IconPersonAdd.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPersonAdd/IconPersonAdd.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconPersonVerified/IconPersonVerified.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPersonVerified/IconPersonVerified.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconPhone/IconPhone.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPhone/IconPhone.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconPlatformAndroid/IconPlatformAndroid.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPlatformAndroid/IconPlatformAndroid.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconPlatformApple/IconPlatformApple.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPlatformApple/IconPlatformApple.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconPositive/IconPositive.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPositive/IconPositive.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconPrint/IconPrint.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPrint/IconPrint.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconProfile/IconProfile.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconProfile/IconProfile.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconPromote/IconPromote.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconPromote/IconPromote.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconQR/IconQR.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconQR/IconQR.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconRecommended/IconRecommended.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconRecommended/IconRecommended.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconRefresh/IconRefresh.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconRefresh/IconRefresh.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconResume/IconResume.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconResume/IconResume.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconRocket/IconRocket.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconRocket/IconRocket.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconSearch/IconSearch.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSearch/IconSearch.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconSecurity/IconSecurity.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSecurity/IconSecurity.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconSend/IconSend.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSend/IconSend.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconSent/IconSent.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSent/IconSent.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconSettings/IconSettings.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSettings/IconSettings.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconShare/IconShare.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconShare/IconShare.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconSkills/IconSkills.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSkills/IconSkills.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialFacebook/IconSocialFacebook.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialFacebook/IconSocialFacebook.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialGitHub/IconSocialGitHub.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialGitHub/IconSocialGitHub.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialInstagram/IconSocialInstagram.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialInstagram/IconSocialInstagram.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialLinkedIn/IconSocialLinkedIn.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialLinkedIn/IconSocialLinkedIn.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialMedium/IconSocialMedium.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialMedium/IconSocialMedium.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialX/IconSocialX.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialX/IconSocialX.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconSocialYouTube/IconSocialYouTube.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSocialYouTube/IconSocialYouTube.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconSort/IconSort.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSort/IconSort.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconStatistics/IconStatistics.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconStatistics/IconStatistics.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconSubCategory/IconSubCategory.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconSubCategory/IconSubCategory.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconTag/IconTag.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconTag/IconTag.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconTick/IconTick.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconTick/IconTick.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconTime/IconTime.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconTime/IconTime.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconTip/IconTip.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconTip/IconTip.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconUpload/IconUpload.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconUpload/IconUpload.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconVideo/IconVideo.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconVideo/IconVideo.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconWorkExperience/IconWorkExperience.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconWorkExperience/IconWorkExperience.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconZoomIn/IconZoomIn.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconZoomIn/IconZoomIn.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/IconZoomOut/IconZoomOut.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconZoomOut/IconZoomOut.docs.tsx
@@ -15,7 +15,7 @@ const docs: ComponentDocs = {
       </Stack>,
     ),
   alternatives: [],
-  additional: [iconDocumentation],
+  additional: [...iconDocumentation],
 };
 
 export default docs;

--- a/packages/braid-design-system/src/lib/components/icons/iconCommon.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/iconCommon.docs.tsx
@@ -1,6 +1,7 @@
 import type { ComponentExample } from 'site/types';
 
-import { Strong, Text, TextLink } from '../';
+import { Text, TextLink } from '../';
+import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 export const iconDocumentation: ComponentExample[] = [
   {
@@ -15,27 +16,13 @@ export const iconDocumentation: ComponentExample[] = [
       </Text>
     ),
   },
-  {
-    label: 'Data attributes',
-    description: (
-      <>
-        <Text>
-          Braid components are very explicit about the properties they accept,
-          which makes providing arbitrary{' '}
-          <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
-            data attributes
-          </TextLink>{' '}
-          not possible. Instead, all Braid components accept a{' '}
-          <Strong>data</Strong> prop, allowing a single collection of data
-          attributes to be provided.
-        </Text>
-      </>
-    ),
+  dataAttributeDocs({
     code: `
-        <Icon
-          data={{ testid: 'icon-1' }}
-          // => data-testid="icon-1"
-        />
-      `,
-  },
+      <Icon
+        data={{ testid: 'icon-1' }}
+        // => data-testid="icon-1"
+      />
+    `,
+    supportsNativeSyntax: false,
+  }),
 ];

--- a/packages/braid-design-system/src/lib/components/icons/iconCommon.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/iconCommon.docs.tsx
@@ -1,16 +1,41 @@
 import type { ComponentExample } from 'site/types';
 
-import { Text, TextLink } from '../';
+import { Strong, Text, TextLink } from '../';
 
-export const iconDocumentation: ComponentExample = {
-  label: 'Customising the appearance',
-  description: (
-    <Text>
-      For details about customising the appearance of icons see the{' '}
-      <TextLink href="/foundations/iconography">
-        iconography documentation
-      </TextLink>
-      .
-    </Text>
-  ),
-};
+export const iconDocumentation: ComponentExample[] = [
+  {
+    label: 'Customising the appearance',
+    description: (
+      <Text>
+        For details about customising the appearance of icons see the{' '}
+        <TextLink href="/foundations/iconography">
+          iconography documentation
+        </TextLink>
+        .
+      </Text>
+    ),
+  },
+  {
+    label: 'Data attributes',
+    description: (
+      <>
+        <Text>
+          Braid components are very explicit about the properties they accept,
+          which makes providing arbitrary{' '}
+          <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+            data attributes
+          </TextLink>{' '}
+          not possible. Instead, all Braid components accept a{' '}
+          <Strong>data</Strong> prop, allowing a single collection of data
+          attributes to be provided.
+        </Text>
+      </>
+    ),
+    code: `
+        <Icon
+          data={{ testid: 'icon-1' }}
+          // => data-testid="icon-1"
+        />
+      `,
+  },
+];

--- a/packages/braid-design-system/src/lib/components/private/dataAttribute.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/private/dataAttribute.docs.tsx
@@ -1,0 +1,43 @@
+import type { ComponentExample } from 'site/types';
+
+import { Notice, Strong, Text, TextLink } from '../';
+
+type CreateDataAttributeDocs = (
+  params: {
+    code: string;
+  } & (
+    | { supportsNativeSyntax: false }
+    | { supportsNativeSyntax: true; componentName: string }
+  ),
+) => ComponentExample;
+
+export const dataAttributeDocs: CreateDataAttributeDocs = ({
+  code,
+  supportsNativeSyntax,
+  ...restProps
+}) => ({
+  label: 'Data attributes',
+  description: (
+    <>
+      <Text>
+        Braid components are very explicit about the properties they accept,
+        which makes providing arbitrary{' '}
+        <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+          data attributes
+        </TextLink>{' '}
+        not possible. Instead, a <Strong>data</Strong> prop can be provided as a
+        single collection of data attributes.
+      </Text>
+      {supportsNativeSyntax ? (
+        <Notice>
+          <Text>
+            While {'componentName' in restProps && restProps.componentName} does
+            support the native HTML syntax, it also supports the{' '}
+            <Strong>data</Strong> prop for consistency.
+          </Text>
+        </Notice>
+      ) : null}
+    </>
+  ),
+  code,
+});

--- a/packages/braid-design-system/src/lib/components/private/dataAttribute.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/private/dataAttribute.docs.tsx
@@ -22,7 +22,7 @@ export const dataAttributeDocs: CreateDataAttributeDocs = ({
       <Text>
         Braid components are very explicit about the properties they accept,
         which makes providing arbitrary{' '}
-        <TextLink href="https://developer.mozilla.org/en-US/docs/Learn/HTML/Howto/Use_data_attributes">
+        <TextLink href="https://developer.mozilla.org/en-US/docs/Learn_web_development/Howto/Solve_HTML_problems/Use_data_attributes">
           data attributes
         </TextLink>{' '}
         not possible. Instead, a <Strong>data</Strong> prop can be provided as a


### PR DESCRIPTION
The `data` prop has previously been documented only on the `Box` component docs, as it is the basis for all components, but that is not discoverable by consumers using the other components (and not all `Box` APIs are exposed for every component).

Adding explicit `data` prop docs to each component to increase awareness and discoverability.

#### Review Note
Also updated the icon generation script to sort the dependencies correctly, and not rely on the format step.