### PR TITLE
ButtonIcon: Add `loading` support

### DIFF
--- a/.changeset/curly-teeth-clap.md
+++ b/.changeset/curly-teeth-clap.md
@@ -1,0 +1,21 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - ButtonIcon
+---
+
+**ButtonIcon:** Add `loading` support
+
+Provide the same `loading` behaviour as available on `Button` 
+
+**EXAMPLE USAGE:**
+```jsx
+<ButtonIcon
+  icon={<IconSend />}
+  label="Send"
+  loading
+/>
+```

--- a/.changeset/modern-jobs-cross.md
+++ b/.changeset/modern-jobs-cross.md
@@ -1,0 +1,26 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Autosuggest
+  - Checkbox
+  - Dialog
+  - Drawer
+  - Dropdown
+  - ButtonIcon
+  - MonthPicker
+  - PasswordField
+  - RadioGroup
+  - RadioItem
+  - TabsProvider
+  - TextDropdown
+  - TextField
+  - Textarea
+  - TooltipRenderer
+---
+
+Ensure fallback ids pass HTML validation
+
+Adopt recommended practice of ensuring all generated `id` attributes start with a letter as per HTML validation rules.

--- a/packages/braid-design-system/src/lib/components/Button/Button.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.docs.tsx
@@ -926,7 +926,7 @@ const docs: ComponentDocs = {
     ],
     interaction: [
       {
-        label: 'Loading Button',
+        label: 'Loading state',
         description: (
           <>
             <Text>

--- a/packages/braid-design-system/src/lib/components/Button/Button.test.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.test.tsx
@@ -18,6 +18,9 @@ describe('Button', () => {
       ),
     ).toHTMLValidate({
       extends: ['html-validate:recommended'],
+      rules: {
+        'attribute-boolean-style': 'warn', // React generates `disabled=""` which cannot be changed
+      },
     });
   });
 

--- a/packages/braid-design-system/src/lib/components/Button/Button.test.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.test.tsx
@@ -11,11 +11,25 @@ describe('Button', () => {
         <BraidTestProvider>
           <Button>Button</Button>
           <Button icon={<IconSend />}>Button</Button>
+          <Button icon={<IconSend />} loading>
+            Button
+          </Button>
         </BraidTestProvider>,
       ),
     ).toHTMLValidate({
       extends: ['html-validate:recommended'],
     });
+  });
+
+  it('should be disabled when loading', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <Button loading>Button</Button>
+      </BraidTestProvider>,
+    );
+
+    const button = getByRole('button');
+    expect(button).toBeDisabled();
   });
 
   it('should honour aria-label if provided', () => {

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.docs.tsx
@@ -296,6 +296,22 @@ const docs: ComponentDocs = {
           ),
       },
     ],
+    interaction: [
+      {
+        label: 'Loading state',
+        description: (
+          <>
+            <Text>
+              You can indicate a loading state inline with the{' '}
+              <Strong>loading</Strong> prop, which also ensures that the button
+              is disabled.
+            </Text>
+          </>
+        ),
+        Example: () =>
+          source(<ButtonIcon icon={<IconSend />} label="Loading" loading />),
+      },
+    ],
     bestPractices: [
       dataAttributeDocs({
         code: `

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.test.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.test.tsx
@@ -1,22 +1,24 @@
 import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
+import { renderToStaticMarkup } from 'react-dom/server';
 
 import { ButtonIcon, IconBookmark, Text } from '..';
 import { BraidTestProvider } from '../../../test';
 
 describe('ButtonIcon', () => {
   it('should render valid html structure', () => {
-    const { getByLabelText } = render(
-      <BraidTestProvider>
-        <ButtonIcon icon={<IconBookmark />} label="Bookmark" />
-        <ButtonIcon icon={<IconBookmark />} label="Bookmark" loading />
-      </BraidTestProvider>,
-    );
-
-    const button = getByLabelText('Bookmark');
-
-    expect(button).toHTMLValidate({
+    expect(
+      renderToStaticMarkup(
+        <BraidTestProvider>
+          <ButtonIcon icon={<IconBookmark />} label="Bookmark" />
+          <ButtonIcon icon={<IconBookmark />} label="Loading" loading />
+        </BraidTestProvider>,
+      ),
+    ).toHTMLValidate({
       extends: ['html-validate:recommended'],
+      rules: {
+        'attribute-boolean-style': 'warn', // React generates `disabled=""` which cannot be changed
+      },
     });
   });
 

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.test.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.test.tsx
@@ -8,7 +8,8 @@ describe('ButtonIcon', () => {
   it('should render valid html structure', () => {
     const { getByLabelText } = render(
       <BraidTestProvider>
-        <ButtonIcon id="bookmark" icon={<IconBookmark />} label="Bookmark" />
+        <ButtonIcon icon={<IconBookmark />} label="Bookmark" />
+        <ButtonIcon icon={<IconBookmark />} label="Bookmark" loading />
       </BraidTestProvider>,
     );
 
@@ -27,7 +28,6 @@ describe('ButtonIcon', () => {
     );
 
     const button = getByLabelText('Label');
-
     expect(button).toHaveTextContent('');
   });
 
@@ -44,6 +44,17 @@ describe('ButtonIcon', () => {
     const tooltip = getByRole('tooltip');
 
     expect(tooltip).toHaveTextContent('Label');
+  });
+
+  it('should be disabled when loading', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <ButtonIcon icon={<IconBookmark />} label="Bookmark" loading />
+      </BraidTestProvider>,
+    );
+
+    const button = getByLabelText('Bookmark');
+    expect(button).toBeDisabled();
   });
 
   it('should honour aria-describedby if provided', () => {

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.tsx
@@ -21,6 +21,7 @@ import {
   ButtonOverlays,
   useButtonStyles,
 } from '../Button/Button';
+import { ButtonLoader } from '../Button/ButtonLoader';
 import { Text } from '../Text/Text';
 import { TooltipRenderer } from '../TooltipRenderer/TooltipRenderer';
 import buildDataAttributes, {
@@ -56,6 +57,7 @@ export interface ButtonIconProps {
   'aria-expanded'?: NativeButtonProps['aria-expanded'];
   'aria-describedby'?: NativeButtonProps['aria-describedby'];
   tabIndex?: number;
+  loading?: boolean;
   data?: DataAttributeMap;
   bleed?: boolean;
   tooltipPlacement?: 'bottom' | 'top';
@@ -79,6 +81,7 @@ const ButtonIconContent = forwardRef<HTMLButtonElement, ButtonIconProps>(
       type = 'button',
       bleed,
       tooltipPlacement,
+      loading,
       onClick,
       onMouseDown,
       onKeyUp,
@@ -95,6 +98,7 @@ const ButtonIconContent = forwardRef<HTMLButtonElement, ButtonIconProps>(
     const { root, content } = useButtonStyles({
       variant,
       tone,
+      loading,
       size: size === 'small' ? 'small' : 'standard',
       radius: 'full',
     });
@@ -122,6 +126,7 @@ const ButtonIconContent = forwardRef<HTMLButtonElement, ButtonIconProps>(
         maxWidth="content"
         tabIndex={tabIndex}
         {...root}
+        disabled={loading}
         className={[root.className, styles.button]}
         {...buildDataAttributes({ data, validateRestProps: restProps })}
       >
@@ -142,10 +147,14 @@ const ButtonIconContent = forwardRef<HTMLButtonElement, ButtonIconProps>(
                 : iconSize({ size, crop: true })
             }
           >
-            {cloneElement(icon, {
+            {loading ? (
+              <ButtonLoader tone={icon.props.tone || tone} size="fill" />
+            ) : (
+              cloneElement(icon, {
               tone: icon.props.tone || tone,
               size: 'fill',
-            })}
+              })
+            )}
           </Box>
         </Box>
       </Box>

--- a/packages/braid-design-system/src/lib/hooks/useFallbackId.ts
+++ b/packages/braid-design-system/src/lib/hooks/useFallbackId.ts
@@ -2,5 +2,5 @@ import { useId } from 'react';
 
 export const useFallbackId = (id?: string) => {
   const fallbackId = useId();
-  return id || fallbackId;
+  return id || `id-${fallbackId}`;
 };

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -2186,6 +2186,7 @@ exports[`ButtonIcon 1`] = `
     icon: ReactElement<UseIconProps, string | JSXElementConstructor<any>>
     id?: string
     label: string
+    loading?: boolean
     onClick?: MouseEventHandler<HTMLButtonElement>
     onKeyDown?: KeyboardEventHandler<HTMLButtonElement>
     onKeyUp?: KeyboardEventHandler<HTMLButtonElement>


### PR DESCRIPTION
Provide the same `loading` behaviour as available on `Button` 

**EXAMPLE USAGE:**
```jsx
<ButtonIcon
  icon={<IconSend />}
  label="Send"
  loading
/>
```