### PR TITLE
OverflowMenu: Remove playroom wrapper component

### DIFF
--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.playroom.tsx
@@ -1,3 +1,0 @@
-import { OverflowMenu as BraidOverflowMenu } from './OverflowMenu';
-
-export const OverflowMenu = BraidOverflowMenu;

--- a/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/OverflowMenu/OverflowMenu.playroom.tsx
@@ -1,11 +1,3 @@
-import { useFallbackId } from '../../playroom/utils';
+import { OverflowMenu as BraidOverflowMenu } from './OverflowMenu';
 
-import {
-  type OverflowMenuProps,
-  OverflowMenu as BraidOverflowMenu,
-} from './OverflowMenu';
-
-export const OverflowMenu = ({ id, ...restProps }: OverflowMenuProps) => {
-  const fallbackId = useFallbackId();
-  return <BraidOverflowMenu id={id ?? fallbackId} {...restProps} />;
-};
+export const OverflowMenu = BraidOverflowMenu;

--- a/packages/braid-design-system/src/lib/playroom/components.ts
+++ b/packages/braid-design-system/src/lib/playroom/components.ts
@@ -30,7 +30,6 @@ export { MenuItem } from '../components/MenuItem/MenuItem.playroom';
 export { MenuItemLink } from '../components/MenuItem/MenuItemLink.playroom';
 export { MenuItemCheckbox } from '../components/MenuItemCheckbox/MenuItemCheckbox.playroom';
 export { Notice } from '../components/Notice/Notice.playroom';
-export { OverflowMenu } from '../components/OverflowMenu/OverflowMenu.playroom';
 export { Pagination } from '../components/Pagination/Pagination.playroom';
 export { PasswordField } from '../components/PasswordField/PasswordField.playroom';
 export { RadioGroup } from '../components/RadioGroup/RadioGroup.playroom';


### PR DESCRIPTION
`id` for `OverflowMenu` is already optional