### PR TITLE
Isolate `chromatic` to a manual CI workflow

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,36 @@
+name: Chromatic
+
+on: workflow_dispatch
+
+jobs:
+  chromatic:
+    name: Run Chromatic
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          # This makes Actions fetch all Git history so that chromatic can diff against previous commits
+          fetch-depth: 0
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version-file: package.json
+
+      - name: Install Dependencies
+        run: pnpm i
+
+      - name: Build Braid
+        run: pnpm build
+
+      - name: Chromatic
+        run: pnpm storybook:chromatic
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_APP_CODE }}

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -14,9 +14,6 @@ jobs:
     steps:
       - name: Checkout Repo
         uses: actions/checkout@v4
-        with:
-          # This makes Actions fetch all Git history so that chromatic can diff against previous commits
-          fetch-depth: 0
 
       - name: Set up pnpm
         uses: pnpm/action-setup@v3
@@ -38,8 +35,3 @@ jobs:
           pnpm test
           pnpm build
           pnpm postbuild
-
-      - name: Chromatic
-        run: pnpm storybook:chromatic
-        env:
-          CHROMATIC_PROJECT_TOKEN: ${{ secrets.CHROMATIC_APP_CODE }}


### PR DESCRIPTION
So we can choose when to run chromatic screenshot tests. Incidentally, this means the `validate` workflow can now do a shallow clone, speeding up that workflow by almost 3 minutes.

Currently the chromatic CI check is mandatory for merging. If you don't want to run chromatic, but do want to merge a PR, that check either needs to be temporarily disabled, or the merge must be performed with admin override (probably the better option for the time being).

Note that the manual workflow isn't available in [the Actions tab](https://github.com/seek-oss/braid-design-system/actions) yet as I believe that only reflects the state of `master`.