### PR TITLE
Popover: Fix Autosuggest full width when resizing window, and MenuRenderer offset space

### DIFF
--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.tsx
@@ -12,7 +12,7 @@ import {
   useEffect,
 } from 'react';
 
-import type { ResponsiveSpace, Space } from '../../css/atoms/atoms';
+import type { ResponsiveSpace } from '../../css/atoms/atoms';
 import flattenChildren from '../../utils/flattenChildren';
 import { Box } from '../Box/Box';
 import { useBraidTheme } from '../BraidProvider/BraidThemeContext';
@@ -25,17 +25,12 @@ import buildDataAttributes, {
 } from '../private/buildDataAttributes';
 import { getNextIndex } from '../private/getNextIndex';
 import { normalizeKey } from '../private/normalizeKey';
-import { useResponsiveValue } from '../useResponsiveValue/useResponsiveValue';
 
 import { type Action, actionTypes } from './MenuRenderer.actions';
 import { MenuRendererContext } from './MenuRendererContext';
 import { MenuRendererItemContext } from './MenuRendererItemContext';
 
 import * as styles from './MenuRenderer.css';
-import {
-  normalizeResponsiveValue,
-  type RequiredResponsiveObject,
-} from '../../css/atoms/sprinkles.css';
 import { vars } from '../../themes/vars.css';
 
 interface TriggerProps {
@@ -115,27 +110,6 @@ export const MenuRenderer = ({
   data,
   ...restProps
 }: MenuRendererProps) => {
-  const responsiveValue = useResponsiveValue();
-  const resolveOffsetSpace = (): Space => {
-    if (typeof offsetSpace === 'string') {
-      return offsetSpace;
-    }
-
-    const normalizedOffsetSpace = normalizeResponsiveValue(offsetSpace);
-    const offsetSpaceForResponsiveValue: RequiredResponsiveObject<Space> = {
-      mobile: normalizedOffsetSpace.mobile ?? 'none',
-      tablet: normalizedOffsetSpace.tablet,
-      desktop: normalizedOffsetSpace.desktop,
-      wide: normalizedOffsetSpace.wide,
-    };
-
-    return (
-      responsiveValue(offsetSpaceForResponsiveValue) ??
-      offsetSpaceForResponsiveValue.mobile
-    );
-  };
-  const resolvedOffsetSpace = resolveOffsetSpace();
-
   const buttonRef = useRef<HTMLButtonElement>(null);
   const lastOpen = useRef(false);
   const items = flattenChildren(children);
@@ -314,7 +288,7 @@ export const MenuRenderer = ({
         triggerRef={triggerProps.ref}
         align={align}
         placement={placement}
-        offsetSpace={resolvedOffsetSpace}
+        offsetSpace={offsetSpace}
         role={false}
       >
         <Menu

--- a/packages/braid-design-system/src/lib/components/private/Popover/Popover.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Popover/Popover.tsx
@@ -23,10 +23,12 @@ import {
 import type { ResponsiveSpace } from '../../../css/atoms/atoms';
 import { Box } from '../../Box/Box';
 import { BraidPortal } from '../../BraidPortal/BraidPortal';
+import { useResponsiveValue } from '../../useResponsiveValue/useResponsiveValue';
 import { useSpace } from '../../useSpace/useSpace';
 import { animationTimeout } from '../animationTimeout';
 
 import * as styles from './Popover.css';
+import { normalizeResponsiveValue } from '../../../css/atoms/sprinkles.css';
 
 type Placement = 'top' | 'bottom';
 type Align = 'left' | 'right' | 'center';
@@ -125,10 +127,19 @@ const PopoverContent = forwardRef<HTMLElement, PopoverProps>(
   ) => {
     const ref = useRef<HTMLElement>(null);
     useImperativeHandle(forwardedRef, () => ref.current as HTMLElement);
+
+    const normalized = normalizeResponsiveValue(offsetSpace);
+    const mobile = normalized.mobile ?? 'none';
+    const tablet = normalized.tablet ?? mobile;
+    const desktop = normalized.desktop ?? tablet;
+    const wide = normalized.wide ?? desktop;
+    const resolvedOffsetSpace =
+      useResponsiveValue()({ mobile, tablet, desktop, wide }) ?? mobile;
+
     const spaceScale = useSpace();
     let offsetSpacePx = 0;
-    if (offsetSpace !== 'none' && typeof offsetSpace === 'string') {
-      offsetSpacePx = spaceScale.space[offsetSpace] * spaceScale.grid;
+    if (resolvedOffsetSpace !== 'none') {
+      offsetSpacePx = spaceScale.space[resolvedOffsetSpace] * spaceScale.grid;
     }
 
     const floatingUiRequestedPosition = getFloatingUiPosition(placement, align);


### PR DESCRIPTION
Following from #1926 noticing these two issues with the migration to `floating-ui/react-dom` after testing.

Each commit can be reviewed individually. Not adding a changeset as this should bring the behaviour back to master.