### PR TITLE
Fix Dialog/Drawer Jest crash from react-focus-lock CJS interop

### DIFF
--- a/.changeset/calm-cups-focus.md
+++ b/.changeset/calm-cups-focus.md
@@ -1,0 +1,5 @@
+---
+'braid-design-system': patch
+---
+
+Fix Dialog/Drawer crashing under Jest (CJS) when resolving `react-focus-lock` as Modal's focus trap

--- a/.changeset/calm-cups-focus.md
+++ b/.changeset/calm-cups-focus.md
@@ -2,4 +2,4 @@
 'braid-design-system': patch
 ---
 
-Fix Dialog/Drawer crashing under Jest (CJS) when resolving `react-focus-lock` as Modal's focus trap
+Fix Dialog/Drawer crashing under Jest (CJS) when resolving `react-focus-lock`

--- a/packages/braid-design-system/src/lib/components/private/Modal/Modal.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Modal/Modal.tsx
@@ -8,7 +8,7 @@ import {
   useContext,
   useReducer,
 } from 'react';
-import FocusLock from 'react-focus-lock';
+import FocusLockImport from 'react-focus-lock';
 
 import { Box } from '../../Box/Box';
 import { BraidPortal } from '../../BraidPortal/BraidPortal';
@@ -18,6 +18,11 @@ import { externalGutter } from './ModalExternalGutter';
 import { ariaHideOthers } from './ariaHideOthers';
 
 import * as styles from './Modal.css';
+
+// Some CJS interop paths expose the module namespace as the default export.
+const FocusLock =
+  (FocusLockImport as unknown as { default: typeof FocusLockImport }).default ??
+  FocusLockImport;
 
 export interface ModalProps extends Omit<
   ModalContentProps,


### PR DESCRIPTION
## Summary
- Dialog/Drawer unit tests (Jest/CJS) were crashing with `Element type is invalid… Check the render method of Modal` after the `tsdown` 0.22 bump
- Modal’s CJS build can resolve `react-focus-lock`’s default export to the module namespace instead of the FocusLock component
- Unwrap the default export in Modal so FocusLock always resolves to the real component, without pinning `tsdown`

## Test plan
- [x] Rebuild `braid-design-system` and confirm Modal CJS emits the unwrap
- [x] Against Chalice linked to this local build: previously failing Dialog/Drawer suites pass (7 suites / 93 tests)
- [ ] Confirm Braid’s own Dialog/Drawer modal test suite still passes in CI


Made with [Cursor](https://cursor.com)