### PR TITLE
ButtonIcon: Add `brandAccent` tone and default accents to `solid`

### DIFF
--- a/.changeset/bright-icons-send.md
+++ b/.changeset/bright-icons-send.md
@@ -11,6 +11,8 @@ updated:
 
 Introduces support for the `brandAccent` tone on `ButtonIcon`.
 
+Accent tones now default to `solid` when `variant` is omitted — existing `formAccent` usage can pass `variant="soft"` to keep the previous look.
+
 **EXAMPLE USAGE:**
 ```jsx
 <ButtonIcon tone="brandAccent" icon={<IconAdd />} label="Add" />

--- a/.changeset/bright-icons-send.md
+++ b/.changeset/bright-icons-send.md
@@ -11,8 +11,6 @@ updated:
 
 Introduces support for the `brandAccent` tone on `ButtonIcon`.
 
-Accent tones now default to `solid` when `variant` is omitted — existing `formAccent` usage can pass `variant="soft"` to keep the previous look.
-
 **EXAMPLE USAGE:**
 ```jsx
 <ButtonIcon tone="brandAccent" icon={<IconAdd />} label="Add" />

--- a/.changeset/bright-icons-send.md
+++ b/.changeset/bright-icons-send.md
@@ -1,0 +1,17 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - ButtonIcon
+---
+
+**ButtonIcon:** Add `brandAccent` tone
+
+Introduces support for the `brandAccent` tone on `ButtonIcon`.
+
+**EXAMPLE USAGE:**
+```jsx
+<ButtonIcon tone="brandAccent" icon={<IconAdd />} label="Add" />
+```

--- a/.changeset/calm-buttons-glow.md
+++ b/.changeset/calm-buttons-glow.md
@@ -1,0 +1,17 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - ButtonIcon
+---
+
+**ButtonIcon:** Default accent tones to `solid` when `variant` is omitted
+
+Accent tones (`formAccent`, `brandAccent`) now default to `solid` when `variant` is omitted — existing `formAccent` usage can pass `variant="soft"` to keep the previous look.
+
+**EXAMPLE USAGE:**
+```jsx
+<ButtonIcon tone="formAccent" icon={<IconAdd />} label="Add" />
+```

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.docs.tsx
@@ -114,9 +114,10 @@ const docs: ComponentDocs = {
         label: 'Tones',
         description: (
           <Text>
-            By default, the button adopts the <Strong>neutral</Strong> tone,
-            however, actions can be emphasised by setting the{' '}
-            <Strong>tone</Strong> prop to <Strong>formAccent</Strong>.
+            By default, the button adopts the <Strong>neutral</Strong> tone.
+            Actions can be emphasised by setting the <Strong>tone</Strong> prop
+            to <Strong>formAccent</Strong>, or to <Strong>brandAccent</Strong>{' '}
+            for the most important actions.
           </Text>
         ),
         Example: () =>
@@ -142,6 +143,17 @@ const docs: ComponentDocs = {
                 />
                 <Text tone="secondary" size="xsmall">
                   FORMACCENT
+                </Text>
+              </Inline>
+              <Inline space="gutter" alignY="center">
+                <ButtonIcon
+                  tone="brandAccent"
+                  variant="soft"
+                  icon={<IconClear />}
+                  label="Brand Accent tone"
+                />
+                <Text tone="secondary" size="xsmall">
+                  BRANDACCENT
                 </Text>
               </Inline>
             </Stack>,

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.docs.tsx
@@ -137,7 +137,6 @@ const docs: ComponentDocs = {
               <Inline space="gutter" alignY="center">
                 <ButtonIcon
                   tone="formAccent"
-                  variant="soft"
                   icon={<IconClear />}
                   label="Form Accent tone"
                 />
@@ -148,7 +147,6 @@ const docs: ComponentDocs = {
               <Inline space="gutter" alignY="center">
                 <ButtonIcon
                   tone="brandAccent"
-                  variant="soft"
                   icon={<IconClear />}
                   label="Brand Accent tone"
                 />
@@ -156,6 +154,66 @@ const docs: ComponentDocs = {
                   BRANDACCENT
                 </Text>
               </Inline>
+            </Stack>,
+          ),
+      },
+      {
+        label: 'Impact of variant on tone',
+        description: (
+          <>
+            <Text>
+              By default, a button has a <Strong>neutral</Strong> tone and uses
+              the <Strong>soft</Strong> variant, allowing the visual prominence
+              to be increased or decreased as required.
+            </Text>
+            <Text>
+              This enables colour to be applied as accents and with purpose,
+              rather than by default — improving the management of user
+              attention and supporting a more declarative hierarchy of actions.
+            </Text>
+          </>
+        ),
+        playroom: false,
+        code: false,
+        Example: () =>
+          source(
+            <Stack space="small">
+              <Text size="small" tone="secondary">
+                Default is a <Strong>neutral</Strong> tone and{' '}
+                <Strong>soft</Strong> variant
+              </Text>
+              <ButtonIcon
+                variant="soft"
+                tone="neutral"
+                icon={<IconSend />}
+                label="Button"
+              />
+            </Stack>,
+          ),
+      },
+      {
+        description: (
+          <Text>
+            To compliment this, when an accent <Strong>tone</Strong> is applied
+            to a button, the default variant becomes <Strong>solid</Strong> to
+            maximise its impact — allowing the visual prominence to be reduced
+            as needed.
+          </Text>
+        ),
+        playroom: false,
+        code: false,
+        Example: () =>
+          source(
+            <Stack space="small">
+              <Text size="small" tone="secondary">
+                Default variant becomes <Strong>solid</Strong> when an accent{' '}
+                <Strong>tone</Strong> is applied
+              </Text>
+              <ButtonIcon
+                tone="brandAccent"
+                icon={<IconSend />}
+                label="Button"
+              />
             </Stack>,
           ),
       },

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.gallery.tsx
@@ -101,6 +101,24 @@ export const galleryItems: GalleryComponent = {
                 FORMACCENT
               </Text>
             </Inline>
+            <Inline space="small" alignY="center">
+              <ButtonIcon
+                tone="brandAccent"
+                variant="soft"
+                icon={<IconAdd />}
+                label="Add"
+              />
+              <ButtonIcon
+                tone="brandAccent"
+                variant="transparent"
+                bleed={false}
+                icon={<IconAdd />}
+                label="Add"
+              />
+              <Text tone="secondary" size="xsmall">
+                BRANDACCENT
+              </Text>
+            </Inline>
           </Stack>,
         ),
     },

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.gallery.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.gallery.tsx
@@ -84,12 +84,7 @@ export const galleryItems: GalleryComponent = {
               </Text>
             </Inline>
             <Inline space="small" alignY="center">
-              <ButtonIcon
-                tone="formAccent"
-                variant="soft"
-                icon={<IconAdd />}
-                label="Add"
-              />
+              <ButtonIcon tone="formAccent" icon={<IconAdd />} label="Add" />
               <ButtonIcon
                 tone="formAccent"
                 variant="transparent"
@@ -102,12 +97,7 @@ export const galleryItems: GalleryComponent = {
               </Text>
             </Inline>
             <Inline space="small" alignY="center">
-              <ButtonIcon
-                tone="brandAccent"
-                variant="soft"
-                icon={<IconAdd />}
-                label="Add"
-              />
+              <ButtonIcon tone="brandAccent" icon={<IconAdd />} label="Add" />
               <ButtonIcon
                 tone="brandAccent"
                 variant="transparent"

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.screenshots.tsx
@@ -253,6 +253,32 @@ export const ToneFormAccent: Story = {
   ),
 };
 
+export const ToneBrandAccent: Story = {
+  name: 'Tone - brandAccent',
+  render: () => (
+    <Inline space="large" alignY="center">
+      <ButtonIcon
+        variant="transparent"
+        tone="brandAccent"
+        icon={<IconBookmark />}
+        label="Bookmark"
+      />
+      <ButtonIcon
+        variant="soft"
+        tone="brandAccent"
+        icon={<IconBookmark />}
+        label="Bookmark"
+      />
+      <ButtonIcon
+        variant="solid"
+        tone="brandAccent"
+        icon={<IconBookmark />}
+        label="Bookmark"
+      />
+    </Inline>
+  ),
+};
+
 export const VirtualTouchTarget: Story = {
   name: 'Virtual touch target',
   render: () => (

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.snippets.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.snippets.tsx
@@ -41,4 +41,10 @@ export const snippets: Snippets = [
       <ButtonIcon tone="formAccent" icon={<IconAdd />} label="Add" />,
     ),
   },
+  {
+    description: 'Brand accent',
+    code: source(
+      <ButtonIcon tone="brandAccent" icon={<IconAdd />} label="Add" />,
+    ),
+  },
 ];

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.tsx
@@ -70,6 +70,19 @@ const padding: Record<ButtonIconSize, Space> = {
   large: 'xsmall',
 };
 
+const resolveToneAndVariant = ({
+  variant: variantProp,
+  tone: toneProp,
+}: Pick<ButtonIconProps, 'variant' | 'tone'>) => {
+  const fallbackVariant =
+    toneProp === 'formAccent' || toneProp === 'brandAccent' ? 'solid' : 'soft';
+
+  return {
+    variant: variantProp ?? fallbackVariant,
+    tone: toneProp ?? 'neutral',
+  };
+};
+
 const ButtonIconContent = forwardRef<HTMLButtonElement, ButtonIconProps>(
   (
     {
@@ -77,8 +90,8 @@ const ButtonIconContent = forwardRef<HTMLButtonElement, ButtonIconProps>(
       label,
       id,
       size = 'standard',
-      tone = 'neutral',
-      variant = 'soft',
+      tone: toneProp,
+      variant: variantProp,
       type = 'button',
       bleed,
       tooltipPlacement,
@@ -97,6 +110,11 @@ const ButtonIconContent = forwardRef<HTMLButtonElement, ButtonIconProps>(
     },
     forwardedRef,
   ) => {
+    const { tone, variant } = resolveToneAndVariant({
+      variant: variantProp,
+      tone: toneProp,
+    });
+
     const { root, content } = useButtonStyles({
       variant,
       tone,

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.tsx
@@ -35,8 +35,8 @@ export const buttonIconVariants: Array<
 > = ['soft', 'transparent', 'solid'];
 
 export const buttonIconTones: Array<
-  Extract<ButtonStyleProps['tone'], 'neutral' | 'formAccent'>
-> = ['neutral', 'formAccent'];
+  Extract<ButtonStyleProps['tone'], 'neutral' | 'formAccent' | 'brandAccent'>
+> = ['neutral', 'formAccent', 'brandAccent'];
 export const buttonIconSizes = ['small', 'standard', 'large'] as const;
 
 type ButtonIconSize = (typeof buttonIconSizes)[number];

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -2212,6 +2212,7 @@ exports[`ButtonIcon 1`] = `
         | "standard"
     tabIndex?: number
     tone?: 
+        | "brandAccent"
         | "formAccent"
         | "neutral"
     tooltipPlacement?: 


### PR DESCRIPTION
Introduces support for the `brandAccent` tone on `ButtonIcon`.

### Example usage
```jsx
<ButtonIcon tone="brandAccent" icon={<IconAdd />} label="Add" />
```