### PR TITLE
RadioGroup: Ensure `id` is assigned to `fieldset`

### DIFF
--- a/.changeset/brown-pillows-pull.md
+++ b/.changeset/brown-pillows-pull.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - RadioGroup
+---
+
+**RadioGroup:** Ensure provided `id` is assigned to `fieldset`
+
+Fixes a bug where the provided `id` was not being passed through to the `fieldset` element.

--- a/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.test.tsx
+++ b/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.test.tsx
@@ -36,6 +36,19 @@ describe('RadioGroup', () => {
     expect(getByLabelText('Options').tagName).toBe('FIELDSET');
   });
 
+  it('associates the group with id correctly', () => {
+    const { container } = render(
+      <BraidTestProvider>
+        <RadioGroup id="my-id" value="" onChange={() => {}} label="Options">
+          <RadioItem label="Option 1" value="1" />
+          <RadioItem label="Option 2" value="2" />
+        </RadioGroup>
+      </BraidTestProvider>,
+    );
+
+    expect(container.querySelector('#my-id')?.tagName).toBe('FIELDSET');
+  });
+
   it('associates radio items with their labels correctly', () => {
     const { getByLabelText } = render(
       <BraidTestProvider>

--- a/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.tsx
+++ b/packages/braid-design-system/src/lib/components/RadioGroup/RadioGroup.tsx
@@ -36,7 +36,6 @@ const stackSpaceForSize = {
 } as Record<NonNullable<RadioGroupProps['size']>, StackProps['space']>;
 
 const RadioGroup = ({
-  id,
   children,
   value,
   name,


### PR DESCRIPTION
Fixes a bug where the provided `id` was not being passed through to the `fieldset` element.