### PR TITLE
make the docs site "type module"

### DIFF
--- a/site/package.json
+++ b/site/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "1.0.0",
   "main": "index.js",
+  "type": "module",
   "scripts": {
     "build:site": "NODE_ENV=production SKU_TELEMETRY=false sku build",
     "build:playroom": "NODE_ENV=production playroom build",


### PR DESCRIPTION
Making the braid docs site "type: module" to be able to start testing the experimental Vite bundling in sku.

Starting the site seems to work fine with no additional changes.