### PR TITLE
TooltipRenderer: Optimise performance

### DIFF
--- a/.changeset/itchy-boats-wonder.md
+++ b/.changeset/itchy-boats-wonder.md
@@ -1,0 +1,11 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - ButtonIcon
+  - TooltipRenderer
+---
+
+**TooltipRenderer:** Optimise performance by reducing unnecessary recalculations of the trigger position

--- a/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.tsx
@@ -199,17 +199,19 @@ export const TooltipRenderer = ({
 
   const handleTooltipPosition = () => {
     const setPositions = () => {
-      setTooltipPosition(tooltipRef.current?.getBoundingClientRect());
-      setTriggerPosition(triggerRef.current?.getBoundingClientRect());
+      if (tooltipRef.current) {
+        setTooltipPosition(tooltipRef.current.getBoundingClientRect());
+      }
+      if (triggerRef.current) {
+        setTriggerPosition(triggerRef.current.getBoundingClientRect());
+      }
     };
 
-    const timeoutId = setTimeout(() => {
+    setTimeout(() => {
       const frameId = requestAnimationFrame(setPositions);
       return () => cancelAnimationFrame(frameId);
       // Needs to be slightly less than the animation timeout to update position before showing
     }, animationTimeout / 2);
-
-    return () => clearTimeout(timeoutId);
   };
 
   useIsomorphicLayoutEffect(() => {
@@ -217,19 +219,13 @@ export const TooltipRenderer = ({
       return;
     }
 
-    const handleResize = () => {
-      handleTooltipPosition();
-    };
-
-    window.addEventListener('resize', handleResize);
-    const resizeObserver = new ResizeObserver(handleResize);
-    resizeObserver.observe(document.body);
+    handleTooltipPosition();
+    window.addEventListener('resize', handleTooltipPosition);
 
     return () => {
-      window.removeEventListener('resize', handleResize);
-      resizeObserver.disconnect();
+      window.removeEventListener('resize', handleTooltipPosition);
     };
-  }, [showTooltip, triggerRef]);
+  }, [showTooltip]);
 
   let inferredPlacement: typeof placement = placement;
   let arrowLeftOffset = 0;


### PR DESCRIPTION
Optimise performance by only calculating trigger position when tooltip is open and when the window is resized, instead of on every render

Noticed this when testing #1782 