### PR TITLE
snippets: Ensure 'table' is only used in `Table` snippets

### DIFF
--- a/packages/braid-design-system/src/lib/components/Columns/Columns.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/Columns/Columns.snippets.tsx
@@ -18,7 +18,7 @@ export const snippets: Snippets = [
     ),
   },
   {
-    name: 'Collapse Below Tablet',
+    name: 'Responsive columns',
     code: source(
       <Columns space="large" collapseBelow="tablet">
         <Column>


### PR DESCRIPTION
Renaming this snippet, so when I search 'table' , the `Table` component is the first result

'Responsive columns' fits with the convention of other responsive snippets, so seems appropriate

Noticing there might be an optimisation for sorting results in Playroom, but will address that separately 