### PR TITLE
docs: Fix site crashing when switching in and out of the `useToast` page

### DIFF
--- a/.changeset/two-parts-rhyme.md
+++ b/.changeset/two-parts-rhyme.md
@@ -1,0 +1,10 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - useToast
+---
+
+**useToast**: Simplify internal logic, refining how the theme is applied to Toasts

--- a/packages/braid-design-system/src/lib/components/useToast/Toast.tsx
+++ b/packages/braid-design-system/src/lib/components/useToast/Toast.tsx
@@ -70,7 +70,6 @@ const Toast = forwardRef<HTMLDivElement, ToastProps>(
   (
     {
       toastKey,
-      vanillaTheme,
       dedupeKey,
       message,
       description,
@@ -147,7 +146,6 @@ const Toast = forwardRef<HTMLDivElement, ToastProps>(
         ref={ref}
         onMouseEnter={stopTimeout}
         onMouseLeave={startTimeout}
-        className={vanillaTheme}
         {...buildDataAttributes({ data, validateRestProps: restProps })}
       >
         <Box boxShadow="large" borderRadius={borderRadius}>

--- a/packages/braid-design-system/src/lib/components/useToast/ToastTypes.ts
+++ b/packages/braid-design-system/src/lib/components/useToast/ToastTypes.ts
@@ -13,7 +13,6 @@ export interface InternalToast {
   toastKey: string;
   /** Used to guarantee that only a single toast with a given key is visible at once. */
   dedupeKey: string;
-  vanillaTheme: string;
   tone: 'positive' | 'critical' | 'neutral';
   icon?: ReactElement<UseIconProps> | null;
   message: string;

--- a/packages/braid-design-system/src/lib/components/useToast/useToast.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/useToast/useToast.docs.tsx
@@ -17,6 +17,12 @@ import {
 
 import Toast, { toastDuration } from './Toast';
 
+// For static Toast examples, keys do not need to be unique
+const defaultProps = {
+  toastKey: `toastKey`,
+  dedupeKey: `dedupeKey`,
+} as const;
+
 const docs: ComponentDocs = {
   category: 'Content',
   Example: ({ showToast }) => {
@@ -40,8 +46,7 @@ const docs: ComponentDocs = {
       value: (
         <Stack space="large" align="center">
           <Toast
-            toastKey="content"
-            dedupeKey="content"
+            {...defaultProps}
             shouldRemove={false}
             onClose={() => {}}
             message="Positive toast"
@@ -199,32 +204,28 @@ const docs: ComponentDocs = {
         const { value } = source(
           <Stack space="large" align="center">
             <Toast
-              toastKey="tones_1"
-              dedupeKey="tones_1"
+              {...defaultProps}
               shouldRemove={false}
               onClose={() => {}}
               message="Positive message"
               tone="positive"
             />
             <Toast
-              toastKey="tones_2"
-              dedupeKey="tones_2"
+              {...defaultProps}
               shouldRemove={false}
               onClose={() => {}}
               message="Critical message"
               tone="critical"
             />
             <Toast
-              toastKey="tones_3"
-              dedupeKey="tones_3"
+              {...defaultProps}
               shouldRemove={false}
               onClose={() => {}}
               message="Neutral message"
               tone="neutral"
             />
             <Toast
-              toastKey="tones_4"
-              dedupeKey="tones_4"
+              {...defaultProps}
               shouldRemove={false}
               onClose={() => {}}
               message="Neutral message with icon"
@@ -269,8 +270,7 @@ const docs: ComponentDocs = {
         const { value } = source(
           <Stack space="large" align="center">
             <Toast
-              toastKey="descriptions"
-              dedupeKey="descriptions"
+              {...defaultProps}
               shouldRemove={false}
               onClose={() => {}}
               message="Positive message"
@@ -328,8 +328,7 @@ const docs: ComponentDocs = {
         const { value } = source(
           <Stack space="large" align="center">
             <Toast
-              toastKey="actions"
-              dedupeKey="actions"
+              {...defaultProps}
               shouldRemove={false}
               onClose={() => {}}
               message="Positive message"
@@ -383,8 +382,7 @@ const docs: ComponentDocs = {
         const { value } = source(
           <Stack space="large" align="center">
             <Toast
-              toastKey="actionsWithDescription"
-              dedupeKey="actionsWithDescription"
+              {...defaultProps}
               shouldRemove={false}
               onClose={() => {}}
               message="Positive message"
@@ -443,8 +441,7 @@ const docs: ComponentDocs = {
         const { value } = source(
           <Stack space="large" align="center">
             <Toast
-              toastKey="dismissingMessage"
-              dedupeKey="dismissingMessage"
+              {...defaultProps}
               shouldRemove={false}
               onClose={() => {}}
               tone="positive"

--- a/packages/braid-design-system/src/lib/components/useToast/useToast.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/useToast/useToast.docs.tsx
@@ -1,7 +1,5 @@
 import source from '@braid-design-system/source.macro';
-import { useId } from 'react';
 import Code from 'site/App/Code/Code';
-import { useThemeSettings } from 'site/App/ThemeSetting';
 import type { ComponentDocs } from 'site/types';
 
 import {
@@ -22,9 +20,6 @@ import Toast, { toastDuration } from './Toast';
 const docs: ComponentDocs = {
   category: 'Content',
   Example: ({ showToast }) => {
-    const id = useId();
-    const { theme } = useThemeSettings();
-
     const { code, value } = source(
       <Inline space="large" align="center">
         <Button
@@ -45,10 +40,9 @@ const docs: ComponentDocs = {
       value: (
         <Stack space="large" align="center">
           <Toast
-            toastKey={id}
-            dedupeKey={id}
+            toastKey="content"
+            dedupeKey="content"
             shouldRemove={false}
-            vanillaTheme={theme.vanillaTheme}
             onClose={() => {}}
             message="Positive toast"
             tone="positive"
@@ -146,9 +140,6 @@ const docs: ComponentDocs = {
         </>
       ),
       Example: ({ showToast }) => {
-        const id = useId();
-        const { theme } = useThemeSettings();
-
         const { code } = source(
           <Box padding="medium">
             <Stack space="small">
@@ -208,37 +199,33 @@ const docs: ComponentDocs = {
         const { value } = source(
           <Stack space="large" align="center">
             <Toast
-              toastKey={`${id}_1`}
-              dedupeKey={`${id}_1`}
+              toastKey="tones_1"
+              dedupeKey="tones_1"
               shouldRemove={false}
-              vanillaTheme={theme.vanillaTheme}
               onClose={() => {}}
               message="Positive message"
               tone="positive"
             />
             <Toast
-              toastKey={`${id}_2`}
-              dedupeKey={`${id}_2`}
+              toastKey="tones_2"
+              dedupeKey="tones_2"
               shouldRemove={false}
-              vanillaTheme={theme.vanillaTheme}
               onClose={() => {}}
               message="Critical message"
               tone="critical"
             />
             <Toast
-              toastKey={`${id}_3`}
-              dedupeKey={`${id}_3`}
+              toastKey="tones_3"
+              dedupeKey="tones_3"
               shouldRemove={false}
-              vanillaTheme={theme.vanillaTheme}
               onClose={() => {}}
               message="Neutral message"
               tone="neutral"
             />
             <Toast
-              toastKey={`${id}_4`}
-              dedupeKey={`${id}_4`}
+              toastKey="tones_4"
+              dedupeKey="tones_4"
               shouldRemove={false}
-              vanillaTheme={theme.vanillaTheme}
               onClose={() => {}}
               message="Neutral message with icon"
               tone="neutral"
@@ -262,9 +249,6 @@ const docs: ComponentDocs = {
         </Text>
       ),
       Example: ({ showToast }) => {
-        const id = useId();
-        const { theme } = useThemeSettings();
-
         const { code } = source(
           <Inline space="small" align="center">
             <Button
@@ -285,10 +269,9 @@ const docs: ComponentDocs = {
         const { value } = source(
           <Stack space="large" align="center">
             <Toast
-              toastKey={id}
-              dedupeKey={id}
+              toastKey="descriptions"
+              dedupeKey="descriptions"
               shouldRemove={false}
-              vanillaTheme={theme.vanillaTheme}
               onClose={() => {}}
               message="Positive message"
               tone="positive"
@@ -322,9 +305,6 @@ const docs: ComponentDocs = {
         </>
       ),
       Example: ({ showToast }) => {
-        const id = useId();
-        const { theme } = useThemeSettings();
-
         /* eslint-disable no-alert */
         const { code } = source(
           <Inline space="small" align="center">
@@ -348,10 +328,9 @@ const docs: ComponentDocs = {
         const { value } = source(
           <Stack space="large" align="center">
             <Toast
-              toastKey={id}
-              dedupeKey={id}
+              toastKey="actions"
+              dedupeKey="actions"
               shouldRemove={false}
-              vanillaTheme={theme.vanillaTheme}
               onClose={() => {}}
               message="Positive message"
               tone="positive"
@@ -379,9 +358,6 @@ const docs: ComponentDocs = {
         </Text>
       ),
       Example: ({ showToast }) => {
-        const id = useId();
-        const { theme } = useThemeSettings();
-
         /* eslint-disable no-alert */
         const { code } = source(
           <Inline space="small" align="center">
@@ -407,10 +383,9 @@ const docs: ComponentDocs = {
         const { value } = source(
           <Stack space="large" align="center">
             <Toast
-              toastKey={id}
-              dedupeKey={id}
+              toastKey="actionsWithDescription"
+              dedupeKey="actionsWithDescription"
               shouldRemove={false}
-              vanillaTheme={theme.vanillaTheme}
               onClose={() => {}}
               message="Positive message"
               description="Longer description providing more context for the user."
@@ -448,9 +423,6 @@ const docs: ComponentDocs = {
         </>
       ),
       Example: ({ showToast }) => {
-        const id = useId();
-        const { theme } = useThemeSettings();
-
         const { code } = source(
           <Inline space="small" align="center">
             <Button
@@ -471,10 +443,9 @@ const docs: ComponentDocs = {
         const { value } = source(
           <Stack space="large" align="center">
             <Toast
-              toastKey={id}
-              dedupeKey={id}
+              toastKey="dismissingMessage"
+              dedupeKey="dismissingMessage"
               shouldRemove={false}
-              vanillaTheme={theme.vanillaTheme}
               onClose={() => {}}
               tone="positive"
               message="Message"

--- a/packages/braid-design-system/src/lib/playroom/useScope.ts
+++ b/packages/braid-design-system/src/lib/playroom/useScope.ts
@@ -12,6 +12,8 @@ import {
 
 export default function useScope() {
   const responsiveValue = useResponsiveValue();
+  const showToast = useToast();
+  const playroomState = usePlayroomStore();
 
   // TODO: COLORMODE RELEASE
   // Revisit when dark mode frames are first class
@@ -81,9 +83,9 @@ export default function useScope() {
     vars,
     atoms,
     breakpoints,
-    showToast: useToast(),
+    showToast,
     responsiveValue: playroomResponsiveValue,
     colorModeValue: playroomColorModeValue,
-    ...usePlayroomStore(),
+    ...playroomState,
   };
 }


### PR DESCRIPTION
The `useToast` page would sometimes crash when switching between it and another component page on the docs site.

Looks like the problem is calling hooks within examples in the docs page. When you switch pages, React complains that `DocExample` is calling a different set of hooks (in this case also calling `useId`).

```
hook.js:608 
Warning: React has detected a change in the order of Hooks called by DocExample.
This will lead to bugs and errors if not fixed.
For more information, read the Rules of Hooks: https://reactjs.org/link/rules-of-hooks

   Previous render            Next render
   ------------------------------------------------------
1. useContext                 useContext
2. useContext                 useContext
3. useContext                 useContext
4. useCallback                useCallback
5. useContext                 useContext
6. useState                   useState
7. useEffect                  useEffect
8. undefined                  useId
```

Looks like a fix is to remove all hook calls from `useToast.docs`. `vanillaTheme` doesn't seem to be adding anything, so that is removed.

Also avoiding some conditional hook calls in `useScope` to be safe.