### PR TITLE
chromatic: Add diff threshold

### DIFF
--- a/packages/braid-design-system/.storybook/preview.tsx
+++ b/packages/braid-design-system/.storybook/preview.tsx
@@ -22,7 +22,10 @@ if (typeof document !== 'undefined') {
 const preview: Preview = {
   decorators: [withTheme],
   parameters: {
-    chromatic: setChromatic({ root: true }),
+    chromatic: {
+      ...setChromatic({ root: true }),
+      diffThreshold: 0.1,
+    },
     layout: 'fullscreen',
   },
   globalTypes: {


### PR DESCRIPTION
Attempt to prevent diffs with antialiasing as per [docs](https://www.chromatic.com/docs/threshold/).

Default is `.063` but bumping this to `0.1` to see if there's an improvement. Issue is predominantly with `TooltipRenderer` text. Keen to try this out.