### PR TITLE
`site`: Replace some `braid-src` imports with public `braid-design-system` entrypoints

### DIFF
--- a/site/sku.config.ts
+++ b/site/sku.config.ts
@@ -3,6 +3,7 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 import type { SkuConfig } from 'sku';
+import { DefinePlugin } from 'webpack';
 
 import routes from './sku.routes';
 
@@ -50,6 +51,12 @@ const skuConfig: SkuConfig = {
       test: resolveFromBraid('CHANGELOG.md'),
       type: 'asset/source',
     });
+
+    config.plugins.push(
+      new DefinePlugin({
+        'globalThis.__IS_PLAYROOM_ENVIRONMENT__': JSON.stringify('clearly'),
+      }),
+    );
 
     return config;
   },

--- a/site/src/App/App.tsx
+++ b/site/src/App/App.tsx
@@ -1,10 +1,10 @@
-import 'braid-src/reset';
+import 'braid-design-system/reset';
 
 import {
   BraidProvider,
   ToastProvider,
   makeLinkComponent,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
 import { darkMode } from 'braid-src/lib/css/atoms/sprinkles.css';
 import docsTheme from 'braid-src/themes/docs';
 import { StrictMode, useEffect } from 'react';

--- a/site/src/App/Code/Code.tsx
+++ b/site/src/App/Code/Code.tsx
@@ -8,7 +8,7 @@ import {
   IconPositive,
   IconCopy,
   IconVideo,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
 // TODO: COLORMODE RELEASE
 // Use public import
 import { type BoxProps, Box } from 'braid-src/lib/components/Box/Box';

--- a/site/src/App/DocNavigation/DocDetails.tsx
+++ b/site/src/App/DocNavigation/DocDetails.tsx
@@ -7,7 +7,7 @@ import {
   Secondary,
   Text,
   Heading,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
 import { PlayroomStateProvider } from 'braid-src/lib/playroom/playroomState';
 import { useContext, useMemo } from 'react';
 

--- a/site/src/App/DocNavigation/DocExample.tsx
+++ b/site/src/App/DocNavigation/DocExample.tsx
@@ -1,4 +1,4 @@
-import { Stack } from 'braid-src/lib/components';
+import { Stack } from 'braid-design-system';
 import type { ReactNode } from 'react';
 
 import type { ComponentExample } from '../../types';

--- a/site/src/App/DocNavigation/DocNavigation.tsx
+++ b/site/src/App/DocNavigation/DocNavigation.tsx
@@ -12,7 +12,7 @@ import {
   Inline,
   ButtonIcon,
   IconChevron,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
 import type { BadgeProps } from 'braid-src/lib/components/Badge/Badge';
 import { useBackgroundLightness } from 'braid-src/lib/components/Box/BackgroundContext';
 import { negativeMargin } from 'braid-src/lib/css/negativeMargin/negativeMargin';

--- a/site/src/App/DocNavigation/DocProps.tsx
+++ b/site/src/App/DocNavigation/DocProps.tsx
@@ -14,7 +14,7 @@ import {
   TextLink,
   IconInfo,
   Heading,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
 import partition from 'lodash.partition';
 import { Fragment, useContext, useMemo } from 'react';
 

--- a/site/src/App/DocNavigation/DocReleases.tsx
+++ b/site/src/App/DocNavigation/DocReleases.tsx
@@ -9,7 +9,7 @@ import {
   Spread,
   List,
   Divider,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
 import { Fragment, useContext } from 'react';
 
 import { Markdown } from '../Markdown/Markdown';

--- a/site/src/App/DocNavigation/DocSection.tsx
+++ b/site/src/App/DocNavigation/DocSection.tsx
@@ -5,7 +5,7 @@ import {
   Heading,
   Bleed,
   HiddenVisually,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
 import type { ResponsiveSpace } from 'braid-src/lib/css/atoms/atoms';
 import { PlayroomStateProvider } from 'braid-src/lib/playroom/playroomState';
 

--- a/site/src/App/DocNavigation/DocSnippets.tsx
+++ b/site/src/App/DocNavigation/DocSnippets.tsx
@@ -1,4 +1,4 @@
-import { Stack, Text } from 'braid-src/lib/components';
+import { Stack, Text } from 'braid-design-system';
 import { PlayroomStateProvider } from 'braid-src/lib/playroom/playroomState';
 import { Fragment, useContext } from 'react';
 

--- a/site/src/App/DocNavigation/DocToC.tsx
+++ b/site/src/App/DocNavigation/DocToC.tsx
@@ -1,4 +1,4 @@
-import { Text, Box, Stack, Link } from 'braid-src/lib/components';
+import { Text, Box, Stack, Link } from 'braid-design-system';
 import { ScrollContainer } from 'braid-src/lib/components/private/ScrollContainer/ScrollContainer';
 import { useEffect, useState } from 'react';
 

--- a/site/src/App/InlineCode/InlineCode.tsx
+++ b/site/src/App/InlineCode/InlineCode.tsx
@@ -1,4 +1,4 @@
-import { Box } from 'braid-src/lib/components';
+import { Box } from 'braid-design-system';
 
 import * as styles from './InlineCode.css';
 

--- a/site/src/App/JumpToModal/JumpToModal.tsx
+++ b/site/src/App/JumpToModal/JumpToModal.tsx
@@ -1,10 +1,4 @@
-import {
-  Box,
-  Dialog,
-  TextField,
-  IconSearch,
-  Bleed,
-} from 'braid-src/lib/components';
+import { Box, Dialog, TextField, IconSearch, Bleed } from 'braid-design-system';
 import { ScrollContainer } from 'braid-src/lib/components/private/ScrollContainer/ScrollContainer';
 import { useEffect, useRef, useState, useMemo } from 'react';
 import { useNavigate } from 'react-router';

--- a/site/src/App/JumpToModal/SearchResults.tsx
+++ b/site/src/App/JumpToModal/SearchResults.tsx
@@ -9,7 +9,7 @@ import {
   Bleed,
   ButtonLink,
   Spread,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
 
 import type { GroupedResults, SearchItem } from './getSearchItems';
 

--- a/site/src/App/Logo/Logo.tsx
+++ b/site/src/App/Logo/Logo.tsx
@@ -1,4 +1,4 @@
-import { Box } from 'braid-src/lib/components';
+import { Box } from 'braid-design-system';
 import * as typographyStyles from 'braid-src/lib/css/typography.css';
 
 interface LogoProps {

--- a/site/src/App/Markdown/Markdown.tsx
+++ b/site/src/App/Markdown/Markdown.tsx
@@ -7,7 +7,7 @@ import {
   Strong,
   Box,
   TextLink,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
 import { TextContext } from 'braid-src/lib/components/Text/TextContext';
 import type { ReactNodeNoStrings } from 'braid-src/lib/components/private/ReactNodeNoStrings';
 import { DefaultTextPropsProvider } from 'braid-src/lib/components/private/defaultTextProps';

--- a/site/src/App/Markdown/Markdown.tsx
+++ b/site/src/App/Markdown/Markdown.tsx
@@ -9,15 +9,16 @@ import {
   TextLink,
 } from 'braid-design-system';
 import { TextContext } from 'braid-src/lib/components/Text/TextContext';
-import type { ReactNodeNoStrings } from 'braid-src/lib/components/private/ReactNodeNoStrings';
 import { DefaultTextPropsProvider } from 'braid-src/lib/components/private/defaultTextProps';
-import { Children } from 'react';
+import { Children, type ComponentProps } from 'react';
 import ReactMarkdown, { type Components } from 'react-markdown';
 import { SKIP, visit } from 'unist-util-visit';
 
 import { CodeBlock } from '../Code/Code';
 import type { SupportedLanguage } from '../Code/supportedLanguages';
 import { InlineCode } from '../InlineCode/InlineCode';
+
+type ReactNodeNoStrings = ComponentProps<typeof Stack>['children'];
 
 const Code = ({ lang, value }: { lang: string | null; value: string }) => (
   <TextContext.Provider value={null}>

--- a/site/src/App/Navigation/Navigation.tsx
+++ b/site/src/App/Navigation/Navigation.tsx
@@ -9,7 +9,7 @@ import {
   MenuRenderer,
   Text,
   useResponsiveValue,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
 // TODO: COLORMODE RELEASE
 // Use public import
 import { type BoxProps, Box } from 'braid-src/lib/components/Box/Box';

--- a/site/src/App/SideNavigation/SideNavigation.tsx
+++ b/site/src/App/SideNavigation/SideNavigation.tsx
@@ -1,5 +1,5 @@
 import { SideNavigationSection } from '@braid-design-system/docs-ui';
-import { Stack } from 'braid-src/lib/components';
+import { Stack } from 'braid-design-system';
 import { useMemo } from 'react';
 import { matchPath, useLocation } from 'react-router';
 

--- a/site/src/App/TextStack/TextStack.tsx
+++ b/site/src/App/TextStack/TextStack.tsx
@@ -1,4 +1,4 @@
-import { Stack } from 'braid-src/lib/components';
+import { Stack } from 'braid-design-system';
 import type { StackProps } from 'braid-src/lib/components/Stack/Stack';
 import type { ReactNodeNoStrings } from 'braid-src/lib/components/private/ReactNodeNoStrings';
 

--- a/site/src/App/TextStack/TextStack.tsx
+++ b/site/src/App/TextStack/TextStack.tsx
@@ -1,9 +1,10 @@
 import { Stack } from 'braid-design-system';
-import type { StackProps } from 'braid-src/lib/components/Stack/Stack';
-import type { ReactNodeNoStrings } from 'braid-src/lib/components/private/ReactNodeNoStrings';
+import type { ComponentProps } from 'react';
+
+type StackProps = ComponentProps<typeof Stack>;
 
 interface TextStackProps {
-  children: ReactNodeNoStrings;
+  children: StackProps['children'];
   space?: StackProps['space'];
 }
 

--- a/site/src/App/ThemeSetting/ThemeToggle.tsx
+++ b/site/src/App/ThemeSetting/ThemeToggle.tsx
@@ -1,4 +1,4 @@
-import { Text, TextDropdown } from 'braid-src/lib/components';
+import { Text, TextDropdown } from 'braid-design-system';
 import type { TextProps } from 'braid-src/lib/components/Text/Text';
 import * as themes from 'braid-src/lib/themes';
 import { Fragment } from 'react';

--- a/site/src/App/ThemeSetting/ThemedExample.tsx
+++ b/site/src/App/ThemeSetting/ThemedExample.tsx
@@ -1,4 +1,4 @@
-import { BraidProvider } from 'braid-src/lib/components';
+import { BraidProvider } from 'braid-design-system';
 import { type BoxProps, Box } from 'braid-src/lib/components/Box/Box';
 import type { ReactNode } from 'react';
 

--- a/site/src/App/navigationHelpers.ts
+++ b/site/src/App/navigationHelpers.ts
@@ -1,5 +1,5 @@
+import * as components from 'braid-design-system';
 import * as css from 'braid-src/css';
-import * as components from 'braid-src/lib/components';
 import type { Snippets } from 'braid-src/lib/components/private/Snippets';
 import * as testComponents from 'braid-src/test';
 

--- a/site/src/App/routes/examples/basic-form/basic-form.tsx
+++ b/site/src/App/routes/examples/basic-form/basic-form.tsx
@@ -11,14 +11,14 @@ import {
   Button,
   Actions,
   filterSuggestions,
-} from 'braid-src/lib/components';
-import type { ReactNodeNoStrings } from 'braid-src/lib/components/private/ReactNodeNoStrings';
+} from 'braid-design-system';
 import {
   Autosuggest,
   TextField,
   MonthPicker,
   Textarea,
-} from 'braid-src/lib/playroom/components';
+} from 'braid-design-system/playroom/components';
+import type { ReactNodeNoStrings } from 'braid-src/lib/components/private/ReactNodeNoStrings';
 import type { ComponentProps } from 'react';
 
 import type { Page } from '../../../../types';

--- a/site/src/App/routes/examples/basic-form/basic-form.tsx
+++ b/site/src/App/routes/examples/basic-form/basic-form.tsx
@@ -18,7 +18,6 @@ import {
   MonthPicker,
   Textarea,
 } from 'braid-design-system/playroom/components';
-import type { ReactNodeNoStrings } from 'braid-src/lib/components/private/ReactNodeNoStrings';
 import type { ComponentProps } from 'react';
 
 import type { Page } from '../../../../types';
@@ -28,7 +27,7 @@ import { TextStack } from '../../../TextStack/TextStack';
 
 interface StepProps {
   heading?: string;
-  detail: ReactNodeNoStrings;
+  detail: ComponentProps<typeof Stack>['children'];
   children: ComponentProps<typeof Code>['children'];
 }
 const Step = ({ heading, detail, children }: StepProps) => (

--- a/site/src/App/routes/examples/job-summary/job-summary.tsx
+++ b/site/src/App/routes/examples/job-summary/job-summary.tsx
@@ -19,13 +19,14 @@ import {
   Spread,
 } from 'braid-design-system';
 import { Placeholder } from 'braid-design-system/playroom/components';
-import type { ReactNodeNoStrings } from 'braid-src/lib/components/private/ReactNodeNoStrings';
 import type { ComponentProps } from 'react';
 
 import type { Page } from '../../../../types';
 import Code from '../../../Code/Code';
 import { PageTitle } from '../../../Seo/PageTitle';
 import { TextStack } from '../../../TextStack/TextStack';
+
+type ReactNodeNoStrings = ComponentProps<typeof Stack>['children'];
 
 interface StepProps {
   heading?: string;

--- a/site/src/App/routes/examples/job-summary/job-summary.tsx
+++ b/site/src/App/routes/examples/job-summary/job-summary.tsx
@@ -17,9 +17,9 @@ import {
   List,
   ButtonIcon,
   Spread,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
+import { Placeholder } from 'braid-design-system/playroom/components';
 import type { ReactNodeNoStrings } from 'braid-src/lib/components/private/ReactNodeNoStrings';
-import { Placeholder } from 'braid-src/lib/playroom/components';
 import type { ComponentProps } from 'react';
 
 import type { Page } from '../../../../types';

--- a/site/src/App/routes/examples/marketing-banner/marketing-banner.tsx
+++ b/site/src/App/routes/examples/marketing-banner/marketing-banner.tsx
@@ -13,9 +13,9 @@ import {
   Box,
   ContentBlock,
   Button,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
+import { Placeholder } from 'braid-design-system/playroom/components';
 import type { ReactNodeNoStrings } from 'braid-src/lib/components/private/ReactNodeNoStrings';
-import { Placeholder } from 'braid-src/lib/playroom/components';
 import type { ComponentProps } from 'react';
 
 import type { Page } from '../../../../types';

--- a/site/src/App/routes/examples/marketing-banner/marketing-banner.tsx
+++ b/site/src/App/routes/examples/marketing-banner/marketing-banner.tsx
@@ -15,7 +15,6 @@ import {
   Button,
 } from 'braid-design-system';
 import { Placeholder } from 'braid-design-system/playroom/components';
-import type { ReactNodeNoStrings } from 'braid-src/lib/components/private/ReactNodeNoStrings';
 import type { ComponentProps } from 'react';
 
 import type { Page } from '../../../../types';
@@ -25,7 +24,7 @@ import { TextStack } from '../../../TextStack/TextStack';
 
 interface StepProps {
   heading?: string;
-  detail: ReactNodeNoStrings;
+  detail: ComponentProps<typeof Stack>['children'];
   children: ComponentProps<typeof Code>['children'];
 }
 const Step = ({ heading, detail, children }: StepProps) => (

--- a/site/src/App/routes/foundations/iconography/IconsBrowse.tsx
+++ b/site/src/App/routes/foundations/iconography/IconsBrowse.tsx
@@ -7,7 +7,7 @@ import {
   TextField,
   IconSearch,
   Strong,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
 import * as icons from 'braid-src/lib/components/icons';
 import { Overlay } from 'braid-src/lib/components/private/Overlay/Overlay';
 import didYouMean, { ReturnTypeEnums } from 'didyoumean2';

--- a/site/src/App/routes/foundations/iconography/IconsDetails.tsx
+++ b/site/src/App/routes/foundations/iconography/IconsDetails.tsx
@@ -22,7 +22,7 @@ import {
   IconMinus,
   List,
   IconRenderer,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
 import { iconScaleIncrease } from 'braid-src/lib/hooks/useIcon/icon.css';
 import { PlayroomStateProvider } from 'braid-src/lib/playroom/playroomState';
 

--- a/site/src/App/routes/foundations/iconography/iconography.tsx
+++ b/site/src/App/routes/foundations/iconography/iconography.tsx
@@ -1,4 +1,4 @@
-import { Stack, Heading } from 'braid-src/lib/components';
+import { Stack, Heading } from 'braid-design-system';
 import { Outlet, Route } from 'react-router';
 
 import type { Page } from '../../../../types';

--- a/site/src/App/routes/foundations/layout/layout.tsx
+++ b/site/src/App/routes/foundations/layout/layout.tsx
@@ -25,9 +25,9 @@ import {
   PageBlock,
   Page,
   Spread,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
+import { Placeholder } from 'braid-design-system/playroom/components';
 import { ContainerForPageDocs } from 'braid-src/lib/components/Page/Page.docs';
-import { Placeholder } from 'braid-src/lib/playroom/components';
 import tokens from 'braid-src/lib/themes/wireframe/tokens';
 
 import type { Page as DocsPage } from '../../../../types';

--- a/site/src/App/routes/foundations/tones/tones.tsx
+++ b/site/src/App/routes/foundations/tones/tones.tsx
@@ -7,7 +7,7 @@ import {
   Stack,
   Divider,
   Hidden,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
 // TODO: COLORMODE RELEASE
 // Use public import
 import { type BoxProps, Box } from 'braid-src/lib/components/Box/Box';

--- a/site/src/App/routes/gallery/Gallery.tsx
+++ b/site/src/App/routes/gallery/Gallery.tsx
@@ -22,7 +22,7 @@ import {
   IconCopy,
   ButtonIcon,
   Spread,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
 // TODO: COLORMODE RELEASE
 // Use public import
 import { Box } from 'braid-src/lib/components/Box/Box';

--- a/site/src/App/routes/gallery/GalleryPanel.tsx
+++ b/site/src/App/routes/gallery/GalleryPanel.tsx
@@ -1,4 +1,4 @@
-import { Box } from 'braid-src/lib/components';
+import { Box } from 'braid-design-system';
 import { Overlay } from 'braid-src/lib/components/private/Overlay/Overlay';
 import type { ReactNodeNoStrings } from 'braid-src/lib/components/private/ReactNodeNoStrings';
 

--- a/site/src/App/routes/gallery/GalleryPanel.tsx
+++ b/site/src/App/routes/gallery/GalleryPanel.tsx
@@ -1,6 +1,6 @@
-import { Box } from 'braid-design-system';
+import { Box, type Stack } from 'braid-design-system';
 import { Overlay } from 'braid-src/lib/components/private/Overlay/Overlay';
-import type { ReactNodeNoStrings } from 'braid-src/lib/components/private/ReactNodeNoStrings';
+import type { ComponentProps } from 'react';
 
 import * as styles from './gallery.css';
 
@@ -11,7 +11,7 @@ export const GalleryPanel = ({
   right,
   top,
 }: {
-  children: ReactNodeNoStrings;
+  children: ComponentProps<typeof Stack>['children'];
   bottom?: boolean;
   left?: boolean;
   right?: boolean;

--- a/site/src/App/routes/gallery/index.tsx
+++ b/site/src/App/routes/gallery/index.tsx
@@ -1,4 +1,4 @@
-import { Box } from 'braid-src/lib/components';
+import { Box } from 'braid-design-system';
 import { darkMode } from 'braid-src/lib/css/atoms/sprinkles.css';
 import { parseToHsl, setLightness } from 'polished';
 import { useState, useEffect } from 'react';

--- a/site/src/App/routes/guides/contribution.tsx
+++ b/site/src/App/routes/guides/contribution.tsx
@@ -1,11 +1,5 @@
 import { LinkableHeading } from '@braid-design-system/docs-ui';
-import {
-  Heading,
-  Text,
-  TextLink,
-  Strong,
-  Divider,
-} from 'braid-src/lib/components';
+import { Heading, Text, TextLink, Strong, Divider } from 'braid-design-system';
 
 import type { Page } from '../../../types';
 import { PageTitle } from '../../Seo/PageTitle';

--- a/site/src/App/routes/guides/design-workflow.tsx
+++ b/site/src/App/routes/guides/design-workflow.tsx
@@ -1,11 +1,5 @@
 import { LinkableHeading } from '@braid-design-system/docs-ui';
-import {
-  Heading,
-  Text,
-  TextLink,
-  Divider,
-  List,
-} from 'braid-src/lib/components';
+import { Heading, Text, TextLink, Divider, List } from 'braid-design-system';
 
 import type { Page } from '../../../types';
 import { useConfig } from '../../ConfigContext';

--- a/site/src/App/routes/guides/development-workflow.tsx
+++ b/site/src/App/routes/guides/development-workflow.tsx
@@ -12,7 +12,7 @@ import {
   Columns,
   Column,
   Box,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
 
 import type { Page } from '../../../types';
 import Code from '../../Code/Code';

--- a/site/src/App/routes/guides/playroom-prototyping.tsx
+++ b/site/src/App/routes/guides/playroom-prototyping.tsx
@@ -17,7 +17,7 @@ import {
   Box,
   Columns,
   Column,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
 import {
   Checkbox,
   Drawer,
@@ -26,7 +26,7 @@ import {
   PlaceholderFooter,
   PlaceholderHeader,
   TextField,
-} from 'braid-src/lib/playroom/components';
+} from 'braid-design-system/playroom/components';
 
 import type { Page } from '../../../types';
 import Code from '../../Code/Code';

--- a/site/src/App/routes/guides/testing-guide.tsx
+++ b/site/src/App/routes/guides/testing-guide.tsx
@@ -6,7 +6,7 @@ import {
   TextLink,
   List,
   Strong,
-} from 'braid-src/lib/components';
+} from 'braid-design-system';
 
 import type { Page } from '../../../types';
 import Code from '../../Code/Code';

--- a/site/src/App/routes/home/index.tsx
+++ b/site/src/App/routes/home/index.tsx
@@ -1,10 +1,4 @@
-import {
-  Text,
-  TextLink,
-  Stack,
-  Heading,
-  Divider,
-} from 'braid-src/lib/components';
+import { Text, TextLink, Stack, Heading, Divider } from 'braid-design-system';
 
 import { useConfig } from '../../ConfigContext';
 

--- a/site/src/playroom.components.ts
+++ b/site/src/playroom.components.ts
@@ -1,3 +1,3 @@
-import 'braid-src/reset';
+import 'braid-design-system/reset';
 
 export * from 'braid-design-system/playroom/components';

--- a/site/src/playroom.frame.ts
+++ b/site/src/playroom.frame.ts
@@ -1,3 +1,3 @@
-import 'braid-src/reset';
+import 'braid-design-system/reset';
 
 export { default } from 'braid-design-system/playroom/FrameComponent';

--- a/site/src/playroom.scope.ts
+++ b/site/src/playroom.scope.ts
@@ -1,3 +1,3 @@
-import 'braid-src/reset';
+import 'braid-design-system/reset';
 
 export { default } from 'braid-design-system/playroom/scope';

--- a/site/src/types.d.ts
+++ b/site/src/types.d.ts
@@ -6,7 +6,7 @@ import type { ReactNode, ReactElement, ComponentProps } from 'react';
 import type { HelmetData } from 'react-helmet-async';
 import type { RouteProps } from 'react-router';
 
-type ReactNodeNoStrings = ComponentProps<typeof Stack>;
+type ReactNodeNoStrings = ComponentProps<typeof Stack>['children'];
 
 export interface AppConfig {
   playroomUrl: string;

--- a/site/src/types.d.ts
+++ b/site/src/types.d.ts
@@ -1,10 +1,12 @@
 import type { Source } from '@braid-design-system/source.macro';
+import type { Stack } from 'braid-design-system';
 import type useScope from 'braid-design-system/playroom/scope';
 import type { BoxProps } from 'braid-src/lib/components/Box/Box';
-import type { ReactNodeNoStrings } from 'braid-src/lib/components/private/ReactNodeNoStrings';
-import type { ReactNode, ReactElement } from 'react';
+import type { ReactNode, ReactElement, ComponentProps } from 'react';
 import type { HelmetData } from 'react-helmet-async';
 import type { RouteProps } from 'react-router';
+
+type ReactNodeNoStrings = ComponentProps<typeof Stack>;
 
 export interface AppConfig {
   playroomUrl: string;

--- a/site/src/types.d.ts
+++ b/site/src/types.d.ts
@@ -1,7 +1,7 @@
 import type { Source } from '@braid-design-system/source.macro';
+import type useScope from 'braid-design-system/playroom/scope';
 import type { BoxProps } from 'braid-src/lib/components/Box/Box';
 import type { ReactNodeNoStrings } from 'braid-src/lib/components/private/ReactNodeNoStrings';
-import type useScope from 'braid-src/lib/playroom/useScope';
 import type { ReactNode, ReactElement } from 'react';
 import type { HelmetData } from 'react-helmet-async';
 import type { RouteProps } from 'react-router';


### PR DESCRIPTION
- `'braid-src/lib/components'` -> `braid-design-system`
- `'braid-src/reset'` -> `'braid-design-system/reset'`
- `'braid-src/lib/playroom/useScope'` -> `'braid-design-system/playroom/scope'`
- `'braid-src/lib/playroom/components'` -> `'braid-design-system/playroom/components'`

Also replaced `ReactNodeNoStrings` private imports with derived types.

As a side-effect, the site no longer skips the `globalThis.__IS_PLAYROOM_ENVIRONMENT__` check because it's now using the public playroom components entrypoint - I added a webpack `DefinePlugin` to solve this.