### PR TITLE
site: Use ScrollContainer for side navigation

### DIFF
--- a/site/src/App/Navigation/Navigation.css.ts
+++ b/site/src/App/Navigation/Navigation.css.ts
@@ -1,13 +1,7 @@
-import { style, globalStyle, createVar } from '@vanilla-extract/css';
+import { style, globalStyle } from '@vanilla-extract/css';
 import { calc } from '@vanilla-extract/css-utils';
-import {
-  breakpoints,
-  responsiveStyle,
-  colorModeStyle,
-} from 'braid-src/entries/css';
-import { palette } from 'braid-src/lib/color/palette';
+import { breakpoints, responsiveStyle } from 'braid-src/entries/css';
 import { vars } from 'braid-src/lib/themes/vars.css';
-import { rgba } from 'polished';
 
 import { menuWidth, headerHeight, gutterSize } from './navigationSizes';
 
@@ -57,46 +51,10 @@ const subNavOffsetAboveMobile = style(
   }),
 );
 
-const backgroundVar = createVar();
-const shadowVar = createVar();
-const transparent = 'rgba(0, 0, 0, 0)';
-const scrollShadows = style([
-  {
-    backgroundPosition: 'center top',
-    backgroundRepeat: 'no-repeat',
-    backgroundAttachment: 'local, scroll',
-  },
-  colorModeStyle({
-    lightMode: {
-      vars: {
-        [backgroundVar]: vars.backgroundColor.body,
-        [shadowVar]: rgba(palette.grey['800'], 0.2),
-      },
-      backgroundImage: [
-        `linear-gradient(${backgroundVar} 30%, ${transparent})`,
-        `radial-gradient(farthest-side at 50% 0, ${shadowVar}, ${transparent})`,
-      ].join(', '),
-      backgroundSize: '100% 40px, 100% 18px',
-    },
-    darkMode: {
-      vars: {
-        [backgroundVar]: vars.backgroundColor.bodyDark,
-        [shadowVar]: palette.grey['800'],
-      },
-      backgroundImage: [
-        `linear-gradient(45deg, ${backgroundVar}, ${backgroundVar})`,
-        `linear-gradient(90deg, ${transparent}, ${shadowVar} 15%, ${shadowVar} 85%, ${transparent})`,
-      ].join(', '),
-      backgroundSize: '100% 2px',
-    },
-  }),
-]);
-
 export const sideNavigationContainer = style([
   headerOffset,
   fixedWidthAboveMobile,
   hideOnMobileWhenClosed,
-  scrollShadows,
 ]);
 
 export const pageContent = style([

--- a/site/src/App/Navigation/Navigation.css.ts
+++ b/site/src/App/Navigation/Navigation.css.ts
@@ -37,6 +37,7 @@ const hideOnMobileWhenClosed = style({
       selectors: {
         [`&:not(${isOpen})`]: {
           opacity: 0,
+          transform: `translateY(${calc.negate(vars.space.xsmall)})`,
         },
       },
     },

--- a/site/src/App/Navigation/Navigation.tsx
+++ b/site/src/App/Navigation/Navigation.tsx
@@ -169,10 +169,7 @@ export const Navigation = () => {
           bottom={0}
           transition="fast"
           width="full"
-          display={{
-            mobile: isMenuOpen ? 'block' : 'none',
-            wide: 'block',
-          }}
+          pointerEvents={!isMenuOpen ? 'none' : undefined}
           zIndex="sticky"
           className={[
             styles.sideNavigationContainer,

--- a/site/src/App/Navigation/Navigation.tsx
+++ b/site/src/App/Navigation/Navigation.tsx
@@ -13,6 +13,7 @@ import {
 // TODO: COLORMODE RELEASE
 // Use public import
 import { type BoxProps, Box } from 'braid-src/lib/components/Box/Box';
+import { ScrollContainer } from 'braid-src/lib/components/private/ScrollContainer/ScrollContainer';
 import { useState, useRef, useEffect, forwardRef } from 'react';
 import { RemoveScroll } from 'react-remove-scroll';
 import { useLocation, Outlet } from 'react-router-dom';
@@ -163,11 +164,10 @@ export const Navigation = () => {
       </Box>
 
       <RemoveScroll enabled={isMenuOpen} forwardProps>
-        <FixedContentBlock
-          overflow="auto"
+        <Box
+          position="fixed"
           bottom={0}
-          paddingX={gutterSize}
-          paddingBottom="xxlarge"
+          transition="fast"
           width="full"
           display={{
             mobile: isMenuOpen ? 'block' : 'none',
@@ -179,8 +179,12 @@ export const Navigation = () => {
             isMenuOpen ? styles.isOpen : undefined,
           ]}
         >
-          <SideNavigation onSelect={() => setMenuOpen(false)} />
-        </FixedContentBlock>
+          <ScrollContainer direction="vertical">
+            <Box paddingX={gutterSize} paddingBottom="xxlarge">
+              <SideNavigation onSelect={() => setMenuOpen(false)} />
+            </Box>
+          </ScrollContainer>
+        </Box>
       </RemoveScroll>
 
       <Box


### PR DESCRIPTION
As part of the colour re-work the scroll shadow got out of sync with the background on the docs site. Realised we can adopt our `ScrollContainer` (still private i know) component and leverage the masking technique rather than try and guess the background colours.