### PR TITLE
🐛 Fix docs search shortcut hydration mismatch

### DIFF
--- a/packages/docs-ui/src/components/HeaderNavigation/HeaderNavigation.tsx
+++ b/packages/docs-ui/src/components/HeaderNavigation/HeaderNavigation.tsx
@@ -24,8 +24,7 @@ interface HeaderNavigationProps {
   themeToggle?: ReactNode;
 }
 
-const isApplePlatform = () =>
-  /Mac|iPhone|iPod|iPad/i.test(navigator.userAgent);
+const isApplePlatform = () => /Mac|iPhone|iPod|iPad/i.test(navigator.userAgent);
 
 export const HeaderNavigation = ({
   menuOpen = false,

--- a/packages/docs-ui/src/components/HeaderNavigation/HeaderNavigation.tsx
+++ b/packages/docs-ui/src/components/HeaderNavigation/HeaderNavigation.tsx
@@ -36,10 +36,12 @@ export const HeaderNavigation = ({
   logoHref = '/',
   themeToggle = null,
 }: HeaderNavigationProps) => {
-  const [modifierKey, setModifierKey] = useState<string | null>(null);
+  const [modifierKey, setModifierKey] = useState('⌘');
 
   useLayoutEffect(() => {
-    setModifierKey(isApplePlatform() ? '⌘' : 'Ctrl');
+    if (!isApplePlatform()) {
+      setModifierKey('Ctrl');
+    }
   }, []);
 
   return (
@@ -76,7 +78,7 @@ export const HeaderNavigation = ({
             onClick={onSearchClick}
           >
             <KeyboardShortcut
-              keys={modifierKey ? [modifierKey, 'K'] : []}
+              keys={[modifierKey, 'K']}
               shortcutLabel={<IconSearch />}
             />
           </Box>

--- a/packages/docs-ui/src/components/HeaderNavigation/HeaderNavigation.tsx
+++ b/packages/docs-ui/src/components/HeaderNavigation/HeaderNavigation.tsx
@@ -7,7 +7,7 @@ import {
   Link,
   Text,
 } from 'braid-design-system';
-import type { ReactNode } from 'react';
+import { type ReactNode, useLayoutEffect, useState } from 'react';
 
 import { KeyboardShortcut } from '../KeyboardShortcut/KeyboardShortcut';
 import { MenuButton } from '../MenuButton/MenuButton';
@@ -24,6 +24,9 @@ interface HeaderNavigationProps {
   themeToggle?: ReactNode;
 }
 
+const isApplePlatform = () =>
+  /Mac|iPhone|iPod|iPad/i.test(navigator.userAgent);
+
 export const HeaderNavigation = ({
   menuOpen = false,
   menuClick = () => {},
@@ -32,53 +35,53 @@ export const HeaderNavigation = ({
   logoLabel,
   logoHref = '/',
   themeToggle = null,
-}: HeaderNavigationProps) => (
-  <Box display="flex" alignItems="center">
-    <Hidden print>
-      <Box
-        paddingRight="medium"
-        display={{
-          mobile: 'flex',
-          wide: 'none',
-        }}
-        alignItems="center"
-      >
-        <MenuButton open={menuOpen} onClick={menuClick} />
-      </Box>
-    </Hidden>
-    <Box paddingRight="medium">
-      <Text component="div" baseline={false}>
-        <Link href={logoHref} tabIndex={menuOpen ? -1 : undefined}>
-          {logo}
-          <HiddenVisually>{logoLabel}</HiddenVisually>
-        </Link>
-      </Text>
-    </Box>
-    <div>
-      <>{themeToggle}</>
-      <Bleed horizontal="xxsmall" bottom="xxsmall">
+}: HeaderNavigationProps) => {
+  const [modifierKey, setModifierKey] = useState<string | null>(null);
+
+  useLayoutEffect(() => {
+    setModifierKey(isApplePlatform() ? '⌘' : 'Ctrl');
+  }, []);
+
+  return (
+    <Box display="flex" alignItems="center">
+      <Hidden print>
         <Box
-          component="button"
-          padding="xxsmall"
-          paddingRight="xsmall"
-          borderRadius="standard"
-          className={searchButton}
-          onClick={onSearchClick}
+          paddingRight="medium"
+          display={{
+            mobile: 'flex',
+            wide: 'none',
+          }}
+          alignItems="center"
         >
-          <KeyboardShortcut
-            keys={[
-              navigator.platform.startsWith('Mac') ||
-              navigator.platform === 'iPhone' ||
-              navigator.platform === 'iPad' ||
-              navigator.platform === 'iPod'
-                ? '⌘'
-                : 'Ctrl',
-              'K',
-            ]}
-            shortcutLabel={<IconSearch />}
-          />
+          <MenuButton open={menuOpen} onClick={menuClick} />
         </Box>
-      </Bleed>
-    </div>
-  </Box>
-);
+      </Hidden>
+      <Box paddingRight="medium">
+        <Text component="div" baseline={false}>
+          <Link href={logoHref} tabIndex={menuOpen ? -1 : undefined}>
+            {logo}
+            <HiddenVisually>{logoLabel}</HiddenVisually>
+          </Link>
+        </Text>
+      </Box>
+      <div>
+        <>{themeToggle}</>
+        <Bleed horizontal="xxsmall" bottom="xxsmall">
+          <Box
+            component="button"
+            padding="xxsmall"
+            paddingRight="xsmall"
+            borderRadius="standard"
+            className={searchButton}
+            onClick={onSearchClick}
+          >
+            <KeyboardShortcut
+              keys={modifierKey ? [modifierKey, 'K'] : []}
+              shortcutLabel={<IconSearch />}
+            />
+          </Box>
+        </Bleed>
+      </div>
+    </Box>
+  );
+};


### PR DESCRIPTION
## 📝 What changed

- Default the docs header search shortcut to `⌘` + `K` for SSR/first paint (Mac-first)
- After mount, swap to `Ctrl` + `K` only when not on an Apple platform (`useLayoutEffect`)
- Detect Apple platforms with `navigator.userAgent` (avoids deprecated `navigator.platform`)

## 💡 Why

- Production docs (`seek-oss.github.io/braid-design-system`) were reading platform during render, so Linux SSR HTML (`Ctrl`) disagreed with Mac client hydration (`⌘`) and triggered React minified error #418
- Most docs users are on Mac, so defaulting to `⌘` keeps that path stable with no flash

## ⚠️ Impact

- Docs UI only
- Non-Apple platforms may briefly show `⌘` before swapping to `Ctrl`
- No change to Braid component APIs