### PR TITLE
Autosuggest, TextDropdown, TextField: Change `id` prop from required to optional

### DIFF
--- a/.changeset/cuddly-radios-remain.md
+++ b/.changeset/cuddly-radios-remain.md
@@ -7,6 +7,7 @@ updated:
   - AccordionItem
   - Autosuggest
   - Disclosure
+  - TextDropdown
   - TextField
 ---
 

--- a/.changeset/cuddly-radios-remain.md
+++ b/.changeset/cuddly-radios-remain.md
@@ -7,6 +7,7 @@ updated:
   - AccordionItem
   - Autosuggest
   - Disclosure
+  - TextField
 ---
 
 Change `id` prop from required to optional, allowing simplified usage

--- a/.changeset/cuddly-radios-remain.md
+++ b/.changeset/cuddly-radios-remain.md
@@ -5,12 +5,11 @@
 ---
 updated:
   - AccordionItem
+  - Autosuggest
   - Disclosure
 ---
 
-**AccordionItem, Disclosure**: Change `id` prop from required to optional
-
-The id prop is now optional on both components, allowing simplified usage.
+Change `id` prop from required to optional, allowing simplified usage
 
 **EXAMPLE USAGE:**
 

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.docs.tsx
@@ -462,7 +462,7 @@ const docs: ComponentDocs = {
           each suggestion.
         </Text>
       ),
-      Example: ({ id, setDefaultState, setState, getState }) =>
+      Example: ({ setDefaultState, setState, getState }) =>
         source(
           <>
             {setDefaultState('textfield', 'App')}
@@ -471,7 +471,6 @@ const docs: ComponentDocs = {
             <Stack space="large">
               <TextField
                 label="Label"
-                id={id}
                 onChange={setState('textfield')}
                 value={getState('textfield')}
               />

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.docs.tsx
@@ -32,14 +32,13 @@ export const makeSuggestions = (
 
 const docs: ComponentDocs = {
   category: 'Content',
-  Example: ({ id, setDefaultState, getState, setState, resetState }) =>
+  Example: ({ setDefaultState, getState, setState, resetState }) =>
     source(
       <>
         {setDefaultState('value', { text: '' })}
 
         <Autosuggest
           label="Label"
-          id={id}
           value={getState('value')}
           onChange={setState('value')}
           onClear={() => resetState('value')}
@@ -88,7 +87,7 @@ const docs: ComponentDocs = {
           </List>
         </>
       ),
-      Example: ({ id, setDefaultState, getState, setState, resetState }) =>
+      Example: ({ setDefaultState, getState, setState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: '' })}
@@ -101,7 +100,6 @@ const docs: ComponentDocs = {
                   Help
                 </TextLink>
               }
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -133,7 +131,7 @@ const docs: ComponentDocs = {
           </Text>
         </>
       ),
-      Example: ({ id, setDefaultState, getState, setState, resetState }) =>
+      Example: ({ setDefaultState, getState, setState, resetState }) =>
         source(
           <>
             {setDefaultState('value1', { text: '' })}
@@ -143,7 +141,6 @@ const docs: ComponentDocs = {
             <Stack space="large">
               <Autosuggest
                 label="Label"
-                id={`${id}_1`}
                 value={getState('value1')}
                 onChange={setState('value1')}
                 onClear={() => resetState('value1')}
@@ -158,7 +155,6 @@ const docs: ComponentDocs = {
               />
               <Autosuggest
                 label="Label"
-                id={`${id}_2`}
                 value={getState('value2')}
                 onChange={setState('value2')}
                 onClear={() => resetState('value2')}
@@ -173,7 +169,6 @@ const docs: ComponentDocs = {
               />
               <Autosuggest
                 label="Label"
-                id={`${id}_3`}
                 value={getState('value3')}
                 onChange={setState('value3')}
                 onClear={() => resetState('value3')}
@@ -188,7 +183,6 @@ const docs: ComponentDocs = {
               />
               <Autosuggest
                 label="Label"
-                id={`${id}_4`}
                 value={getState('value4')}
                 onChange={setState('value4')}
                 onClear={() => resetState('value4')}
@@ -214,14 +208,13 @@ const docs: ComponentDocs = {
           screen reader when the field is focused.
         </Text>
       ),
-      Example: ({ id, setDefaultState, getState, setState, resetState }) =>
+      Example: ({ setDefaultState, getState, setState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: '' })}
 
             <Autosuggest
               label="Label"
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -244,14 +237,13 @@ const docs: ComponentDocs = {
           <Strong>disabled</Strong> prop.
         </Text>
       ),
-      Example: ({ id, setDefaultState, getState, setState, resetState }) =>
+      Example: ({ setDefaultState, getState, setState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: 'Text in disabled field' })}
 
             <Autosuggest
               label="Label"
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -274,14 +266,13 @@ const docs: ComponentDocs = {
           the user when no value is selected.
         </Text>
       ),
-      Example: ({ id, setDefaultState, getState, setState, resetState }) =>
+      Example: ({ setDefaultState, getState, setState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: '' })}
 
             <Autosuggest
               label="Label"
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -314,14 +305,13 @@ const docs: ComponentDocs = {
           </Text>
         </>
       ),
-      Example: ({ id, getState, setState, resetState, setDefaultState }) =>
+      Example: ({ getState, setState, resetState, setDefaultState }) =>
         source(
           <>
             {setDefaultState('value', { text: '' })}
 
             <Autosuggest
               label="Label"
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -353,7 +343,7 @@ const docs: ComponentDocs = {
           </Text>
         </>
       ),
-      Example: ({ id, setDefaultState, getState, setState, resetState }) =>
+      Example: ({ setDefaultState, getState, setState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: '' })}
@@ -361,7 +351,6 @@ const docs: ComponentDocs = {
             <Autosuggest
               automaticSelection
               label="Label"
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -380,14 +369,13 @@ const docs: ComponentDocs = {
       description: (
         <Text>Suggestion items can optionally be nested into groups.</Text>
       ),
-      Example: ({ id, setDefaultState, getState, setState, resetState }) =>
+      Example: ({ setDefaultState, getState, setState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: '' })}
 
             <Autosuggest
               label="Label"
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -428,14 +416,13 @@ const docs: ComponentDocs = {
       description: (
         <Text>Suggestion items can optionally contain a description.</Text>
       ),
-      Example: ({ id, setDefaultState, getState, setState, resetState }) =>
+      Example: ({ setDefaultState, getState, setState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: '' })}
 
             <Autosuggest
               label="Label"
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -532,14 +519,13 @@ const docs: ComponentDocs = {
           </Text>
         </>
       ),
-      Example: ({ id, setDefaultState, getState, setState, resetState }) =>
+      Example: ({ setDefaultState, getState, setState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: 'App' })}
 
             <Autosuggest
               label="Label"
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -613,7 +599,6 @@ const docs: ComponentDocs = {
         </>
       ),
       Example: ({
-        id,
         setDefaultState,
         getState,
         setState,
@@ -630,7 +615,6 @@ const docs: ComponentDocs = {
 
             <Autosuggest
               label="Label"
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -675,7 +659,7 @@ const docs: ComponentDocs = {
           </Text>
         </>
       ),
-      Example: ({ id, setDefaultState, getState, setState, resetState }) =>
+      Example: ({ setDefaultState, getState, setState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: '' })}
@@ -684,7 +668,6 @@ const docs: ComponentDocs = {
               showMobileBackdrop
               scrollToTopOnMobile
               label="Label"
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -727,7 +710,7 @@ const docs: ComponentDocs = {
           </Text>
         </>
       ),
-      Example: ({ id, setDefaultState, getState, setState, resetState }) =>
+      Example: ({ setDefaultState, getState, setState, resetState }) =>
         source(
           <>
             {setDefaultState('field1', { text: '' })}
@@ -739,7 +722,6 @@ const docs: ComponentDocs = {
                 scrollToTopOnMobile
                 label="Label"
                 description="Focus the field to see a simple message"
-                id={`${id}_noSuggestionsMessage1`}
                 value={getState('field1')}
                 onChange={setState('field1')}
                 onClear={() => resetState('field1')}
@@ -751,7 +733,6 @@ const docs: ComponentDocs = {
                 scrollToTopOnMobile
                 label="Label"
                 description="Focus the field to see more structured prompt"
-                id={`${id}_noSuggestionsMessage2`}
                 value={getState('field2')}
                 onChange={setState('field2')}
                 onClear={() => resetState('field2')}

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.gallery.tsx
@@ -9,7 +9,7 @@ export const galleryItems: GalleryComponent = {
   examples: [
     {
       label: 'Standard suggestions',
-      Example: ({ id, setDefaultState, getState, setState, resetState }) =>
+      Example: ({ setDefaultState, getState, setState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: '' })}
@@ -17,7 +17,6 @@ export const galleryItems: GalleryComponent = {
 
             <Autosuggest
               label="I like to eat"
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -43,14 +42,13 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Grouped suggestions',
-      Example: ({ id, getState, setState, setDefaultState, resetState }) =>
+      Example: ({ getState, setState, setDefaultState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: '' })}
 
             <Autosuggest
               label="I like to eat"
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -70,7 +68,7 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Standard suggestions with descriptions',
-      Example: ({ id, setDefaultState, getState, setState, resetState }) =>
+      Example: ({ setDefaultState, getState, setState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: '' })}
@@ -78,7 +76,6 @@ export const galleryItems: GalleryComponent = {
 
             <Autosuggest
               label="I like to eat"
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -107,14 +104,13 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Grouped suggestions with descriptions',
-      Example: ({ id, getState, setState, setDefaultState, resetState }) =>
+      Example: ({ getState, setState, setDefaultState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: '' })}
 
             <Autosuggest
               label="I like to eat"
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -143,7 +139,7 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Standard suggestions with an icon',
-      Example: ({ id, getState, setState, setDefaultState, resetState }) =>
+      Example: ({ getState, setState, setDefaultState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: '' })}
@@ -151,7 +147,6 @@ export const galleryItems: GalleryComponent = {
             <Autosuggest
               label="I like to eat"
               icon={<IconSearch />}
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -164,14 +159,13 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'With a critical message',
-      Example: ({ id, getState, setState, setDefaultState, resetState }) =>
+      Example: ({ getState, setState, setDefaultState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: '' })}
 
             <Autosuggest
               label="I like to eat"
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -186,14 +180,13 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'With a positive message',
-      Example: ({ id, getState, setState, setDefaultState, resetState }) =>
+      Example: ({ getState, setState, setDefaultState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: '' })}
 
             <Autosuggest
               label="I like to eat"
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}
@@ -208,14 +201,13 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'With a caution message',
-      Example: ({ id, getState, setState, setDefaultState, resetState }) =>
+      Example: ({ getState, setState, setDefaultState, resetState }) =>
         source(
           <>
             {setDefaultState('value', { text: '' })}
 
             <Autosuggest
               label="I like to eat"
-              id={id}
               value={getState('value')}
               onChange={setState('value')}
               onClear={() => resetState('value')}

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.playroom.tsx
@@ -1,7 +1,6 @@
 import type { Optional } from 'utility-types';
 
 import { type StateProp, useFallbackState } from '../../playroom/playroomState';
-import { useFallbackId } from '../../playroom/utils';
 import { validTabIndexes } from '../private/validateTabIndex';
 
 import {
@@ -15,7 +14,6 @@ type PlayroomAutosuggestProps<Value> = StateProp &
   AutosuggestLabelProps;
 
 export function Autosuggest<Value>({
-  id,
   stateName,
   value,
   onChange,
@@ -23,7 +21,6 @@ export function Autosuggest<Value>({
   tabIndex,
   ...restProps
 }: PlayroomAutosuggestProps<Value>) {
-  const fallbackId = useFallbackId();
   const blankValue = { text: '' };
   const [state, handleChange] = useFallbackState(
     stateName,
@@ -34,7 +31,6 @@ export function Autosuggest<Value>({
 
   return (
     <BraidAutosuggest
-      id={id ?? fallbackId}
       value={state}
       onChange={handleChange}
       onClear={() => {

--- a/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.tsx
+++ b/packages/braid-design-system/src/lib/components/Autosuggest/Autosuggest.tsx
@@ -14,6 +14,7 @@ import {
   useCallback,
   useEffect,
   forwardRef,
+  useId,
 } from 'react';
 import { RemoveScroll } from 'react-remove-scroll';
 
@@ -277,8 +278,9 @@ type HighlightOptions = 'matching' | 'remaining';
 
 export type AutosuggestBaseProps<Value> = Omit<
   FieldBaseProps,
-  'value' | 'autoComplete' | 'prefix'
+  'value' | 'autoComplete' | 'prefix' | 'id'
 > & {
+  id?: FieldBaseProps['id'];
   value: AutosuggestValue<Value>;
   suggestions:
     | Suggestions<Value>
@@ -376,6 +378,9 @@ export const Autosuggest = forwardRef(function <Value>(
       );
     }
   }
+
+  const fallbackId = useId();
+  const resolvedId = id || fallbackId;
 
   // We need a ref regardless so we can imperatively
   // focus the field when clicking the clear button
@@ -546,7 +551,7 @@ export const Autosuggest = forwardRef(function <Value>(
 
   const highlightedItem =
     typeof highlightedIndex === 'number'
-      ? document.getElementById(getItemId(id, highlightedIndex))
+      ? document.getElementById(getItemId(resolvedId, highlightedIndex))
       : null;
 
   highlightedItem?.scrollIntoView({ block: 'nearest' });
@@ -662,7 +667,7 @@ export const Autosuggest = forwardRef(function <Value>(
   };
 
   const a11y = createAccessibilityProps({
-    id,
+    id: resolvedId,
     isOpen,
     highlightedIndex,
   });
@@ -739,13 +744,13 @@ export const Autosuggest = forwardRef(function <Value>(
           <Field
             {...restProps}
             componentName="Autosuggest"
-            id={id}
+            id={resolvedId}
             value={value.text}
             prefix={undefined}
             secondaryIcon={
               onClear ? (
                 <ClearField
-                  id={`${id}-clearfield`}
+                  id={`${resolvedId}-clearfield`}
                   hide={!clearable}
                   onClear={onClear}
                   label={clearLabel}

--- a/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/Disclosure/Disclosure.gallery.tsx
@@ -8,35 +8,22 @@ export const galleryItems: GalleryComponent = {
   examples: [
     {
       label: 'Standard',
-      Example: ({ id }) =>
+      Example: () =>
         source(
-          <Disclosure
-            id={id}
-            expandLabel="Show content"
-            collapseLabel="Hide content"
-          >
+          <Disclosure expandLabel="Show content" collapseLabel="Hide content">
             <Placeholder height={100} />
           </Disclosure>,
         ),
     },
     {
       label: 'Visual weight',
-      Example: ({ id }) =>
+      Example: () =>
         source(
           <Stack space="large">
-            <Disclosure
-              id={`${id}_1`}
-              expandLabel="Regular weight"
-              weight="regular"
-            >
+            <Disclosure expandLabel="Regular weight" weight="regular">
               <Placeholder height={100} />
             </Disclosure>
-            <Disclosure
-              id={`${id}_2`}
-              expandLabel="Weak weight"
-              size="standard"
-              weight="weak"
-            >
+            <Disclosure expandLabel="Weak weight" size="standard" weight="weak">
               <Placeholder height={100} />
             </Disclosure>
           </Stack>,
@@ -44,11 +31,10 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Sizing',
-      Example: ({ id, handler }) =>
+      Example: ({ handler }) =>
         source(
           <Stack space="large">
             <Disclosure
-              id={`${id}_1`}
               expandLabel="Large size"
               size="large"
               expanded={true}
@@ -59,7 +45,6 @@ export const galleryItems: GalleryComponent = {
               </Text>
             </Disclosure>
             <Disclosure
-              id={`${id}_2`}
               expandLabel="Standard size"
               size="standard"
               expanded={true}
@@ -70,7 +55,6 @@ export const galleryItems: GalleryComponent = {
               </Text>
             </Disclosure>
             <Disclosure
-              id={`${id}_3`}
               expandLabel="Small size"
               size="small"
               expanded={true}
@@ -81,7 +65,6 @@ export const galleryItems: GalleryComponent = {
               </Text>
             </Disclosure>
             <Disclosure
-              id={`${id}_4`}
               expandLabel="Xsmall size"
               size="xsmall"
               expanded={true}

--- a/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.docs.tsx
@@ -105,6 +105,7 @@ const docs: ComponentDocs = {
       code: `
         <TextDropdown
           data={{ testid: 'text-dropdown-1' }}
+          // => data-testid="text-dropdown-1"
         >
           ...
         </TextDropdown>

--- a/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.docs.tsx
@@ -6,7 +6,7 @@ import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
-  Example: ({ id, setState, getState, setDefaultState }) =>
+  Example: ({ setState, getState, setDefaultState }) =>
     source(
       <>
         {setDefaultState('textdropdown', 'Option 1')}
@@ -14,7 +14,6 @@ const docs: ComponentDocs = {
         <Text>
           <TextDropdown
             label="Options"
-            id={id}
             value={getState('textdropdown')}
             onChange={setState('textdropdown')}
             options={['Option 1', 'Option 2', 'Option 3']}
@@ -46,7 +45,7 @@ const docs: ComponentDocs = {
           </Text>
         </>
       ),
-      Example: ({ id, setState, getState, setDefaultState }) =>
+      Example: ({ setState, getState, setDefaultState }) =>
         source(
           <>
             {setDefaultState('sortby', 'Relevance')}
@@ -56,7 +55,6 @@ const docs: ComponentDocs = {
               <Strong>
                 <TextDropdown
                   label="Sort by"
-                  id={id}
                   value={getState('sortby')}
                   onChange={setState('sortby')}
                   options={['Relevance', 'Date', 'Keyword']}
@@ -76,7 +74,7 @@ const docs: ComponentDocs = {
           <Strong>value</Strong> properties.
         </Text>
       ),
-      Example: ({ id, setState, getState, setDefaultState }) =>
+      Example: ({ setState, getState, setDefaultState }) =>
         source(
           <>
             {setDefaultState('textdropdown', 200)}
@@ -85,7 +83,6 @@ const docs: ComponentDocs = {
               <Text>
                 <TextDropdown
                   label="Options"
-                  id={id}
                   value={getState('textdropdown')}
                   onChange={setState('textdropdown')}
                   options={[
@@ -108,7 +105,6 @@ const docs: ComponentDocs = {
       code: `
         <TextDropdown
           data={{ testid: 'text-dropdown-1' }}
-          // => data-testid="text-dropdown-1"
         >
           ...
         </TextDropdown>

--- a/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.gallery.tsx
@@ -7,7 +7,7 @@ export const galleryItems: GalleryComponent = {
   examples: [
     {
       label: 'Standard',
-      Example: ({ id, setState, getState, setDefaultState }) =>
+      Example: ({ setState, getState, setDefaultState }) =>
         source(
           <>
             {setDefaultState('textdropdown', 'Option 1')}
@@ -15,7 +15,6 @@ export const galleryItems: GalleryComponent = {
             <Text>
               <TextDropdown
                 label="Options"
-                id={id}
                 value={getState('textdropdown')}
                 onChange={setState('textdropdown')}
                 options={['Option 1', 'Option 2', 'Option 3']}
@@ -26,7 +25,7 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Emphasised within a sentence',
-      Example: ({ id, setState, getState, setDefaultState }) =>
+      Example: ({ setState, getState, setDefaultState }) =>
         source(
           <>
             {setDefaultState('sortby', 'Relevance')}
@@ -36,7 +35,6 @@ export const galleryItems: GalleryComponent = {
               <Strong>
                 <TextDropdown
                   label="Sort by"
-                  id={id}
                   value={getState('sortby')}
                   onChange={setState('sortby')}
                   options={['Relevance', 'Date', 'Keyword']}
@@ -48,7 +46,7 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Within a heading',
-      Example: ({ id, setState, getState, setDefaultState }) =>
+      Example: ({ setState, getState, setDefaultState }) =>
         source(
           <>
             {setDefaultState('textdropdown', 'Option 1')}
@@ -57,7 +55,6 @@ export const galleryItems: GalleryComponent = {
               Heading with{' '}
               <TextDropdown
                 label="Options"
-                id={id}
                 value={getState('textdropdown')}
                 onChange={setState('textdropdown')}
                 options={['Option 1', 'Option 2', 'Option 3']}

--- a/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.playroom.tsx
@@ -1,7 +1,6 @@
 import { useState, useEffect } from 'react';
 import type { Optional } from 'utility-types';
 
-import { useFallbackId } from '../../playroom/utils';
 import { validTabIndexes } from '../private/validateTabIndex';
 
 import {
@@ -39,7 +38,6 @@ function resolveOptions<Value>(
 }
 
 export function TextDropdown<Value>({
-  id,
   value,
   label,
   onChange,
@@ -47,7 +45,6 @@ export function TextDropdown<Value>({
   tabIndex,
   ...restProps
 }: PlayroomTextDropdownProps<Value | string>) {
-  const fallbackId = useFallbackId();
   const [internalValue, setInternalValue] = useState(
     resolveValue(value, options),
   );
@@ -64,7 +61,6 @@ export function TextDropdown<Value>({
 
   return (
     <BraidTextDropdown
-      id={id ?? fallbackId}
       label={label ?? 'No label provided'}
       value={internalValue}
       options={internalOptions}

--- a/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.tsx
+++ b/packages/braid-design-system/src/lib/components/TextDropdown/TextDropdown.tsx
@@ -1,6 +1,6 @@
 import assert from 'assert';
 
-import { type FormEvent, useContext } from 'react';
+import { type FormEvent, useContext, useId } from 'react';
 
 import { Box } from '../Box/Box';
 import HeadingContext from '../Heading/HeadingContext';
@@ -21,7 +21,7 @@ interface TextDropdownOption<Value> {
 type TextDropdownValue<Value> = Value | TextDropdownOption<Value>;
 
 export interface TextDropdownProps<Value> {
-  id: string;
+  id?: string;
   value: Value;
   onChange: (value: Value) => void;
   onBlur?: () => void;
@@ -78,6 +78,9 @@ export function TextDropdown<Value>({
     );
   }
 
+  const fallbackId = useId();
+  const resolvedId = id || fallbackId;
+
   return (
     <Box
       display="inlineBlock"
@@ -97,7 +100,7 @@ export function TextDropdown<Value>({
         className={styles.select}
         aria-label={label}
         title={label}
-        id={id}
+        id={resolvedId}
         tabIndex={tabIndex}
         value={String(value)}
         onChange={(ev: FormEvent<HTMLSelectElement>) => {

--- a/packages/braid-design-system/src/lib/components/TextField/TextField.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/TextField/TextField.docs.tsx
@@ -318,7 +318,7 @@ const docs: ComponentDocs = {
           </Text>
         </>
       ),
-      Example: ({ id, getState, setState, setDefaultState }) =>
+      Example: ({ getState, setState, setDefaultState }) =>
         source(
           <>
             {setDefaultState('inputmode', 'numeric')}
@@ -327,7 +327,6 @@ const docs: ComponentDocs = {
                 Selected input mode:{' '}
                 <Strong>
                   <TextDropdown
-                    id={`${id}_mode`}
                     label="Input mode"
                     value={getState('inputmode')}
                     onChange={setState('inputmode')}

--- a/packages/braid-design-system/src/lib/components/TextField/TextField.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/TextField/TextField.docs.tsx
@@ -19,11 +19,10 @@ import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
 const docs: ComponentDocs = {
   category: 'Content',
-  Example: ({ id, getState, setState }) =>
+  Example: ({ getState, setState }) =>
     source(
       <TextField
         label="Label"
-        id={id}
         onChange={setState('textfield')}
         value={getState('textfield')}
         onClear={() => setState('textfield', '')}
@@ -61,11 +60,10 @@ const docs: ComponentDocs = {
           </List>
         </>
       ),
-      Example: ({ id, getState, setState }) =>
+      Example: ({ getState, setState }) =>
         source(
           <TextField
             label="Label"
-            id={id}
             onChange={setState('textfield')}
             value={getState('textfield')}
             secondaryLabel="optional"
@@ -95,12 +93,11 @@ const docs: ComponentDocs = {
           </Text>
         </>
       ),
-      Example: ({ id, getState, setState }) =>
+      Example: ({ getState, setState }) =>
         source(
           <Stack space="large">
             <TextField
               label="Label"
-              id={`${id}_1`}
               onChange={setState('textfield')}
               value={getState('textfield')}
               tone="critical"
@@ -108,7 +105,6 @@ const docs: ComponentDocs = {
             />
             <TextField
               label="Label"
-              id={`${id}_2`}
               onChange={setState('textfield2')}
               value={getState('textfield2')}
               tone="positive"
@@ -116,7 +112,6 @@ const docs: ComponentDocs = {
             />
             <TextField
               label="Label"
-              id={`${id}_3`}
               onChange={setState('textfield3')}
               value={getState('textfield3')}
               tone="caution"
@@ -124,7 +119,6 @@ const docs: ComponentDocs = {
             />
             <TextField
               label="Label"
-              id={`${id}_4`}
               onChange={setState('textfield4')}
               value={getState('textfield4')}
               tone="neutral"
@@ -142,11 +136,10 @@ const docs: ComponentDocs = {
           screen reader when the field is focused.
         </Text>
       ),
-      Example: ({ id, getState, setState }) =>
+      Example: ({ getState, setState }) =>
         source(
           <TextField
             label="Label"
-            id={id}
             onChange={setState('textfield')}
             value={getState('textfield')}
             description="Extra information about the field"
@@ -161,11 +154,10 @@ const docs: ComponentDocs = {
           <Strong>disabled</Strong> prop.
         </Text>
       ),
-      Example: ({ id, setState }) =>
+      Example: ({ setState }) =>
         source(
           <TextField
             label="Label"
-            id={id}
             onChange={setState('textfield')}
             value="Text in disabled field"
             disabled={true}
@@ -180,11 +172,10 @@ const docs: ComponentDocs = {
           the user when no value is entered.
         </Text>
       ),
-      Example: ({ id, getState, setState }) =>
+      Example: ({ getState, setState }) =>
         source(
           <TextField
             label="Label"
-            id={id}
             onChange={setState('textfield')}
             value={getState('textfield')}
             placeholder="Enter text"
@@ -209,14 +200,13 @@ const docs: ComponentDocs = {
           </Text>
         </>
       ),
-      Example: ({ id, getState, setState, setDefaultState }) =>
+      Example: ({ getState, setState, setDefaultState }) =>
         source(
           <>
             {setDefaultState('textfield', 'User entered text')}
 
             <TextField
               label="Label"
-              id={id}
               value={getState('textfield')}
               onChange={setState('textfield')}
               onClear={() => setState('textfield', '')}
@@ -246,10 +236,9 @@ const docs: ComponentDocs = {
           of the field and is not interactive.
         </Text>
       ),
-      Example: ({ id, getState, setState }) =>
+      Example: ({ getState, setState }) =>
         source(
           <TextField
-            id={id}
             label="Label"
             onChange={setState('textfield')}
             value={getState('textfield')}
@@ -267,10 +256,9 @@ const docs: ComponentDocs = {
           currency symbols, country codes, etc.
         </Text>
       ),
-      Example: ({ id, getState, setState }) =>
+      Example: ({ getState, setState }) =>
         source(
           <TextField
-            id={id}
             label="Phone number"
             onChange={setState('textfield')}
             value={getState('textfield')}
@@ -292,7 +280,7 @@ const docs: ComponentDocs = {
           </Text>
         </>
       ),
-      Example: ({ id, getState, setState, setDefaultState }) =>
+      Example: ({ getState, setState, setDefaultState }) =>
         source(
           <>
             {setDefaultState(
@@ -302,7 +290,6 @@ const docs: ComponentDocs = {
 
             <TextField
               label="Label"
-              id={id}
               onChange={setState('text')}
               value={getState('text')}
               description="Character limit of 50"
@@ -357,7 +344,6 @@ const docs: ComponentDocs = {
                 </Strong>
               </Text>
               <TextField
-                id={id}
                 label="Label"
                 onChange={setState('textfield')}
                 value={getState('textfield')}
@@ -380,7 +366,7 @@ const docs: ComponentDocs = {
           or <Strong>aria-labelledby</Strong> can be provided.
         </Text>
       ),
-      Example: ({ id, getState, setState }) =>
+      Example: ({ getState, setState }) =>
         source(
           <Stack space="large">
             <Heading level="2" id="field1Label">
@@ -388,7 +374,6 @@ const docs: ComponentDocs = {
             </Heading>
             <TextField
               aria-labelledby="field1Label"
-              id={`${id}_1`}
               onChange={setState('text')}
               value={getState('text')}
               message="The label for this field is the Heading element before it."
@@ -396,7 +381,6 @@ const docs: ComponentDocs = {
 
             <TextField
               aria-label="Hidden label for field"
-              id={`${id}_2`}
               onChange={setState('text2')}
               value={getState('text2')}
               message="The label for this field is hidden."

--- a/packages/braid-design-system/src/lib/components/TextField/TextField.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/TextField/TextField.gallery.tsx
@@ -7,11 +7,10 @@ export const galleryItems: GalleryComponent = {
   examples: [
     {
       label: 'Standard',
-      Example: ({ id, getState, setState }) =>
+      Example: ({ getState, setState }) =>
         source(
           <TextField
             label="Label"
-            id={id}
             onChange={setState('textfield')}
             value={getState('textfield')}
             onClear={() => setState('textfield', '')}
@@ -20,11 +19,10 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'With additional labels',
-      Example: ({ id, getState, setState }) =>
+      Example: ({ getState, setState }) =>
         source(
           <TextField
             label="Label"
-            id={id}
             onChange={setState('textfield')}
             value={getState('textfield')}
             secondaryLabel="optional"
@@ -38,11 +36,10 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'With a description',
-      Example: ({ id, getState, setState }) =>
+      Example: ({ getState, setState }) =>
         source(
           <TextField
             label="Label"
-            id={id}
             onChange={setState('textfield')}
             value={getState('textfield')}
             onClear={() => setState('textfield', '')}
@@ -52,11 +49,10 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'With a critical message',
-      Example: ({ id, getState, setState }) =>
+      Example: ({ getState, setState }) =>
         source(
           <TextField
             label="Label"
-            id={id}
             onChange={setState('textfield')}
             value={getState('textfield')}
             tone="critical"
@@ -66,11 +62,10 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'With a positive message',
-      Example: ({ id, getState, setState }) =>
+      Example: ({ getState, setState }) =>
         source(
           <TextField
             label="Label"
-            id={id}
             onChange={setState('textfield')}
             value={getState('textfield')}
             tone="positive"
@@ -80,11 +75,10 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'With a caution message',
-      Example: ({ id, getState, setState }) =>
+      Example: ({ getState, setState }) =>
         source(
           <TextField
             label="Label"
-            id={id}
             onChange={setState('textfield')}
             value={getState('textfield')}
             tone="caution"
@@ -94,11 +88,10 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'With a neutral message',
-      Example: ({ id, getState, setState }) =>
+      Example: ({ getState, setState }) =>
         source(
           <TextField
             label="Label"
-            id={id}
             onChange={setState('textfield')}
             value={getState('textfield')}
             tone="neutral"
@@ -108,11 +101,10 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'With an icon',
-      Example: ({ id, getState, setState }) =>
+      Example: ({ getState, setState }) =>
         source(
           <TextField
             label="Job Title"
-            id={id}
             onChange={setState('textfield')}
             value={getState('textfield')}
             icon={<IconSearch />}
@@ -122,11 +114,10 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'With a prefix',
-      Example: ({ id, getState, setState }) =>
+      Example: ({ getState, setState }) =>
         source(
           <TextField
             label="Phone number"
-            id={id}
             onChange={setState('textfield')}
             value={getState('textfield')}
             prefix="+61"
@@ -135,11 +126,10 @@ export const galleryItems: GalleryComponent = {
     },
     {
       label: 'Disabled field',
-      Example: ({ id, getState, setState }) =>
+      Example: ({ getState, setState }) =>
         source(
           <TextField
             label="Label"
-            id={id}
             onChange={setState('textfield')}
             value={getState('textfield')}
             disabled={true}

--- a/packages/braid-design-system/src/lib/components/TextField/TextField.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/TextField/TextField.playroom.tsx
@@ -1,7 +1,6 @@
 import type { Optional } from 'utility-types';
 
 import { type StateProp, useFallbackState } from '../../playroom/playroomState';
-import { useFallbackId } from '../../playroom/utils';
 import { validTabIndexes } from '../private/validateTabIndex';
 
 import {
@@ -18,7 +17,6 @@ type PlayroomTextFieldProps = StateProp &
   };
 
 export const TextField = ({
-  id,
   stateName,
   value,
   onChange,
@@ -26,7 +24,6 @@ export const TextField = ({
   tabIndex,
   ...restProps
 }: PlayroomTextFieldProps) => {
-  const fallbackId = useFallbackId();
   const [state, handleChange] = useFallbackState(
     stateName,
     value,
@@ -45,7 +42,6 @@ export const TextField = ({
 
   return (
     <BraidTextField
-      id={id ?? fallbackId}
       value={state}
       onChange={handleChange}
       onClear={handleOnClear}

--- a/packages/braid-design-system/src/lib/components/TextField/TextField.tsx
+++ b/packages/braid-design-system/src/lib/components/TextField/TextField.tsx
@@ -1,4 +1,10 @@
-import { type AllHTMLAttributes, forwardRef, Fragment, useRef } from 'react';
+import {
+  type AllHTMLAttributes,
+  forwardRef,
+  Fragment,
+  useId,
+  useRef,
+} from 'react';
 
 import { Box } from '../Box/Box';
 import { ClearField } from '../private/Field/ClearField';
@@ -36,8 +42,9 @@ type InputProps = AllHTMLAttributes<HTMLInputElement>;
 
 export type TextFieldBaseProps = Omit<
   FieldBaseProps,
-  'value' | 'secondaryMessage'
+  'value' | 'secondaryMessage' | 'id'
 > & {
+  id?: FieldBaseProps['id'];
   value: NonNullable<InputProps['value']>;
   type?: keyof typeof validTypes;
   inputMode?: InputProps['inputMode'];
@@ -72,6 +79,9 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
     },
     forwardedRef,
   ) => {
+    const fallbackId = useId();
+    const resolvedId = id || fallbackId;
+
     // We need a ref regardless so we can imperatively
     // focus the field when clicking the clear button
     const defaultRef = useRef<HTMLInputElement | null>(null);
@@ -88,7 +98,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
       <Field
         {...restProps}
         componentName="TextField"
-        id={id}
+        id={resolvedId}
         value={value}
         secondaryMessage={
           characterLimit
@@ -101,7 +111,7 @@ export const TextField = forwardRef<HTMLInputElement, TextFieldProps>(
         secondaryIcon={
           onClear ? (
             <ClearField
-              id={`${id}-clear`}
+              id={`${resolvedId}-clear`}
               hide={!clearable}
               onClear={onClear}
               label={clearLabel}

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -8597,7 +8597,7 @@ exports[`TextDropdown 1`] = `
   exportType: component,
   props: {
     data?: DataAttributeMap
-    id: string
+    id?: string
     label: string
     onBlur?: () => void
     onChange: (value: Value) => void

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -8625,7 +8625,7 @@ exports[`TextField 1`] = `
     description?: ReactNode
     disabled?: boolean
     icon?: ReactNode
-    id: string
+    id?: string
     inputMode?: 
         | "decimal"
         | "email"

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -104,7 +104,7 @@ exports[`Autosuggest 1`] = `
     disabled?: boolean
     hideSuggestionsOnSelection?: boolean
     icon?: ReactNode
-    id: string
+    id?: string
     label: ReactNode
     message?: ReactNode
     name?: string


### PR DESCRIPTION
Grouping these three components together because their docs files use each other. Easier to remove all ids from these files at once.

Also - forgot to remove `ids` from `Disclosure.gallery.tsx` in #1743. Adding it here