### PR TITLE
IconRenderer: Support custom icons in ButtonIcon

### DIFF
--- a/.changeset/legal-hairs-relate.md
+++ b/.changeset/legal-hairs-relate.md
@@ -7,28 +7,24 @@ updated:
   - IconRenderer
 ---
 
-**IconRenderer:** Support custom icons in ButtonIcon
-
-`IconRenderer` can now be passed to the `icon` slot of `ButtonIcon`. `ButtonIcon` injects `size="fill"`, which sizes the custom SVG to fill the button while preserving tone inheritance.
+**IconRenderer:** Add support for `size="fill"`
 
 **EXAMPLE USAGE:**
+Provides the ability for custom icons to be sized to their container in the same way as Braid icons.
 
 ```jsx
-<ButtonIcon
-  label="Custom icon"
-  icon={
-    <IconRenderer>
-      {({ className }) => (
-        <svg
-          viewBox="0 0 24 24"
-          className={className}
-          fill="currentColor"
-          aria-hidden
-        >
-          ...
-        </svg>
-      )}
-    </IconRenderer>
-  }
-/>
+<Box style={{ height: 60, width: 60 }}>
+  <IconRenderer size="fill">
+    {({ className }) => (
+      <svg
+        viewBox="0 0 24 24"
+        className={className}
+        fill="currentcolor"
+        aria-hidden
+      >
+        ...
+      </svg>
+    )}
+  </IconRenderer>
+</Box>
 ```

--- a/.changeset/legal-hairs-relate.md
+++ b/.changeset/legal-hairs-relate.md
@@ -1,0 +1,34 @@
+---
+'braid-design-system': minor
+---
+
+---
+updated:
+  - IconRenderer
+---
+
+**IconRenderer:** Support custom icons in ButtonIcon
+
+`IconRenderer` can now be passed to the `icon` slot of `ButtonIcon`. `ButtonIcon` injects `size="fill"`, which sizes the custom SVG to fill the button while preserving tone inheritance.
+
+**EXAMPLE USAGE:**
+
+```jsx
+<ButtonIcon
+  label="Custom icon"
+  icon={
+    <IconRenderer>
+      {({ className }) => (
+        <svg
+          viewBox="0 0 24 24"
+          className={className}
+          fill="currentColor"
+          aria-hidden
+        >
+          ...
+        </svg>
+      )}
+    </IconRenderer>
+  }
+/>
+```

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.docs.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.docs.tsx
@@ -20,6 +20,7 @@ import {
   IconOverflow,
   IconAdd,
   IconArrow,
+  IconRenderer,
 } from '..';
 import { dataAttributeDocs } from '../private/dataAttribute.docs';
 
@@ -270,6 +271,39 @@ const docs: ComponentDocs = {
                 </Text>
               </Inline>
             </Stack>,
+          ),
+      },
+      {
+        label: 'Custom icons',
+        description: (
+          <Text>
+            Product-specific icons can be passed to the <Strong>icon</Strong>{' '}
+            slot using <Strong>IconRenderer</Strong>. See{' '}
+            <TextLink href="/foundations/iconography#custom-icons-size">
+              Using custom icons
+            </TextLink>{' '}
+            for guidance on sizing, colour and accessibility.
+          </Text>
+        ),
+        Example: () =>
+          source(
+            <ButtonIcon
+              label="Custom icon"
+              icon={
+                <IconRenderer>
+                  {({ className }) => (
+                    <svg
+                      viewBox="0 0 24 24"
+                      className={className}
+                      fill="currentColor"
+                      aria-hidden
+                    >
+                      <circle cx="12" cy="12" r="10" />
+                    </svg>
+                  )}
+                </IconRenderer>
+              }
+            />,
           ),
       },
     ],

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.screenshots.tsx
@@ -1,6 +1,15 @@
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
+import type { ComponentProps } from 'react';
 
-import { Box, ButtonIcon, Inline, Heading, IconBookmark, Stack } from '../';
+import {
+  Box,
+  ButtonIcon,
+  Inline,
+  Heading,
+  IconBookmark,
+  Stack,
+  IconRenderer,
+} from '../';
 import { BackgroundContrastTest } from '../../utils/BackgroundContrastTest';
 import { LayoutTest } from '../../utils/LayoutTest';
 import { debugTouchableAttrForDataProp } from '../private/touchable/debugTouchable';
@@ -30,6 +39,25 @@ const meta = {
 export default meta;
 
 type Story = StoryObj<typeof ButtonIcon>;
+
+const CustomIcon = ({
+  size,
+  tone,
+}: Pick<ComponentProps<typeof IconRenderer>, 'size' | 'tone'>) => (
+  <IconRenderer size={size} tone={tone}>
+    {({ className }) => (
+      <svg
+        viewBox="0 0 24 24"
+        focusable="false"
+        fill="currentColor"
+        aria-hidden
+        className={className}
+      >
+        <rect x="3" y="3" width="18" height="18" rx="5" />
+      </svg>
+    )}
+  </IconRenderer>
+);
 
 export const Default: Story = {
   args: {
@@ -367,6 +395,32 @@ export const Contrast: Story = {
         />
       </Inline>
     </BackgroundContrastTest>
+  ),
+};
+
+export const CustomIconSlot: Story = {
+  name: 'Custom icon',
+  render: () => (
+    <Inline space="large" alignY="center">
+      <ButtonIcon
+        variant="soft"
+        size="small"
+        icon={<CustomIcon />}
+        label="Small"
+      />
+      <ButtonIcon
+        variant="soft"
+        size="standard"
+        icon={<CustomIcon />}
+        label="Standard"
+      />
+      <ButtonIcon
+        variant="soft"
+        size="large"
+        icon={<CustomIcon />}
+        label="Large"
+      />
+    </Inline>
   ),
 };
 

--- a/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.test.tsx
+++ b/packages/braid-design-system/src/lib/components/ButtonIcon/ButtonIcon.test.tsx
@@ -2,7 +2,7 @@ import { render } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { renderToStaticMarkup } from 'react-dom/server';
 
-import { ButtonIcon, IconBookmark, Text } from '..';
+import { ButtonIcon, IconBookmark, IconRenderer, Text } from '..';
 import { BraidTestProvider } from '../../../test';
 
 describe('ButtonIcon', () => {
@@ -89,5 +89,31 @@ describe('ButtonIcon', () => {
 
     const button = getByLabelText('Bookmark');
     expect(button).toHaveAttribute('aria-pressed', 'true');
+  });
+
+  it('should support IconRenderer in icon slot', () => {
+    const { getByLabelText } = render(
+      <BraidTestProvider>
+        <ButtonIcon
+          label="Custom"
+          icon={
+            <IconRenderer>
+              {({ className }) => (
+                <svg
+                  viewBox="0 0 24 24"
+                  className={className}
+                  fill="currentColor"
+                  aria-hidden
+                >
+                  <rect x="3" y="3" width="18" height="18" rx="5" />
+                </svg>
+              )}
+            </IconRenderer>
+          }
+        />
+      </BraidTestProvider>,
+    );
+
+    expect(getByLabelText('Custom')).toBeInTheDocument();
   });
 });

--- a/packages/braid-design-system/src/lib/components/icons/IconRenderer.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconRenderer.screenshots.tsx
@@ -1,7 +1,7 @@
 import type { Meta, StoryObj } from '@storybook/react-webpack5';
 import type { ComponentProps } from 'react';
 
-import { Text, Heading, IconRenderer, Stack } from '../';
+import { ButtonIcon, IconRenderer, Inline, Text, Heading, Stack } from '../';
 
 const meta = {
   title: 'Components/IconRenderer',
@@ -13,8 +13,9 @@ type Story = StoryObj<typeof IconRenderer>;
 
 const CustomIcon = ({
   tone,
-}: Pick<ComponentProps<typeof IconRenderer>, 'tone'>) => (
-  <IconRenderer tone={tone}>
+  size,
+}: Pick<ComponentProps<typeof IconRenderer>, 'tone' | 'size'>) => (
+  <IconRenderer tone={tone} size={size}>
     {({ className }) => (
       <svg
         xmlns="http://www.w3.org/2000/svg"
@@ -80,5 +81,15 @@ export const ExplicitToneInHeading: Story = {
     <Heading level="2" icon={<CustomIcon tone="brandAccent" />}>
       Heading 2 with custom icon
     </Heading>
+  ),
+};
+
+export const InButtonIcon: Story = {
+  render: () => (
+    <Inline space="large" alignY="center">
+      <ButtonIcon size="small" icon={<CustomIcon />} label="Small" />
+      <ButtonIcon size="standard" icon={<CustomIcon />} label="Standard" />
+      <ButtonIcon size="large" icon={<CustomIcon />} label="Large" />
+    </Inline>
   ),
 };

--- a/packages/braid-design-system/src/lib/components/icons/IconRenderer.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconRenderer.screenshots.tsx
@@ -89,7 +89,11 @@ export const InButtonIcon: Story = {
     <Inline space="large" alignY="center">
       <ButtonIcon size="small" icon={<CustomIcon />} label="Small" />
       <ButtonIcon size="standard" icon={<CustomIcon />} label="Standard" />
-      <ButtonIcon size="large" icon={<CustomIcon />} label="Large" />
+      <ButtonIcon
+        size="large"
+        icon={<CustomIcon tone="critical" />}
+        label="Large"
+      />
     </Inline>
   ),
 };

--- a/packages/braid-design-system/src/lib/components/icons/IconRenderer.tsx
+++ b/packages/braid-design-system/src/lib/components/icons/IconRenderer.tsx
@@ -3,23 +3,37 @@ import assert from 'assert';
 import clsx from 'clsx';
 import { type ReactElement, useContext, type FC } from 'react';
 
+import { atoms } from '../../css/atoms/atoms';
 import { iconInlineSize, useIconTone } from '../../hooks/useIcon';
 import HeadingContext from '../Heading/HeadingContext';
 import { TextContext } from '../Text/TextContext';
 
 interface IconRendererProps {
+  size?: 'fill';
   tone?: Parameters<typeof useIconTone>[0]['tone'];
   children: ({ className }: { className: string }) => ReactElement | null;
 }
-export const IconRenderer: FC<IconRendererProps> = ({ tone, children }) => {
+export const IconRenderer: FC<IconRendererProps> = ({
+  children,
+  size,
+  tone,
+}) => {
   const textContext = useContext(TextContext);
   const headingContext = useContext(HeadingContext);
   const toneClass = useIconTone({ tone });
+  const isFillSize = size === 'fill';
 
   assert(
-    Boolean(textContext || headingContext),
-    `IconRenderer must be inside either a \`Text\` or \`Heading\` component.`,
+    isFillSize || Boolean(textContext || headingContext),
+    `IconRenderer must be inside either a \`Text\` or \`Heading\` component, or provided to an \`icon\` slot.`,
   );
 
-  return children({ className: clsx(toneClass, iconInlineSize()) });
+  return children({
+    className: clsx(
+      toneClass,
+      isFillSize
+        ? atoms({ width: 'full', height: 'full', display: 'block' })
+        : iconInlineSize(),
+    ),
+  });
 };

--- a/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
+++ b/packages/generate-component-docs/src/__snapshots__/contract.test.ts.snap
@@ -6048,6 +6048,7 @@ exports[`IconRenderer 1`] = `
   exportType: component,
   props: {
     children: ({ className }: { className: string; }) => ReactElement<unknown, string | JSXElementConstructor<any>> | null
+    size?: "fill"
     tone?: 
         | "brandAccent"
         | "caution"

--- a/site/src/App/routes/foundations/iconography/IconsDetails.tsx
+++ b/site/src/App/routes/foundations/iconography/IconsDetails.tsx
@@ -366,9 +366,11 @@ export const IconsDetails = () => (
             To make the alignment of icons and typography as seamless as
             possible, IconRenderer supports{' '}
             <TextLink href="#size-inline">inline sizing</TextLink>. As a result,
-            it must be used inside either a{' '}
+            for inline sizing, it must be used inside either a{' '}
             <TextLink href="/components/Text">Text</TextLink> or{' '}
             <TextLink href="/components/Heading">Heading</TextLink> component.
+            It can also be passed to the <Strong>icon</Strong> slot of{' '}
+            <TextLink href="/components/ButtonIcon">ButtonIcon</TextLink>.
           </Text>
           <Text>For example, here is a custom circle alongside a Heading:</Text>
           <PlayroomStateProvider>


### PR DESCRIPTION
IconRenderer can now be passed to the `icon` slot of `ButtonIcon`.

### Example usage
```jsx
<ButtonIcon
  label="Custom icon"
  icon={
    <IconRenderer>
      {({ className }) => (
        <svg
          viewBox="0 0 24 24"
          className={className}
          fill="currentColor"
          aria-hidden
        >
          ...
        </svg>
      )}
    </IconRenderer>
  }
/>