### PR TITLE
Textarea: Ensure focus ring displays correctly

### DIFF
--- a/.changeset/gold-ghosts-pay.md
+++ b/.changeset/gold-ghosts-pay.md
@@ -1,0 +1,10 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Textarea
+---
+
+**Textarea:** Ensure focus ring displays correctly

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.css.ts
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.css.ts
@@ -1,5 +1,6 @@
 import { style } from '@vanilla-extract/css';
 
+import { outlineStyle } from '../../css/outlineStyle';
 import { fieldPaddingX } from '../private/Field/fieldPaddingX';
 
 import { vars } from '../../themes/vars.css';
@@ -8,7 +9,10 @@ export const field = style({
   resize: 'vertical',
   background: 'transparent',
   minHeight: vars.touchableSize,
+  outline: 'none',
 });
+
+export const focusRing = style(outlineStyle('&:focus-within'));
 
 export const highlights = style({
   color: 'transparent !important',

--- a/packages/braid-design-system/src/lib/components/Textarea/Textarea.tsx
+++ b/packages/braid-design-system/src/lib/components/Textarea/Textarea.tsx
@@ -156,6 +156,7 @@ export const Textarea = forwardRef<HTMLTextAreaElement, TextareaProps>(
             zIndex={0}
             background={background}
             borderRadius={borderRadius}
+            className={styles.focusRing}
           >
             {hasHighlights ? (
               <Box


### PR DESCRIPTION
In [a previous PR] the outer field container of `Textarea` hid the overflow to prevent scrollbars being visible outside the radius of the field. This inadvertently meant the focus ring was also being hidden.

Shifting the focus ring to the field container wrapper to ensure it always shows when the field is focused regardless of scrolling.

[a previous PR]: https://github.com/seek-oss/braid-design-system/pull/2030/changes#diff-33902c1af8b1ebd2ee24c955f73363e3d290a34cd0154dbd06abc123952ae8efR155