### PR TITLE
ci: Reduce preview site history

### DIFF
--- a/.github/workflows/clean-up-previews.yml
+++ b/.github/workflows/clean-up-previews.yml
@@ -11,7 +11,7 @@ jobs:
     env:
       CI: true
       PREVIEW_DIR: preview
-      DAYS_OLD: 12
+      DAYS_OLD: 7
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4

--- a/.github/workflows/clean-up-previews.yml
+++ b/.github/workflows/clean-up-previews.yml
@@ -1,6 +1,7 @@
 name: Clean up preview site
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '00 8 * * 1'
 


### PR DESCRIPTION
Allow manual clean up in addition to schedule. Also reducing the window to 7 days.