### PR TITLE
Spread: Ensure explicitly sized content doesnt shrink

### DIFF
--- a/.changeset/funky-pots-lose.md
+++ b/.changeset/funky-pots-lose.md
@@ -1,0 +1,12 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Spread
+---
+
+**Spread:** Ensure explicitly sized content doesnt shrink
+
+Ensure the child of a `Spread` maintains its specified size when larger than the container — instead of being squashed to fit.

--- a/packages/braid-design-system/src/lib/components/Spread/Spread.css.ts
+++ b/packages/braid-design-system/src/lib/components/Spread/Spread.css.ts
@@ -1,5 +1,10 @@
 import { globalStyle, style } from '@vanilla-extract/css';
 
+export const noFlexShrink = style({});
+globalStyle(`${noFlexShrink} > *`, {
+  flexShrink: 0,
+});
+
 export const fitContent = style({});
 globalStyle(`${fitContent} > *`, {
   flexBasis: 'auto',

--- a/packages/braid-design-system/src/lib/components/Spread/Spread.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Spread/Spread.screenshots.tsx
@@ -298,3 +298,14 @@ export const TestTextTruncationVerticalShouldBeLimitedToContainerWidthAndRespect
       </Stack>
     ),
   };
+
+export const TestChildrenShouldNotShrink: Story = {
+  name: 'Test: Children should not change dimensions based on available space (should not shrink)',
+  render: () => (
+    <Box style={{ height: 150, background: 'rgba(255,0,255,0.3)' }}>
+      <Spread space="none" direction="vertical">
+        <Placeholder height={400} label="Should not squash into pink box" />
+      </Spread>
+    </Box>
+  ),
+};

--- a/packages/braid-design-system/src/lib/components/Spread/Spread.tsx
+++ b/packages/braid-design-system/src/lib/components/Spread/Spread.tsx
@@ -68,6 +68,7 @@ export const Spread: FC<SpreadProps> = ({
       alignItems={alignItems}
       gap={space}
       className={[
+        styles.noFlexShrink,
         isHorizontal ? styles.fitContent : undefined,
         isVertical ? styles.maxWidth : undefined,
       ]}


### PR DESCRIPTION
Ensure the child of a `Spread` maintains its specified size when larger than the container — instead of being squashed to fit.

#### Playroom Demos
[Before]
[After] 

[Before]: https://seek-oss.github.io/braid-design-system/playroom/#?code=N4Igxg9gJgpiBcIA8AhCAPABAZwC4E8AbGAXmGEwAsYBLAc0t3kwEYBWABgBpMAjAQzABrOgCcIAVwB2UZgB0QougIAUAJjZsu3DVo4A6AMwBKBZgC%2B5gHxypmTEgDKAB1Ex%2BUHM8GkFUiFIwZlA0bmC4NAEkCgBuMKIRYPyECjZ29g4ACoQ%2BlBCEsKJUtAy4ZAAsHBzmmDm8MITRII55EgWY-rg4AI4S-NiUmDRSuBCYzsNCfBhmAPRp9kizLm4eaUto6GkgXCC41AC2MNgIANog2DAwQgBSELwnALq7AO40UPsn8KeGAJwczz2NFwxAQIAAIjADmMAAYrdxQGH2AaiSZ8CR0HYgGAhUaiAAS71gUgQuFEEhg5iAA

[After]: https://seek-oss.github.io/braid-design-system/preview/d2f62cb540f091286762224cb87ca72486f1f29c/playroom/#?code=N4Igxg9gJgpiBcIA8AhCAPABAZwC4E8AbGAXmGEwAsYBLAc0t3kwEYBWABgBpMAjAQzABrOgCcIAVwB2UZgB0QougIAUAJjZsu3DVo4A6AMwBKBZgC%2B5gHxypmTEgDKAB1Ex%2BUHM8GkFUiFIwZlA0bmC4NAEkCgBuMKIRYPyECjZ29g4ACoQ%2BlBCEsKJUtAy4ZAAsHBzmmDm8MITRII55EgWY-rg4AI4S-NiUmDRSuBCYzsNCfBhmAPRp9kizLm4eaUto6GkgXCC41AC2MNgIANog2DAwQgBSELwnALq7AO40UPsn8KeGAJwczz2NFwxAQIAAIjADmMAAYrdxQGH2AaiSaYABmNHQOxAMBCo1EAAl3rApAhcKIJDBzEA