### PR TITLE
Button, ButtonIcon: Add `aria-pressed` support

### DIFF
--- a/.changeset/curly-items-chew.md
+++ b/.changeset/curly-items-chew.md
@@ -5,6 +5,7 @@
 ---
 updated:
   - Button
+  - ButtonLink
 ---
 
 **Button:** Update `loading` indicator

--- a/.changeset/nine-jobs-play.md
+++ b/.changeset/nine-jobs-play.md
@@ -1,0 +1,11 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - Button
+  - ButtonIcon
+---
+
+**Button, ButtonIcon:** Add `aria-pressed` support

--- a/packages/braid-design-system/src/lib/components/Button/Button.test.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.test.tsx
@@ -32,4 +32,15 @@ describe('Button', () => {
     const button = queryByLabelText('Visible Label');
     expect(button).toBeNull();
   });
+
+  it('should honour aria-pressed if provided', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <Button aria-pressed="true">Toggle</Button>
+      </BraidTestProvider>,
+    );
+
+    const button = getByRole('button');
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+  });
 });

--- a/packages/braid-design-system/src/lib/components/Button/Button.tsx
+++ b/packages/braid-design-system/src/lib/components/Button/Button.tsx
@@ -67,6 +67,7 @@ export interface ButtonProps extends ButtonStyleProps {
   'aria-expanded'?: NativeButtonProps['aria-expanded'];
   'aria-describedby'?: NativeButtonProps['aria-describedby'];
   'aria-label'?: NativeButtonProps['aria-label'];
+  'aria-pressed'?: NativeButtonProps['aria-pressed'];
   tabIndex?: NativeButtonProps['tabIndex'];
   data?: DataAttributeMap;
 }
@@ -481,6 +482,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
       'aria-expanded': ariaExpanded,
       'aria-describedby': ariaDescribedBy,
       'aria-label': ariaLabel,
+      'aria-pressed': ariaPressed,
       data,
       ...restProps
     },
@@ -509,6 +511,7 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(
           aria-expanded={ariaExpanded}
           aria-describedby={ariaDescribedBy}
           aria-label={ariaLabel}
+          aria-pressed={ariaPressed}
           onClick={onClick}
           disabled={loading}
           {...root}

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.test.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.test.tsx
@@ -62,4 +62,19 @@ describe('ButtonIcon', () => {
 
     expect(button).toHaveAccessibleDescription('Actual description');
   });
+
+  it('should honour aria-pressed if provided', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <ButtonIcon
+          icon={<IconBookmark />}
+          label="Bookmark"
+          aria-pressed="true"
+        />
+      </BraidTestProvider>,
+    );
+
+    const button = getByLabelText('Bookmark');
+    expect(button).toHaveAttribute('aria-pressed', 'true');
+  });
 });

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.tsx
@@ -55,6 +55,7 @@ export interface ButtonIconProps {
   'aria-haspopup'?: NativeButtonProps['aria-haspopup'];
   'aria-expanded'?: NativeButtonProps['aria-expanded'];
   'aria-describedby'?: NativeButtonProps['aria-describedby'];
+  'aria-pressed'?: NativeButtonProps['aria-pressed'];
   tabIndex?: number;
   data?: DataAttributeMap;
   bleed?: boolean;
@@ -86,6 +87,7 @@ const ButtonIconContent = forwardRef<HTMLButtonElement, ButtonIconProps>(
       'aria-haspopup': ariaHasPopUp,
       'aria-expanded': ariaExpanded,
       'aria-describedby': ariaDescribedBy,
+      'aria-pressed': ariaPressed,
       tabIndex,
       data,
       ...restProps
@@ -116,6 +118,7 @@ const ButtonIconContent = forwardRef<HTMLButtonElement, ButtonIconProps>(
         aria-haspopup={ariaHasPopUp}
         aria-expanded={ariaExpanded}
         aria-describedby={ariaDescribedBy}
+        aria-pressed={ariaPressed}
         onClick={onClick}
         onKeyUp={onKeyUp}
         onKeyDown={onKeyDown}

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -2124,6 +2124,12 @@ exports[`Button 1`] = `
         | false
         | true
     aria-label?: string
+    aria-pressed?: 
+        | "false"
+        | "mixed"
+        | "true"
+        | false
+        | true
     bleed?: boolean
     children?: ReactNode
     data?: DataAttributeMap
@@ -2178,6 +2184,12 @@ exports[`ButtonIcon 1`] = `
         | "listbox"
         | "menu"
         | "tree"
+        | "true"
+        | false
+        | true
+    aria-pressed?: 
+        | "false"
+        | "mixed"
         | "true"
         | false
         | true


### PR DESCRIPTION
Enable users to mark up our button components with pressed states when required.

Note: Also adding `ButtonLink` to previous changeset for updated loading indicator. Its necessary to add `ButtonLink` to this PR changeset as it already exposes all HTMLAnchorAttributes.