### PR TITLE
storybook: Condifure braid-dev customCondition

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "build:docs-ui": "nx run docs-ui:build",
     "build:site": "nx run site:build",
     "build:codemod": "nx run codemod:build",
-    "postbuild": "concurrently --group 'pnpm:test:integration' 'pnpm:validate'",
+    "postbuild": "concurrently --group 'pnpm:test:integration' 'pnpm:validate' 'pnpm:storybook:build'",
     "storybook": "nx run braid-design-system:generate && nx run storybook:dev",
     "storybook:build": "nx run braid-design-system:generate && nx run storybook:build",
     "storybook:chromatic": "nx run storybook:chromatic",

--- a/storybook/main.ts
+++ b/storybook/main.ts
@@ -47,6 +47,10 @@ const config: StorybookConfig = {
       'braid-storybook': import.meta.dirname,
       'braid-src': braidSrc,
     };
+    skuConfig.resolve.conditionNames = [
+      ...(skuConfig.resolve?.conditionNames ?? []),
+      'braid-dev',
+    ];
 
     return skuConfig;
   },


### PR DESCRIPTION
In recent changes we missed configuring the `braid-dev` custom condition for Storybook. This fixes the Storybook build and adds it to `validate` so we catch it earlier next time.