### PR TITLE
chore: add source macro package metadata

### DIFF
--- a/.changeset/quiet-macros-smile.md
+++ b/.changeset/quiet-macros-smile.md
@@ -1,0 +1,5 @@
+---
+'@braid-design-system/source.macro': patch
+---
+
+Add package homepage and issue tracker metadata.

--- a/packages/source.macro/package.json
+++ b/packages/source.macro/package.json
@@ -12,6 +12,10 @@
     "url": "https://github.com/seek-oss/braid-design-system.git",
     "directory": "packages/source.macro"
   },
+  "homepage": "https://github.com/seek-oss/braid-design-system/tree/master/packages/source.macro#readme",
+  "bugs": {
+    "url": "https://github.com/seek-oss/braid-design-system/issues"
+  },
   "scripts": {
     "lint:eslint": "eslint --cache .",
     "lint:prettier": "prettier --cache --list-different .",


### PR DESCRIPTION
## Summary

- add package-level `homepage` metadata for `@braid-design-system/source.macro`
- add package-level `bugs.url` metadata for the repository issue tracker

## Why

The package already has repository metadata with the correct workspace directory, but the published npm metadata does not currently expose direct homepage or issue tracker links. This fills in those package support fields without changing runtime behavior.

## Checks

- `node -e "const p=require('./packages/source.macro/package.json'); const homepage='https://github.com/seek-oss/braid-design-system/tree/master/packages/source.macro#readme'; const bugs='https://github.com/seek-oss/braid-design-system/issues'; if (p.homepage !== homepage) throw new Error('bad homepage'); if (!p.bugs || p.bugs.url !== bugs) throw new Error('bad bugs'); console.log(JSON.stringify({name:p.name,version:p.version,repository:p.repository,homepage:p.homepage,bugs:p.bugs}, null, 2));"`
- `git diff --check`
- `corepack pnpm --dir packages/source.macro pack --dry-run`
- `corepack pnpm install --frozen-lockfile --ignore-scripts`
- `corepack pnpm --filter @braid-design-system/source.macro lint:tsc`
- `corepack pnpm --filter @braid-design-system/source.macro lint:prettier`
- `corepack pnpm --filter @braid-design-system/source.macro lint:eslint`

