### PR TITLE
docs: Fix `TooltipRenderer` formatting example

### DIFF
--- a/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.docs.tsx
@@ -169,7 +169,7 @@ const docs: ComponentDocs = {
             placement="bottom"
             tooltip={
               <Stack space="medium">
-                <Text weight="strong">Strong text</Text>
+                <Text size="large">Large text</Text>
                 <Text>
                   The quick brown fox jumps over the lazy dog. The quick brown
                   fox jumps over the lazy dog. The quick brown fox jumps over
@@ -196,7 +196,7 @@ const docs: ComponentDocs = {
               placement="bottom"
               tooltip={
                 <Stack space="medium">
-                  <Text weight="strong">Strong text</Text>
+                  <Text size="large">Large text</Text>
                   <Text>
                     The quick brown fox jumps over the lazy dog. The quick brown
                     fox jumps over the lazy dog. The quick brown fox jumps over


### PR DESCRIPTION
The current example shows text formatted with `weight="strong"`, which is the same as the default `Text` weight in `Tooltips` in the flagship themes.

Changing this to large `Text`, but could also use regular `Text` or another example