### PR TITLE
Rating: Add role="img" so the accessible name is announced

### DIFF
--- a/.changeset/breezy-gifts-mate.md
+++ b/.changeset/breezy-gifts-mate.md
@@ -1,0 +1,10 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Rating
+---
+
+**Rating:** Expose the star graphic with `role="img"` so the `aria-label` is announced reliably by assistive technologies.

--- a/packages/braid-design-system/src/lib/components/Rating/Rating.test.tsx
+++ b/packages/braid-design-system/src/lib/components/Rating/Rating.test.tsx
@@ -1,0 +1,36 @@
+import { render } from '@testing-library/react';
+
+import { Rating } from '..';
+import { BraidTestProvider } from '../../../test';
+
+describe('Rating', () => {
+  it('should expose the stars as an image with an accessible name', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <Rating rating={3} />
+      </BraidTestProvider>,
+    );
+
+    expect(getByRole('img', { name: '3.0 out of 5' })).toBeInTheDocument();
+  });
+
+  it('should expose starsOnly as an image with an accessible name', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <Rating rating={3} variant="starsOnly" />
+      </BraidTestProvider>,
+    );
+
+    expect(getByRole('img', { name: '3.0 out of 5' })).toBeInTheDocument();
+  });
+
+  it('should honour aria-label if provided', () => {
+    const { getByRole } = render(
+      <BraidTestProvider>
+        <Rating rating={4.2} aria-label="Rated 4.2 stars" />
+      </BraidTestProvider>,
+    );
+
+    expect(getByRole('img', { name: 'Rated 4.2 stars' })).toBeInTheDocument();
+  });
+});

--- a/packages/braid-design-system/src/lib/components/Rating/Rating.tsx
+++ b/packages/braid-design-system/src/lib/components/Rating/Rating.tsx
@@ -93,6 +93,7 @@ export const Rating: FC<RatingProps> = ({
       <Box
         component="span"
         className={styles.inlineFlex}
+        role="img"
         aria-label={
           ariaLabel || `${rating.toFixed(1)} out of ${ratingArr.length}`
         }


### PR DESCRIPTION
Add `role="img"` to the star wrapper so the existing `aria-label` is announced reliably.

Includes tests for the default name, `starsOnly`, and a custom `aria-label`.