### PR TITLE
`docs`: Fix code formatting in `atoms` and `responsiveStyle` docs

### DIFF
--- a/packages/braid-design-system/src/entries/css/atoms.docs.tsx
+++ b/packages/braid-design-system/src/entries/css/atoms.docs.tsx
@@ -1,10 +1,8 @@
-import source from '@braid-design-system/source.macro';
 import dedent from 'dedent';
 import Code from 'site/App/Code/Code';
 import { ThemedExample } from 'site/App/ThemeSetting';
 import type { CssDoc } from 'site/types';
 
-import { atoms } from 'braid-src/entries/css';
 import {
   Stack,
   Columns,
@@ -86,26 +84,22 @@ const docs: CssDoc = {
             of custom CSS in your application.
           </Text>
           <Code playroom={false}>
-            {dedent`
+            {`
               // styles.css.ts
               import { atoms } from 'braid-design-system/css';
 
-              export const className = ${
-                source(
-                  atoms({
-                    display: 'flex',
-                    justifyContent: {
-                      mobile: 'center',
-                      tablet: 'flexStart',
-                    },
-                    position: 'absolute',
-                    top: 0,
-                    left: 0,
-                    width: 'full',
-                    height: 'full',
-                  }),
-                ).code
-              };
+              export const className = atoms({
+                display: 'flex',
+                justifyContent: {
+                  mobile: 'center',
+                  tablet: 'flexStart',
+                },
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: 'full',
+                height: 'full',
+              });
             `}
           </Code>
           <Box paddingBottom="large">
@@ -170,9 +164,7 @@ const docs: CssDoc = {
               // styles.css.ts
               import { atoms } from 'braid-design-system/css';
 
-              export const className = ${
-                source(atoms({ paddingX: 'gutter', paddingY: 'large' })).code
-              };
+              export const className = atoms({ paddingX: 'gutter', paddingY: 'large' });
             `}
           </Code>
           <ThemedExample>
@@ -302,22 +294,18 @@ const docs: CssDoc = {
             </Strong>
           </Text>
           <Code playroom={false}>
-            {dedent`
+            {`
               // styles.css.ts
               import { atoms } from 'braid-design-system/css';
 
-              export const className = ${
-                source(
-                  atoms({
-                    padding: {
-                      mobile: 'small',
-                      tablet: 'medium',
-                      desktop: 'large',
-                      wide: 'xlarge',
-                    },
-                  }),
-                ).code
-              };
+              export const className = atoms({
+                padding: {
+                  mobile: 'small',
+                  tablet: 'medium',
+                  desktop: 'large',
+                  wide: 'xlarge',
+                },
+              });
             `}
           </Code>
           <ThemedExample>
@@ -356,17 +344,11 @@ const docs: CssDoc = {
             presence doesn’t alter the dimensions of the element.
           </Text>
           <Code playroom={false}>
-            {dedent`
+            {`
               // styles.css.ts
               import { atoms } from 'braid-design-system/css';
 
-              export const className = ${
-                source(
-                  atoms({
-                    boxShadow: 'large',
-                  }),
-                ).code
-              };
+              export const className = atoms({ boxShadow: 'large' });
             `}
           </Code>
           <Alert tone="caution">
@@ -482,17 +464,13 @@ const docs: CssDoc = {
             native element type.
           </Text>
           <Code playroom={false}>
-            {dedent`
+            {`
               // styles.css.ts
               import { atoms } from 'braid-design-system/css';
 
-              export const className = ${
-                source(
-                  atoms({
-                    reset: 'span',
-                  }),
-                ).code
-              };
+              export const className = atoms({
+                reset: 'span',
+              });
             `}
           </Code>
         </>

--- a/packages/braid-design-system/src/entries/css/responsiveStyle.docs.tsx
+++ b/packages/braid-design-system/src/entries/css/responsiveStyle.docs.tsx
@@ -1,10 +1,8 @@
-import source from '@braid-design-system/source.macro';
-import dedent from 'dedent';
 import { Fragment } from 'react';
 import Code from 'site/App/Code/Code';
 import type { CssDoc } from 'site/types';
 
-import { responsiveStyle, vars, breakpoints } from 'braid-src/entries/css';
+import { breakpoints } from 'braid-src/entries/css';
 import { Notice, Strong, Text, TextLink } from 'braid-src/lib/components';
 
 const bps = Object.keys(breakpoints);
@@ -54,21 +52,19 @@ const docs: CssDoc = {
             , e.g. <Strong>style</Strong>, to create the actual styles.
           </Text>
           <Code>
-            {dedent`
+            {`
               // styles.css.ts
               import { style } from '@vanilla-extract/css';
               import { vars, responsiveStyle } from 'braid-design-system/css';
 
-              export const className = style(${
-                source(
-                  responsiveStyle({
-                    mobile: { flexBasis: vars.space.small },
-                    tablet: { flexBasis: vars.space.medium },
-                    desktop: { flexBasis: vars.space.large },
-                    wide: { flexBasis: vars.space.xlarge },
-                  }),
-                ).code
-              });
+              export const className = style(
+                responsiveStyle({
+                  mobile: { flexBasis: vars.space.small },
+                  tablet: { flexBasis: vars.space.medium },
+                  desktop: { flexBasis: vars.space.large },
+                  wide: { flexBasis: vars.space.xlarge },
+                }),
+              );
 
               // is equivalent to
               import { style } from '@vanilla-extract/css';


### PR DESCRIPTION
Interpolating `source` macro code inside a code block doesn't really work anymore now that code block contents isn't run through `prettier` at runtime (#1770).

In this example:

```jsx
<Code playroom={false}>
  {dedent`
    // styles.css.ts
    import { atoms } from 'braid-design-system/css';
    export const className = ${
      source(
        atoms({
          reset: 'span',
        }),
      ).code
    };
  `}
</Code>
```

The `source` macro code has no indentation, so the dedent doesn't do anything, and you end up with the comment and `import` lines improperly indented.

The quick fix for this is to use a multiline string instead of the `source` macro for these few code snippets. The downside is that we lose the benefits of the `source` macro, namely 

After chatting with @felixhabib, we felt like there was little risk of updating an API in a breaking way without touching its corresponding docs page, so we're happy with this tradeoff.

In the long term we may want to look into a way of maintaining separate snippets files that are inlined at build-time, so they can benefit from formatting and linting. Alternatively we could revert the `source` macro/code component formatting at runtime change, but I'm strongly against that.

Additionally, I've removed some redundant `dedent` usage because the `Code` component dedents its children already.