### PR TITLE
ButtonIcon, TooltipRenderer: Close tooltips after click on desktop

### DIFF
--- a/.changeset/cozy-dryers-train.md
+++ b/.changeset/cozy-dryers-train.md
@@ -1,0 +1,11 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - ButtonIcon
+  - TooltipRenderer
+---
+
+**ButtonIcon, TooltipRenderer:** Close tooltips after clicking the trigger on desktop devices

--- a/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.tsx
@@ -212,6 +212,7 @@ export const TooltipRenderer = ({
         triggerRef.current.addEventListener('focus', openTooltip);
         triggerRef.current.addEventListener('mouseenter', openTooltip);
         triggerRef.current.addEventListener('mouseleave', closeTooltip);
+        triggerRef.current.addEventListener('click', closeTooltip);
       }
     }
 
@@ -225,6 +226,7 @@ export const TooltipRenderer = ({
           triggerRef.current.removeEventListener('focus', openTooltip);
           triggerRef.current.removeEventListener('mouseenter', openTooltip);
           triggerRef.current.removeEventListener('mouseleave', closeTooltip);
+          triggerRef.current.removeEventListener('click', closeTooltip);
         }
       }
     };


### PR DESCRIPTION
Been around for a bit, but it's annoying me now. 

For things like `Dialog` you will see the close button tooltip stay after clicking it during the close animation, which is pretty janky. Once the interaction is done, the tooltip no longer serves a purpose and should be hidden imo.