### PR TITLE
Modal footer

### DIFF
--- a/.changeset/nine-sails-peel.md
+++ b/.changeset/nine-sails-peel.md
@@ -1,0 +1,28 @@
+---
+'braid-design-system': minor
+---
+
+---
+new:
+  - Drawer
+---
+
+**Drawer**: Allow users to add fixed footer content to Drawer.
+
+**EXAMPLE USAGE:**
+```jsx
+  <Drawer
+    title="Drawer"
+    open={true}
+    footer={
+      <Actions>
+        <Button variant="solid" tone="formAccent">
+          Save
+        </Button>
+        <Button variant="transparent" tone="formAccent">
+          Cancel
+        </Button>
+      </Actions>
+    }
+  >
+```

--- a/.changeset/spicy-dancers-raise.md
+++ b/.changeset/spicy-dancers-raise.md
@@ -1,0 +1,28 @@
+---
+'braid-design-system': minor
+---
+
+---
+new:
+  - Dialog
+---
+
+**Dialog**: Allow users to add fixed footer content to Dialog.
+
+**EXAMPLE USAGE:**
+```jsx
+  <Dialog
+    title="Dialog"
+    open={true}
+    footer={
+      <Actions>
+        <Button variant="solid" tone="formAccent">
+          Save
+        </Button>
+        <Button variant="transparent" tone="formAccent">
+          Cancel
+        </Button>
+      </Actions>
+    }
+  >
+```

--- a/packages/braid-design-system/src/lib/components/Dialog/Dialog.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Dialog/Dialog.docs.tsx
@@ -18,6 +18,7 @@ import {
   TextDropdown,
   List,
   Notice,
+  Actions,
 } from '../';
 import { Placeholder } from '../../playroom/components';
 import { externalGutter } from '../private/Modal/ModalExternalGutter';
@@ -325,6 +326,54 @@ const docs: ComponentDocs = {
                   {...dialogPreviewPropsFromSourceValue(value)}
                   width="xsmall"
                 >
+                  <Placeholder
+                    height={100}
+                    width="100%"
+                    label="Dialog Content"
+                  />
+                </DialogContent>
+                <Screen />
+              </DialogPreview>
+            </Box>
+          ),
+        };
+      },
+    },
+    {
+      label: 'Footer Content',
+      description: (
+        <Text>
+          You can use the <Strong>footer</Strong> prop to render fixed footer content.
+        </Text>
+      ),
+      background: false,
+      Example: () => {
+        const { code, value } = source<DialogElement>(
+          <Dialog
+            title="Footer Content Example"
+            open={true}
+            onClose={() => { }}
+            footer={
+              <Actions>
+                <Button variant="solid" tone="formAccent">
+                  Save
+                </Button>
+                <Button variant="transparent" tone="formAccent">
+                  Cancel
+                </Button>
+              </Actions>
+            }
+          >
+            <Placeholder height={100} width="100%" label="Dialog Content" />
+          </Dialog>,
+        );
+
+        return {
+          code,
+          value: (
+            <Box borderRadius="xlarge" overflow="hidden">
+              <DialogPreview>
+                <DialogContent {...dialogPreviewPropsFromSourceValue(value)}>
                   <Placeholder
                     height={100}
                     width="100%"

--- a/packages/braid-design-system/src/lib/components/Dialog/Dialog.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Dialog/Dialog.docs.tsx
@@ -343,7 +343,8 @@ const docs: ComponentDocs = {
       label: 'Footer Content',
       description: (
         <Text>
-          You can use the <Strong>footer</Strong> prop to render fixed footer content.
+          You can use the <Strong>footer</Strong> prop to render fixed footer
+          content.
         </Text>
       ),
       background: false,
@@ -352,7 +353,7 @@ const docs: ComponentDocs = {
           <Dialog
             title="Footer Content Example"
             open={true}
-            onClose={() => { }}
+            onClose={() => {}}
             footer={
               <Actions>
                 <Button variant="solid" tone="formAccent">

--- a/packages/braid-design-system/src/lib/components/Dialog/Dialog.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Dialog/Dialog.screenshots.tsx
@@ -259,6 +259,16 @@ export const LongUnbrokenTitle: Story = {
   },
 };
 
+export const FooterLayout: Story = {
+  name: 'Test: Footer Layout',
+  args: {
+    title: 'Footer test',
+    width: 'medium',
+    footer: <Box style={{ height: 100 }} />,
+    children: <Placeholder height={100} width="100%" label="Small Drawer" />,
+  },
+};
+
 export const CloseButtonLayout: Story = {
   name: 'Test: Close button layout',
   args: {

--- a/packages/braid-design-system/src/lib/components/Dialog/Dialog.tsx
+++ b/packages/braid-design-system/src/lib/components/Dialog/Dialog.tsx
@@ -31,11 +31,13 @@ interface DialogContentProps extends Omit<
   keyof typeof modalStyle | 'width'
 > {
   width?: ModalContentProps['width'];
+  footer?: ModalContentProps['footer'];
 }
 
 export const DialogContent = ({
   width = defaultWidth,
+  footer,
   ...restProps
 }: DialogContentProps) => (
-  <ModalContent width={width} {...restProps} {...modalStyle} />
+  <ModalContent width={width} {...restProps} {...modalStyle} footer={footer} />
 );

--- a/packages/braid-design-system/src/lib/components/Drawer/Drawer.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Drawer/Drawer.docs.tsx
@@ -13,6 +13,7 @@ import {
   Checkbox,
   Alert,
   Box,
+  Actions,
 } from '../';
 import { Placeholder } from '../../playroom/components';
 import { dataAttributeDocs } from '../private/dataAttribute.docs';
@@ -147,6 +148,54 @@ const docs: ComponentDocs = {
           </Drawer>,
         );
 
+        return {
+          code,
+          value: (
+            <Box borderRadius="xlarge" overflow="hidden">
+              <DrawerPreview>
+                <DrawerContent {...drawerPreviewPropsFromSourceValue(value)}>
+                  <Placeholder
+                    height={200}
+                    width="100%"
+                    label="Drawer Content"
+                  />
+                </DrawerContent>
+                <Screen />
+              </DrawerPreview>
+            </Box>
+          ),
+        };
+      },
+    },
+    {
+      label: 'Footer Content',
+      description: (
+        <Text>
+          You can use the <Strong>footer</Strong> prop to render fixed footer content.
+        </Text>
+      ),
+      background: false,
+      Example: () => {
+        const { code, value } = source<DrawerElement>(
+          <Drawer
+            title="Example Title"
+            width="small"
+            open={true}
+            onClose={() => { }}
+            footer={
+              <Actions>
+                <Button variant="solid" tone="formAccent">
+                  Save
+                </Button>
+                <Button variant="transparent" tone="formAccent">
+                  Cancel
+                </Button>
+              </Actions>
+            }
+          >
+            <Placeholder height={200} width="100%" label="Drawer Content" />
+          </Drawer>,
+        );
         return {
           code,
           value: (

--- a/packages/braid-design-system/src/lib/components/Drawer/Drawer.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Drawer/Drawer.docs.tsx
@@ -171,7 +171,8 @@ const docs: ComponentDocs = {
       label: 'Footer Content',
       description: (
         <Text>
-          You can use the <Strong>footer</Strong> prop to render fixed footer content.
+          You can use the <Strong>footer</Strong> prop to render fixed footer
+          content.
         </Text>
       ),
       background: false,
@@ -181,7 +182,7 @@ const docs: ComponentDocs = {
             title="Example Title"
             width="small"
             open={true}
-            onClose={() => { }}
+            onClose={() => {}}
             footer={
               <Actions>
                 <Button variant="solid" tone="formAccent">

--- a/packages/braid-design-system/src/lib/components/Drawer/Drawer.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Drawer/Drawer.screenshots.tsx
@@ -107,6 +107,16 @@ export const CloseButtonLayout: Story = {
   },
 };
 
+export const FooterLayout: Story = {
+  name: 'Test: Footer Layout',
+  args: {
+    title: 'footer test',
+    width: 'medium',
+    footer: <Box style={{ height: 100 }} />,
+    children: <Placeholder height={100} width="100%" label="Small Drawer" />,
+  },
+};
+
 export const LeftAlignedInCenteredStack: Story = {
   name: 'Test: Should be left aligned in a centered Stack',
   args: {

--- a/packages/braid-design-system/src/lib/components/Drawer/Drawer.tsx
+++ b/packages/braid-design-system/src/lib/components/Drawer/Drawer.tsx
@@ -25,11 +25,13 @@ export interface DrawerProps extends Omit<
 > {
   width?: (typeof validWidths)[number];
   position?: (typeof validPositions)[number];
+  footer?: ModalContentProps['footer'];
 }
 
 export const Drawer: FC<DrawerProps> = ({
   width = defaultWidth,
   position = defaultPosition,
+  footer,
   ...restProps
 }) => {
   assert(validWidths.indexOf(width) >= 0, `Invalid width: ${width}`);
@@ -39,7 +41,13 @@ export const Drawer: FC<DrawerProps> = ({
   );
 
   return (
-    <Modal width={width} position={position} {...restProps} {...modalStyle} />
+    <Modal
+      width={width}
+      position={position}
+      footer={footer}
+      {...restProps}
+      {...modalStyle}
+    />
   );
 };
 
@@ -49,11 +57,13 @@ interface DrawerContentProps extends Omit<
 > {
   width?: (typeof validWidths)[number];
   position?: (typeof validPositions)[number];
+  footer?: ModalContentProps['footer'];
 }
 
 export const DrawerContent = ({
   width = defaultWidth,
   position = defaultPosition,
+  footer,
   ...restProps
 }: DrawerContentProps) => {
   assert(validWidths.indexOf(width) >= 0, `Invalid width: ${width}`);
@@ -66,6 +76,7 @@ export const DrawerContent = ({
     <ModalContent
       width={width}
       position={position}
+      footer={footer}
       {...restProps}
       {...modalStyle}
     />

--- a/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
@@ -42,14 +42,15 @@ type ModalContentCommonProps = {
   headingRef?: Ref<HTMLElement>;
   modalRef?: Ref<HTMLElement>;
   data?: DataAttributeMap;
+  footer?: ReactNode;
 };
 
 export type ModalContentProps = ModalContentCommonProps &
   (
     | {
-        coverImage?: never;
-        illustration?: ReactNodeNoStrings;
-      }
+      coverImage?: never;
+      illustration?: ReactNodeNoStrings;
+    }
     | { coverImage?: string; illustration?: never }
   );
 
@@ -125,6 +126,20 @@ const ModalContentHeader = forwardRef<HTMLElement, ModalContentHeaderProps>(
       resolvedLayout
     );
   },
+);
+
+type ModalFooterProps = {
+  children: ReactNode;
+};
+
+const ModalFooter = ({ children }: ModalFooterProps) => (
+  <Box
+    background="neutralSoft"
+    width="full"
+    padding="small"
+  >
+    {children}
+  </Box>
 );
 
 const ModalContentScrollLayout = ({
@@ -227,6 +242,7 @@ export const ModalContent = ({
   position,
   headingLevel,
   data,
+  footer,
   ...restProps
 }: ModalContentInternalProps) => {
   const resolvedId = useFallbackId(id);
@@ -338,6 +354,7 @@ export const ModalContent = ({
                 modalLayout
               )}
             </ScrollContainer>
+            {footer && <ModalFooter>{footer}</ModalFooter>}
           </Box>
         </RemoveScroll>
         <Box

--- a/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
@@ -48,9 +48,9 @@ type ModalContentCommonProps = {
 export type ModalContentProps = ModalContentCommonProps &
   (
     | {
-      coverImage?: never;
-      illustration?: ReactNodeNoStrings;
-    }
+        coverImage?: never;
+        illustration?: ReactNodeNoStrings;
+      }
     | { coverImage?: string; illustration?: never }
   );
 
@@ -133,11 +133,7 @@ type ModalFooterProps = {
 };
 
 const ModalFooter = ({ children }: ModalFooterProps) => (
-  <Box
-    background="neutralSoft"
-    width="full"
-    padding="small"
-  >
+  <Box background="neutralSoft" width="full" padding="small">
     {children}
   </Box>
 );

--- a/packages/braid-design-system/src/lib/components/private/Modal/modalTestSuite.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Modal/modalTestSuite.tsx
@@ -15,13 +15,19 @@ import type { ModalProps } from './Modal';
 export const modalTestSuite = (
   name: string,
   ModalImplementation: ComponentType<
-    Pick<ModalProps, 'title' | 'closeLabel' | 'open' | 'onClose' | 'children'>
+    Pick<
+      ModalProps,
+      'title' | 'closeLabel' | 'open' | 'onClose' | 'children' | 'footer'
+    >
   >,
 ) => {
   const CLOSE_LABEL = 'Close button';
   const TITLE = 'Test Title';
 
-  const TestCase = ({ onClose }: Pick<ModalProps, 'onClose'>) => {
+  const TestCase = ({
+    onClose,
+    footer,
+  }: Pick<ModalProps, 'onClose' | 'footer'>) => {
     const [open, setOpen] = useState(false);
     return (
       <div>
@@ -41,6 +47,7 @@ export const modalTestSuite = (
 
             setOpen(newOpenState);
           }}
+          footer={footer}
         >
           <Button data={{ testid: 'buttonInside' }}>Inside</Button>
         </ModalImplementation>
@@ -56,11 +63,12 @@ export const modalTestSuite = (
 
   function renderTestCase({
     onClose = vi.fn(),
-  }: Optional<Pick<ModalProps, 'onClose'>> = {}) {
+    footer,
+  }: Optional<Pick<ModalProps, 'onClose' | 'footer'>> = {}) {
     return {
       ...render(
         <BraidTestProvider>
-          <TestCase onClose={onClose} />
+          <TestCase onClose={onClose} footer={footer} />
         </BraidTestProvider>,
       ),
       closeHandler: onClose,
@@ -70,6 +78,15 @@ export const modalTestSuite = (
   const EXIT_TIMEOUT = 1500;
 
   describe(`Modal: ${name}`, () => {
+    it('should render footer content when provided', async () => {
+      const footer = 'Footer content';
+      const { getByText, getByTestId } = renderTestCase({ footer });
+
+      await userEvent.click(getByTestId('buttonBefore'));
+
+      expect(getByText('Footer content')).toBeVisible();
+    });
+
     it('should not focus content when closed', async () => {
       const { getByTestId } = renderTestCase();
 

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -3001,6 +3001,7 @@ exports[`Dialog 1`] = `
     coverImage?: string
     data?: DataAttributeMap
     description?: ReactNodeNoStrings
+    footer?: ReactNode
     id?: string
     illustration?: ReactNodeNoStrings
     onClose: (openState: false) => false | void
@@ -3071,6 +3072,7 @@ exports[`Drawer 1`] = `
     closeLabel?: string
     data?: DataAttributeMap
     description?: ReactNodeNoStrings
+    footer?: ReactNode
     id?: string
     onClose: (openState: false) => false | void
     open: boolean


### PR DESCRIPTION
Added footer to modal-like components to display persistent information such as actions. Also fixed minor bug around drawer padding.

**Components affected:**
- Drawer
- Dialog

**API changes:**
- Add `footer` to Dialog and Drawer
