### PR TITLE
MenuItem, MenuItemCheckbox, MenuItemLink: Fix iOS double tap trigger bug

### DIFF
--- a/.changeset/fuzzy-snakes-enjoy.md
+++ b/.changeset/fuzzy-snakes-enjoy.md
@@ -5,7 +5,8 @@
 ---
 updated:
   - MenuItem
+  - MenuItemCheckbox
   - MenuItemLink
 ---
 
-**MenuItem, MenuItemLink**: Fixes an issue which could cause MenuItems to require multiple taps to trigger on iOS
+**MenuItem, MenuItemCheckbox, MenuItemLink**: Fixes an issue which could cause MenuItems to require multiple taps to trigger on iOS

--- a/.changeset/fuzzy-snakes-enjoy.md
+++ b/.changeset/fuzzy-snakes-enjoy.md
@@ -1,0 +1,11 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - MenuItem
+  - MenuItemLink
+---
+
+**MenuItem, MenuItemLink**: Fixes an issue which could cause MenuItems to require multiple taps to trigger on iOS

--- a/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.tsx
@@ -156,7 +156,7 @@ export function useMenuItem<MenuItemElement extends HTMLElement>({
         }
       },
       /*
-      On mobile, using 'undefined' as the fallback background converts the element to a `ColoredBox` on touch.
+      On mobile, switching between 'undefined' and a specified background converts the element to a `ColoredBox` on touch.
       This can interrupt href navigation and click events on iOS.
       */
       background: isHighlighted ? hoverBackground : 'surface',

--- a/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuItem/useMenuItem.tsx
@@ -155,7 +155,11 @@ export function useMenuItem<MenuItemElement extends HTMLElement>({
           onClick();
         }
       },
-      background: isHighlighted ? hoverBackground : undefined,
+      /*
+      On mobile, using 'undefined' as the fallback background converts the element to a `ColoredBox` on touch.
+      This can interrupt href navigation and click events on iOS.
+      */
+      background: isHighlighted ? hoverBackground : 'surface',
       className: [
         styles.menuItem,
         size === 'small' ? virtualTouchable : undefined,


### PR DESCRIPTION
On iOS, `MenuItemLink` would require one tap to activate the hover style, and a secondary tap to trigger `href` and `onClick` - [Problem Demo](https://seek-oss.github.io/braid-design-system/playroom/#?code=N4Igxg9gJgpiBcJgGcYBcAiMBmBDArgDZoDKauaMAFADohoQDmjhMdANAAR6GoCUAXxoA7EQB4AQhAAenAA64oUAJbDGAXjqFcAJ0ZsQAPhGdOYknJ0xFnZArAxNIbXoPHhp02ICyMYfgAlP1grHRNPUwhsbFRSe0c6ZABbXEJCOnCItB1lZhgddWAqbNz9HQAFHQg5ZC5gTmq-TgE%2BTnVDTloPCM9JGU58VB0SGFYwNCdhCGEDTjB8HWQIAro5CFVKMJBOYAA6fZK8iqqagXcenrEAFRhpNHOLnt9-YDpOOiFux96ASUhhADCAAsYAA3KqiL7fTwqKzjZTTQqNDwAfneIHwcje8HRUAgAHdRCBPtCeqlcsIAJpOQgE-JgXCoDJQ74Aege3zErJudw5l1ZUmkfNMgkynGFZme%2BB%2BlCSABlVABrMURIFWbBOIFoNA1eCs1n4w27RgQJisXaQJKs5nfaYAwjKMCKwpUVrtTgMZisMgUah0T0sAyilnilWeBXCZUhrlSmUweVKvkxvyBYL5fLuMXAfSkciUWj0JiBuitNFdC7XW5oWzKABeCWcun0b3xMFyWqcyGy00YdAlpgBcp%2BAIA0gBRDAAQjDXJ59zFrRx%2BGEsGwqhgUBJZlZFisincXMF7hA7HoIKSMGQCAA2iBUDBFQApCAAIyvAF1T-jlFA0ECr-A14AMwAJwAAzvgIQA)

When the adaptive colour system is built, we may not need to conditionally render a `ColoredBox`, and this flip between undefined and defined backgrounds won't be a problem. This is a relatively simple solution for the time being.

**NB**: not sure what's up with diff in the screenshot tests, I can't quite see the difference.