### PR TITLE
Make remaining doc TitleLinks copyable

### DIFF
--- a/site/src/App/DocNavigation/DocDetails.tsx
+++ b/site/src/App/DocNavigation/DocDetails.tsx
@@ -192,7 +192,7 @@ export const DocDetails = () => {
               {'accessibility' in docs && docs.accessibility ? (
                 <Stack space={headingSpacing}>
                   <Heading level="3">
-                    <TitleLink>Accessibility</TitleLink>
+                    <TitleLink copyable>Accessibility</TitleLink>
                   </Heading>
                   {docs.accessibility}
                 </Stack>
@@ -228,7 +228,7 @@ export const DocDetails = () => {
                           docs.alternatives.length > 0 ? (
                             <Stack space={headingSpacing}>
                               <Heading level="3">
-                                <TitleLink label="Alternatives">
+                                <TitleLink copyable label="Alternatives">
                                   Alternatives
                                 </TitleLink>
                               </Heading>
@@ -266,7 +266,9 @@ export const DocDetails = () => {
               docs.alternatives.length > 0 ? (
                 <Stack space={headingSpacing}>
                   <Heading level="3">
-                    <TitleLink label="Alternatives">Alternatives</TitleLink>
+                    <TitleLink copyable label="Alternatives">
+                      Alternatives
+                    </TitleLink>
                   </Heading>
                   <List space="medium">
                     {docs.alternatives.map((alt) => (

--- a/site/src/App/DocNavigation/DocProps.tsx
+++ b/site/src/App/DocNavigation/DocProps.tsx
@@ -201,7 +201,7 @@ export const DocProps = () => {
           propsToDocument.map((c) => (
             <Stack space="large" key={c}>
               <Heading level="3">
-                <TitleLink>{c}</TitleLink>
+                <TitleLink copyable>{c}</TitleLink>
               </Heading>
 
               <ComponentProps componentName={c} />
@@ -213,7 +213,7 @@ export const DocProps = () => {
 
         <Stack space="large">
           <Heading level="3" component="h4">
-            <TitleLink>Further References</TitleLink>
+            <TitleLink copyable>Further References</TitleLink>
           </Heading>
           <Text>
             <TextLink href={sourceUrl}>View Source</TextLink>


### PR DESCRIPTION
Enable `copyable` on Details headings that were still jump-only (Accessibility, Alternatives), so TOC-linked sections share the same copy-link behaviour as category/section headings

Enable `copyable` on Props TitleLinks (component names, Further References) for consistency with Details/Releases/Templates

No change to `TitleLink`’s default, and no change to guides/examples (`LinkableHeading` stays jump-to for now)