### PR TITLE
IconRenderer: Add `tone` support

### DIFF
--- a/.changeset/rare-boats-bow.md
+++ b/.changeset/rare-boats-bow.md
@@ -1,0 +1,28 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - IconRenderer
+---
+
+**IconRenderer:** Add `tone` support
+
+Enable custom icons to use Braid tones in the same way as first-class Braid icons.
+
+**EXAMPLE USAGE:**
+```jsx
+<IconRenderer tone={tone}>
+  {({ className }) => (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      className={className}
+    >
+      ...
+    </svg>
+  )}
+</IconRenderer>
+```

--- a/packages/braid-design-system/src/lib/components/icons/IconRenderer.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconRenderer.screenshots.tsx
@@ -67,7 +67,7 @@ export const InheritedTone: Story = {
   ),
 };
 
-export const ExplictToneInText: Story = {
+export const ExplicitToneInText: Story = {
   render: () => (
     <Text size="large" icon={<CustomIcon tone="brandAccent" />} tone="positive">
       Text large with custom icon
@@ -75,7 +75,7 @@ export const ExplictToneInText: Story = {
   ),
 };
 
-export const ExplictToneInHeading: Story = {
+export const ExplicitToneInHeading: Story = {
   render: () => (
     <Heading level="2" icon={<CustomIcon tone="brandAccent" />}>
       Heading 2 with custom icon

--- a/packages/braid-design-system/src/lib/components/icons/IconRenderer.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconRenderer.screenshots.tsx
@@ -1,4 +1,5 @@
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import type { ComponentProps } from 'react';
 
 import { Text, Heading, IconRenderer, Stack } from '../';
 
@@ -10,8 +11,10 @@ const meta = {
 export default meta;
 type Story = StoryObj<typeof IconRenderer>;
 
-const customIcon = (
-  <IconRenderer>
+const CustomIcon = ({
+  tone,
+}: Pick<ComponentProps<typeof IconRenderer>, 'tone'>) => (
+  <IconRenderer tone={tone}>
     {({ className }) => (
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -28,30 +31,54 @@ const customIcon = (
 export const Default: Story = {
   render: () => (
     <Stack space="large">
-      <Text size="xsmall" icon={customIcon}>
+      <Text size="xsmall" icon={<CustomIcon />}>
         Text xsmall with custom icon
       </Text>
-      <Text size="small" icon={customIcon}>
+      <Text size="small" icon={<CustomIcon />}>
         Text small with custom icon
       </Text>
-      <Text size="standard" icon={customIcon}>
+      <Text size="standard" icon={<CustomIcon />}>
         Text standard with custom icon
       </Text>
-      <Text size="large" icon={customIcon}>
+      <Text size="large" icon={<CustomIcon />}>
         Text large with custom icon
       </Text>
-      <Heading level="4" icon={customIcon}>
+      <Heading level="4" icon={<CustomIcon />}>
         Heading 4 with custom icon
       </Heading>
-      <Heading level="3" icon={customIcon}>
+      <Heading level="3" icon={<CustomIcon />}>
         Heading 3 with custom icon
       </Heading>
-      <Heading level="2" icon={customIcon}>
+      <Heading level="2" icon={<CustomIcon />}>
         Heading 2 with custom icon
       </Heading>
-      <Heading level="1" icon={customIcon}>
+      <Heading level="1" icon={<CustomIcon />}>
         Heading 1 with custom icon
       </Heading>
     </Stack>
+  ),
+};
+
+export const InheritedTone: Story = {
+  render: () => (
+    <Text size="large" icon={<CustomIcon />} tone="positive">
+      Text large with custom icon
+    </Text>
+  ),
+};
+
+export const ExplictToneInText: Story = {
+  render: () => (
+    <Text size="large" icon={<CustomIcon tone="brandAccent" />} tone="positive">
+      Text large with custom icon
+    </Text>
+  ),
+};
+
+export const ExplictToneInHeading: Story = {
+  render: () => (
+    <Heading level="2" icon={<CustomIcon tone="brandAccent" />}>
+      Heading 2 with custom icon
+    </Heading>
   ),
 };

--- a/packages/braid-design-system/src/lib/components/icons/IconRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconRenderer.tsx
@@ -3,43 +3,23 @@ import assert from 'assert';
 import clsx from 'clsx';
 import { type ReactElement, useContext, type FC } from 'react';
 
-import { atoms } from '../../css/atoms/atoms';
+import { iconInlineSize, useIconTone } from '../../hooks/useIcon';
 import HeadingContext from '../Heading/HeadingContext';
 import { TextContext } from '../Text/TextContext';
 
-import * as styles from '../../hooks/useIcon/icon.css';
-
-type AlignY = keyof typeof styles.alignY;
-interface IconStyles {
-  alignY?: AlignY;
-  verticalCorrection?: keyof (typeof styles.alignY)[AlignY];
-}
-export const iconInlineSize = ({
-  alignY = 'uppercase',
-  verticalCorrection = 'none',
-}: IconStyles = {}) =>
-  clsx(
-    atoms({
-      display: 'inlineBlock',
-      position: 'relative',
-    }),
-    styles.size,
-    styles.inlineCrop,
-    styles.inline,
-    styles.alignY[alignY][verticalCorrection],
-  );
-
 interface IconRendererProps {
+  tone?: Parameters<typeof useIconTone>[0]['tone'];
   children: ({ className }: { className: string }) => ReactElement | null;
 }
-export const IconRenderer: FC<IconRendererProps> = ({ children }) => {
+export const IconRenderer: FC<IconRendererProps> = ({ tone, children }) => {
   const textContext = useContext(TextContext);
   const headingContext = useContext(HeadingContext);
+  const toneClass = useIconTone({ tone });
 
   assert(
     Boolean(textContext || headingContext),
     `IconRenderer must be inside either a \`Text\` or \`Heading\` component.`,
   );
 
-  return children({ className: iconInlineSize() });
+  return children({ className: clsx(toneClass, iconInlineSize()) });
 };

--- a/packages/braid-design-system/src/lib/hooks/useIcon/index.ts
+++ b/packages/braid-design-system/src/lib/hooks/useIcon/index.ts
@@ -6,7 +6,6 @@ import { useContext } from 'react';
 import type { PublicBoxProps } from '../../components/Box/Box';
 import HeadingContext from '../../components/Heading/HeadingContext';
 import { TextContext } from '../../components/Text/TextContext';
-import { iconInlineSize } from '../../components/icons/IconRenderer';
 import type { OptionalTitle } from '../../components/icons/SVGTypes';
 import buildDataAttributes, {
   type DataAttributeMap,
@@ -57,6 +56,38 @@ const defaultVerticalCorrection = {
   lowercase: 'none',
 } as const;
 
+type AlignY = keyof typeof styles.alignY;
+interface IconStyles {
+  alignY?: AlignY;
+  verticalCorrection?: keyof (typeof styles.alignY)[AlignY];
+}
+export const iconInlineSize = ({
+  alignY = 'uppercase',
+  verticalCorrection = 'none',
+}: IconStyles = {}) =>
+  clsx(
+    atoms({
+      display: 'inlineBlock',
+      position: 'relative',
+    }),
+    styles.size,
+    styles.inlineCrop,
+    styles.inline,
+    styles.alignY[alignY][verticalCorrection],
+  );
+
+export const useIconTone = ({ tone }: Pick<UseIconProps, 'tone'>) => {
+  const textContext = useContext(TextContext);
+  const headingContext = useContext(HeadingContext);
+
+  const resolvedTone =
+    typographyStyles.tone[tone || textContext?.tone || 'neutral'];
+
+  return tone || (!headingContext && !textContext?.tone)
+    ? resolvedTone
+    : undefined;
+};
+
 export default (
   { size, tone, alignY, data, title, titleId, ...restProps }: UseIconProps,
   { verticalCorrection = defaultVerticalCorrection }: PrivateIconProps = {},
@@ -65,10 +96,7 @@ export default (
 ): { isInline: boolean; svgProps: PublicBoxProps } => {
   const textContext = useContext(TextContext);
   const headingContext = useContext(HeadingContext);
-  const resolvedTone =
-    typographyStyles.tone[tone || textContext?.tone || 'neutral'];
-  const toneClass =
-    tone || (!headingContext && !textContext?.tone) ? resolvedTone : undefined;
+  const toneClass = useIconTone({ tone });
   const isInline = Boolean(textContext || headingContext);
   const a11yProps = title
     ? { title, titleId, role: 'img' }

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -6014,6 +6014,17 @@ exports[`IconRenderer 1`] = `
   exportType: component,
   props: {
     children: ({ className }: { className: string; }) => ReactElement<unknown, string | JSXElementConstructor<any>> | null
+    tone?: 
+        | "brandAccent"
+        | "caution"
+        | "critical"
+        | "formAccent"
+        | "info"
+        | "link"
+        | "neutral"
+        | "positive"
+        | "promote"
+        | "secondary"
 },
 }
 `;

--- a/site/src/App/routes/foundations/iconography/IconsDetails.tsx
+++ b/site/src/App/routes/foundations/iconography/IconsDetails.tsx
@@ -424,19 +424,63 @@ export const IconsDetails = () => (
                       EXAMPLE: Setting “fill=currentColor” on custom icon inside
                       “brandAccent” Text
                     </Text>
-                    <Text size="large" tone="brandAccent">
-                      <IconRenderer>
-                        {({ className }) => (
-                          <svg
-                            xmlns="http://www.w3.org/2000/svg"
-                            viewBox="0 0 24 24"
-                            className={className}
-                            fill="currentColor"
-                          >
-                            <circle cx="12" cy="12" r="10" />
-                          </svg>
-                        )}
-                      </IconRenderer>
+                    <Text
+                      size="large"
+                      tone="brandAccent"
+                      icon={
+                        <IconRenderer>
+                          {({ className }) => (
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              viewBox="0 0 24 24"
+                              className={className}
+                              fill="currentColor"
+                            >
+                              <circle cx="12" cy="12" r="10" />
+                            </svg>
+                          )}
+                        </IconRenderer>
+                      }
+                    >
+                      Text
+                    </Text>
+                  </Stack>,
+                )
+              }
+            />
+          </PlayroomStateProvider>
+          <Text>
+            A <TextLink href="tones">tone</TextLink> may also be provided
+            explicitly when the icon is required to deviate from the parent
+            text.
+          </Text>
+          <PlayroomStateProvider>
+            <DocExample
+              Example={() =>
+                source(
+                  <Stack space="medium">
+                    <Text size="xsmall" tone="secondary">
+                      EXAMPLE: Setting “fill=currentColor” on custom icon and
+                      explicitly applying “brandAccent” to it.
+                    </Text>
+                    <Text
+                      size="large"
+                      icon={
+                        <IconRenderer tone="brandAccent">
+                          {({ className }) => (
+                            <svg
+                              xmlns="http://www.w3.org/2000/svg"
+                              viewBox="0 0 24 24"
+                              className={className}
+                              fill="currentColor"
+                            >
+                              <circle cx="12" cy="12" r="10" />
+                            </svg>
+                          )}
+                        </IconRenderer>
+                      }
+                    >
+                      Text
                     </Text>
                   </Stack>,
                 )


### PR DESCRIPTION
Enable custom icons to use Braid tones in the same way as first-class Braid icons.

**EXAMPLE USAGE:**
```jsx
<IconRenderer tone={tone}>
  {({ className }) => (
    <svg
      xmlns="http://www.w3.org/2000/svg"
      viewBox="0 0 24 24"
      fill="currentColor"
      className={className}
    >
      ...
    </svg>
  )}
</IconRenderer>
```