### PR TITLE
Button, ButtonLink: Ensure focus ring supports `bleed` layout

### DIFF
--- a/.changeset/all-ties-report.md
+++ b/.changeset/all-ties-report.md
@@ -1,0 +1,13 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Button
+  - ButtonLink
+---
+
+**Button, ButtonLink:** Ensure focus ring supports `bleed` layout
+
+Fixes the focus ring layout when combined with the `bleed` prop to ensure the outline wraps the visual boundary of the button.

--- a/packages/braid-design-system/src/lib/components/Button/Button.css.ts
+++ b/packages/braid-design-system/src/lib/components/Button/Button.css.ts
@@ -8,6 +8,7 @@ import { calc } from '@vanilla-extract/css-utils';
 import { rgba } from 'polished';
 
 import { colorModeStyle } from '../../css/colorModeStyle';
+import { outlineStyle } from '../../css/outlineStyle';
 import { responsiveStyle } from '../../css/responsiveStyle';
 
 import { vars } from '../../themes/vars.css';
@@ -45,6 +46,9 @@ export const hoverOverlay = style({
     },
   },
 });
+
+// Applied to nested element to keep outline correct on button using `bleed`
+export const focusRing = style(outlineStyle(`${root}:focus-visible > &`));
 
 const minHeightValueForSize = {
   standard: vars.touchableSize,

--- a/packages/braid-design-system/src/lib/components/Button/Button.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.tsx
@@ -439,6 +439,7 @@ export const useButtonStyles = ({
       width: 'full',
       borderRadius: radius,
       cursor: !loading ? 'pointer' : undefined,
+      outline: 'none',
       className: [styles.root, size === 'small' ? virtualTouchable : undefined],
     },
     content: {
@@ -458,6 +459,7 @@ export const useButtonStyles = ({
           ? colorContrast(stylesForVariant.background)
           : stylesForVariant.background,
       className: [
+        styles.focusRing,
         variant === 'soft' && lightness.lightMode === 'dark'
           ? styles.invertedBackgroundsLightMode.soft
           : null,


### PR DESCRIPTION
Fixes the focus ring layout when combined with the `bleed` prop to ensure the outline wraps the visual boundary of the button.