### PR TITLE
Dialog: Apply screenshot override to coverImage height limit

### DIFF
--- a/packages/braid-design-system/src/lib/components/Dialog/coverImagePlaceholder.css.ts
+++ b/packages/braid-design-system/src/lib/components/Dialog/coverImagePlaceholder.css.ts
@@ -1,4 +1,4 @@
-export const coverImagePlaceholderUrl = `${`data:image/svg+xml;base64,${Buffer.from(
+export const coverImagePlaceholderUrl = `data:image/svg+xml;base64,${Buffer.from(
   `<svg
 xmlns="http://www.w3.org/2000/svg"
 height="450"
@@ -9,4 +9,4 @@ style="background: #051A49;"
 <circle cx="400" cy="225" r="80" fill="#E60278" />
 </svg>
 `,
-).toString('base64')}`}`;
+).toString('base64')}`;

--- a/packages/braid-design-system/src/lib/components/private/Modal/Modal.css.ts
+++ b/packages/braid-design-system/src/lib/components/private/Modal/Modal.css.ts
@@ -173,7 +173,10 @@ export const maximumHeightForCoverImage = '60vh';
 export const coverImageHeightLimit = style(
   responsiveStyle({
     tablet: {
-      maxHeight: maximumHeightForCoverImage,
+      maxHeight: fallbackVar(
+        overrideMaxHeightForScreenshot,
+        maximumHeightForCoverImage,
+      ),
     },
   }),
 );


### PR DESCRIPTION
Fix for the Chromatic screenshots which render a Dialog a little differently — they render the content outside of the normal modal container so it can be screenshot. This means when trying to override the max-height for screenshot testing we need to ensure no elements are incorrectly sizing off the window or external nodes.

Also removed the unnecessary double string interpolation for the test image.