### PR TITLE
docs: Simplify `DocNavigation` component

### DIFF
--- a/site/src/App/DocNavigation/DocNavigation.css.ts
+++ b/site/src/App/DocNavigation/DocNavigation.css.ts
@@ -2,10 +2,16 @@ import { createVar, style, styleVariants } from '@vanilla-extract/css';
 import { calc } from '@vanilla-extract/css-utils';
 import { atoms, colorModeStyle, vars } from 'braid-src/entries/css';
 
+export const navItemPaddingY = 'medium' as const;
+export const navItemPaddingX = ['small', 'medium'] as const;
+
 export const docNavLink = style([
   atoms({
-    display: 'block',
     borderRadius: 'standard',
+    position: 'relative',
+    display: 'flex',
+    alignItems: 'center',
+    paddingX: navItemPaddingX,
   }),
   {
     outlineOffset: calc.negate(vars.space.xxsmall),

--- a/site/src/App/DocNavigation/DocNavigation.tsx
+++ b/site/src/App/DocNavigation/DocNavigation.tsx
@@ -76,7 +76,7 @@ export const DocNavigationItem = ({
   ) : undefined;
 
   return (
-    <Box component="li">
+    <Box component="li" position="relative" paddingX={navItemPaddingX}>
       <Link
         href={href}
         onMouseEnter={() => setHovered(true)}
@@ -84,53 +84,50 @@ export const DocNavigationItem = ({
         aria-current={active ? 'page' : undefined}
         className={styles.docNavLink}
       >
-        <Box display="flex" alignItems="center" paddingX={navItemPaddingX}>
-          <Box position="relative">
-            <Box
-              display="flex"
-              position="relative"
-              alignItems="center"
-              opacity={active ? undefined : 0}
-              paddingY={navItemPaddingY}
-            >
-              <Box
-                position="absolute"
-                width="full"
-                zIndex={1}
-                bottom={0}
-                className={[
-                  styles.activeUnderline,
-                  styles.activeUnderlineColor[lightness.lightMode],
-                  styles.activeUnderlineColor[lightness.darkMode],
-                ]}
-              />
-              <Text size="standard" weight="strong">
-                {children}
-              </Text>
-              {badgeElement}
-            </Box>
-            <Box
-              aria-hidden
-              display="flex"
-              alignItems="center"
-              position="absolute"
-              top={0}
-              paddingY={navItemPaddingY}
-              opacity={active ? 0 : undefined}
-              {...(index === 0
-                ? { left: 0 }
-                : { className: styles.centerHorizontally })}
-            >
-              <Text
-                size="standard"
-                weight="medium"
-                tone={hovered ? 'neutral' : 'secondary'}
-              >
-                {children}
-              </Text>
-              {badgeElement}
-            </Box>
-          </Box>
+        {/* Active, strong title */}
+        <Box
+          display="flex"
+          position="relative"
+          alignItems="center"
+          opacity={active ? undefined : 0}
+          paddingY={navItemPaddingY}
+        >
+          <Box
+            position="absolute"
+            width="full"
+            zIndex={1}
+            bottom={0}
+            className={[
+              styles.activeUnderline,
+              styles.activeUnderlineColor[lightness.lightMode],
+              styles.activeUnderlineColor[lightness.darkMode],
+            ]}
+          />
+          <Text size="standard" weight="strong">
+            {children}
+          </Text>
+          {badgeElement}
+        </Box>
+
+        {/* Inactive, weak title */}
+        <Box
+          aria-hidden
+          display="flex"
+          alignItems="center"
+          position="absolute"
+          top={0}
+          paddingY={navItemPaddingY}
+          opacity={active ? 0 : undefined}
+          className={index !== 0 ? styles.centerHorizontally : undefined}
+        >
+          <Text
+            size="standard"
+            weight="medium"
+            tone={hovered ? 'neutral' : 'secondary'}
+          >
+            {children}
+          </Text>
+          {badgeElement}
         </Box>
       </Link>
     </Box>

--- a/site/src/App/DocNavigation/DocNavigation.tsx
+++ b/site/src/App/DocNavigation/DocNavigation.tsx
@@ -76,7 +76,7 @@ export const DocNavigationItem = ({
   ) : undefined;
 
   return (
-    <Box component="li" position="relative" paddingX={navItemPaddingX}>
+    <Box component="li">
       <Link
         href={href}
         onMouseEnter={() => setHovered(true)}
@@ -84,50 +84,57 @@ export const DocNavigationItem = ({
         aria-current={active ? 'page' : undefined}
         className={styles.docNavLink}
       >
-        {/* Active, strong title */}
         <Box
-          display="flex"
           position="relative"
-          alignItems="center"
-          opacity={active ? undefined : 0}
-          paddingY={navItemPaddingY}
-        >
-          <Box
-            position="absolute"
-            width="full"
-            zIndex={1}
-            bottom={0}
-            className={[
-              styles.activeUnderline,
-              styles.activeUnderlineColor[lightness.lightMode],
-              styles.activeUnderlineColor[lightness.darkMode],
-            ]}
-          />
-          <Text size="standard" weight="strong">
-            {children}
-          </Text>
-          {badgeElement}
-        </Box>
-
-        {/* Inactive, weak title */}
-        <Box
-          aria-hidden
           display="flex"
           alignItems="center"
-          position="absolute"
-          top={0}
-          paddingY={navItemPaddingY}
-          opacity={active ? 0 : undefined}
-          className={index !== 0 ? styles.centerHorizontally : undefined}
+          paddingX={navItemPaddingX}
         >
-          <Text
-            size="standard"
-            weight="medium"
-            tone={hovered ? 'neutral' : 'secondary'}
+          {/* Active, strong title */}
+          <Box
+            display="flex"
+            position="relative"
+            alignItems="center"
+            opacity={active ? undefined : 0}
+            paddingY={navItemPaddingY}
           >
-            {children}
-          </Text>
-          {badgeElement}
+            <Box
+              position="absolute"
+              width="full"
+              zIndex={1}
+              bottom={0}
+              className={[
+                styles.activeUnderline,
+                styles.activeUnderlineColor[lightness.lightMode],
+                styles.activeUnderlineColor[lightness.darkMode],
+              ]}
+            />
+            <Text size="standard" weight="strong">
+              {children}
+            </Text>
+            {badgeElement}
+          </Box>
+
+          {/* Inactive, weak title */}
+          <Box
+            aria-hidden
+            display="flex"
+            alignItems="center"
+            position="absolute"
+            top={0}
+            paddingY={navItemPaddingY}
+            opacity={active ? 0 : undefined}
+            className={index !== 0 ? styles.centerHorizontally : undefined}
+          >
+            <Text
+              size="standard"
+              weight="medium"
+              tone={hovered ? 'neutral' : 'secondary'}
+            >
+              {children}
+            </Text>
+            {badgeElement}
+          </Box>
         </Box>
       </Link>
     </Box>

--- a/site/src/App/DocNavigation/DocNavigation.tsx
+++ b/site/src/App/DocNavigation/DocNavigation.tsx
@@ -69,9 +69,9 @@ export const DocNavigationItem = ({
   const [hovered, setHovered] = useState(false);
 
   const badgeSpacing = 'xsmall';
-  const badgeElement = badge ? (
-    <>{cloneElement(badge, { bleedY: true })}</>
-  ) : undefined;
+  const badgeElement = badge
+    ? cloneElement(badge, { bleedY: true })
+    : undefined;
 
   return (
     <Box component="li">

--- a/site/src/App/DocNavigation/DocNavigation.tsx
+++ b/site/src/App/DocNavigation/DocNavigation.tsx
@@ -34,9 +34,6 @@ import {
 
 import * as styles from './DocNavigation.css';
 
-const navItemPaddingX = ['small', 'medium'] as const;
-const navItemPaddingY = 'medium' as const;
-
 const DocNavigationItemIndexContext = createContext(-1);
 interface DocsProviderContextValue {
   docsName: string;
@@ -71,8 +68,9 @@ export const DocNavigationItem = ({
   const index = useContext(DocNavigationItemIndexContext);
   const [hovered, setHovered] = useState(false);
 
+  const badgeSpacing = 'xsmall';
   const badgeElement = badge ? (
-    <Box paddingLeft="xsmall">{cloneElement(badge, { bleedY: true })}</Box>
+    <>{cloneElement(badge, { bleedY: true })}</>
   ) : undefined;
 
   return (
@@ -84,57 +82,55 @@ export const DocNavigationItem = ({
         aria-current={active ? 'page' : undefined}
         className={styles.docNavLink}
       >
+        {/* Active, strong title */}
         <Box
-          position="relative"
+          component="span"
           display="flex"
+          gap={badgeSpacing}
+          position="relative"
           alignItems="center"
-          paddingX={navItemPaddingX}
+          opacity={active ? undefined : 0}
+          paddingY={styles.navItemPaddingY}
         >
-          {/* Active, strong title */}
           <Box
-            display="flex"
-            position="relative"
-            alignItems="center"
-            opacity={active ? undefined : 0}
-            paddingY={navItemPaddingY}
-          >
-            <Box
-              position="absolute"
-              width="full"
-              zIndex={1}
-              bottom={0}
-              className={[
-                styles.activeUnderline,
-                styles.activeUnderlineColor[lightness.lightMode],
-                styles.activeUnderlineColor[lightness.darkMode],
-              ]}
-            />
-            <Text size="standard" weight="strong">
-              {children}
-            </Text>
-            {badgeElement}
-          </Box>
-
-          {/* Inactive, weak title */}
-          <Box
-            aria-hidden
-            display="flex"
-            alignItems="center"
+            component="span"
             position="absolute"
-            top={0}
-            paddingY={navItemPaddingY}
-            opacity={active ? 0 : undefined}
-            className={index !== 0 ? styles.centerHorizontally : undefined}
+            width="full"
+            zIndex={1}
+            bottom={0}
+            className={[
+              styles.activeUnderline,
+              styles.activeUnderlineColor[lightness.lightMode],
+              styles.activeUnderlineColor[lightness.darkMode],
+            ]}
+          />
+          <Text size="standard" weight="strong">
+            {children}
+          </Text>
+          {badgeElement}
+        </Box>
+
+        {/* Inactive, weak title */}
+        <Box
+          component="span"
+          aria-hidden
+          display="flex"
+          gap={badgeSpacing}
+          alignItems="center"
+          position="absolute"
+          top={0}
+          paddingY={styles.navItemPaddingY}
+          opacity={active ? 0 : undefined}
+          className={index !== 0 ? styles.centerHorizontally : undefined}
+        >
+          <Text
+            size="standard"
+            weight="medium"
+            tone={hovered ? 'neutral' : 'secondary'}
           >
-            <Text
-              size="standard"
-              weight="medium"
-              tone={hovered ? 'neutral' : 'secondary'}
-            >
-              {children}
-            </Text>
-            {badgeElement}
-          </Box>
+            {children}
+          </Text>
+          {badgeElement}
         </Box>
       </Link>
     </Box>
@@ -165,8 +161,8 @@ export const DocNavigationBar = ({
       component="nav"
       aria-label={title}
       className={[
-        negativeMargin('top', navItemPaddingY),
-        negativeMargin('left', navItemPaddingX),
+        negativeMargin('top', styles.navItemPaddingY),
+        negativeMargin('left', styles.navItemPaddingX),
       ]}
     >
       <Box component="ul" display="flex" alignItems="center" overflow="auto">
@@ -177,7 +173,7 @@ export const DocNavigationBar = ({
         ))}
       </Box>
       <Box
-        paddingLeft={navItemPaddingX}
+        paddingLeft={styles.navItemPaddingX}
         className={styles.inactiveUnderlineCorrection}
       >
         <Divider />


### PR DESCRIPTION
Did this as part of debugging but feel like it's worth keeping. Splitting out for ease of PR review, but it should have no functional impact.

1. This component requires a unique layout solution, so I think the code should be a bit more explicit for ease of reading (i.e. comments)
2. Tried to consolidate some `Box` components