### PR TITLE
Enable all knip lints, remove unused exports and dead code

### DIFF
--- a/knip.jsonc
+++ b/knip.jsonc
@@ -15,6 +15,9 @@
       // `site` is imported by .docs.tsx files which are only consumed by the site workspace
       "ignoreDependencies": ["assert", "site"],
     },
+    "packages/codemod": {
+      "entry": ["src/index.ts", "src/wrapper.ts"],
+    },
     "site": {
       "entry": [
         "playroom.config.mts",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "storybook:chromatic": "nx run storybook:chromatic",
     "lint": "concurrently --group 'pnpm:lint:*'",
     "lint:eslint": "eslint --cache .",
-    "lint:knip": "knip --dependencies --treat-config-hints-as-errors",
+    "lint:knip": "knip --treat-config-hints-as-errors",
     "lint:manypkg": "manypkg check",
     "lint:prettier": "prettier --cache --list-different .",
     "lint:tsc": "nx run-many --target=lint:tsc",

--- a/packages/braid-design-system/src/lib/components/Actions/Actions.tsx
+++ b/packages/braid-design-system/src/lib/components/Actions/Actions.tsx
@@ -14,7 +14,7 @@ export interface ActionsProps {
   data?: InlineProps['data'];
 }
 
-export const actionsSpace = 'xsmall';
+const actionsSpace = 'xsmall';
 
 export const Actions: FC<ActionsProps> = ({ size, data, children }) => {
   const contextValue = useMemo(() => ({ size }), [size]);

--- a/packages/braid-design-system/src/lib/components/Dialog/Dialog.tsx
+++ b/packages/braid-design-system/src/lib/components/Dialog/Dialog.tsx
@@ -6,8 +6,6 @@ import {
   ModalContent,
 } from '../private/Modal/ModalContent';
 
-export { AllowCloseContext } from '../private/Modal/Modal';
-
 const defaultWidth = 'small';
 const modalStyle = {
   position: 'center',

--- a/packages/braid-design-system/src/lib/components/Inline/Inline.tsx
+++ b/packages/braid-design-system/src/lib/components/Inline/Inline.tsx
@@ -15,19 +15,11 @@ import buildDataAttributes, {
 
 import * as styles from './Inline.css';
 
-export const validInlineComponents = [
-  'div',
-  'span',
-  'p',
-  'nav',
-  'ul',
-  'ol',
-  'li',
-] as const;
+type ValidInlineComponent = 'div' | 'span' | 'p' | 'nav' | 'ul' | 'ol' | 'li';
 
 export type InlineProps = CollapsibleAlignmentProps & {
   space: ResponsiveSpace;
-  component?: (typeof validInlineComponents)[number];
+  component?: ValidInlineComponent;
   data?: DataAttributeMap;
   children: ReactNodeNoStrings;
   noWrap?: boolean;

--- a/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.css.ts
+++ b/packages/braid-design-system/src/lib/components/MenuRenderer/MenuRenderer.css.ts
@@ -5,26 +5,6 @@ import { vars } from '../../themes/vars.css';
 
 export const menuYPadding = createVar();
 
-export const backdrop = style({
-  width: '100vw',
-  height: '100vh',
-});
-
-export const triggerVars = {
-  top: createVar(),
-  left: createVar(),
-  bottom: createVar(),
-  right: createVar(),
-};
-
-// Top and bottom reversed to allow for a more natural API
-export const menuPosition = style({
-  top: triggerVars.bottom,
-  bottom: triggerVars.top,
-  left: triggerVars.left,
-  right: triggerVars.right,
-});
-
 const widthVar = createVar();
 const baseWidth = style({
   width: calc(widthVar).divide(4).toString(),

--- a/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.tsx
+++ b/packages/braid-design-system/src/lib/components/MonthPicker/MonthPicker.tsx
@@ -75,7 +75,7 @@ export type MonthPickerBaseProps = Omit<
   monthNames?: MonthNames;
 };
 export type MonthPickerLabelProps = FieldLabelVariant;
-export type MonthPickerProps = MonthPickerBaseProps & MonthPickerLabelProps;
+type MonthPickerProps = MonthPickerBaseProps & MonthPickerLabelProps;
 
 const getMonths = (monthNames: MonthNames) =>
   monthNames.map((monthName, i) => (

--- a/packages/braid-design-system/src/lib/components/Pagination/Pagination.css.ts
+++ b/packages/braid-design-system/src/lib/components/Pagination/Pagination.css.ts
@@ -19,14 +19,6 @@ export const focusRing = style([
 
 export const hover = style({});
 
-export const lightModeCurrentKeyline = style(
-  colorModeStyle({
-    lightMode: {
-      opacity: 0.3,
-    },
-  }),
-);
-
 export const darkModeCurrentKeyline = style(
   colorModeStyle({
     darkMode: {

--- a/packages/braid-design-system/src/lib/components/Stepper/StepperContext.tsx
+++ b/packages/braid-design-system/src/lib/components/Stepper/StepperContext.tsx
@@ -23,16 +23,16 @@ export const StepContext = createContext<StepContextValues>({
 });
 
 // Action type IDs (allows action type names to be minified)
-export const NAV_RIGHT = 0;
-export const NAV_DOWN = 1;
-export const NAV_LEFT = 2;
-export const NAV_UP = 3;
-export const NAV_HOME = 4;
-export const NAV_END = 5;
-export const NAV_TAB = 6;
-export const NAV_CLICKED = 7;
-export const NAV_FOCUSED = 8;
-export const NAV_BLURRED = 9;
+const NAV_RIGHT = 0;
+const NAV_DOWN = 1;
+const NAV_LEFT = 2;
+const NAV_UP = 3;
+const NAV_HOME = 4;
+const NAV_END = 5;
+const NAV_TAB = 6;
+const NAV_CLICKED = 7;
+const NAV_FOCUSED = 8;
+const NAV_BLURRED = 9;
 
 export type Action =
   | { type: typeof NAV_RIGHT }

--- a/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/TooltipRenderer/TooltipRenderer.tsx
@@ -22,7 +22,7 @@ import { useThemeName } from '../useThemeName/useThemeName';
 
 import * as styles from './TooltipRenderer.css';
 
-export const offsetSpace = 'small';
+const offsetSpace = 'small';
 
 const StaticTooltipContext = createContext(false);
 
@@ -39,7 +39,7 @@ export const StaticTooltipProvider = ({
   </StaticTooltipContext.Provider>
 );
 
-export const TooltipTextDefaultsProvider = ({
+const TooltipTextDefaultsProvider = ({
   children,
 }: {
   children: ReactNodeNoStrings;

--- a/packages/braid-design-system/src/lib/components/private/InlineField/InlineField.css.ts
+++ b/packages/braid-design-system/src/lib/components/private/InlineField/InlineField.css.ts
@@ -105,7 +105,7 @@ export const hoverOverlay = style({
   },
 });
 
-export const indicator = style({
+const indicator = style({
   selectors: {
     [`${hoverOverlay} > &`]: {
       opacity: 0.2,

--- a/packages/braid-design-system/src/lib/components/private/InlineField/StyledInput.tsx
+++ b/packages/braid-design-system/src/lib/components/private/InlineField/StyledInput.tsx
@@ -19,7 +19,7 @@ import * as styles from './InlineField.css';
 import type { Size } from './InlineField.css';
 
 const tones = ['neutral', 'critical'] as const;
-export type InlineFieldTone = (typeof tones)[number];
+type InlineFieldTone = (typeof tones)[number];
 
 export type CheckboxChecked =
   NonNullable<InputElementProps['checked']> | 'mixed';

--- a/packages/braid-design-system/src/lib/components/private/Popover/Popover.css.ts
+++ b/packages/braid-design-system/src/lib/components/private/Popover/Popover.css.ts
@@ -17,7 +17,7 @@ export const invertPlacement = style({
   },
 });
 
-export const transitionThreshold = 'xxsmall';
+const transitionThreshold = 'xxsmall';
 
 const popupAnimation = keyframes({
   from: {

--- a/packages/braid-design-system/src/lib/components/private/Popover/Popover.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Popover/Popover.tsx
@@ -17,7 +17,6 @@ import {
   type RefObject,
   type AllHTMLAttributes,
   createContext,
-  useContext,
 } from 'react';
 
 import type { ResponsiveSpace } from '../../../css/atoms/atoms';
@@ -68,7 +67,7 @@ function getFloatingUiPosition(
 // Ensures it matches the highest available zIndex. Not semantically correct
 const zIndex = 'notification';
 
-export interface PopoverPlacementData {
+interface PopoverPlacementData {
   placement: Placement;
   arrow?: {
     x?: number;
@@ -95,7 +94,7 @@ export interface PopoverProps {
   children: ReactNode;
 }
 
-export interface PopoverMiddlewareData {
+interface PopoverMiddlewareData {
   arrow?: {
     x?: number;
     y?: number;
@@ -104,11 +103,6 @@ export interface PopoverMiddlewareData {
 }
 
 const PopoverContext = createContext<PopoverMiddlewareData | null>(null);
-
-export const usePopoverContext = () => {
-  const context = useContext(PopoverContext);
-  return context;
-};
 
 const PopoverContent = forwardRef<HTMLElement, PopoverProps>(
   (

--- a/packages/braid-design-system/src/lib/css/atoms/atomicProperties.ts
+++ b/packages/braid-design-system/src/lib/css/atoms/atomicProperties.ts
@@ -95,8 +95,6 @@ export const colorProperties = {
 
 export type Background = keyof typeof vars.backgroundColor;
 
-export type ColorProperties = keyof typeof colorProperties;
-
 export const responsiveProperties = {
   display: {
     none: 'none',

--- a/packages/braid-design-system/src/lib/hooks/useIcon/index.ts
+++ b/packages/braid-design-system/src/lib/hooks/useIcon/index.ts
@@ -30,9 +30,6 @@ export const iconSize = ({
     [styles.cropToTextSize]: crop,
   });
 
-export interface IconContainerSizeProps {
-  size?: Exclude<IconSize, 'fill'>;
-}
 export const iconContainerSize = (
   size: Exclude<IconSize, 'fill'> = 'standard',
 ) => clsx(styles.blockWidths[size], lineHeightContainer[size]);

--- a/packages/braid-design-system/src/lib/themes/tokenType.ts
+++ b/packages/braid-design-system/src/lib/themes/tokenType.ts
@@ -20,7 +20,7 @@ export const extractFontMetricsForTheme = ({
   unitsPerEm,
 });
 
-export type TextBreakpoint = Exclude<Breakpoint, 'desktop' | 'wide'>;
+type TextBreakpoint = Exclude<Breakpoint, 'desktop' | 'wide'>;
 
 type FontSizeText =
   | {

--- a/packages/braid-design-system/src/lib/utils/a11y/index.ts
+++ b/packages/braid-design-system/src/lib/utils/a11y/index.ts
@@ -10,7 +10,7 @@ import {
 const AA_TEXT_CONTRAST = 4.52;
 
 // http://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html#key-terms
-export function contrast(color1: string, color2: string): number {
+function contrast(color1: string, color2: string): number {
   // `0.05` seems to be to avoid "divide by zero"
   // errors in the case of black
   const L1 = getLuminance(color1) + 0.05;
@@ -69,7 +69,7 @@ export function findClosestAccessibleLighterColor(
   return maxColor;
 }
 
-export function findClosestAccessibleDarkerColor(
+function findClosestAccessibleDarkerColor(
   inputColor: string,
   fixedColor: string,
   contrastRatio: number = AA_TEXT_CONTRAST,

--- a/packages/codemod/src/codemod.ts
+++ b/packages/codemod/src/codemod.ts
@@ -32,7 +32,7 @@ const pluginsForVersion = {
 
 type Version = keyof typeof pluginsForVersion;
 
-export function babelRecast({
+function babelRecast({
   version,
   code,
   filePath,

--- a/packages/codemod/src/warning-renderer/SyntaxHighlight.tsx
+++ b/packages/codemod/src/warning-renderer/SyntaxHighlight.tsx
@@ -2,7 +2,7 @@ import { type Theme, highlight } from 'cli-highlight';
 import { Text } from 'ink';
 import * as React from 'react';
 
-export interface Props {
+interface Props {
   code: string;
   language?: string;
   theme?: Theme;

--- a/packages/codemod/src/warning-renderer/codeFrame.tsx
+++ b/packages/codemod/src/warning-renderer/codeFrame.tsx
@@ -3,8 +3,6 @@ import { Box, Text } from 'ink';
 // eslint-disable-next-line @typescript-eslint/no-unused-vars
 import React from 'react';
 
-import { renderToString } from '../ink/ink-to-string';
-
 import SyntaxHighlight from './SyntaxHighlight';
 
 interface CodeLineProps {
@@ -95,6 +93,3 @@ export const CodeFrame = ({ code, location }: CodeFrameProps) => {
     </Box>
   );
 };
-
-export const renderCodeFrame = (props: CodeFrameProps) =>
-  `\n${renderToString(<CodeFrame {...props} />)}`;

--- a/packages/codemod/src/warning-renderer/warning.tsx
+++ b/packages/codemod/src/warning-renderer/warning.tsx
@@ -16,7 +16,7 @@ interface UntraceableImportWarningProps {
   componentName: string;
 }
 
-export const UntraceableImportWarning = ({
+const UntraceableImportWarning = ({
   code,
   importLocation,
   componentName,
@@ -77,7 +77,7 @@ const Stack = ({ children }: { children: React.ReactNode }) => (
   </Box>
 );
 
-export const UntraceablePropertyWarning = ({
+const UntraceablePropertyWarning = ({
   code,
   componentName,
   propLocation,
@@ -110,7 +110,7 @@ interface RecursiveDepthProps {
   filePath?: string;
 }
 
-export const RecursiveDepthWarning = ({ filePath }: RecursiveDepthProps) => (
+const RecursiveDepthWarning = ({ filePath }: RecursiveDepthProps) => (
   <Stack>
     <Text>File parsing depth limit met.</Text>
     {filePath ? (

--- a/packages/generate-component-docs/src/generate.ts
+++ b/packages/generate-component-docs/src/generate.ts
@@ -53,12 +53,12 @@ export type NormalisedPropType =
   | { type: 'alias'; alias: string; params: NormalisedPropType[] }
   | NormalisedInterface;
 
-export interface ComponentDoc {
+interface ComponentDoc {
   exportType: 'component';
   props: NormalisedInterface;
 }
 
-export interface HookDoc {
+interface HookDoc {
   exportType: 'hook';
   params: NormalisedPropType[];
   returnType: NormalisedPropType;

--- a/site/src/App/DocNavigation/DocToC.tsx
+++ b/site/src/App/DocNavigation/DocToC.tsx
@@ -10,7 +10,7 @@ import {
   tocHeightSet,
 } from './DocDetails.css';
 
-export interface TocItem {
+interface TocItem {
   id: string;
   label: string;
   isChild?: boolean;

--- a/site/src/App/Navigation/navigationSizes.ts
+++ b/site/src/App/Navigation/navigationSizes.ts
@@ -4,7 +4,6 @@ const menuButton = 32;
 
 export const headerSpaceY = 'large';
 const headerPaddingY = tokens.grid * tokens.space[headerSpaceY];
-export const menuButtonSize = `${menuButton}px`;
 export const headerHeight = `${menuButton + headerPaddingY * 2}px`;
 export const menuWidth = '280px';
 export const gutterSize = 'medium';

--- a/site/src/App/ThemeSetting/ThemedExample.css.ts
+++ b/site/src/App/ThemeSetting/ThemedExample.css.ts
@@ -3,10 +3,6 @@ import { colorModeStyle } from 'braid-design-system/css';
 import { palette } from 'braid-src/lib/color/palette';
 import tokens from 'braid-src/lib/themes/docs/tokens';
 
-export const unthemedBorderRadius = style({
-  borderRadius: tokens.border.radius.large,
-});
-
 const bgColor = createVar();
 const dotColor = createVar();
 const dotSize = createVar();

--- a/site/src/App/Updates/index.ts
+++ b/site/src/App/Updates/index.ts
@@ -36,7 +36,7 @@ interface Updated {
 
 type Update = Updated | New;
 
-export interface Release {
+interface Release {
   version: string;
   updates: Update[];
 }
@@ -113,13 +113,6 @@ const getNew = memo((...names: string[]) =>
 );
 
 export const isNew = (...names: string[]) => getNew(...names).length > 0;
-
-const getUpdated = memo((...names: string[]) =>
-  intersection(names, Array.from(updatedThings.values())),
-);
-
-export const isUpdated = (...names: string[]) =>
-  getUpdated(...names).length > 0;
 
 export const getHistory = memo((...names: string[]) => {
   let releventReleases = new Set<string>();

--- a/site/src/App/navigationHelpers.ts
+++ b/site/src/App/navigationHelpers.ts
@@ -149,10 +149,6 @@ export const allTemplateDocs = templateDocsContext.keys().map((filename) => {
   return { group, name, slug: slugify(docs.title), ...docs };
 });
 
-export const getTemplateDoc = (group: string, name: string): TemplateDocs =>
-  templateDocsContext(`./${group}/${name}/${name}.docs.tsx`)
-    .default as TemplateDocs;
-
 /**
  * Static lookup mapping slugged template names to template metadata.
  * Enables URL-based resolution like `/templates/standard-page` without knowing the group.


### PR DESCRIPTION
This PR turns on [all `knip` lints](https://knip.dev/reference/issue-types). This surfaced some unused `export`s, as well as a bit of dead code, both of which have been removed.

While these changes _do_ affect published packages, they don't affect public API, so I chose not to add a changeset.