### PR TITLE
Button: Update `loading` indicator

### DIFF
--- a/.changeset/curly-items-chew.md
+++ b/.changeset/curly-items-chew.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Button
+---
+
+**Button:** Update `loading` indicator
+
+Update design asset for loading state, moving from progressive ellipsis animation, to a spinning indicator.

--- a/.changeset/empty-experts-juggle.md
+++ b/.changeset/empty-experts-juggle.md
@@ -1,0 +1,10 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Button
+---
+
+**Button:** Ensure active state is not applied when disabled

--- a/packages/braid-design-system/src/lib/components/Button/Button.css.ts
+++ b/packages/braid-design-system/src/lib/components/Button/Button.css.ts
@@ -1,9 +1,4 @@
-import {
-  createVar,
-  keyframes,
-  style,
-  styleVariants,
-} from '@vanilla-extract/css';
+import { createVar, style, styleVariants } from '@vanilla-extract/css';
 import { calc } from '@vanilla-extract/css-utils';
 import { rgba } from 'polished';
 
@@ -25,7 +20,7 @@ export const forceActive = style({});
 
 export const activeAnimation = style({
   selectors: {
-    [`${root}:active &, ${forceActive}&`]: {
+    [`${root}:not(:disabled):active &, ${forceActive}&`]: {
       transform: vars.transform.touchable,
     },
   },
@@ -33,7 +28,7 @@ export const activeAnimation = style({
 
 export const activeOverlay = style({
   selectors: {
-    [`${root}:active &, ${forceActive}&`]: {
+    [`${root}:not(:disabled):active &, ${forceActive}&`]: {
       opacity: 1,
     },
   },
@@ -97,50 +92,6 @@ export const bleedVerticallyToCapHeight = style({
 export const padToMinHeight = style({
   paddingTop: capHeightToMinHeight,
   paddingBottom: capHeightToMinHeight,
-});
-
-const dot1 = keyframes({
-  '14%': {
-    opacity: 0,
-  },
-  '15%,100%': {
-    opacity: 1,
-  },
-});
-
-const dot2 = keyframes({
-  '29%': {
-    opacity: 0,
-  },
-  '30%,100%': {
-    opacity: 1,
-  },
-});
-
-const dot3 = keyframes({
-  '44%': {
-    opacity: 0,
-  },
-  '45%,100%': {
-    opacity: 1,
-  },
-});
-
-export const loadingDot = style({
-  animationDuration: '1s',
-  animationIterationCount: 'infinite',
-  opacity: 0,
-  selectors: {
-    [`&:nth-child(1)`]: {
-      animationName: dot1,
-    },
-    [`&:nth-child(2)`]: {
-      animationName: dot2,
-    },
-    [`&:nth-child(3)`]: {
-      animationName: dot3,
-    },
-  },
 });
 
 export const invertedBackgroundsLightMode = styleVariants({

--- a/packages/braid-design-system/src/lib/components/Button/Button.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.tsx
@@ -25,7 +25,9 @@ import { FieldOverlay } from '../private/FieldOverlay/FieldOverlay';
 import buildDataAttributes, {
   type DataAttributeMap,
 } from '../private/buildDataAttributes';
+import { iconSlotSpace } from '../private/iconSlotSpace';
 
+import { ButtonLoader } from './ButtonLoader';
 import type { buttonTones } from './buttonTones';
 
 import * as styles from './Button.css';
@@ -209,20 +211,6 @@ const variants: Record<ButtonVariant, Record<ButtonTone, ButtonStyles>> = {
   },
 } as const;
 
-const ButtonLoader = () => (
-  <Box aria-hidden component="span" display="inlineBlock">
-    <Box component="span" className={styles.loadingDot}>
-      .
-    </Box>
-    <Box component="span" className={styles.loadingDot}>
-      .
-    </Box>
-    <Box component="span" className={styles.loadingDot}>
-      .
-    </Box>
-  </Box>
-);
-
 const transparentPaddingX = 'small';
 const buttonRadius = 'standard';
 
@@ -378,7 +366,11 @@ export const ButtonText = ({
           </AvoidWidowIcon>
         ) : null}
         {children}
-        {loading ? <ButtonLoader /> : null}
+        {loading ? (
+          <Box component="span" paddingLeft={iconSlotSpace}>
+            <ButtonLoader />
+          </Box>
+        ) : null}
         {!loading && icon && iconPosition === 'trailing' ? (
           <AvoidWidowIcon
             iconPosition={iconPosition}

--- a/packages/braid-design-system/src/lib/components/Button/ButtonLoader.css.ts
+++ b/packages/braid-design-system/src/lib/components/Button/ButtonLoader.css.ts
@@ -1,0 +1,10 @@
+import { keyframes, style } from '@vanilla-extract/css';
+
+const spin = keyframes({
+  to: {
+    transform: 'rotate(360deg)',
+  },
+});
+export const loading = style({
+  animation: `${spin} 0.7s linear infinite`,
+});

--- a/packages/braid-design-system/src/lib/components/Button/ButtonLoader.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/ButtonLoader.tsx
@@ -1,0 +1,36 @@
+import type { FC } from 'react';
+
+import { Box } from '../Box/Box';
+import { IconContainer, type IconContainerProps } from '../icons/IconContainer';
+import type { SVGProps } from '../icons/SVGTypes';
+
+import * as styles from './ButtonLoader.css';
+
+const LoaderSvg: FC<SVGProps> = ({ title, titleId, ...props }) => (
+  <svg
+    xmlns="http://www.w3.org/2000/svg"
+    viewBox="0 0 24 24"
+    xmlSpace="preserve"
+    focusable="false"
+    fill="currentColor"
+    width={16}
+    height={16}
+    aria-labelledby={titleId}
+    {...props}
+  >
+    {title ? <title id={titleId}>{title}</title> : null}
+    <path d="M12 22C6.486 22 2 17.514 2 12S6.486 2 12 2s10 4.486 10 10a1 1 0 1 1-2 0c0-4.411-3.589-8-8-8s-8 3.589-8 8 3.589 8 8 8a1 1 0 1 1 0 2" />
+  </svg>
+);
+
+export const ButtonLoader: FC<IconContainerProps> = (props) => (
+  <IconContainer {...props}>
+    {({ className, ...svgProps }) => (
+      <Box
+        component={LoaderSvg}
+        className={[className, styles.loading]}
+        {...svgProps}
+      />
+    )}
+  </IconContainer>
+);


### PR DESCRIPTION
Update design asset for loading state, moving from progressive ellipsis animation, to a spinning indicator.

Also noticed an issue where the `Button` still applies the active treatment when disabled (or loading), so fixing while we are here.