### PR TITLE
Support null in some more places

### DIFF
--- a/.changeset/nasty-rooms-stay.md
+++ b/.changeset/nasty-rooms-stay.md
@@ -2,9 +2,27 @@
 'braid-design-system': patch
 ---
 
-Support `null` for components' optional props, in addition to `undefined`
+---
+updated:
+  - AccordionItem
+  - Button
+  - ButtonLink
+  - Checkbox
+  - Heading
+  - MenuItem
+  - MenuItemLink
+  - RadioItem
+  - Tab
+  - Text
+  - TextLink
+  - TextLinkButton
+  - useToast
+---
 
-Previously, optional props could only be explicitly omitted with  `undefined`. This change allows you to alternatively pass `null`.
+Support `null` for `badge` and `icon` slots, in addition to `undefined`.
+
+Previously, `badge` and `icon` props could only be explicitly omitted with `undefined`.
+This change allows passing `null`.
 
 **EXAMPLE USAGE:**
 

--- a/.changeset/nasty-rooms-stay.md
+++ b/.changeset/nasty-rooms-stay.md
@@ -2,4 +2,13 @@
 'braid-design-system': patch
 ---
 
-Accept `null` for some optional arguments
+Support `null` for components' optional props, in addition to `undefined`
+
+Previously, optional props could only be explicitly omitted with  `undefined`. This change allows you to alternatively pass `null`.
+
+**EXAMPLE USAGE:**
+
+```diff
+- <AccordionItem badge={undefined} />
++ <AccordionItem badge={null} />
+```

--- a/.changeset/nasty-rooms-stay.md
+++ b/.changeset/nasty-rooms-stay.md
@@ -1,0 +1,5 @@
+---
+'braid-design-system': patch
+---
+
+Accept `null` for some optional arguments

--- a/.changeset/nasty-rooms-stay.md
+++ b/.changeset/nasty-rooms-stay.md
@@ -8,7 +8,6 @@ Previously, optional props could only be explicitly omitted with  `undefined`. T
 
 **EXAMPLE USAGE:**
 
-```diff
-- <AccordionItem badge={undefined} />
-+ <AccordionItem badge={null} />
+```tsx
++ <Button icon={null} />
 ```

--- a/packages/braid-design-system/src/lib/components/Accordion/AccordionItem.tsx
+++ b/packages/braid-design-system/src/lib/components/Accordion/AccordionItem.tsx
@@ -49,7 +49,7 @@ export interface AccordionItemBaseProps {
   weight?: AccordionContextValue['weight'];
   icon?: TextProps['icon'];
   data?: DataAttributeMap;
-  badge?: ReactElement<BadgeProps>;
+  badge?: ReactElement<BadgeProps> | null;
 }
 
 export type AccordionItemProps = AccordionItemBaseProps & UseDisclosureProps;

--- a/packages/braid-design-system/src/lib/components/Button/Button.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.tsx
@@ -55,7 +55,7 @@ export interface ButtonProps extends ButtonStyleProps {
   id?: NativeButtonProps['id'];
   onClick?: NativeButtonProps['onClick'];
   type?: 'button' | 'submit' | 'reset';
-  icon?: ReactElement<UseIconProps>;
+  icon?: ReactElement<UseIconProps> | null;
   iconPosition?: 'leading' | 'trailing';
   children?: ReactNode;
   onKeyUp?: NativeButtonProps['onKeyUp'];

--- a/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.tsx
@@ -183,7 +183,7 @@ export function useMenuItem<MenuItemElement extends HTMLElement>({
 export interface MenuItemChildrenProps {
   children: ReactNode;
   tone: MenuItemTone;
-  badge: ReactElement<BadgeProps> | undefined;
+  badge: ReactElement<BadgeProps> | undefined | null;
   leftSlot: ReactNode | undefined;
   isCheckbox?: boolean;
 }

--- a/packages/braid-design-system/src/lib/components/Tabs/Tab.tsx
+++ b/packages/braid-design-system/src/lib/components/Tabs/Tab.tsx
@@ -46,7 +46,7 @@ import * as styles from './Tabs.css';
 export interface TabProps {
   children: ReactNode;
   item?: string;
-  badge?: ReactElement<BadgeProps>;
+  badge?: ReactElement<BadgeProps> | null;
   icon?: TextProps['icon'];
   data?: DataAttributeMap;
 }

--- a/packages/braid-design-system/src/lib/components/TextLink/TextLink.tsx
+++ b/packages/braid-design-system/src/lib/components/TextLink/TextLink.tsx
@@ -34,7 +34,7 @@ export interface TextLinkProps
   extends TextLinkStyles,
     Omit<LinkComponentProps, 'className' | 'style'> {
   data?: DataAttributeMap;
-  icon?: ReactElement<UseIconProps>;
+  icon?: ReactElement<UseIconProps> | null;
 }
 
 const isPlainBackground = (

--- a/packages/braid-design-system/src/lib/components/TextLinkButton/TextLinkButton.tsx
+++ b/packages/braid-design-system/src/lib/components/TextLinkButton/TextLinkButton.tsx
@@ -30,7 +30,7 @@ export interface TextLinkButtonProps
   'aria-describedby'?: NativeSpanProps['aria-describedby'];
   'aria-label'?: NativeSpanProps['aria-label'];
   tabIndex?: NativeSpanProps['tabIndex'];
-  icon?: ReactElement<UseIconProps>;
+  icon?: ReactElement<UseIconProps> | null;
 }
 
 const noop = () => {};

--- a/packages/braid-design-system/src/lib/components/private/InlineField/InlineField.tsx
+++ b/packages/braid-design-system/src/lib/components/private/InlineField/InlineField.tsx
@@ -33,7 +33,7 @@ interface InlineFieldBaseProps {
   reserveMessageSpace?: FieldMessageProps['reserveMessageSpace'];
   children?: ReactNode;
   description?: ReactNode;
-  badge?: ReactElement<BadgeProps>;
+  badge?: ReactElement<BadgeProps> | null;
 }
 
 export type InlineFieldProps = Omit<

--- a/packages/braid-design-system/src/lib/components/private/Typography/Typography.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Typography/Typography.tsx
@@ -13,7 +13,7 @@ import { descenderCropFixForWebkitBox } from '../MaxLines/MaxLines.css';
 
 export interface TypographyProps extends Pick<BoxProps, 'id' | 'component'> {
   children?: ReactNode;
-  icon?: ReactElement<UseIconProps>;
+  icon?: ReactElement<UseIconProps> | null;
   align?: BoxProps['textAlign'];
   maxLines?: number;
   data?: DataAttributeMap;

--- a/packages/braid-design-system/src/lib/components/useToast/ToastTypes.ts
+++ b/packages/braid-design-system/src/lib/components/useToast/ToastTypes.ts
@@ -15,7 +15,7 @@ export interface InternalToast {
   dedupeKey: string;
   vanillaTheme: string;
   tone: 'positive' | 'critical' | 'neutral';
-  icon?: ReactElement<UseIconProps>;
+  icon?: ReactElement<UseIconProps> | null;
   message: string;
   shouldRemove: boolean;
   description?: string;


### PR DESCRIPTION
As a consumer, I found it surprising I couldn't do `<Checkbox badge={something ? <Badge ... /> : null}`; only undefined was accepted. Typically react node props accept `ReactNode` which has `null` built-in, but the strongly-typed arguments like this don't. 