### PR TITLE
Migrate to trusted publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -8,6 +8,7 @@ on:
 jobs:
   release:
     name: Publish & Deploy
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     env:
       CI: true
@@ -39,7 +40,6 @@ jobs:
           publish: pnpm release
         env:
           GITHUB_TOKEN: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Build site
         if: steps.changesets.outputs.published == 'true' || steps.changesets.outputs.hasChangesets == 'false'
@@ -57,3 +57,35 @@ jobs:
           clean-exclude: |
             /preview/*
             /grad-connection/*
+  snapshot:
+    name: Publish snapshot version
+    if: github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    env:
+      CI: true
+    steps:
+      - name: Checkout Repo
+        uses: actions/checkout@v4
+        with:
+          # This makes Actions fetch all Git history so that Changesets can generate changelogs with the correct commits
+          fetch-depth: 0
+          token: ${{ secrets.SEEK_OSS_CI_GITHUB_TOKEN }}
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          cache: pnpm
+          node-version-file: package.json
+
+      - name: Install Dependencies
+        run: pnpm i
+
+      - name: Publish
+        uses: seek-oss/changesets-snapshot@v0
+        with:
+          pre-publish: pnpm prepare-publish
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master
+  workflow_dispatch:
 
 jobs:
   release:
@@ -31,6 +32,9 @@ jobs:
 
       - name: Install Dependencies
         run: pnpm i
+
+      - name: Install latest npm
+        run: npm install -g npm@latest
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
@@ -82,6 +86,9 @@ jobs:
 
       - name: Install Dependencies
         run: pnpm i
+
+      - name: Install latest npm
+        run: npm install -g npm@latest
 
       - name: Publish
         uses: seek-oss/changesets-snapshot@v0


### PR DESCRIPTION
In order to create a snapshot, just manually run the release workflow on any branch.

We're removing all of our npm tokens and moving to trusted publishing