### PR TITLE
Playroom: remove `apac` from default visible themes

### DIFF
--- a/site/playroom.config.mjs
+++ b/site/playroom.config.mjs
@@ -20,7 +20,7 @@ export default {
   components: require.resolve('./src/playroom.components.ts'),
   snippets: resolveFromBraid('entries/playroom/snippets.ts'),
   themes: resolveFromBraid('lib/themes/index.ts'),
-  defaultVisibleThemes: ['apac', 'seekJobs'],
+  defaultVisibleThemes: ['seekJobs'],
   frameComponent: require.resolve('./src/playroom.frame.ts'),
   scope: require.resolve('./src/playroom.scope.ts'),
   typeScriptFiles: [resolveFromBraid('entries/playroom/components.ts')],


### PR DESCRIPTION
Still seeing too much of this and it hurts my soul