### PR TITLE
Add `ref` to Table components

### DIFF
--- a/.changeset/rare-chairs-occur.md
+++ b/.changeset/rare-chairs-occur.md
@@ -2,4 +2,15 @@
 'braid-design-system': minor
 ---
 
-Add `ref` to table components
+---
+updated:
+  - Table
+  - TableBody
+  - TableCell
+  - TableFooter
+  - TableHeader
+  - TableHeaderCell
+  - TableRow
+---
+
+Add `ref` support to table components

--- a/.changeset/rare-chairs-occur.md
+++ b/.changeset/rare-chairs-occur.md
@@ -2,4 +2,4 @@
 'braid-design-system': minor
 ---
 
-Add `ref` to TableBody and TableRow
+Add `ref` to table components

--- a/.changeset/rare-chairs-occur.md
+++ b/.changeset/rare-chairs-occur.md
@@ -1,0 +1,5 @@
+---
+'braid-design-system': minor
+---
+
+Add `ref` to TableBody and TableRow

--- a/packages/braid-design-system/src/lib/components/Table/Table.test.tsx
+++ b/packages/braid-design-system/src/lib/components/Table/Table.test.tsx
@@ -1,6 +1,7 @@
 import '@testing-library/jest-dom';
 import 'html-validate/jest';
 import { render } from '@testing-library/react';
+import { createRef } from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 
 import {
@@ -143,6 +144,50 @@ describe('Table', () => {
       ).toHTMLValidate({
         extends: ['html-validate:recommended'],
       });
+    });
+  });
+
+  describe('ref forwarding', () => {
+    it('should forward ref to TableBody', () => {
+      const bodyRef = createRef<HTMLTableSectionElement>();
+
+      render(
+        <BraidTestProvider>
+          <Table label="Table with refs">
+            <TableBody ref={bodyRef}>
+              <TableRow>
+                <TableCell>
+                  <Text>Content</Text>
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </BraidTestProvider>,
+      );
+
+      expect(bodyRef.current).not.toBeNull();
+      expect(bodyRef.current?.tagName).toBe('TBODY');
+    });
+
+    it('should forward ref to TableRow', () => {
+      const rowRef = createRef<HTMLTableRowElement>();
+
+      render(
+        <BraidTestProvider>
+          <Table label="Table with refs">
+            <TableBody>
+              <TableRow ref={rowRef}>
+                <TableCell>
+                  <Text>Content</Text>
+                </TableCell>
+              </TableRow>
+            </TableBody>
+          </Table>
+        </BraidTestProvider>,
+      );
+
+      expect(rowRef.current).not.toBeNull();
+      expect(rowRef.current?.tagName).toBe('TR');
     });
   });
 });

--- a/packages/braid-design-system/src/lib/components/Table/Table.test.tsx
+++ b/packages/braid-design-system/src/lib/components/Table/Table.test.tsx
@@ -148,46 +148,49 @@ describe('Table', () => {
   });
 
   describe('ref forwarding', () => {
-    it('should forward ref to TableBody', () => {
+    it('should forward refs to all table components', () => {
+      const tableRef = createRef<HTMLTableElement>();
+      const headerRef = createRef<HTMLTableSectionElement>();
+      const rowRef = createRef<HTMLTableRowElement>();
       const bodyRef = createRef<HTMLTableSectionElement>();
+      const cellRef = createRef<HTMLTableCellElement>();
+      const footerRef = createRef<HTMLTableSectionElement>();
+      const headerCellRef = createRef<HTMLTableCellElement>();
 
       render(
         <BraidTestProvider>
-          <Table label="Table with refs">
+          <Table label="Table with refs" ref={tableRef}>
+            <TableHeader ref={headerRef}>
+              <TableRow ref={rowRef}>
+                <TableHeaderCell ref={headerCellRef}>
+                  <Text>Header</Text>
+                </TableHeaderCell>
+              </TableRow>
+            </TableHeader>
             <TableBody ref={bodyRef}>
               <TableRow>
-                <TableCell>
+                <TableCell ref={cellRef}>
                   <Text>Content</Text>
                 </TableCell>
               </TableRow>
             </TableBody>
+            <TableFooter ref={footerRef}>
+              <TableRow>
+                <TableCell>
+                  <Text>Footer</Text>
+                </TableCell>
+              </TableRow>
+            </TableFooter>
           </Table>
         </BraidTestProvider>,
       );
 
-      expect(bodyRef.current).not.toBeNull();
+      expect(tableRef.current?.tagName).toBe('TABLE');
+      expect(headerRef.current?.tagName).toBe('THEAD');
+      expect(headerCellRef.current?.tagName).toBe('TH');
       expect(bodyRef.current?.tagName).toBe('TBODY');
-    });
-
-    it('should forward ref to TableRow', () => {
-      const rowRef = createRef<HTMLTableRowElement>();
-
-      render(
-        <BraidTestProvider>
-          <Table label="Table with refs">
-            <TableBody>
-              <TableRow ref={rowRef}>
-                <TableCell>
-                  <Text>Content</Text>
-                </TableCell>
-              </TableRow>
-            </TableBody>
-          </Table>
-        </BraidTestProvider>,
-      );
-
-      expect(rowRef.current).not.toBeNull();
-      expect(rowRef.current?.tagName).toBe('TR');
+      expect(cellRef.current?.tagName).toBe('TD');
+      expect(footerRef.current?.tagName).toBe('TFOOT');
     });
   });
 });

--- a/packages/braid-design-system/src/lib/components/Table/Table.tsx
+++ b/packages/braid-design-system/src/lib/components/Table/Table.tsx
@@ -1,4 +1,4 @@
-import type { ReactNode } from 'react';
+import { forwardRef, type ReactNode } from 'react';
 
 import { Box } from '../Box/Box';
 import { ScrollContainer } from '../private/ScrollContainer/ScrollContainer';
@@ -17,13 +17,16 @@ export interface TableProps {
   data?: DataAttributeMap;
 }
 
-export const Table = ({
-  alignY = 'center',
-  children,
-  label,
-  data,
-  ...restProps
-}: TableProps) => (
+export const Table = forwardRef<HTMLTableElement, TableProps>((
+  {
+    alignY = 'center',
+    children,
+    label,
+    data,
+    ...restProps
+  },
+  ref
+) => (
   <TableContext.Provider value={{ alignY }}>
     <ScrollContainer>
       <Box
@@ -34,10 +37,11 @@ export const Table = ({
         overflow="hidden"
         aria-label={label}
         className={styles.table}
+        ref={ref}
         {...buildDataAttributes({ data, validateRestProps: restProps })}
       >
         {children}
       </Box>
     </ScrollContainer>
   </TableContext.Provider>
-);
+));

--- a/packages/braid-design-system/src/lib/components/Table/Table.tsx
+++ b/packages/braid-design-system/src/lib/components/Table/Table.tsx
@@ -17,31 +17,24 @@ export interface TableProps {
   data?: DataAttributeMap;
 }
 
-export const Table = forwardRef<HTMLTableElement, TableProps>((
-  {
-    alignY = 'center',
-    children,
-    label,
-    data,
-    ...restProps
-  },
-  ref
-) => (
-  <TableContext.Provider value={{ alignY }}>
-    <ScrollContainer>
-      <Box
-        component="table"
-        width="full"
-        background="surface"
-        borderRadius="large"
-        overflow="hidden"
-        aria-label={label}
-        className={styles.table}
-        ref={ref}
-        {...buildDataAttributes({ data, validateRestProps: restProps })}
-      >
-        {children}
-      </Box>
-    </ScrollContainer>
-  </TableContext.Provider>
-));
+export const Table = forwardRef<HTMLTableElement, TableProps>(
+  ({ alignY = 'center', children, label, data, ...restProps }, ref) => (
+    <TableContext.Provider value={{ alignY }}>
+      <ScrollContainer>
+        <Box
+          component="table"
+          width="full"
+          background="surface"
+          borderRadius="large"
+          overflow="hidden"
+          aria-label={label}
+          className={styles.table}
+          ref={ref}
+          {...buildDataAttributes({ data, validateRestProps: restProps })}
+        >
+          {children}
+        </Box>
+      </ScrollContainer>
+    </TableContext.Provider>
+  ),
+);

--- a/packages/braid-design-system/src/lib/components/Table/TableBody.tsx
+++ b/packages/braid-design-system/src/lib/components/Table/TableBody.tsx
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import { useContext, type ReactNode } from 'react';
+import { useContext, type ReactNode, forwardRef } from 'react';
 
 import { Box } from '../Box/Box';
 import buildDataAttributes, {
@@ -16,20 +16,23 @@ interface TableBodyProps {
   data?: DataAttributeMap;
 }
 
-export const TableBody = ({ children, data, ...restProps }: TableBodyProps) => {
-  const tableContext = useContext(TableContext);
+export const TableBody = forwardRef<HTMLTableSectionElement, TableBodyProps>(
+  ({ children, data, ...restProps }, ref) => {
+    const tableContext = useContext(TableContext);
 
-  assert(tableContext, 'TableBody must be used within a Table component');
+    assert(tableContext, 'TableBody must be used within a Table component');
 
-  return (
-    <TableBodyContext.Provider value={true}>
-      <Box
-        component="tbody"
-        className={styles.tableSection}
-        {...buildDataAttributes({ data, validateRestProps: restProps })}
-      >
-        {children}
-      </Box>
-    </TableBodyContext.Provider>
-  );
-};
+    return (
+      <TableBodyContext.Provider value={true}>
+        <Box
+          component="tbody"
+          className={styles.tableSection}
+          ref={ref}
+          {...buildDataAttributes({ data, validateRestProps: restProps })}
+        >
+          {children}
+        </Box>
+      </TableBodyContext.Provider>
+    );
+  },
+);

--- a/packages/braid-design-system/src/lib/components/Table/TableCell.tsx
+++ b/packages/braid-design-system/src/lib/components/Table/TableCell.tsx
@@ -1,7 +1,7 @@
 import assert from 'assert';
 
 import { assignInlineVars } from '@vanilla-extract/dynamic';
-import { useContext, type ReactNode } from 'react';
+import { useContext, type ReactNode, forwardRef } from 'react';
 
 import {
   resolveResponsiveRangeProps,
@@ -57,21 +57,24 @@ const resolveSoftWidth = (width: CellProps['width']) => {
   return width;
 };
 
-const Cell = ({
-  header: isHeaderCell,
-  children,
-  hideAbove,
-  hideBelow,
-  align = 'left',
-  wrap = false,
-  width = 'auto',
-  minWidth,
-  maxWidth,
-  colspan,
-  scope,
-  data,
-  ...restProps
-}: CellProps & BaseCellProps) => {
+const Cell = forwardRef<HTMLTableCellElement, CellProps & BaseCellProps>((
+  {
+    header: isHeaderCell,
+    children,
+    hideAbove,
+    hideBelow,
+    align = 'left',
+    wrap = false,
+    width = 'auto',
+    minWidth,
+    maxWidth,
+    colspan,
+    scope,
+    data,
+    ...restProps
+  },
+  ref
+) => {
   const [hideOnMobile, hideOnTablet, hideOnDesktop, hideOnWide] =
     resolveResponsiveRangeProps({
       below: hideBelow,
@@ -123,6 +126,7 @@ const Cell = ({
         [styles.maxWidthVar]:
           typeof maxWidth !== 'undefined' ? `${maxWidth}px` : undefined,
       })}
+      ref={ref}
       {...buildDataAttributes({ data, validateRestProps: restProps })}
     >
       <DefaultBadgePropsProvider bleedY>
@@ -142,9 +146,9 @@ const Cell = ({
       </DefaultBadgePropsProvider>
     </Box>
   );
-};
+});
 
-export const TableCell = (props: CellProps) => {
+export const TableCell = forwardRef<HTMLTableCellElement, CellProps>((props, ref) => {
   const tableHeaderContext = useContext(TableHeaderContext);
   const tableRowContext = useContext(TableRowContext);
 
@@ -158,10 +162,10 @@ export const TableCell = (props: CellProps) => {
     'TableCell cannot be used outside a TableRow component',
   );
 
-  return <Cell {...props} header={false} scope={undefined} />;
-};
+  return <Cell {...props} header={false} scope={undefined} ref={ref} />;
+});
 
-export const TableHeaderCell = (props: CellProps) => {
+export const TableHeaderCell = forwardRef<HTMLTableCellElement, CellProps>((props, ref) => {
   const tableHeaderContext = useContext(TableHeaderContext);
   const tableRowContext = useContext(TableRowContext);
 
@@ -171,6 +175,6 @@ export const TableHeaderCell = (props: CellProps) => {
   );
 
   return (
-    <Cell {...props} header={true} scope={tableHeaderContext ? 'col' : 'row'} />
+    <Cell {...props} header={true} scope={tableHeaderContext ? 'col' : 'row'} ref={ref} />
   );
-};
+});

--- a/packages/braid-design-system/src/lib/components/Table/TableCell.tsx
+++ b/packages/braid-design-system/src/lib/components/Table/TableCell.tsx
@@ -57,124 +57,135 @@ const resolveSoftWidth = (width: CellProps['width']) => {
   return width;
 };
 
-const Cell = forwardRef<HTMLTableCellElement, CellProps & BaseCellProps>((
-  {
-    header: isHeaderCell,
-    children,
-    hideAbove,
-    hideBelow,
-    align = 'left',
-    wrap = false,
-    width = 'auto',
-    minWidth,
-    maxWidth,
-    colspan,
-    scope,
-    data,
-    ...restProps
+const Cell = forwardRef<HTMLTableCellElement, CellProps & BaseCellProps>(
+  (
+    {
+      header: isHeaderCell,
+      children,
+      hideAbove,
+      hideBelow,
+      align = 'left',
+      wrap = false,
+      width = 'auto',
+      minWidth,
+      maxWidth,
+      colspan,
+      scope,
+      data,
+      ...restProps
+    },
+    ref,
+  ) => {
+    const [hideOnMobile, hideOnTablet, hideOnDesktop, hideOnWide] =
+      resolveResponsiveRangeProps({
+        below: hideBelow,
+        above: hideAbove,
+      });
+
+    const tableFooterContext = useContext(TableFooterContext);
+    const tableContext = useContext(TableContext);
+
+    assert(tableContext, 'TableCell cannot be used outside a Table component');
+
+    const isFooterCell = tableFooterContext;
+
+    const softWidth = resolveSoftWidth(width);
+    const hasMaxWidth = typeof maxWidth !== 'undefined';
+
+    return (
+      <Box
+        component={isHeaderCell ? 'th' : 'td'}
+        scope={scope}
+        colSpan={colspan}
+        padding="small"
+        textAlign={align}
+        background={isHeaderCell ? 'neutralLight' : undefined}
+        display={{
+          mobile: hideOnMobile ? 'none' : undefined,
+          tablet: hideOnTablet ? 'none' : undefined,
+          desktop: hideOnDesktop ? 'none' : undefined,
+          wide: hideOnWide ? 'none' : undefined,
+        }}
+        className={{
+          [styles.cell]: true,
+          [styles.headCell]: isHeaderCell,
+          [styles.nowrap]: !wrap,
+          [styles.softWidth]: softWidth,
+          [styles.minWidth]: typeof minWidth !== 'undefined',
+          [styles.maxWidth]: hasMaxWidth,
+          [styles.alignYCenter]: tableContext.alignY === 'center',
+          [styles.showOnTablet]: !hideOnTablet && hideOnMobile,
+          [styles.showOnDesktop]:
+            !hideOnDesktop && (hideOnTablet || hideOnMobile),
+          [styles.showOnWide]:
+            !hideOnWide && (hideOnDesktop || hideOnTablet || hideOnMobile),
+        }}
+        style={assignInlineVars({
+          [styles.softWidthVar]: softWidth,
+          [styles.minWidthVar]:
+            typeof minWidth !== 'undefined' ? `${minWidth}px` : undefined,
+          [styles.maxWidthVar]:
+            typeof maxWidth !== 'undefined' ? `${maxWidth}px` : undefined,
+        })}
+        ref={ref}
+        {...buildDataAttributes({ data, validateRestProps: restProps })}
+      >
+        <DefaultBadgePropsProvider bleedY>
+          <DefaultTextPropsProvider
+            size="small"
+            weight={isHeaderCell || isFooterCell ? 'strong' : undefined}
+            maxLines={hasMaxWidth && !wrap ? 1 : undefined}
+          >
+            {align !== 'left' ? (
+              <Inline space="none" align={align}>
+                <>{children}</>
+              </Inline>
+            ) : (
+              children
+            )}
+          </DefaultTextPropsProvider>
+        </DefaultBadgePropsProvider>
+      </Box>
+    );
   },
-  ref
-) => {
-  const [hideOnMobile, hideOnTablet, hideOnDesktop, hideOnWide] =
-    resolveResponsiveRangeProps({
-      below: hideBelow,
-      above: hideAbove,
-    });
+);
 
-  const tableFooterContext = useContext(TableFooterContext);
-  const tableContext = useContext(TableContext);
+export const TableCell = forwardRef<HTMLTableCellElement, CellProps>(
+  (props, ref) => {
+    const tableHeaderContext = useContext(TableHeaderContext);
+    const tableRowContext = useContext(TableRowContext);
 
-  assert(tableContext, 'TableCell cannot be used outside a Table component');
+    assert(
+      !tableHeaderContext,
+      'TableCell cannot be used inside a TableHeader component. Please use TableHeaderCell instead.',
+    );
 
-  const isFooterCell = tableFooterContext;
+    assert(
+      tableRowContext,
+      'TableCell cannot be used outside a TableRow component',
+    );
 
-  const softWidth = resolveSoftWidth(width);
-  const hasMaxWidth = typeof maxWidth !== 'undefined';
+    return <Cell {...props} header={false} scope={undefined} ref={ref} />;
+  },
+);
 
-  return (
-    <Box
-      component={isHeaderCell ? 'th' : 'td'}
-      scope={scope}
-      colSpan={colspan}
-      padding="small"
-      textAlign={align}
-      background={isHeaderCell ? 'neutralLight' : undefined}
-      display={{
-        mobile: hideOnMobile ? 'none' : undefined,
-        tablet: hideOnTablet ? 'none' : undefined,
-        desktop: hideOnDesktop ? 'none' : undefined,
-        wide: hideOnWide ? 'none' : undefined,
-      }}
-      className={{
-        [styles.cell]: true,
-        [styles.headCell]: isHeaderCell,
-        [styles.nowrap]: !wrap,
-        [styles.softWidth]: softWidth,
-        [styles.minWidth]: typeof minWidth !== 'undefined',
-        [styles.maxWidth]: hasMaxWidth,
-        [styles.alignYCenter]: tableContext.alignY === 'center',
-        [styles.showOnTablet]: !hideOnTablet && hideOnMobile,
-        [styles.showOnDesktop]:
-          !hideOnDesktop && (hideOnTablet || hideOnMobile),
-        [styles.showOnWide]:
-          !hideOnWide && (hideOnDesktop || hideOnTablet || hideOnMobile),
-      }}
-      style={assignInlineVars({
-        [styles.softWidthVar]: softWidth,
-        [styles.minWidthVar]:
-          typeof minWidth !== 'undefined' ? `${minWidth}px` : undefined,
-        [styles.maxWidthVar]:
-          typeof maxWidth !== 'undefined' ? `${maxWidth}px` : undefined,
-      })}
-      ref={ref}
-      {...buildDataAttributes({ data, validateRestProps: restProps })}
-    >
-      <DefaultBadgePropsProvider bleedY>
-        <DefaultTextPropsProvider
-          size="small"
-          weight={isHeaderCell || isFooterCell ? 'strong' : undefined}
-          maxLines={hasMaxWidth && !wrap ? 1 : undefined}
-        >
-          {align !== 'left' ? (
-            <Inline space="none" align={align}>
-              <>{children}</>
-            </Inline>
-          ) : (
-            children
-          )}
-        </DefaultTextPropsProvider>
-      </DefaultBadgePropsProvider>
-    </Box>
-  );
-});
+export const TableHeaderCell = forwardRef<HTMLTableCellElement, CellProps>(
+  (props, ref) => {
+    const tableHeaderContext = useContext(TableHeaderContext);
+    const tableRowContext = useContext(TableRowContext);
 
-export const TableCell = forwardRef<HTMLTableCellElement, CellProps>((props, ref) => {
-  const tableHeaderContext = useContext(TableHeaderContext);
-  const tableRowContext = useContext(TableRowContext);
+    assert(
+      tableRowContext,
+      'TableHeaderCell cannot be used outside a TableRow component',
+    );
 
-  assert(
-    !tableHeaderContext,
-    'TableCell cannot be used inside a TableHeader component. Please use TableHeaderCell instead.',
-  );
-
-  assert(
-    tableRowContext,
-    'TableCell cannot be used outside a TableRow component',
-  );
-
-  return <Cell {...props} header={false} scope={undefined} ref={ref} />;
-});
-
-export const TableHeaderCell = forwardRef<HTMLTableCellElement, CellProps>((props, ref) => {
-  const tableHeaderContext = useContext(TableHeaderContext);
-  const tableRowContext = useContext(TableRowContext);
-
-  assert(
-    tableRowContext,
-    'TableHeaderCell cannot be used outside a TableRow component',
-  );
-
-  return (
-    <Cell {...props} header={true} scope={tableHeaderContext ? 'col' : 'row'} ref={ref} />
-  );
-});
+    return (
+      <Cell
+        {...props}
+        header={true}
+        scope={tableHeaderContext ? 'col' : 'row'}
+        ref={ref}
+      />
+    );
+  },
+);

--- a/packages/braid-design-system/src/lib/components/Table/TableFooter.tsx
+++ b/packages/braid-design-system/src/lib/components/Table/TableFooter.tsx
@@ -16,14 +16,10 @@ interface TableFooterProps {
   data?: DataAttributeMap;
 }
 
-export const TableFooter = forwardRef<HTMLTableSectionElement, TableFooterProps>((
-  {
-    children,
-    data,
-    ...restProps
-  },
-  ref
-) => {
+export const TableFooter = forwardRef<
+  HTMLTableSectionElement,
+  TableFooterProps
+>(({ children, data, ...restProps }, ref) => {
   const tableContext = useContext(TableContext);
 
   assert(tableContext, 'TableFooter must be used within a Table component');

--- a/packages/braid-design-system/src/lib/components/Table/TableFooter.tsx
+++ b/packages/braid-design-system/src/lib/components/Table/TableFooter.tsx
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import { useContext, type ReactNode } from 'react';
+import { useContext, type ReactNode, forwardRef } from 'react';
 
 import { Box } from '../Box/Box';
 import buildDataAttributes, {
@@ -11,16 +11,19 @@ import { TableContext, TableFooterContext } from './TableContext';
 
 import * as styles from './Table.css';
 
-interface TableHeaderProps {
+interface TableFooterProps {
   children: ReactNode;
   data?: DataAttributeMap;
 }
 
-export const TableFooter = ({
-  children,
-  data,
-  ...restProps
-}: TableHeaderProps) => {
+export const TableFooter = forwardRef<HTMLTableSectionElement, TableFooterProps>((
+  {
+    children,
+    data,
+    ...restProps
+  },
+  ref
+) => {
   const tableContext = useContext(TableContext);
 
   assert(tableContext, 'TableFooter must be used within a Table component');
@@ -30,10 +33,11 @@ export const TableFooter = ({
       <Box
         component="tfoot"
         className={styles.tableSection}
+        ref={ref}
         {...buildDataAttributes({ data, validateRestProps: restProps })}
       >
         {children}
       </Box>
     </TableFooterContext.Provider>
   );
-};
+});

--- a/packages/braid-design-system/src/lib/components/Table/TableHeader.tsx
+++ b/packages/braid-design-system/src/lib/components/Table/TableHeader.tsx
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import { useContext, type ReactNode } from 'react';
+import { useContext, type ReactNode, forwardRef } from 'react';
 
 import { Box } from '../Box/Box';
 import buildDataAttributes, {
@@ -16,11 +16,14 @@ interface TableHeaderProps {
   data?: DataAttributeMap;
 }
 
-export const TableHeader = ({
-  children,
-  data,
-  ...restProps
-}: TableHeaderProps) => {
+export const TableHeader = forwardRef<HTMLTableSectionElement, TableHeaderProps>((
+  {
+    children,
+    data,
+    ...restProps
+  },
+  ref
+) => {
   const tableContext = useContext(TableContext);
 
   assert(tableContext, 'TableHeader must be used within a Table component');
@@ -30,10 +33,11 @@ export const TableHeader = ({
       <Box
         component="thead"
         className={[styles.tableSection, styles.tableHeader]}
+        ref={ref}
         {...buildDataAttributes({ data, validateRestProps: restProps })}
       >
         {children}
       </Box>
     </TableHeaderContext.Provider>
   );
-};
+});

--- a/packages/braid-design-system/src/lib/components/Table/TableHeader.tsx
+++ b/packages/braid-design-system/src/lib/components/Table/TableHeader.tsx
@@ -16,14 +16,10 @@ interface TableHeaderProps {
   data?: DataAttributeMap;
 }
 
-export const TableHeader = forwardRef<HTMLTableSectionElement, TableHeaderProps>((
-  {
-    children,
-    data,
-    ...restProps
-  },
-  ref
-) => {
+export const TableHeader = forwardRef<
+  HTMLTableSectionElement,
+  TableHeaderProps
+>(({ children, data, ...restProps }, ref) => {
   const tableContext = useContext(TableContext);
 
   assert(tableContext, 'TableHeader must be used within a Table component');

--- a/packages/braid-design-system/src/lib/components/Table/TableRow.tsx
+++ b/packages/braid-design-system/src/lib/components/Table/TableRow.tsx
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import { useContext, type ReactNode } from 'react';
+import { useContext, type ReactNode, forwardRef } from 'react';
 
 import { Box } from '../Box/Box';
 import buildDataAttributes, {
@@ -22,34 +22,37 @@ export interface TableRowProps {
   data?: DataAttributeMap;
 }
 
-export const TableRow = ({ children, data, ...restProps }: TableRowProps) => {
-  const tableContext = useContext(TableContext);
-  const tableHeaderContext = useContext(TableHeaderContext);
-  const tableBodyContext = useContext(TableBodyContext);
-  const tableFooterContext = useContext(TableFooterContext);
-  const tableRowContext = useContext(TableRowContext);
+export const TableRow = forwardRef<HTMLTableRowElement, TableRowProps>(
+  ({ children, data, ...restProps }, ref) => {
+    const tableContext = useContext(TableContext);
+    const tableHeaderContext = useContext(TableHeaderContext);
+    const tableBodyContext = useContext(TableBodyContext);
+    const tableFooterContext = useContext(TableFooterContext);
+    const tableRowContext = useContext(TableRowContext);
 
-  assert(tableContext, 'TableRow must be used within a Table component');
+    assert(tableContext, 'TableRow must be used within a Table component');
 
-  assert(
-    !tableRowContext,
-    'TableRow cannot be nested instead another TableRow',
-  );
+    assert(
+      !tableRowContext,
+      'TableRow cannot be nested instead another TableRow',
+    );
 
-  assert(
-    tableBodyContext || tableHeaderContext || tableFooterContext,
-    'TableRow must be used within a table section, e.g. TableHeader, TableBody or TableFooter component',
-  );
+    assert(
+      tableBodyContext || tableHeaderContext || tableFooterContext,
+      'TableRow must be used within a table section, e.g. TableHeader, TableBody or TableFooter component',
+    );
 
-  return (
-    <TableRowContext.Provider value={true}>
-      <Box
-        component="tr"
-        className={styles.row}
-        {...buildDataAttributes({ data, validateRestProps: restProps })}
-      >
-        {children}
-      </Box>
-    </TableRowContext.Provider>
-  );
-};
+    return (
+      <TableRowContext.Provider value={true}>
+        <Box
+          component="tr"
+          className={styles.row}
+          ref={ref}
+          {...buildDataAttributes({ data, validateRestProps: restProps })}
+        >
+          {children}
+        </Box>
+      </TableRowContext.Provider>
+    );
+  },
+);

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -8177,6 +8177,10 @@ exports[`TableBody 1`] = `
   props: {
     children: ReactNode
     data?: DataAttributeMap
+    ref?: 
+        | (instance: HTMLTableSectionElement | null) => void
+        | RefObject<HTMLTableSectionElement>
+        | string
 },
 }
 `;
@@ -8267,6 +8271,10 @@ exports[`TableRow 1`] = `
   props: {
     children: ReactNode
     data?: DataAttributeMap
+    ref?: 
+        | (instance: HTMLTableRowElement | null) => void
+        | RefObject<HTMLTableRowElement>
+        | string
 },
 }
 `;

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -8167,6 +8167,10 @@ exports[`Table 1`] = `
     children: ReactNode
     data?: DataAttributeMap
     label: string
+    ref?: 
+        | (instance: HTMLTableElement | null) => void
+        | RefObject<HTMLTableElement>
+        | string
 },
 }
 `;
@@ -8206,6 +8210,10 @@ exports[`TableCell 1`] = `
         | "wide"
     maxWidth?: number
     minWidth?: number
+    ref?: 
+        | (instance: HTMLTableCellElement | null) => void
+        | RefObject<HTMLTableCellElement>
+        | string
     width?: 
         | "auto"
         | "content"
@@ -8221,6 +8229,10 @@ exports[`TableFooter 1`] = `
   props: {
     children: ReactNode
     data?: DataAttributeMap
+    ref?: 
+        | (instance: HTMLTableSectionElement | null) => void
+        | RefObject<HTMLTableSectionElement>
+        | string
 },
 }
 `;
@@ -8231,6 +8243,10 @@ exports[`TableHeader 1`] = `
   props: {
     children: ReactNode
     data?: DataAttributeMap
+    ref?: 
+        | (instance: HTMLTableSectionElement | null) => void
+        | RefObject<HTMLTableSectionElement>
+        | string
 },
 }
 `;
@@ -8256,6 +8272,10 @@ exports[`TableHeaderCell 1`] = `
         | "wide"
     maxWidth?: number
     minWidth?: number
+    ref?: 
+        | (instance: HTMLTableCellElement | null) => void
+        | RefObject<HTMLTableCellElement>
+        | string
     width?: 
         | "auto"
         | "content"


### PR DESCRIPTION
TODO

- [x] Test snapshot

note: [`forwardRef` is deprecated](https://react.dev/blog/2024/12/05/react-19#ref-as-a-prop). We could migrate now or wait for the codemod?