### PR TITLE
Allow an `id` prop in RadioItem

### DIFF
--- a/.changeset/lucky-garlics-think.md
+++ b/.changeset/lucky-garlics-think.md
@@ -1,0 +1,10 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - RadioItem
+---
+
+**RadioItem**: Accept an `id` property

--- a/packages/braid-design-system/src/lib/components/RadioGroup/RadioItem.tsx
+++ b/packages/braid-design-system/src/lib/components/RadioGroup/RadioItem.tsx
@@ -19,7 +19,6 @@ export interface RadioItemProps
     | 'reserveMessageSpace'
     | 'required'
     | 'onChange'
-    | 'id'
     | 'tone'
     | 'size'
     | 'tabIndex'

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -7930,6 +7930,7 @@ exports[`RadioItem 1`] = `
     data?: DataAttributeMap
     description?: ReactNode
     disabled?: boolean
+    id?: string
     label: ReactNode
     ref?: 
         | (instance: HTMLInputElement | null) => void


### PR DESCRIPTION
Previously, while undocumented, it was possible to have a deterministic (but not fully controllable) ID on `RadioItem`s.

After https://github.com/seek-oss/braid-design-system/pull/1769, it is no longer possible to have any id at the type level. It is possible at the runtime level however.