### PR TITLE
Table: Ensure `alignY` applied consistently across browsers

### DIFF
--- a/.changeset/long-ways-peel.md
+++ b/.changeset/long-ways-peel.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Table
+---
+
+**Table:** Ensure `alignY` applied consistently across browsers
+
+Fixes an issue where setting the `alignY` prop to `top` would not apply the `vertical-align` CSS property — instead falling through to our CSS reset which sets `vertical-align: baseline` (rendering inconsistently across browsers).

--- a/packages/braid-design-system/src/lib/components/Table/Table.css.ts
+++ b/packages/braid-design-system/src/lib/components/Table/Table.css.ts
@@ -1,4 +1,9 @@
-import { createVar, globalStyle, style } from '@vanilla-extract/css';
+import {
+  createVar,
+  globalStyle,
+  style,
+  styleVariants,
+} from '@vanilla-extract/css';
 
 import { colorModeStyle } from '../../css/colorModeStyle';
 import { responsiveStyle } from '../../css/responsiveStyle';
@@ -63,8 +68,13 @@ globalStyle(
   },
 );
 
-export const alignYCenter = style({
-  verticalAlign: 'middle',
+export const alignY = styleVariants({
+  center: {
+    verticalAlign: 'middle',
+  },
+  top: {
+    verticalAlign: 'top',
+  },
 });
 
 export const nowrap = style({

--- a/packages/braid-design-system/src/lib/components/Table/Table.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Table/Table.screenshots.tsx
@@ -235,13 +235,13 @@ export const screenshots: ComponentScreenshot = {
             {data.map((row) => (
               <TableRow key={row.column1}>
                 <TableCell>
-                  <Stack space="small">
-                    <Text>{row.column1}</Text>
-                    <Text>{row.column1}</Text>
-                  </Stack>
+                  <Placeholder width="100%" height={70} />
                 </TableCell>
                 <TableCell>
-                  <Text>{row.column2}</Text>
+                  <Stack space="small">
+                    <Text>{row.column2}</Text>
+                    <Text>{row.column2}</Text>
+                  </Stack>
                 </TableCell>
                 <TableCell>
                   <Text>{row.column3}</Text>
@@ -273,13 +273,13 @@ export const screenshots: ComponentScreenshot = {
             {data.map((row) => (
               <TableRow key={row.column1}>
                 <TableCell>
-                  <Stack space="small">
-                    <Text>{row.column1}</Text>
-                    <Text>{row.column1}</Text>
-                  </Stack>
+                  <Placeholder width="100%" height={70} />
                 </TableCell>
                 <TableCell>
-                  <Text>{row.column2}</Text>
+                  <Stack space="small">
+                    <Text>{row.column2}</Text>
+                    <Text>{row.column2}</Text>
+                  </Stack>
                 </TableCell>
                 <TableCell>
                   <Text>{row.column3}</Text>

--- a/packages/braid-design-system/src/lib/components/Table/Table.tsx
+++ b/packages/braid-design-system/src/lib/components/Table/Table.tsx
@@ -13,7 +13,7 @@ import * as styles from './Table.css';
 export interface TableProps {
   label: string;
   children: ReactNode;
-  alignY?: 'top' | 'center';
+  alignY?: keyof typeof styles.alignY;
   data?: DataAttributeMap;
 }
 

--- a/packages/braid-design-system/src/lib/components/Table/TableCell.tsx
+++ b/packages/braid-design-system/src/lib/components/Table/TableCell.tsx
@@ -113,7 +113,7 @@ const Cell = forwardRef<HTMLTableCellElement, CellProps & BaseCellProps>(
           [styles.softWidth]: softWidth,
           [styles.minWidth]: typeof minWidth !== 'undefined',
           [styles.maxWidth]: hasMaxWidth,
-          [styles.alignYCenter]: tableContext.alignY === 'center',
+          [styles.alignY[tableContext.alignY]]: Boolean(tableContext.alignY),
           [styles.showOnTablet]: !hideOnTablet && hideOnMobile,
           [styles.showOnDesktop]:
             !hideOnDesktop && (hideOnTablet || hideOnMobile),


### PR DESCRIPTION
Fixes an issue where setting the `alignY` prop to `top` would not apply the `vertical-align` CSS property — instead falling through to our CSS reset which sets `vertical-align: baseline` (rendering inconsistently across browsers).