### PR TITLE
Drawer: Fix unintentional reduction in available content height

### DIFF
--- a/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
@@ -133,12 +133,14 @@ const ModalContentScrollLayout = ({
   contentStartRef,
   coverImageEnabled,
   applyPageBlockGutters,
+  applyFullHeight,
 }: {
   children: ReactNode;
   applyPageBlockGutters: boolean;
   applyCoverImageHeightLimit?: boolean;
   contentStartRef?: Ref<HTMLDivElement>;
   coverImageEnabled?: boolean;
+  applyFullHeight?: boolean;
 }) => (
   <ScrollContainer direction="vertical">
     {
@@ -153,11 +155,13 @@ const ModalContentScrollLayout = ({
       className={
         applyCoverImageHeightLimit ? styles.coverImageHeightLimit : undefined
       }
+      height={applyFullHeight ? 'full' : undefined}
     >
       <Box
         display="flex"
         gap="large"
         flexDirection="column"
+        height={applyFullHeight ? 'full' : undefined}
         paddingY={modalPadding}
         paddingX={applyPageBlockGutters ? pageBlockGutters : modalPadding}
       >
@@ -255,6 +259,7 @@ export const ModalContent = ({
     <ModalContentScrollLayout
       applyCoverImageHeightLimit={allowColumnLayout}
       applyPageBlockGutters={isDrawer}
+      applyFullHeight={isDrawer}
       contentStartRef={contentStartRef}
       coverImageEnabled={coverImageEnabled}
     >


### PR DESCRIPTION
Another unintentional regression caught by the screen shots. The propagation of height full must carry through to ensure content is able to consume the available space in the Drawer.

No changeset as we are correcting before release