### PR TITLE
`docs-ui`: Don't run `dev` script before `validate:dist`

### DIFF
--- a/.changeset/shiny-states-listen.md
+++ b/.changeset/shiny-states-listen.md
@@ -1,0 +1,5 @@
+---
+'@braid-design-system/docs-ui': patch
+---
+
+Fixes a bug that caused versions 3.0.1 to 3.0.4 to be published with broken artifacts

--- a/packages/docs-ui/project.json
+++ b/packages/docs-ui/project.json
@@ -12,10 +12,6 @@
     },
     "lint": {},
     "format": {},
-    "validate": {},
-    "validate:dist": {
-      "dependsOn": ["dev"],
-      "executor": "nx:noop"
-    }
+    "validate": {}
   }
 }


### PR DESCRIPTION
`validate` scripts for `braid-design-system` and `docs-ui` are run during [`postbuild`](https://github.com/seek-oss/braid-design-system/blob/f6363acac318fb9a69c38328be2d061b3a4b6bdb/package.json#L16). `validate:dist` for `docs-ui` had a dependency on its `dev` script, which results in `crackle dev` being run right before publishing, causing published artifacts to contain dev-time code that fails to resolve.

The following versions were affected by this bug:
- [`3.0.1`](www.npmjs.com/package/@braid-design-system/docs-ui/v/3.0.1)
- [`3.0.2`](www.npmjs.com/package/@braid-design-system/docs-ui/v/3.0.2)
- [`3.0.3`](www.npmjs.com/package/@braid-design-system/docs-ui/v/3.0.3)
- [`3.0.4`](www.npmjs.com/package/@braid-design-system/docs-ui/v/3.0.4)

This dependency was added in https://github.com/seek-oss/braid-design-system/pull/1535 to fix a bug, but it may no longer be necessary.