### PR TITLE
BraidTestProvider: Use `window` consistently

### DIFF
--- a/packages/braid-design-system/src/lib/components/BraidTestProvider/BraidTestProvider.tsx
+++ b/packages/braid-design-system/src/lib/components/BraidTestProvider/BraidTestProvider.tsx
@@ -33,7 +33,7 @@ if (
     unobserve = jest.fn();
     disconnect = jest.fn();
   }
-  global.ResizeObserver = MockResizeObserver;
+  window.ResizeObserver = MockResizeObserver;
 
   /**
    * Mocking `IntersectionObserver` API.
@@ -48,7 +48,7 @@ if (
     disconnect = jest.fn();
     takeRecords = jest.fn();
   }
-  global.IntersectionObserver = MockIntersectionObserver;
+  window.IntersectionObserver = MockIntersectionObserver;
 }
 
 interface BraidTestProviderProps


### PR DESCRIPTION
An unsaved file locally meant we were inconsistent in our usage of `global` and `window` when stubbing APIs in jsdom 🤦 