### PR TITLE
`Accordion`: add new `subText` prop

### DIFF
--- a/.changeset/tangy-hornets-design.md
+++ b/.changeset/tangy-hornets-design.md
@@ -1,0 +1,15 @@
+---
+'braid-design-system': minor
+---
+
+**AccordionItem:** Add `subText` prop to display a caption beneath the label.
+
+**EXAMPLE USAGE:**
+
+```jsx
+<Accordion>
+  <AccordionItem label="Label" subText="Supporting caption for this item">
+    <Placeholder height={80} />
+  </AccordionItem>
+</Accordion>
+```

--- a/packages/braid-design-system/src/lib/components/Accordion/AccordionItem.test.tsx
+++ b/packages/braid-design-system/src/lib/components/Accordion/AccordionItem.test.tsx
@@ -25,11 +25,55 @@ describe('AccordionItem', () => {
           >
             Content 3
           </AccordionItem>
+          <AccordionItem id="item4" label="Label 4" subText="Supporting detail">
+            Content 4
+          </AccordionItem>
         </BraidTestProvider>,
       ),
     ).toHTMLValidate({
       extends: ['html-validate:recommended'],
     });
+  });
+
+  it('should render subText inside the button', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <AccordionItem label="Label" subText="Supporting detail">
+          Content
+        </AccordionItem>
+      </BraidTestProvider>,
+    );
+
+    const button = getByRole('button');
+    expect(htmlToText(button.innerHTML)).toContain('Supporting detail');
+  });
+
+  it('should not render subText when not provided', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <AccordionItem label="Label">Content</AccordionItem>
+      </BraidTestProvider>,
+    );
+
+    const button = getByRole('button');
+    expect(htmlToText(button.innerHTML)).toEqual('Label');
+  });
+
+  it('should render subText alongside a badge', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <AccordionItem
+          label="Label"
+          badge={<Badge>New</Badge>}
+          subText="Supporting detail"
+        >
+          Content
+        </AccordionItem>
+      </BraidTestProvider>,
+    );
+
+    const button = getByRole('button');
+    expect(htmlToText(button.innerHTML)).toContain('Supporting detail');
   });
 
   it('should provide internal state by default', async () => {

--- a/packages/braid-design-system/src/lib/components/Accordion/AccordionItem.tsx
+++ b/packages/braid-design-system/src/lib/components/Accordion/AccordionItem.tsx
@@ -49,6 +49,7 @@ export interface AccordionItemBaseProps {
   icon?: TextProps['icon'];
   data?: DataAttributeMap;
   badge?: ReactElement<BadgeProps> | null;
+  subText?: string;
 }
 
 export type AccordionItemProps = AccordionItemBaseProps & UseDisclosureProps;
@@ -64,6 +65,7 @@ export const AccordionItem: FC<AccordionItemProps> = ({
   weight: weightProp,
   icon,
   data,
+  subText,
   ...restProps
 }) => {
   const accordionContext = useContext(AccordionContext);
@@ -134,6 +136,26 @@ export const AccordionItem: FC<AccordionItemProps> = ({
     buildDataAttributes({ data, validateRestProps: restProps });
   }
 
+  const subTextSizeMap = {
+    xsmall: 'xsmall',
+    small: 'xsmall',
+    standard: 'xsmall',
+    large: 'small',
+  } as const;
+
+  const labelText = (
+    <Text size={size} weight={weight} tone={tone} icon={icon}>
+      {badge ? (
+        <Box component="span" paddingRight={badgeSlotSpace}>
+          {label}
+        </Box>
+      ) : (
+        label
+      )}
+      {badge ? cloneElement(badge, {}) : null}
+    </Text>
+  );
+
   return (
     <Stack space={itemSpace} data={data}>
       <Box position="relative" display="flex">
@@ -153,16 +175,20 @@ export const AccordionItem: FC<AccordionItemProps> = ({
           */}
           <Box component="span" position="relative">
             <Spread component="span" space={itemSpace}>
-              <Text size={size} weight={weight} tone={tone} icon={icon}>
-                {badge ? (
-                  <Box component="span" paddingRight={badgeSlotSpace}>
-                    {label}
-                  </Box>
-                ) : (
-                  label
-                )}
-                {badge ? cloneElement(badge, {}) : null}
-              </Text>
+              {subText ? (
+                <Stack component="span" space={itemSpace}>
+                  {labelText}
+                  <Text
+                    size={subTextSizeMap[size]}
+                    weight="regular"
+                    tone="secondary"
+                  >
+                    {subText}
+                  </Text>
+                </Stack>
+              ) : (
+                labelText
+              )}
               <Text
                 size={size}
                 weight={weight}

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -46,6 +46,7 @@ exports[`AccordionItem 1`] = `
         | "small"
         | "standard"
         | "xsmall"
+    subText?: string
     tone?: 
         | "neutral"
         | "secondary"


### PR DESCRIPTION
see [thread](https://seekchat.slack.com/archives/CDL5VKRHN/p1782175258679989)
**AccordionItem:** Add `subText` prop to display a caption beneath the label.

**EXAMPLE USAGE:**

```jsx
<Accordion>
  <AccordionItem label="Label" subText="Supporting caption for this item">
    <Placeholder height={80} />
  </AccordionItem>
</Accordion>
```

running local playground: 
| | collapsed | expanded|
| --- | --- | --- |
| with `subText` field | <img width="766" height="101" alt="Screenshot 2026-06-25 at 12 54 03 pm" src="https://github.com/user-attachments/assets/df74ceb1-4b2e-4511-bfc2-f04b8e44a1d9" /> | <img width="766" height="203" alt="Screenshot 2026-06-25 at 12 54 07 pm" src="https://github.com/user-attachments/assets/00cfb3c7-4634-4882-8fb1-7af4f0713679" /> |
| without `subText` field | <img width="766" height="69" alt="Screenshot 2026-06-25 at 12 54 17 pm" src="https://github.com/user-attachments/assets/b1b92e08-0582-4227-8198-dde14c5171c9" /> | <img width="766" height="176" alt="Screenshot 2026-06-25 at 12 54 21 pm" src="https://github.com/user-attachments/assets/1b2ac7be-12bc-4f71-b13c-4bac495b376a" /> |
