### PR TITLE
Drawer: Rollback unintentional horizontal gutter change

### DIFF
--- a/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
@@ -132,8 +132,10 @@ const ModalContentScrollLayout = ({
   applyCoverImageHeightLimit,
   contentStartRef,
   coverImageEnabled,
+  applyPageBlockGutters,
 }: {
   children: ReactNode;
+  applyPageBlockGutters: boolean;
   applyCoverImageHeightLimit?: boolean;
   contentStartRef?: Ref<HTMLDivElement>;
   coverImageEnabled?: boolean;
@@ -156,7 +158,8 @@ const ModalContentScrollLayout = ({
         display="flex"
         gap="large"
         flexDirection="column"
-        padding={modalPadding}
+        paddingY={modalPadding}
+        paddingX={applyPageBlockGutters ? pageBlockGutters : modalPadding}
       >
         {children}
       </Box>
@@ -251,6 +254,7 @@ export const ModalContent = ({
   const modalLayout = (
     <ModalContentScrollLayout
       applyCoverImageHeightLimit={allowColumnLayout}
+      applyPageBlockGutters={isDrawer}
       contentStartRef={contentStartRef}
       coverImageEnabled={coverImageEnabled}
     >


### PR DESCRIPTION
Rolling back an unintentional change to the horizontal gutter of Drawer ([before]/[after]) that crept in during the cover image support for Dialog. The vertical padding should always be consistent, but the horizontal padding on a Drawer should follow the `PageBlock` gutters.

No changeset as we are correcting this before we release. Changesets in master are correct.


[before]: https://github.com/seek-oss/braid-design-system/blob/b62350a4bed0a985778ecbc5d17c3fe317f12ef8/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx#L166-L167
[after]: https://github.com/seek-oss/braid-design-system/blob/ef0e973068ed1d667e18c7e0033280aaade796a3/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx#L159