### PR TITLE
docs: Fix `DocExample` theme in Snippets tabs

### DIFF
--- a/site/src/App/DocNavigation/DocSnippets.tsx
+++ b/site/src/App/DocNavigation/DocSnippets.tsx
@@ -1,15 +1,14 @@
+import docsTheme from 'braid-src/entries/themes/docs';
 import { Stack, Text, BraidProvider } from 'braid-src/lib/components';
 import { PlayroomStateProvider } from 'braid-src/lib/playroom/playroomState';
 import { useContext } from 'react';
 
 import { PageTitle } from '../Seo/PageTitle';
-import { useThemeSettings } from '../ThemeSetting';
 
 import { DocExample } from './DocExample';
 import { DocsContext } from './DocNavigation';
 
 export const DocSnippets = () => {
-  const { theme } = useThemeSettings();
   const { docsName, snippets } = useContext(DocsContext);
 
   return (
@@ -21,7 +20,7 @@ export const DocSnippets = () => {
           snippets.map(({ group, name, code }) => (
             <Stack space="medium" key={`${group}_${name}`}>
               <Text tone="secondary">{name}</Text>
-              <BraidProvider styleBody={false} theme={theme}>
+              <BraidProvider styleBody={false} theme={docsTheme}>
                 <PlayroomStateProvider>
                   <DocExample Example={() => code} showCodeByDefault={false} />
                 </PlayroomStateProvider>


### PR DESCRIPTION
In components' 'Snippets' tab, the `DocExample` theme matches the site theme setting, rather than showing in `docsTheme`

**Before**

![image](https://github.com/user-attachments/assets/5713fec5-dfc1-41c0-ac88-3d63658c1f3a)

**After**

![image](https://github.com/user-attachments/assets/1897df5a-7ef3-449e-ae5c-fc23fbc2a5b1)
