### PR TITLE
Tag: Remove `useFallbackId` call for playroom

### DIFF
--- a/packages/braid-design-system/src/lib/components/Tag/Tag.playroom.tsx
+++ b/packages/braid-design-system/src/lib/components/Tag/Tag.playroom.tsx
@@ -1,15 +1,9 @@
-import { useFallbackId } from '../../playroom/utils';
-
 import { type TagProps, Tag as BraidTag, tagSizes } from './Tag';
 
-export const Tag = ({ icon, id, size, ...restProps }: TagProps) => {
-  const fallbackId = useFallbackId();
-  return (
-    <BraidTag
-      id={id ?? fallbackId}
-      icon={typeof icon !== 'boolean' ? icon : undefined}
-      size={size && tagSizes.includes(size) ? size : undefined}
-      {...restProps}
-    />
-  );
-};
+export const Tag = ({ icon, size, ...restProps }: TagProps) => (
+  <BraidTag
+    icon={typeof icon !== 'boolean' ? icon : undefined}
+    size={size && tagSizes.includes(size) ? size : undefined}
+    {...restProps}
+  />
+);


### PR DESCRIPTION
`id` prop is already optional on `Tag`