### PR TITLE
BraidTestProvider: Provide `ResizeObserver` & `IntersectionObserver` stubs to jsdom

### DIFF
--- a/.changeset/chubby-tires-tie.md
+++ b/.changeset/chubby-tires-tie.md
@@ -1,0 +1,16 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - BraidTestProvider
+---
+
+**BraidTestProvider:** Provide `ResizeObserver` & `IntersectionObserver` stubs to jsdom
+
+Fixes an issue where rendering certain Braid components within a test environment could throw errors due to missing APIs in jsdom, causing tests to fail with the following error:
+
+```
+ReferenceError: IntersectionObserver is not defined
+```

--- a/jest/setupTests.ts
+++ b/jest/setupTests.ts
@@ -1,3 +1,11 @@
+/**
+ * ----------------------------------------------------------------------
+ * NOTE: When adding stub APIs that are unavailable in the `jsdom`
+ * environment, remember to add them to `BraidTestProvider` to ensure
+ * we are stubbing our dependent APIs in consumer test environments too.
+ * ----------------------------------------------------------------------
+ */
+
 import { format, TextEncoder, TextDecoder } from 'util';
 
 // The `jsdom` jest environment doesn't expose `TextEncoder` or `TextDecoder`
@@ -5,28 +13,6 @@ import { format, TextEncoder, TextDecoder } from 'util';
 // so I'm not sure why it has suddenly become an issue
 global.TextEncoder = TextEncoder;
 global.TextDecoder = TextDecoder;
-
-// The `jsdom` jest environment doesn't provide `ResizeObserver`
-class MockResizeObserver {
-  observe = jest.fn();
-  unobserve = jest.fn();
-  disconnect = jest.fn();
-}
-
-global.ResizeObserver = MockResizeObserver;
-
-class MockIntersectionObserver {
-  root = null;
-  rootMargin = '';
-  thresholds = [];
-
-  observe = jest.fn();
-  unobserve = jest.fn();
-  disconnect = jest.fn();
-  takeRecords = jest.fn();
-}
-
-global.IntersectionObserver = MockIntersectionObserver;
 
 const error = global.console.error;
 

--- a/packages/braid-design-system/src/lib/components/BraidTestProvider/BraidTestProvider.tsx
+++ b/packages/braid-design-system/src/lib/components/BraidTestProvider/BraidTestProvider.tsx
@@ -9,18 +9,46 @@ import { breakpointContext } from '../BraidProvider/BreakpointContext';
 import { BraidTestProviderContext } from './BraidTestProviderContext';
 
 /**
- * Mocking for `jsdom` which doesn't support `scrollIntoView`.
- * Can remove this if/when `jsdom` adds a stub for `scrollIntoView`.
- *
- * GitHub issue: https://github.com/jsdom/jsdom/issues/1695
- * Pull request: https://github.com/jsdom/jsdom/pull/3639
+ * Mocking APIs missing from  `jsdom` environment.
  */
 if (
   typeof navigator !== 'undefined' &&
   navigator?.userAgent?.includes('jsdom')
 ) {
+  /**
+   * Mocking `scrollIntoView` API.
+   *
+   * Can remove this if/when `jsdom` adds a stub for `scrollIntoView`.
+   * GitHub issue: https://github.com/jsdom/jsdom/issues/1695
+   * Pull request: https://github.com/jsdom/jsdom/pull/3639
+   */
   window.HTMLElement.prototype.scrollIntoView =
     window.HTMLElement.prototype.scrollIntoView || (() => {});
+
+  /**
+   * Mocking `ResizeObserver` API.
+   */
+  class MockResizeObserver {
+    observe = jest.fn();
+    unobserve = jest.fn();
+    disconnect = jest.fn();
+  }
+  global.ResizeObserver = MockResizeObserver;
+
+  /**
+   * Mocking `IntersectionObserver` API.
+   */
+  class MockIntersectionObserver {
+    root = null;
+    rootMargin = '';
+    thresholds = [];
+
+    observe = jest.fn();
+    unobserve = jest.fn();
+    disconnect = jest.fn();
+    takeRecords = jest.fn();
+  }
+  global.IntersectionObserver = MockIntersectionObserver;
 }
 
 interface BraidTestProviderProps


### PR DESCRIPTION
Fixes an issue where rendering certain Braid components within a test environment could throw errors due to missing APIs in jsdom, causing tests to fail with the following error:

```
ReferenceError: IntersectionObserver is not defined
```