### PR TITLE
Remove `Install latest npm` step from release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,10 +38,6 @@ jobs:
       - name: Install Dependencies
         run: pnpm i
 
-      # Ensure npm 11.5.1 or later is installed
-      - name: Install latest npm
-        run: npm install -g npm@latest
-
       - name: Create Release Pull Request or Publish to npm
         id: changesets
         uses: changesets/action@v1
@@ -94,10 +90,6 @@ jobs:
 
       - name: Install Dependencies
         run: pnpm i
-
-      # Ensure npm 11.5.1 or later is installed
-      - name: Install latest npm
-        run: npm install -g npm@latest
 
       - name: Publish
         uses: seek-oss/changesets-snapshot@v0


### PR DESCRIPTION
## Summary

- Removes the `Install latest npm` step from the release workflow.

Node.js now ships with an up-to-date version of npm, making this step unnecessary. Additionally, npm 12 has broken our release workflows, so explicitly upgrading to the latest npm is now harmful rather than helpful.

Made with [Cursor](https://cursor.com)