### PR TITLE
Autosuggest: Fix layout issue causing minor content overflow in certain scenarios

### DIFF
--- a/.changeset/bitter-vans-pay.md
+++ b/.changeset/bitter-vans-pay.md
@@ -1,0 +1,10 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Autosuggest
+---
+
+**Autosuggest**: Fix layout issue causing minor content overflow in certain scenarios 

--- a/packages/braid-design-system/src/lib/components/private/Announcement/Announcement.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Announcement/Announcement.tsx
@@ -1,9 +1,11 @@
-import { useId } from 'react';
+import { useEffect, useState } from 'react';
+import { createPortal } from 'react-dom';
 
-import { Box } from '../../Box/Box';
+import { atoms } from '../../../css/atoms/atoms';
 
 import * as styles from '../../HiddenVisually/HiddenVisually.css';
 
+let announcementCounter = 0;
 export const containerPrefix = 'braid-announcement-container';
 
 interface AnnouncementProps {
@@ -11,18 +13,40 @@ interface AnnouncementProps {
 }
 
 export const Announcement = ({ children }: AnnouncementProps) => {
-  const announcementContainerId = `${containerPrefix}-${useId()}`;
+  const [announcementElement, setElement] = useState<HTMLElement | null>(null);
+  const className = [
+    atoms({
+      reset: 'div',
+      position: 'absolute',
+      bottom: 0,
+      overflow: 'hidden',
+    }),
+    styles.root,
+  ].join(' ');
 
-  return (
-    <Box
-      id={announcementContainerId}
-      aria-live="polite"
-      aria-atomic="true"
-      position="absolute"
-      overflow="hidden"
-      className={styles.root}
-    >
-      {children}
-    </Box>
-  );
+  useEffect(() => {
+    const announcementContainerId = `${containerPrefix}-${announcementCounter++}`;
+
+    const element = document.createElement('div');
+    element.setAttribute('id', announcementContainerId);
+    element.setAttribute('class', className);
+    element.setAttribute('aria-live', 'polite');
+    element.setAttribute('aria-atomic', 'true');
+
+    document.body.appendChild(element);
+
+    setElement(element);
+
+    return () => {
+      document.body.removeChild(element);
+    };
+  }, [className]);
+
+  if (!announcementElement) {
+    return null;
+  }
+
+  // Portal ensures screen reader announcements complete,
+  // even if the parent component unmounts
+  return createPortal(children, announcementElement);
 };

--- a/packages/braid-design-system/src/lib/components/private/Announcement/Announcement.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Announcement/Announcement.tsx
@@ -1,11 +1,9 @@
-import { useEffect, useState } from 'react';
-import { createPortal } from 'react-dom';
+import { useId } from 'react';
 
-import { atoms } from '../../../css/atoms/atoms';
+import { Box } from '../../Box/Box';
 
 import * as styles from '../../HiddenVisually/HiddenVisually.css';
 
-let announcementCounter = 0;
 export const containerPrefix = 'braid-announcement-container';
 
 interface AnnouncementProps {
@@ -13,37 +11,18 @@ interface AnnouncementProps {
 }
 
 export const Announcement = ({ children }: AnnouncementProps) => {
-  const [announcementElement, setElement] = useState<HTMLElement | null>(null);
-  const className = [
-    atoms({
-      reset: 'div',
-      position: 'absolute',
-      overflow: 'hidden',
-    }),
-    styles.root,
-  ].join(' ');
+  const announcementContainerId = `${containerPrefix}-${useId()}`;
 
-  useEffect(() => {
-    const announcementContainerId = `${containerPrefix}-${announcementCounter++}`;
-
-    const element = document.createElement('div');
-    element.setAttribute('id', announcementContainerId);
-    element.setAttribute('class', className);
-    element.setAttribute('aria-live', 'polite');
-    element.setAttribute('aria-atomic', 'true');
-
-    document.body.appendChild(element);
-
-    setElement(element);
-
-    return () => {
-      document.body.removeChild(element);
-    };
-  }, [className]);
-
-  if (!announcementElement) {
-    return null;
-  }
-
-  return createPortal(children, announcementElement);
+  return (
+    <Box
+      id={announcementContainerId}
+      aria-live="polite"
+      aria-atomic="true"
+      position="absolute"
+      overflow="hidden"
+      className={styles.root}
+    >
+      {children}
+    </Box>
+  );
 };


### PR DESCRIPTION
Not sure of a nice screenshot test for this.

This change ensures `Annoucements` will not cause the document to grow in certain layouts using vh units