### PR TITLE
Drawer, Dialog: Restore default stack spacing to content

### DIFF
--- a/.changeset/red-worms-double.md
+++ b/.changeset/red-worms-double.md
@@ -1,0 +1,11 @@
+---
+'braid-design-system': patch
+---
+
+---
+updated:
+  - Drawer
+  - Dialog
+---
+
+**Drawer, Dialog:** Restore default stack spacing to content

--- a/packages/braid-design-system/src/lib/components/Dialog/Dialog.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Dialog/Dialog.screenshots.tsx
@@ -54,6 +54,19 @@ export const DefaultLayout: Story = {
   },
 };
 
+export const DefaultStackSpace: Story = {
+  name: 'Default stack space',
+  args: {
+    title: 'Default stack space',
+    children: (
+      <>
+        <Placeholder height={100} width="100%" />
+        <Placeholder height={100} width="100%" />
+      </>
+    ),
+  },
+};
+
 export const CoverImageLayout: Story = {
   name: 'Cover Image layout (no width)',
   args: {

--- a/packages/braid-design-system/src/lib/components/Drawer/Drawer.screenshots.tsx
+++ b/packages/braid-design-system/src/lib/components/Drawer/Drawer.screenshots.tsx
@@ -47,6 +47,19 @@ export const DefaultLayout: Story = {
   },
 };
 
+export const DefaultStackSpace: Story = {
+  name: 'Default stack space',
+  args: {
+    title: 'Default stack space',
+    children: (
+      <>
+        <Placeholder height={100} width="100%" />
+        <Placeholder height={100} width="100%" />
+      </>
+    ),
+  },
+};
+
 export const LayoutWithDescription: Story = {
   name: 'Layout with a description',
   args: {

--- a/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
+++ b/packages/braid-design-system/src/lib/components/private/Modal/ModalContent.tsx
@@ -314,7 +314,7 @@ export const ModalContent = ({
         ref={headingRef}
         reserveCloseArea
       />
-      <Box height="full">{children}</Box>
+      {children}
     </ModalContentScrollLayout>
   );
 


### PR DESCRIPTION
Fixes a regression where the default gap spacing was no longer being applied to child content in `Dialog` and `Drawer`.